### PR TITLE
OCPBUGS-39373: Redo the PR #29082

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -45639,7 +45639,7 @@ var _testExtendedTestdataImage_ecosystemPerlHotdeployPerlJson = []byte(`{
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "openshift",
-              "name": "perl:5.30-el7"
+              "name": "perl:5.32-ubi8"
             }
           }
         },

--- a/test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
+++ b/test/extended/testdata/image_ecosystem/perl-hotdeploy/perl.json
@@ -47,7 +47,7 @@
             "from": {
               "kind": "ImageStreamTag",
               "namespace": "openshift",
-              "name": "perl:5.30-el7"
+              "name": "perl:5.32-ubi8"
             }
           }
         },


### PR DESCRIPTION
Turns out the fix in PR #29082 was not correct and wouldn't have been sufficient even if it were.

This PR fixes the Perl test and updates it to work with the new `perl:5.32-ubi8` image that has different defaults and settings available (notice the disappearance of `PERL_APACHE2_RELOAD` env var setting in https://github.com/sclorg/s2i-perl-container/tree/master/5.32 vs https://github.com/sclorg/s2i-perl-container/tree/master/5.30).