### PR TITLE
NO-JIRA: try to track down why the lease acquiring sometimes fails

### DIFF
--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
@@ -122,7 +122,8 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 		}
 	}
 	switch {
-	case strings.Contains(logLine.Line, "attempting to acquire leader lease"):
+	case strings.Contains(logLine.Line, "attempting to acquire leader lease") &&
+		!strings.Contains(logLine.Line, "Degraded"): // need to exclude lines that re-embed the kube-controller-manager log
 		g.recorder.AddIntervals(
 			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
 				Locator(logLine.Locator).
@@ -132,7 +133,8 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 				).
 				Build(logLine.Instant, logLine.Instant),
 		)
-	case strings.Contains(logLine.Line, "successfully acquired lease"):
+	case strings.Contains(logLine.Line, "successfully acquired lease") &&
+		!strings.Contains(logLine.Line, "Degraded"): // need to exclude lines that re-embed the kube-controller-manager log
 		g.recorder.AddIntervals(
 			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
 				Locator(logLine.Locator).


### PR DESCRIPTION
Found it: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29094/pull-ci-openshift-origin-master-e2e-aws-ovn-single-node/1833957493491896320

Operators embed logs of operands when the operand fails.  The operand lease is actually failing and the log lines are embedded in the operator log. This skips those entries.