### PR TITLE
ETCD-664: Add e2e test for scaling when CPMS is disabled

### DIFF
--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -42,8 +43,10 @@ type TestingT interface {
 	Logf(format string, args ...interface{})
 }
 
-// CreateNewMasterMachine creates a new master node by cloning an existing Machine resource
-func CreateNewMasterMachine(ctx context.Context, t TestingT, machineClient machinev1beta1client.MachineInterface) (string, error) {
+// CreateNewMasterMachine creates a new master node by cloning an existing Machine resource.
+// machineIndex is used to identify the index to which machine should be created to.
+// machineIndex of -1 to be passed if index needn't be taken into consideration while creating the machine
+func CreateNewMasterMachine(ctx context.Context, t TestingT, machineClient machinev1beta1client.MachineInterface, machineIndex int64) (string, error) {
 	machineList, err := machineClient.List(ctx, metav1.ListOptions{LabelSelector: masterMachineLabelSelector})
 	if err != nil {
 		return "", err
@@ -63,7 +66,12 @@ func CreateNewMasterMachine(ctx context.Context, t TestingT, machineClient machi
 	}
 	// assigning a new Name and clearing ProviderID is enough
 	// for MAO to pick it up and provision a new master machine/node
-	machineToClone.Name = fmt.Sprintf("%s-clone", machineToClone.Name)
+	if machineIndex == -1 {
+		machineToClone.Name = fmt.Sprintf("%s-clone", machineToClone.Name)
+	} else {
+		machineClusterIdRole := machineToClone.Name[:strings.LastIndex(machineToClone.Name, "-")]
+		machineToClone.Name = fmt.Sprintf("%s-%s-%d", machineClusterIdRole, rand.String(5), machineIndex)
+	}
 	machineToClone.Spec.ProviderID = nil
 	machineToClone.ResourceVersion = ""
 	machineToClone.Annotations = map[string]string{}
@@ -236,6 +244,60 @@ func IsCPMSActive(ctx context.Context, t TestingT, cpmsClient machinev1client.Co
 	return true, nil
 }
 
+// DisableCPMS disables the CPMS by deleting the custom resource and verifies it.
+// Returns error if there was one while disabling or verifying
+func DisableCPMS(ctx context.Context, t TestingT, cpmsClient machinev1client.ControlPlaneMachineSetInterface) error {
+	waitPollInterval := 5 * time.Second
+	waitPollTimeout := 1 * time.Minute
+	if err := cpmsClient.Delete(ctx, "cluster", metav1.DeleteOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	t.Logf("Waiting up to %s for the CPMS to be disabled", waitPollTimeout.String())
+	return wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		isActive, err := IsCPMSActive(ctx, t, cpmsClient)
+		if err != nil {
+			return true, err
+		}
+		if isActive {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// EnableCPMS activates the CPMS setting the .spec.state field to Active and verifies it.
+// Returns error if there was one while activating or verifying
+func EnableCPMS(ctx context.Context, t TestingT, cpmsClient machinev1client.ControlPlaneMachineSetInterface) error {
+	waitPollInterval := 5 * time.Second
+	waitPollTimeout := 1 * time.Minute
+	cpms, err := cpmsClient.Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	cpms.Spec.State = machinev1.ControlPlaneMachineSetStateActive
+	_, err = cpmsClient.Update(ctx, cpms, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	t.Logf("Waiting up to %s for the CPMS to be activated", waitPollTimeout.String())
+	return wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		isActive, err := IsCPMSActive(ctx, t, cpmsClient)
+		if err != nil {
+			return true, err
+		}
+		if !isActive {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
 // EnsureReadyReplicasOnCPMS checks if status.readyReplicas on the cluster CPMS is n
 // this effectively counts the number of control-plane machines with the provider state as running
 func EnsureReadyReplicasOnCPMS(ctx context.Context, t TestingT, expectedReplicaCount int, cpmsClient machinev1client.ControlPlaneMachineSetInterface, nodeClient v1.NodeInterface) error {
@@ -352,6 +414,53 @@ func EnsureVotingMembersCount(ctx context.Context, t TestingT, etcdClientFactory
 		}
 		return true, nil
 	})
+}
+
+// WaitOnExpectedVotingMembersCount waits for 2 minutes and ensures the etcd membership remains at the expected member count. Returns an error if there is a change
+// in the expected voting members count
+func WaitOnExpectedVotingMembersCount(ctx context.Context, t TestingT, etcdClientFactory EtcdClientCreator, kubeClient kubernetes.Interface, expectedMembersCount int) error {
+	waitPollInterval := 15 * time.Second
+	waitPollTimeout := 2 * time.Minute
+	var votingMemberNames []string
+
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, false, func(ctx context.Context) (done bool, err error) {
+		etcdClient, closeFn, err := etcdClientFactory.NewEtcdClient()
+		if err != nil {
+			t.Logf("failed to get etcd client, will retry, err: %v", err)
+			return false, nil
+		}
+		defer closeFn()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		memberList, err := etcdClient.MemberList(ctx)
+		if err != nil {
+			t.Logf("failed to get the member list, will retry, err: %v", err)
+			return false, nil
+		}
+
+		votingMemberNames = []string{}
+		for _, member := range memberList.Members {
+			if !member.IsLearner {
+				votingMemberNames = append(votingMemberNames, member.Name)
+			}
+		}
+		if len(votingMemberNames) != expectedMembersCount {
+			t.Logf("unexpected change in number of voting etcd members from %d to: %v, current members are: %v", expectedMembersCount, len(votingMemberNames), votingMemberNames)
+			return true, nil
+		}
+		return false, nil
+	})
+
+	// the poll will timeout and context deadline exceeded error would be returned if there isn't any change in the membership and
+	// the poll will return early with no error if there is an unexpected change from the expected voting member count.
+	if err != nil {
+		if err == context.DeadlineExceeded {
+			return nil
+		}
+		return fmt.Errorf("polling encountered an error: %v", err)
+	}
+	return fmt.Errorf("failed to confirm that voting membership remained constant, expected %d, got %d, current members are: %v", expectedMembersCount, len(votingMemberNames), votingMemberNames)
 }
 
 func EnsureMemberRemoved(t TestingT, etcdClientFactory EtcdClientCreator, memberName string) error {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -2,18 +2,24 @@ package etcd
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
+	machinev1 "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1"
+	machinev1beta1 "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
 	testlibraryapi "github.com/openshift/library-go/test/library/apiserver"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	scalingtestinglibrary "github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -21,10 +27,42 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-scaling").AsAdmin()
 
+	var (
+		etcdClientFactory *scalingtestinglibrary.EtcdClientFactoryImpl
+		machineClientSet  *machineclient.Clientset
+		machineClient     machinev1beta1.MachineInterface
+		nodeClient        v1.NodeInterface
+		cpmsClient        machinev1.ControlPlaneMachineSetInterface
+		kubeClient        kubernetes.Interface
+		cpmsActive        bool
+		ctx               context.Context
+		err               error
+	)
+
 	cleanupPlatformSpecificConfiguration := func() { /*noop*/ }
 
 	g.BeforeEach(func() {
 		cleanupPlatformSpecificConfiguration = scalingtestinglibrary.InitPlatformSpecificConfiguration(oc)
+
+		//setup
+		ctx = context.TODO()
+		etcdClientFactory = scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())
+		machineClientSet, err = machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		machineClient = machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
+		nodeClient = oc.KubeClient().CoreV1().Nodes()
+		cpmsClient = machineClientSet.MachineV1().ControlPlaneMachineSets("openshift-machine-api")
+		kubeClient = oc.KubeClient()
+
+		// assert the cluster state before we run the test
+		err = scalingtestinglibrary.EnsureInitialClusterState(context.Background(), g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
+		err = errors.Wrap(err, "pre-test: timed out waiting for initial cluster state to have 3 running machines and 3 voting members")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// checks if the current platform has an active CPMS
+		cpmsActive, err = scalingtestinglibrary.IsCPMSActive(context.Background(), g.GinkgoT(), cpmsClient)
+		err = errors.Wrap(err, "pre-test: failed to determine if ControlPlaneMachineSet is present and active")
+		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
 	g.AfterEach(func() {
@@ -40,28 +78,6 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 	// The test will validate the size of the etcd cluster and make sure the cluster membership
 	// changes with the new member added and the old one removed.
 	g.It("is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]", func() {
-		// set up
-		ctx := context.TODO()
-		etcdClientFactory := scalingtestinglibrary.NewEtcdClientFactory(oc.KubeClient())
-		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
-		o.Expect(err).ToNot(o.HaveOccurred())
-		machineClient := machineClientSet.MachineV1beta1().Machines("openshift-machine-api")
-		nodeClient := oc.KubeClient().CoreV1().Nodes()
-		cpmsClient := machineClientSet.MachineV1().ControlPlaneMachineSets("openshift-machine-api")
-		kubeClient := oc.KubeClient()
-
-		// make sure it can be run on the current platform
-		scalingtestinglibrary.SkipIfUnsupportedPlatform(ctx, oc)
-
-		// assert the cluster state before we run the test
-		err = scalingtestinglibrary.EnsureInitialClusterState(ctx, g.GinkgoT(), etcdClientFactory, machineClient, kubeClient)
-		err = errors.Wrap(err, "pre-test: timed out waiting for initial cluster state to have 3 running machines and 3 voting members")
-		o.Expect(err).ToNot(o.HaveOccurred())
-
-		cpmsActive, err := scalingtestinglibrary.IsCPMSActive(ctx, g.GinkgoT(), cpmsClient)
-		err = errors.Wrap(err, "pre-test: failed to determine if ControlPlaneMachineSet is present and active")
-		o.Expect(err).ToNot(o.HaveOccurred())
-
 		if cpmsActive {
 			// TODO: Add cleanup step to recover back to 3 running machines and members if the test fails
 
@@ -81,9 +97,6 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 			//
 			// We previously waited until the CPMS status.readyReplicas showed 4 however that doesn't happen in practice
 			// so we can't use that as a signal for scale-up
-			//
-			// TODO(haseeb): Add a new regression test that disables the CPMS and manually deletes and add a machine
-			// so we can validate that scale-up happens before scale-down.
 
 			// step 3: wait for the machine pending deletion to have its member removed to indicate scale-down
 			framework.Logf("Waiting for etcd member %q to be removed", deletedMachineName)
@@ -143,7 +156,7 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 		}()
 
 		// step 1: add a new master node and wait until it is in Running state
-		machineName, err := scalingtestinglibrary.CreateNewMasterMachine(ctx, g.GinkgoT(), machineClient)
+		machineName, err := scalingtestinglibrary.CreateNewMasterMachine(ctx, g.GinkgoT(), machineClient, -1)
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		err = scalingtestinglibrary.EnsureMasterMachine(ctx, g.GinkgoT(), machineName, machineClient)
@@ -184,6 +197,101 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 
 		err = scalingtestinglibrary.EnsureMasterMachinesAndCount(ctx, g.GinkgoT(), machineClient)
 		err = errors.Wrap(err, "scale-down: timed out waiting for only 3 Running master machines")
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+
+	// The following test covers a basic vertical scaling scenario when CPMS is disabled
+	// and validates that the scale-down does not happen before the scale-up event.
+	// When CPMS is active, we can't ideally confirm that scale-down doesn't happen before scale-up because,
+	// the clustermemberremoval controller will race to remove the old member (from the machine pending deletion)
+	// as soon as the new machine's member is promoted to a voting member.
+	//
+	// 1) If the CPMS is active, first disable it by deleting the CPMS custom resource
+	// 2) Delete a machine
+	// 3) Ensure the voting member count remains at 3 after the deletion of a machine and before a new machine is added,
+	// 	  to verify that scale-down hasn't occurred before scale up when cluster membership is healthy
+	// 4) Create a new master machine that belongs to the same index as the deleted machine and ensure it is running (scale-up)
+	// 5) Scale-down is validated by confirming the member removal and changes in the cluster membership
+	g.It("is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]", func() {
+		if cpmsActive {
+			// step 0: disable the CPMS
+			framework.Logf("Disable the CPMS")
+			err := scalingtestinglibrary.DisableCPMS(ctx, g.GinkgoT(), cpmsClient)
+			err = errors.Wrap(err, "pre-test: failed to disable the CPMS")
+			o.Expect(err).ToNot(o.HaveOccurred())
+
+			// re-enable CPMS after the test
+			defer func() {
+				framework.Logf("Re-enable the CPMS")
+				err := scalingtestinglibrary.EnableCPMS(ctx, g.GinkgoT(), cpmsClient)
+				err = errors.Wrap(err, "post-test: failed to re-enable the CPMS")
+				o.Expect(err).ToNot(o.HaveOccurred())
+			}()
+		}
+
+		framework.Logf("CPMS is disabled. The test will delete an existing machine and manually create a new machine to validate scale-down doesn't happen before scale-up event")
+
+		// step 1: delete a running machine
+		deletedMachineName, err := scalingtestinglibrary.DeleteSingleMachine(ctx, g.GinkgoT(), machineClient)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		framework.Logf("Deleted machine %q", deletedMachineName)
+
+		// step 2: Verify the voting member count remain at 3 after the deletion of a machine and
+		// before a new machine is added to ensure scale-down hasn't occurred before scale up when cluster membership is healthy.
+		framework.Logf("Ensuring the etcd membership remains at 3 voting members to confirm that scale-down hasn't occurred before scale up when cluster membership is healthy")
+		err = scalingtestinglibrary.WaitOnExpectedVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
+		err = errors.Wrap(err, "scale-down should not have happened before scale up when cluster membership is healthy")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 3: add a new master node and wait until it is in Running state.
+		// The new machine should belong to the same index as the deleted machine
+		// to satisfy the requirement of at least 1 Ready Replica per index.
+		deletedMachineIndex, err := strconv.ParseInt(deletedMachineName[strings.LastIndex(deletedMachineName, "-")+1:], 10, 32)
+		err = errors.Wrapf(err, "failed to parse index from deleted machine name: %s", deletedMachineName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		newMachineName, err := scalingtestinglibrary.CreateNewMasterMachine(ctx, g.GinkgoT(), machineClient, deletedMachineIndex)
+		o.Expect(err).ToNot(o.HaveOccurred())
+		framework.Logf("Created machine %q", newMachineName)
+
+		err = scalingtestinglibrary.EnsureMasterMachine(ctx, g.GinkgoT(), newMachineName, machineClient)
+		err = errors.Wrapf(err, "scale-up: timed out waiting for machine (%s) to become Running", newMachineName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 4: wait for the machine pending deletion to have its member removed to indicate scale-down
+		framework.Logf("Waiting for etcd member %q to be removed", deletedMachineName)
+		deletedMemberName, err := scalingtestinglibrary.MachineNameToEtcdMemberName(ctx, oc.KubeClient(), machineClient, deletedMachineName)
+		err = errors.Wrapf(err, "failed to get etcd member name for deleted machine: %v", deletedMachineName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		err = scalingtestinglibrary.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, deletedMemberName)
+		err = errors.Wrapf(err, "scale-down: timed out waiting for member (%v) to be removed", deletedMemberName)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 5: Wait for apiserver revision rollout to stabilize
+		framework.Logf("waiting for api servers to stabilize on the same revision")
+		err = testlibraryapi.WaitForAPIServerToStabilizeOnTheSameRevision(g.GinkgoT(), oc.KubeClient().CoreV1().Pods("openshift-kube-apiserver"))
+		err = errors.Wrap(err, "scale-down: timed out waiting for APIServer pods to stabilize on the same revision")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// step 6: verify member and machine counts go back down to 3
+		framework.Logf("Waiting for etcd membership to show 3 voting members")
+		err = scalingtestinglibrary.EnsureVotingMembersCount(ctx, g.GinkgoT(), etcdClientFactory, kubeClient, 3)
+		err = errors.Wrap(err, "scale-down: timed out waiting for 3 voting members in the etcd cluster and etcd-endpoints configmap")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		framework.Logf("Waiting for 3 ready replicas on CPMS")
+		err = scalingtestinglibrary.EnsureReadyReplicasOnCPMS(ctx, g.GinkgoT(), 3, cpmsClient, nodeClient)
+		err = errors.Wrap(err, "scale-down: timed out waiting for CPMS to show 3 ready replicas")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		framework.Logf("Waiting for 3 Running master machines")
+		err = scalingtestinglibrary.EnsureMasterMachinesAndCount(ctx, g.GinkgoT(), machineClient)
+		err = errors.Wrap(err, "scale-down: timed out waiting for only 3 Running master machines")
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		framework.Logf("Waiting for CPMS replicas to converge")
+		err = scalingtestinglibrary.EnsureCPMSReplicasConverged(ctx, cpmsClient)
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1133,6 +1133,8 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery][Timeout:30m] [Feature:EtcdRecovery][Disruptive] Restore snapshot from node on another single unhealthy node": " [Serial]",
 
+	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]": "",
+
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling] etcd is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",
 
 	"[sig-etcd][OCPFeatureGate:AutomatedEtcdBackup][Suite:openshift/etcd/recovery] etcd is able to apply automated backup no-config configuration [Timeout:70m][apigroup:config.openshift.io]": "",


### PR DESCRIPTION
The following test covers a basic vertical scaling scenario when CPMS is disabled and validates that the scale-down does not happen before the scale-up event.

1. If the CPMS is active, first disable it by deleting the CPMS custom resource
2. Delete the machine
3. Create a new master machine that belongs to the same index as the deleted machine
4. Scale-up happens first before the scale-down
5. Validate scales-up happens first by verifying 4 voting members in etcd cluster
6. Then scale-down is validated by confirming the member removal and changes in the cluster membership