### PR TITLE
NO-JIRA: improve excessive restart tests

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -8,7 +8,6 @@ import (
 )
 
 type Exclusion struct {
-	upgradeJob  bool
 	clusterData platformidentification.ClusterData
 }
 
@@ -17,17 +16,30 @@ func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 	// Our goal is to conquer these restarts.
 	// So we are sadly putting these as exceptions.
 	// If you discover a container restarting more than 3 times, it is a bug and you should investigate it.
-	exceptions := []string{
-		"container/metal3-static-ip-set",      // https://issues.redhat.com/browse/OCPBUGS-39314
-		"container/ingress-operator",          // https://issues.redhat.com/browse/OCPBUGS-39315
-		"container/networking-console-plugin", // https://issues.redhat.com/browse/OCPBUGS-39316
+	type exceptionVariants struct {
+		containerName      string
+		platformsToExclude string
+		topologyToExclude  string
+	}
+	exceptions := []exceptionVariants{
+		{
+			// In this case, we found that we only saw failures for this container on bare metal.
+			// We did not find failures for vsphere where this is also run
+			// So if we start seeing failures on vsphere this would be a regression.
+			containerName:      "container/metal3-static-ip-set", // https://issues.redhat.com/browse/OCPBUGS-39314
+			platformsToExclude: "metal",
+		},
+		{
+			// ingress operator seems to only fail on the single topology.
+			// platform did not matter.
+			containerName:     "container/ingress-operator", // https://issues.redhat.com/browse/OCPBUGS-39315
+			topologyToExclude: "single",
+		},
+		{
+			containerName: "container/networking-console-plugin", // https://issues.redhat.com/browse/OCPBUGS-39316
+		},
 	}
 
-	// Upgrades seem to have a lot of failures.
-	// Let's exclude these for now generally.
-	if exclusion.upgradeJob {
-		return true
-	}
 	for _, val := range exclusion.clusterData.ClusterVersionHistory {
 		if strings.Contains(val, "4.17") {
 			return true
@@ -35,12 +47,21 @@ func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 	}
 
 	for _, val := range exceptions {
-		matched, err := regexp.MatchString(val, locator)
+		matched, err := regexp.MatchString(val.containerName, locator)
 		if err != nil {
 			return false
 		}
 		if matched {
-			return true
+			switch {
+			// if container matches but platform is different, this is a regression.
+			case val.platformsToExclude != "" && val.platformsToExclude == exclusion.clusterData.Platform:
+				return false
+				// if container matches but topology is different, this is a regression.
+			case val.topologyToExclude != "" && val.topologyToExclude == exclusion.clusterData.Topology:
+				return false
+			default:
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/monitortests/node/legacynodemonitortests/kubelet.go
+++ b/pkg/monitortests/node/legacynodemonitortests/kubelet.go
@@ -224,12 +224,16 @@ func testKubeAPIServerGracefulTermination(events monitorapi.Intervals) []*junita
 }
 
 func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	containerExits := make(map[string][]string)
-	failures := []string{}
+	openshiftNamespaces := sets.Set[string]{}
+	containerExitsByNamespace := map[string]map[string][]string{}
+	failuresByNamespace := map[string][]string{}
 	for _, event := range events {
-		if !strings.Contains(event.Locator.Keys[monitorapi.LocatorNamespaceKey], "openshift-") {
+		namespace := event.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		if !strings.Contains(namespace, "openshift-") {
 			continue
 		}
+		openshiftNamespaces.Insert(namespace)
+
 		reason := event.Message.Reason
 		code := event.Message.Annotations[monitorapi.AnnotationContainerExitCode]
 		switch {
@@ -238,47 +242,70 @@ func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Inter
 			if event.Message.Annotations[monitorapi.AnnotationCause] == "ContainerCreating" {
 				continue
 			}
-			failures = append(failures, fmt.Sprintf("container failed to start at %v: %v - %v", event.From, event.Locator.OldLocator(), event.Message.OldMessage()))
+			failuresByNamespace[namespace] = append(failuresByNamespace[namespace], fmt.Sprintf("container failed to start at %v: %v - %v", event.From, event.Locator.OldLocator(), event.Message.OldMessage()))
 
 		// workload containers should never exit non-zero during normal operations
 		case reason == monitorapi.ContainerReasonContainerExit && code != "0":
+			containerExits, ok := containerExitsByNamespace[namespace]
+			if !ok {
+				containerExits = map[string][]string{}
+			}
 			containerExits[event.Locator.OldLocator()] = append(containerExits[event.Locator.OldLocator()], fmt.Sprintf("non-zero exit at %v: %v", event.From, event.Message.OldMessage()))
+			containerExitsByNamespace[namespace] = containerExits
 		}
 	}
 
-	var excessiveExits []string
-	maxRestartCount := 3
+	// This is a map of the tests we want to fail on
+	// In this case, this is any container that restarts more than 3 times
+	excessiveExitsByNamespaceForFailedTests := map[string][]string{}
+	// We want to report restarts of openshift containers as flakes
+	excessiveExitsByNamespaceForFlakeTests := map[string][]string{}
 
-	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(events, time.Time{}, time.Time{})
+	maxRestartCountForFailures := 3
+	maxRestartCountForFlakes := 2
 
 	clusterDataPlatform, _ := platformidentification.BuildClusterData(context.Background(), adminRestConfig)
 
-	exclusions := Exclusion{upgradeJob: isUpgrade, clusterData: clusterDataPlatform}
-	for locator, messages := range containerExits {
-		if len(messages) > 0 {
-			messageSet := sets.NewString(messages...)
-			// Blanket fail for restarts over maxRestartCount
-			if !isThisContainerRestartExcluded(locator, exclusions) && len(messages) > maxRestartCount {
-				excessiveExits = append(excessiveExits, fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
+	exclusions := Exclusion{clusterData: clusterDataPlatform}
+	for namespace, containerExits := range containerExitsByNamespace {
+		for locator, messages := range containerExits {
+			if len(messages) > 0 {
+				messageSet := sets.NewString(messages...)
+				// Blanket fail for restarts over maxRestartCount
+				if !isThisContainerRestartExcluded(locator, exclusions) && len(messages) > maxRestartCountForFailures {
+					excessiveExitsByNamespaceForFailedTests[namespace] = append(excessiveExitsByNamespaceForFailedTests[namespace], fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
+				} else if len(messages) >= maxRestartCountForFlakes {
+					excessiveExitsByNamespaceForFlakeTests[namespace] = append(excessiveExitsByNamespaceForFlakeTests[namespace], fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
+				}
 			}
 		}
 	}
-	sort.Strings(excessiveExits)
+	for namespace, excessiveExitsFails := range excessiveExitsByNamespaceForFailedTests {
+		sort.Strings(excessiveExitsFails)
+		excessiveExitsByNamespaceForFailedTests[namespace] = excessiveExitsFails
+	}
+	for namespace, excessiveExitsFlakes := range excessiveExitsByNamespaceForFlakeTests {
+		sort.Strings(excessiveExitsFlakes)
+		excessiveExitsByNamespaceForFlakeTests[namespace] = excessiveExitsFlakes
+	}
 
 	var testCases []*junitapi.JUnitTestCase
 
-	const failToStartTestName = "[sig-architecture] platform pods should not fail to start"
-	if len(failures) > 0 {
-		testCases = append(testCases, &junitapi.JUnitTestCase{
-			Name:      failToStartTestName,
-			SystemOut: strings.Join(failures, "\n"),
-			FailureOutput: &junitapi.FailureOutput{
-				Output: fmt.Sprintf("%d container starts had issues\n\n%s", len(failures), strings.Join(failures, "\n")),
-			},
-		})
+	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
+		failures := failuresByNamespace[namespace]
+		failToStartTestName := fmt.Sprintf("[sig-architecture] platform pods in ns/%s should not fail to start", namespace)
+		if len(failures) > 0 {
+			testCases = append(testCases, &junitapi.JUnitTestCase{
+				Name:      failToStartTestName,
+				SystemOut: strings.Join(failures, "\n"),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("%d container starts had issues\n\n%s", len(failures), strings.Join(failures, "\n")),
+				},
+			})
+		}
+		// mark flaky for now while we debug
+		testCases = append(testCases, &junitapi.JUnitTestCase{Name: failToStartTestName})
 	}
-	// mark flaky for now while we debug
-	testCases = append(testCases, &junitapi.JUnitTestCase{Name: failToStartTestName})
 
 	// We want to deflake this test.
 	// Plan is to release this test and report any failures for pods
@@ -286,16 +313,34 @@ func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Inter
 	// We will then build exclusion rules for those that we see
 	// and then make this test fail for any case that doesn't match the rules
 	// we have.
-	const excessiveRestartTestName = "[sig-architecture] platform pods should not exit more than once with a non-zero exit code"
-	if len(excessiveExits) > 0 {
-		testCases = append(testCases, &junitapi.JUnitTestCase{
-			Name:      excessiveRestartTestName,
-			SystemOut: strings.Join(excessiveExits, "\n"),
-			FailureOutput: &junitapi.FailureOutput{
-				Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
-			},
-		})
+	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
+		excessiveExits := excessiveExitsByNamespaceForFailedTests[namespace]
+		excessiveRestartTestName := fmt.Sprintf("[sig-architecture] platform pods in ns/%s should not exit more than %d with a non-zero exit code", namespace, maxRestartCountForFailures)
+		if len(excessiveExits) > 0 {
+			testCases = append(testCases, &junitapi.JUnitTestCase{
+				Name:      excessiveRestartTestName,
+				SystemOut: strings.Join(excessiveExits, "\n"),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
+				},
+			})
+		}
 	}
+	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
+		excessiveExits := excessiveExitsByNamespaceForFlakeTests[namespace]
+		excessiveRestartTestNameForFlakes := fmt.Sprintf("[sig-architecture] platform pods in ns/%s that restart more than %d is considered a flake for now", namespace, maxRestartCountForFlakes)
+		if len(excessiveExits) > 0 {
+			testCases = append(testCases, &junitapi.JUnitTestCase{
+				Name:      excessiveRestartTestNameForFlakes,
+				SystemOut: strings.Join(excessiveExits, "\n"),
+				FailureOutput: &junitapi.FailureOutput{
+					Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
+				},
+			})
+		}
+		testCases = append(testCases, &junitapi.JUnitTestCase{Name: excessiveRestartTestNameForFlakes})
+	}
+
 	return testCases
 }
 


### PR DESCRIPTION
1) Add better exclusions to catch more restarts.
2) add a flake test for 1 or more restarts.
3) add ns/%v to the test output to quickly identity the team responsible.