### PR TITLE
MCO-1304: Add boot image update e2e tests

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/images/trigger"
 	_ "github.com/openshift/origin/test/extended/kernel"
 	_ "github.com/openshift/origin/test/extended/kubevirt"
+	_ "github.com/openshift/origin/test/extended/machine_config"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/node_tuning"

--- a/test/extended/machine_config/OWNERS
+++ b/test/extended/machine_config/OWNERS
@@ -1,0 +1,10 @@
+approvers:
+  - djoshy
+  - dkhater-redhat
+  - yuqi-zhang
+  - cheesesashimi
+reviewers:
+  - djoshy
+  - dkhater-redhat
+  - yuqi-zhang
+  - cheesesashimi

--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -1,0 +1,131 @@
+package machine_config
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func AllMachineSetTest(oc *exutil.CLI, fixture string) {
+	// This fixture applies a boot image update configuration that opts in all machinesets
+	err := oc.Run("apply").Args("-f", fixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Step through all machinesets and verify boot images are reconciled correctly.
+	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	for _, ms := range machineSets.Items {
+		verifyMachineSetUpdate(oc, ms, true)
+	}
+}
+
+func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
+
+	// This fixture applies a boot image update configuration that opts in any machineset with the label test=boot
+	err := oc.Run("apply").Args("-f", fixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Pick a random machineset to test
+	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	machineSetUnderTest := getRandomMachineSet(machineClient)
+	framework.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Label this machineset with the test=boot label
+	err = oc.Run("label").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-n", mapiNamespace, "test=boot").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Step through all machinesets and verify that only the opted in machineset's boot images are reconciled.
+	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	for _, ms := range machineSets.Items {
+		verifyMachineSetUpdate(oc, ms, machineSetUnderTest.Name == ms.Name)
+	}
+
+	// Unlabel the machineset
+	err = oc.Run("label").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-n", mapiNamespace, "test-").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func NoneMachineSetTest(oc *exutil.CLI, fixture string) {
+	// This fixture applies a boot image update configuration that opts in no machinesets, i.e. feature is disabled.
+	err := oc.Run("apply").Args("-f", fixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Step through all machinesets and verify boot images are reconciled correctly.
+	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	for _, ms := range machineSets.Items {
+		verifyMachineSetUpdate(oc, ms, false)
+	}
+}
+
+func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
+	// This fixture applies a boot image update configuration that opts in all machinesets
+	err := oc.Run("apply").Args("-f", fixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Pick a random machineset to test
+	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	machineSetUnderTest := getRandomMachineSet(machineClient)
+	framework.Logf("MachineSet under test: %s", machineSetUnderTest.Name)
+
+	// Add an owner reference to this machineset
+	err = oc.Run("patch").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-p", `{"metadata": {"ownerReferences": [{"apiVersion": "test", "kind": "test", "name": "test", "uid": "test"}]}}`, "-n", mapiNamespace, "--type=merge").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify that the MCO cluster operator has degraded with the correct reason
+	o.Eventually(func() bool {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("failed to grab cluster operator, error :%v", err)
+			return false
+		}
+		if IsClusterOperatorConditionFalse(co.Status.Conditions, osconfigv1.OperatorDegraded) {
+			framework.Logf("Cluster Operator has not degraded")
+			return false
+		}
+		degradedCondition := FindClusterOperatorStatusCondition(co.Status.Conditions, osconfigv1.OperatorDegraded)
+		if !strings.Contains(degradedCondition.Message, "error syncing MAPI MachineSet "+machineSetUnderTest.Name+": unexpected OwnerReference: test/test") {
+			framework.Logf("Cluster Operator degrade condition does not have the correct message")
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second).Should(o.BeTrue())
+	framework.Logf("Succesfully verified that the cluster operator is degraded")
+
+	// Remove the owner reference from this machineset
+	err = oc.Run("patch").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-p", `{"metadata": {"ownerReferences": []}}`, "-n", mapiNamespace, "--type=merge").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify that the MCO cluster operator is no longer degraded
+	o.Eventually(func() bool {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(context.TODO(), "machine-config", metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("Failed to grab cluster operator, error :%v", err)
+			return false
+		}
+		if IsClusterOperatorConditionTrue(co.Status.Conditions, osconfigv1.OperatorDegraded) {
+			framework.Logf("Cluster Operator is still degraded")
+			return false
+		}
+		return true
+	}, 30*time.Second, 2*time.Second).Should(o.BeTrue())
+	framework.Logf("Succesfully verified that the cluster operator is no longer degraded")
+}

--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -1,0 +1,53 @@
+package machine_config
+
+import (
+	"context"
+	"path/filepath"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// This test is [Serial] because it modifies the cluster/machineconfigurations.operator.openshift.io object in each test.
+var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", func() {
+	defer g.GinkgoRecover()
+	var (
+		MCOMachineConfigurationBaseDir = exutil.FixturePath("testdata", "machine_config", "machineconfigurations")
+		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
+		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
+		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		//skip this test if not on GCP platform
+		skipUnlessTargetPlatform(oc, osconfigv1.AWSPlatformType)
+		//skip this test if the cluster is not using MachineAPI
+		skipUnlessFunctionalMachineAPI(oc)
+	})
+
+	g.AfterEach(func() {
+		// Clear out boot image configuration between tests
+		err := oc.Run("apply").Args("-f", noneMachineSetFixture).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {
+		PartialMachineSetTest(oc, partialMachineSetFixture)
+	})
+
+	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", func() {
+		AllMachineSetTest(oc, allMachineSetFixture)
+	})
+
+	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", func() {
+		NoneMachineSetTest(oc, noneMachineSetFixture)
+	})
+
+	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
+		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
+	})
+})

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -1,0 +1,53 @@
+package machine_config
+
+import (
+	"context"
+	"path/filepath"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// This test is [Serial] because it modifies the cluster/machineconfigurations.operator.openshift.io object in each test.
+var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func() {
+	defer g.GinkgoRecover()
+	var (
+		MCOMachineConfigurationBaseDir = exutil.FixturePath("testdata", "machine_config", "machineconfigurations")
+		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
+		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
+		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		//skip this test if not on GCP platform
+		skipUnlessTargetPlatform(oc, osconfigv1.GCPPlatformType)
+		//skip this test if the cluster is not using MachineAPI
+		skipUnlessFunctionalMachineAPI(oc)
+	})
+
+	g.AfterEach(func() {
+		// Clear out boot image configuration between tests
+		err := oc.Run("apply").Args("-f", noneMachineSetFixture).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {
+		PartialMachineSetTest(oc, partialMachineSetFixture)
+	})
+
+	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", func() {
+		AllMachineSetTest(oc, allMachineSetFixture)
+	})
+
+	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", func() {
+		NoneMachineSetTest(oc, noneMachineSetFixture)
+	})
+
+	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
+		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
+	})
+})

--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -1,0 +1,262 @@
+package machine_config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	opv1 "github.com/openshift/api/operator/v1"
+	machineclient "github.com/openshift/client-go/machine/clientset/versioned"
+	mcopclient "github.com/openshift/client-go/operator/clientset/versioned"
+
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	mcoNamespace                    = "openshift-machine-config-operator"
+	mapiNamespace                   = "openshift-machine-api"
+	mapiMachinesetQualifiedName     = "machinesets.machine.openshift.io"
+	cmName                          = "coreos-bootimages"
+	mapiMasterMachineLabelSelector  = "machine.openshift.io/cluster-api-machine-role=master"
+	mapiMachineSetArchAnnotationKey = "capacity.cluster-autoscaler.kubernetes.io/labels"
+)
+
+// skipUnlessTargetPlatform skips the test if it is running on the target platform
+func skipUnlessTargetPlatform(oc *exutil.CLI, platformType osconfigv1.PlatformType) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.PlatformStatus.Type != platformType {
+		e2eskipper.Skipf("This test only applies to %s platform", platformType)
+	}
+}
+
+// skipUnlessFunctionalMachineAPI skips the test if the cluster is using Machine API
+func skipUnlessFunctionalMachineAPI(oc *exutil.CLI) {
+	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).ToNot(o.HaveOccurred())
+	machines, err := machineClient.MachineV1beta1().Machines(mapiNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: mapiMasterMachineLabelSelector})
+	// the machine API can be unavailable resulting in a 404 or an empty list
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			o.Expect(err).ToNot(o.HaveOccurred())
+		}
+		e2eskipper.Skipf("haven't found machines resources on the cluster, this test can be run on a platform that supports functional MachineAPI")
+		return
+	}
+	if len(machines.Items) == 0 {
+		e2eskipper.Skipf("got an empty list of machines resources from the cluster, this test can be run on a platform that supports functional MachineAPI")
+		return
+	}
+
+	// we expect just a single machine to be in the Running state
+	for _, machine := range machines.Items {
+		phase := ptr.Deref(machine.Status.Phase, "")
+		if phase == "Running" {
+			return
+		}
+	}
+	e2eskipper.Skipf("haven't found a machine in running state, this test can be run on a platform that supports functional MachineAPI")
+}
+
+// getRandomMachineSet picks a random machineset present on the cluster
+func getRandomMachineSet(machineClient *machineclient.Clientset) machinev1beta1.MachineSet {
+	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	machineSetUnderTest := machineSets.Items[rnd.Intn(len(machineSets.Items))]
+	return machineSetUnderTest
+}
+
+// verifyMachineSetUpdate verifies that the the boot image values of a MachineSet are reconciled correctly
+func verifyMachineSetUpdate(oc *exutil.CLI, machineSet machinev1beta1.MachineSet, updateExpected bool) {
+
+	newProviderSpecPatch, originalProviderSpecPatch, newBootImage, originalBootImage := createFakeUpdatePatch(oc, machineSet)
+	err := oc.Run("patch").Args(mapiMachinesetQualifiedName, machineSet.Name, "-p", fmt.Sprintf(`{"spec":{"template":{"spec":{"providerSpec":{"value":%s}}}}}`, newProviderSpecPatch), "-n", mapiNamespace, "--type=merge").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Ensure boot image controller is not progressing
+	framework.Logf("Waiting until the boot image controller is not progressing...")
+	WaitForBootImageControllerToComplete(oc)
+
+	// Fetch the providerSpec of the machineset under test again
+	providerSpecDisks, err := oc.Run("get").Args(mapiMachinesetQualifiedName, machineSet.Name, "-o", "template", "--template=`{{.spec.template.spec.providerSpec.value}}`", "-n", mapiNamespace).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify that the machineset has the expected boot image values
+	if updateExpected {
+		o.Expect(providerSpecDisks).ShouldNot(o.ContainSubstring(newBootImage))
+	} else {
+		o.Expect(providerSpecDisks).Should(o.ContainSubstring(newBootImage))
+		// Restore machineSet to original boot image in this case, as the machineset may be used by other test variants
+
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.Run("patch").Args(mapiMachinesetQualifiedName, machineSet.Name, "-p", fmt.Sprintf(`{"spec":{"template":{"spec":{"providerSpec":{"value":%s}}}}}`, originalProviderSpecPatch), "-n", mapiNamespace, "--type=merge").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Restored build name in the machineset %s from \"%s\" to \"%s\"", machineSet.Name, originalBootImage, newBootImage)
+	}
+}
+
+// unmarshalProviderSpec unmarshals the machineset's provider spec into
+// a ProviderSpec object. Returns an error if providerSpec field is nil,
+// or the unmarshal fails
+func unmarshalProviderSpec(ms *machinev1beta1.MachineSet, providerSpec interface{}) error {
+	if ms.Spec.Template.Spec.ProviderSpec.Value == nil {
+		return fmt.Errorf("providerSpec field was empty")
+	}
+	if err := yaml.Unmarshal(ms.Spec.Template.Spec.ProviderSpec.Value.Raw, &providerSpec); err != nil {
+		return fmt.Errorf("unmarshal into providerSpec failed %w", err)
+	}
+	return nil
+}
+
+// marshalProviderSpec marshals the ProviderSpec object into a MachineSet object.
+// Returns an error if ProviderSpec or MachineSet is nil, or if the marshal fails
+func marshalProviderSpec(providerSpec interface{}) (string, error) {
+	if providerSpec == nil {
+		return "", fmt.Errorf("ProviderSpec object was nil")
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		return "", fmt.Errorf("marshalling providerSpec failed: %w", err)
+	}
+	return string(rawBytes), nil
+}
+
+// createFakeUpdatePatch creates an update patch for the MachineSet object based on the platform
+func createFakeUpdatePatch(oc *exutil.CLI, machineSet machinev1beta1.MachineSet) (string, string, string, string) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	switch infra.Status.PlatformStatus.Type {
+	case osconfigv1.AWSPlatformType:
+		return generateAWSProviderSpecPatch(machineSet)
+	case osconfigv1.GCPPlatformType:
+		return generateGCPProviderSpecPatch(machineSet)
+	default:
+		exutil.FatalErr(fmt.Errorf("unexpected platform type; should not be here"))
+		return "", "", "", ""
+	}
+}
+
+// generateAWSProviderSpecPatch generates a fake update patch for the AWS MachineSet
+func generateAWSProviderSpecPatch(machineSet machinev1beta1.MachineSet) (string, string, string, string) {
+	providerSpec := new(machinev1beta1.AWSMachineProviderConfig)
+	err := unmarshalProviderSpec(&machineSet, providerSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Modify the boot image to a "fake" value
+	originalBootImage := *providerSpec.AMI.ID
+	newBootImage := originalBootImage + "-fake-update"
+	newProviderSpec := providerSpec.DeepCopy()
+	newProviderSpec.AMI.ID = &newBootImage
+
+	newProviderSpecPatch, err := marshalProviderSpec(newProviderSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	originalProviderSpecPatch, err := marshalProviderSpec(providerSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return newProviderSpecPatch, originalProviderSpecPatch, newBootImage, originalBootImage
+
+}
+
+// generateGCPProviderSpecPatch generates a fake update patch for the GCP MachineSet
+func generateGCPProviderSpecPatch(machineSet machinev1beta1.MachineSet) (string, string, string, string) {
+	providerSpec := new(machinev1beta1.GCPMachineProviderSpec)
+	err := unmarshalProviderSpec(&machineSet, providerSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Modify the boot image to a "fake" value
+	originalBootImage := providerSpec.Disks[0].Image
+	newBootImage := originalBootImage + "-fake-update"
+	newProviderSpec := providerSpec.DeepCopy()
+	for idx := range newProviderSpec.Disks {
+		newProviderSpec.Disks[idx].Image = newBootImage
+	}
+	newProviderSpecPatch, err := marshalProviderSpec(newProviderSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	originalProviderSpecPatch, err := marshalProviderSpec(providerSpec)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	return newProviderSpecPatch, originalProviderSpecPatch, newBootImage, originalBootImage
+}
+
+// WaitForBootImageControllerToComplete waits until the boot image controller is no longer progressing
+func WaitForBootImageControllerToComplete(oc *exutil.CLI) {
+	machineConfigurationClient, err := mcopclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	// This has a MustPassRepeatedly(3) to ensure there isn't a false positive by checking the
+	// controller status too quickly after applying the fixture/labels.
+	o.Eventually(func() bool {
+		mcop, err := machineConfigurationClient.OperatorV1().MachineConfigurations().Get(context.TODO(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("Failed to grab machineconfiguration object, error :%v", err)
+			return false
+		}
+		return IsMachineConfigurationConditionFalse(mcop.Status.Conditions, opv1.MachineConfigurationBootImageUpdateProgressing)
+	}, 3*time.Minute, 5*time.Second).MustPassRepeatedly(3).Should(o.BeTrue())
+}
+
+// IsMachineConfigPoolConditionTrue returns true when the conditionType is present and set to `ConditionTrue`
+func IsMachineConfigPoolConditionTrue(conditions []mcfgv1.MachineConfigPoolCondition, conditionType mcfgv1.MachineConfigPoolConditionType) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// IsMachineConfigurationConditionFalse returns false when the conditionType is present and set to `ConditionFalse`
+func IsMachineConfigurationConditionFalse(conditions []metav1.Condition, conditionType string) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == metav1.ConditionFalse
+		}
+	}
+	return false
+}
+
+// IsClusterOperatorConditionTrue returns true when the conditionType is present and set to `configv1.ConditionTrue`
+func IsClusterOperatorConditionTrue(conditions []osconfigv1.ClusterOperatorStatusCondition, conditionType osconfigv1.ClusterStatusConditionType) bool {
+	return IsClusterOperatorConditionPresentAndEqual(conditions, conditionType, osconfigv1.ConditionTrue)
+}
+
+// IsClusterOperatorConditionFalse returns true when the conditionType is present and set to `configv1.ConditionFalse`
+func IsClusterOperatorConditionFalse(conditions []osconfigv1.ClusterOperatorStatusCondition, conditionType osconfigv1.ClusterStatusConditionType) bool {
+	return IsClusterOperatorConditionPresentAndEqual(conditions, conditionType, osconfigv1.ConditionFalse)
+}
+
+// IsClusterOperatorConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func IsClusterOperatorConditionPresentAndEqual(conditions []osconfigv1.ClusterOperatorStatusCondition, conditionType osconfigv1.ClusterStatusConditionType, status osconfigv1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}
+
+// FindClusterOperatorStatusCondition finds the conditionType in conditions.
+func FindClusterOperatorStatusCondition(conditions []osconfigv1.ClusterOperatorStatusCondition, conditionType osconfigv1.ClusterStatusConditionType) *osconfigv1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -423,6 +423,9 @@
 // test/extended/testdata/ldap/ldapserver-service.yaml
 // test/extended/testdata/long_names/Dockerfile
 // test/extended/testdata/long_names/fixture.json
+// test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml
+// test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml
+// test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml
 // test/extended/testdata/marketplace/csc/02-csc.yaml
 // test/extended/testdata/marketplace/opsrc/02-opsrc.yaml
 // test/extended/testdata/mixed-api-versions.yaml
@@ -48997,6 +49000,97 @@ func testExtendedTestdataLong_namesFixtureJson() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  managedBootImages:
+    machineManagers:
+      - resource: machinesets
+        apiGroup: machine.openshift.io
+        selection:
+          mode: All
+`)
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml, nil
+}
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+`)
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml, nil
+}
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  managedBootImages:
+    machineManagers:
+    - resource: machinesets
+      apiGroup: machine.openshift.io
+      selection:
+        mode: Partial
+        partial:
+          machineResourceSelector:
+            matchLabels:
+              test: boot
+`)
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml, nil
+}
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataMarketplaceCsc02CscYaml = []byte(`apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -55675,6 +55769,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/ldap/ldapserver-service.yaml":                                                    testExtendedTestdataLdapLdapserverServiceYaml,
 	"test/extended/testdata/long_names/Dockerfile":                                                           testExtendedTestdataLong_namesDockerfile,
 	"test/extended/testdata/long_names/fixture.json":                                                         testExtendedTestdataLong_namesFixtureJson,
+	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml":                 testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml,
+	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml":                testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml,
+	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml":             testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml,
 	"test/extended/testdata/marketplace/csc/02-csc.yaml":                                                     testExtendedTestdataMarketplaceCsc02CscYaml,
 	"test/extended/testdata/marketplace/opsrc/02-opsrc.yaml":                                                 testExtendedTestdataMarketplaceOpsrc02OpsrcYaml,
 	"test/extended/testdata/mixed-api-versions.yaml":                                                         testExtendedTestdataMixedApiVersionsYaml,
@@ -56419,6 +56516,13 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"long_names": {nil, map[string]*bintree{
 					"Dockerfile":   {testExtendedTestdataLong_namesDockerfile, map[string]*bintree{}},
 					"fixture.json": {testExtendedTestdataLong_namesFixtureJson, map[string]*bintree{}},
+				}},
+				"machine_config": {nil, map[string]*bintree{
+					"machineconfigurations": {nil, map[string]*bintree{
+						"managedbootimages-all.yaml":     {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml, map[string]*bintree{}},
+						"managedbootimages-none.yaml":    {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml, map[string]*bintree{}},
+						"managedbootimages-partial.yaml": {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml, map[string]*bintree{}},
+					}},
 				}},
 				"marketplace": {nil, map[string]*bintree{
 					"csc": {nil, map[string]*bintree{

--- a/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml
+++ b/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml
@@ -1,0 +1,14 @@
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  managedBootImages:
+    machineManagers:
+      - resource: machinesets
+        apiGroup: machine.openshift.io
+        selection:
+          mode: All

--- a/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml
+++ b/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal

--- a/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml
+++ b/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  managedBootImages:
+    machineManagers:
+    - resource: machinesets
+      apiGroup: machine.openshift.io
+      selection:
+        mode: Partial
+        partial:
+          machineResourceSelector:
+            matchLabels:
+              test: boot

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1311,6 +1311,22 @@ var Annotations = map[string]string{
 
 	"[sig-kubevirt] services when running openshift cluster on KubeVirt virtual machines should allow direct connections to pods from guest cluster pod in pod network across different guest nodes": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
 	"[sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network-edge] DNS should answer endpoint and wildcard queries for the cluster": " [Disabled:Broken]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -62,6 +62,26 @@ spec:
         set the hardware speed to Slower [Timeout:30m][apigroup:machine.openshift.io]'
     - testName: '[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to
         set the hardware speed to Standard [Timeout:30m][apigroup:machine.openshift.io]'
+  - featureGate: ManagedBootImages
+    tests:
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should degrade
+        on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should not update
+        boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update
+        boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update
+        boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]'
+  - featureGate: ManagedBootImagesAWS
+    tests:
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should degrade
+        on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should not
+        update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update
+        boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update
+        boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]'
   - featureGate: NetworkDiagnosticsConfig
     tests:
     - testName: '[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Serial] Should


### PR DESCRIPTION
This PR adds e2e tests for GCP(in GA) and AWS(in tech preview) boot image updates. 

This is also the first set of e2e tests added by the MCO team to origin, so I have added a new OWNERS file for the package.