### PR TITLE
OCPBUGS-39363: Reenable Rails tests and update the sample repos test to support deployments

### DIFF
--- a/test/extended/util/deployment.go
+++ b/test/extended/util/deployment.go
@@ -41,6 +41,7 @@ func WaitForDeploymentReady(oc *CLI, deployName, namespace string) error {
 		deployment, getErr = oc.AdminKubeClient().AppsV1().Deployments(namespace).Get(context.Background(), deployName, metav1.GetOptions{})
 		if getErr != nil {
 			e2e.Logf("Unable to retrieve deployment %q:\n%v", deployName, getErr)
+			return false, nil
 		}
 		if deployment.Status.AvailableReplicas == *deployment.Spec.Replicas {
 			e2e.Logf("Deployment %q is ready", deployName)


### PR DESCRIPTION
After a change of decision about the support for Rails, we need to reenable it in the Samples Operator and therefore also in the integration tests here.

In addition to re-enabling the dedicated ruby test, we also need to support this in the samples_repo tests. Because the rails template now uses Deployments instead of DeploymentConfigs, it was also needed to add support for that in the tests.