### PR TITLE
WRKLDS-1449: Update etcd test data for 1.31 release

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -327,6 +327,33 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 			ExpectedGVK:      gvkP("admissionregistration.k8s.io", "v1", "ValidatingAdmissionPolicyBinding"),
 		}
 
+		// compare https://github.com/kubernetes/kubernetes/pull/125488
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "deviceclasses")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "class1name"}}`,
+			ExpectedEtcdPath: "/registry/deviceclasses/class1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "DeviceClass"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceclaims")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "claim1name"}, "spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}`,
+			ExpectedEtcdPath: "/registry/resourceclaims/" + oc.Namespace() + "/claim1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "ResourceClaim"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceclaimtemplates")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "claimtemplate1name"}, "spec": {"spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}}`,
+			ExpectedEtcdPath: "/registry/resourceclaimtemplates/" + oc.Namespace() + "/claimtemplate1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "ResourceClaimTemplate"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "podschedulingcontexts")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "pod1name"}, "spec": {"selectedNode": "node1name", "potentialNodes": ["node1name", "node2name"]}}`,
+			ExpectedEtcdPath: "/registry/podschedulingcontexts/" + oc.Namespace() + "/pod1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "PodSchedulingContext"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceslices")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "node1slice"}, "spec": {"nodeName": "worker1", "driver": "dra.example.com", "pool": {"name": "worker1", "resourceSliceCount": 1}}}`,
+			ExpectedEtcdPath: "/registry/resourceslices/node1slice",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "ResourceSlice"),
+		}
+
 		// Removed etcd data.
 		// TODO: When rebase has started, remove etcd storage data that has been removed
 		//       from k8s.io/kubernetes/test/integration/etcd/data.go in the 1.29 release.


### PR DESCRIPTION
to fix https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-kubernetes-1647-nightly-4.18-e2e-vsphere-ovn-techpreview-serial/1833870039334260736