### PR TITLE
NO-JIRA: add tracking for apiservices

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionnewapiserver"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/faultyloadbalancer"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/watchapiservices"
 	"github.com/openshift/origin/pkg/monitortests/machines/watchmachines"
 	"github.com/openshift/origin/pkg/monitortests/monitoring/disruptionmetricsapi"
 	"github.com/openshift/origin/pkg/monitortests/monitoring/statefulsetsrecreation"
@@ -163,6 +164,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("audit-log-analyzer", "kube-apiserver", auditloganalyzer.NewAuditLogAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-kube-apiserver-invariants", "kube-apiserver", legacykubeapiservermonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("graceful-shutdown-analyzer", "kube-apiserver", apiservergracefulrestart.NewGracefulShutdownAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("apiservice-watcher", "kube-apiserver", watchapiservices.NewAPIServiceWatcher())
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-networking-invariants", "Networking / cluster-network-operator", legacynetworkmonitortests.NewLegacyTests())
 

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -116,6 +116,14 @@ func (b *LocatorBuilder) MachineFromName(machineName string) Locator {
 		Build()
 }
 
+func (b *LocatorBuilder) APIService(apiServiceName, serviceNamespace string) Locator {
+	return b.
+		withTargetType(LocatorTypeAPIService).
+		withAPIService(apiServiceName).
+		withNamespace(serviceNamespace).
+		Build()
+}
+
 func (b *LocatorBuilder) NodeFromNameWithRow(nodeName, row string) Locator {
 	return b.
 		withTargetType(LocatorTypeNode).
@@ -254,6 +262,11 @@ func (b *LocatorBuilder) withNode(nodeName string) *LocatorBuilder {
 
 func (b *LocatorBuilder) withMachine(machineName string) *LocatorBuilder {
 	b.annotations[LocatorMachineKey] = machineName
+	return b
+}
+
+func (b *LocatorBuilder) withAPIService(apiService string) *LocatorBuilder {
+	b.annotations[LocatorAPIServiceKey] = apiService
 	return b
 }
 

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -99,6 +99,7 @@ const (
 	LocatorTypeContainer       LocatorType = "Container"
 	LocatorTypeNode            LocatorType = "Node"
 	LocatorTypeMachine         LocatorType = "Machine"
+	LocatorTypeAPIService      LocatorType = "APIService"
 	LocatorTypeAlert           LocatorType = "Alert"
 	LocatorTypeMetricsEndpoint LocatorType = "MetricsEndpoint"
 	LocatorTypeClusterOperator LocatorType = "ClusterOperator"
@@ -122,6 +123,7 @@ const (
 	LocatorDeploymentKey      LocatorKey = "deployment"
 	LocatorNodeKey            LocatorKey = "node"
 	LocatorMachineKey         LocatorKey = "machine"
+	LocatorAPIServiceKey      LocatorKey = "apiservice"
 	LocatorEtcdMemberKey      LocatorKey = "etcd-member"
 	LocatorNameKey            LocatorKey = "name"
 	LocatorHmsgKey            LocatorKey = "hmsg"
@@ -209,6 +211,13 @@ const (
 	MachinePhaseChanged IntervalReason = "MachinePhaseChange"
 	MachinePhase        IntervalReason = "MachinePhase"
 
+	APIServiceCreated          IntervalReason = "APIServiceCreated"
+	APIServiceConditionChanged IntervalReason = "APIServiceConditionChanged"
+	APIServiceAvailable        IntervalReason = "APIServiceAvailable"
+	APIServiceUnavailable      IntervalReason = "APIServiceUnavailable"
+	APIServiceUnknown          IntervalReason = "APIServiceUnknown"
+	APIServiceDeletedInAPI     IntervalReason = "APIServiceDeletedInAPI"
+
 	Timeout IntervalReason = "Timeout"
 
 	E2ETestStarted  IntervalReason = "E2ETestStarted"
@@ -264,6 +273,7 @@ const (
 	AnnotationRequestAuditID AnnotationKey = "request-audit-id"
 	AnnotationRoles          AnnotationKey = "roles"
 	AnnotationStatus         AnnotationKey = "status"
+	AnnotationPreviousStatus AnnotationKey = "previousStatus"
 	AnnotationCondition      AnnotationKey = "condition"
 )
 
@@ -277,11 +287,12 @@ const (
 type ConstructionOwner string
 
 const (
-	ConstructionOwnerNodeLifecycle    = "node-lifecycle-constructor"
-	ConstructionOwnerPodLifecycle     = "pod-lifecycle-constructor"
-	ConstructionOwnerEtcdLifecycle    = "etcd-lifecycle-constructor"
-	ConstructionOwnerMachineLifecycle = "machine-lifecycle-constructor"
-	ConstructionOwnerLeaseChecker     = "lease-checker"
+	ConstructionOwnerNodeLifecycle       = "node-lifecycle-constructor"
+	ConstructionOwnerPodLifecycle        = "pod-lifecycle-constructor"
+	ConstructionOwnerEtcdLifecycle       = "etcd-lifecycle-constructor"
+	ConstructionOwnerMachineLifecycle    = "machine-lifecycle-constructor"
+	ConstructionOwnerAPIServiceLifecycle = "apiservice-lifecycle-constructor"
+	ConstructionOwnerLeaseChecker        = "lease-checker"
 )
 
 type Message struct {
@@ -329,6 +340,7 @@ const (
 
 	SourceAPIUnreachableFromClient IntervalSource = "APIUnreachableFromClient"
 	SourceMachine                  IntervalSource = "MachineMonitor"
+	SourceAPIServiceMonitor        IntervalSource = "APIServiceMonitor"
 )
 
 type Interval struct {

--- a/pkg/monitortests/kubeapiserver/watchapiservices/apiservices.go
+++ b/pkg/monitortests/kubeapiserver/watchapiservices/apiservices.go
@@ -1,0 +1,170 @@
+package watchapiservices
+
+import (
+	"context"
+	"fmt"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
+	apiregistrationv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+	"time"
+)
+
+func startAPIServiceMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client *apiregistrationv1client.ApiregistrationV1Client) {
+	apiServiceChangeFns := []func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval{
+		func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
+			if oldAPIService != nil {
+				return intervals
+			}
+			if newAPIService.Spec.Service == nil {
+				return intervals
+			}
+
+			intervals = append(intervals,
+				monitorapi.NewInterval(monitorapi.SourceAPIServiceMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().APIService(newAPIService.Name, newAPIService.Spec.Service.Namespace)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.APIServiceCreated).
+						HumanMessage("APIService created")).
+					Build(newAPIService.ObjectMeta.CreationTimestamp.Time, newAPIService.ObjectMeta.CreationTimestamp.Time))
+			return intervals
+		},
+
+		func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
+			now := time.Now()
+
+			oldHasPhase := oldAPIService != nil && findCondition(oldAPIService.Status.Conditions, apiregistrationv1.Available) != nil
+			newHasPhase := newAPIService != nil && findCondition(newAPIService.Status.Conditions, apiregistrationv1.Available) != nil
+			oldAvailableConditionStatus := "<missing>"
+			newAvailableConditionStatus := "<missing>"
+			newReason := "<missing>"
+			if oldHasPhase {
+				condition := findCondition(oldAPIService.Status.Conditions, apiregistrationv1.Available)
+				oldAvailableConditionStatus = string(condition.Status)
+			}
+			if newHasPhase {
+				condition := findCondition(newAPIService.Status.Conditions, apiregistrationv1.Available)
+				newAvailableConditionStatus = string(condition.Status)
+				newReason = condition.Reason
+			}
+
+			namespaceName := "<unknown>"
+			oldHasService := oldAPIService != nil && oldAPIService.Spec.Service != nil
+			newHasService := newAPIService != nil && newAPIService.Spec.Service != nil
+			if oldHasService {
+				namespaceName = oldAPIService.Spec.Service.Namespace
+			}
+			if newHasService {
+				namespaceName = newAPIService.Spec.Service.Namespace
+			}
+			if !oldHasService && !newHasService {
+				return intervals
+			}
+
+			apiServiceName := "<missing>"
+			if oldAPIService != nil {
+				apiServiceName = oldAPIService.Name
+			}
+			if newAPIService != nil {
+				apiServiceName = newAPIService.Name
+			}
+
+			if oldAvailableConditionStatus != newAvailableConditionStatus {
+				intervals = append(intervals,
+					monitorapi.NewInterval(monitorapi.SourceAPIServiceMonitor, monitorapi.Info).
+						Locator(monitorapi.NewLocator().APIService(apiServiceName, namespaceName)).
+						Message(monitorapi.NewMessage().Reason(monitorapi.APIServiceConditionChanged).
+							WithAnnotation(monitorapi.AnnotationCondition, string(apiregistrationv1.Available)).
+							WithAnnotation(monitorapi.AnnotationPreviousStatus, oldAvailableConditionStatus).
+							WithAnnotation(monitorapi.AnnotationStatus, newAvailableConditionStatus).
+							HumanMessage(fmt.Sprintf(".status.conditions[%q] changed from %s to %s, reason=%s", string(apiregistrationv1.Available), oldAvailableConditionStatus, newAvailableConditionStatus, newReason))).
+						Build(now, now))
+			}
+			return intervals
+		},
+
+		func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
+			if newAPIService != nil {
+				return intervals
+			}
+			if oldAPIService.Spec.Service == nil {
+				return intervals
+			}
+
+			now := time.Now()
+			intervals = append(intervals,
+				monitorapi.NewInterval(monitorapi.SourceAPIServiceMonitor, monitorapi.Info).
+					Locator(monitorapi.NewLocator().APIService(oldAPIService.Name, oldAPIService.Spec.Service.Namespace)).
+					Message(monitorapi.NewMessage().Reason(monitorapi.APIServiceDeletedInAPI).
+						HumanMessage("APIService deleted")).
+					Build(now, now))
+			return intervals
+		},
+	}
+
+	listWatch := cache.NewListWatchFromClient(client.RESTClient(), "apiservices", "", fields.Everything())
+	customStore := monitortestlibrary.NewMonitoringStore(
+		"apiservices",
+		toCreateFns(apiServiceChangeFns),
+		toUpdateFns(apiServiceChangeFns),
+		toDeleteFns(apiServiceChangeFns),
+		m,
+		m,
+	)
+	reflector := cache.NewReflector(listWatch, &apiregistrationv1.APIService{}, customStore, 0)
+	go reflector.Run(ctx.Done())
+}
+
+func findCondition(conditions []apiregistrationv1.APIServiceCondition, conditionType apiregistrationv1.APIServiceConditionType) *apiregistrationv1.APIServiceCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
+func toCreateFns(apiserviceUpdateFns []func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval) []monitortestlibrary.ObjCreateFunc {
+	ret := []monitortestlibrary.ObjCreateFunc{}
+
+	for i := range apiserviceUpdateFns {
+		fn := apiserviceUpdateFns[i]
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
+			return fn(obj.(*apiregistrationv1.APIService), nil)
+		})
+	}
+
+	return ret
+}
+
+func toDeleteFns(apiserviceUpdateFns []func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval) []monitortestlibrary.ObjDeleteFunc {
+	ret := []monitortestlibrary.ObjDeleteFunc{}
+
+	for i := range apiserviceUpdateFns {
+		fn := apiserviceUpdateFns[i]
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
+			return fn(nil, obj.(*apiregistrationv1.APIService))
+		})
+	}
+	return ret
+}
+func toUpdateFns(apiserviceUpdateFns []func(newAPIService, oldAPIService *apiregistrationv1.APIService) []monitorapi.Interval) []monitortestlibrary.ObjUpdateFunc {
+	ret := []monitortestlibrary.ObjUpdateFunc{}
+
+	for i := range apiserviceUpdateFns {
+		fn := apiserviceUpdateFns[i]
+		ret = append(ret, func(obj, oldObj interface{}) []monitorapi.Interval {
+			if oldObj == nil {
+				return fn(obj.(*apiregistrationv1.APIService), nil)
+			}
+			return fn(obj.(*apiregistrationv1.APIService), oldObj.(*apiregistrationv1.APIService))
+		})
+	}
+
+	return ret
+}

--- a/pkg/monitortests/kubeapiserver/watchapiservices/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/watchapiservices/monitortest.go
@@ -1,0 +1,200 @@
+package watchapiservices
+
+import (
+	"context"
+	"fmt"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/rest"
+	apiregistrationv1client "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1"
+)
+
+type machineWatcher struct {
+}
+
+func NewAPIServiceWatcher() monitortestframework.MonitorTest {
+	return &machineWatcher{}
+}
+
+func (w *machineWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	apiserviceClient, err := apiregistrationv1client.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	startAPIServiceMonitoring(ctx, recorder, apiserviceClient)
+
+	return nil
+}
+
+func (w *machineWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	return nil, nil, nil
+}
+
+func (*machineWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	constructedIntervals := monitorapi.Intervals{}
+
+	allAPIServiceChanges := startingIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		if eventInterval.Message.Reason == monitorapi.APIServiceCreated ||
+			(eventInterval.Message.Reason == monitorapi.APIServiceConditionChanged && eventInterval.Message.Annotations[monitorapi.AnnotationCondition] == "Available") ||
+			eventInterval.Message.Reason == monitorapi.APIServiceDeletedInAPI {
+			return true
+		}
+		return false
+	})
+
+	apiserviceToChanges := map[string][]monitorapi.Interval{}
+	for _, apiserviceChange := range allAPIServiceChanges {
+		apiservice := apiserviceChange.Locator.Keys[monitorapi.LocatorAPIServiceKey]
+		apiserviceToChanges[apiservice] = append(apiserviceToChanges[apiservice], apiserviceChange)
+	}
+
+	for _, allAPIServiceChanges := range apiserviceToChanges {
+		previousChangeTime := time.Time{}
+		createdIntervals := monitorapi.Intervals(allAPIServiceChanges).Filter(func(eventInterval monitorapi.Interval) bool {
+			return eventInterval.Message.Reason == monitorapi.APIServiceCreated
+		})
+		if len(createdIntervals) > 0 {
+			previousChangeTime = createdIntervals[0].From
+		}
+		apiserviceLocator := monitorapi.Locator{}
+		previousHumanMesage := ""
+		lastAvailableStatus := ""
+
+		availableConditionChanges := monitorapi.Intervals(allAPIServiceChanges).Filter(func(eventInterval monitorapi.Interval) bool {
+			return eventInterval.Message.Reason == monitorapi.APIServiceConditionChanged && eventInterval.Message.Annotations[monitorapi.AnnotationCondition] == "Available"
+		})
+		for _, availableConditionChange := range availableConditionChanges {
+			previousStatus := availableConditionChange.Message.Annotations[monitorapi.AnnotationPreviousStatus]
+			reason := monitorapi.APIServiceUnavailable
+			intervalLevel := monitorapi.Error
+			if previousStatus == "True" {
+				reason = monitorapi.APIServiceAvailable
+				intervalLevel = monitorapi.Info
+			} else if previousStatus != "False" {
+				reason = monitorapi.APIServiceUnknown
+				intervalLevel = monitorapi.Warning
+			}
+			constructedIntervals = append(constructedIntervals,
+				monitorapi.NewInterval(monitorapi.SourceAPIServiceMonitor, intervalLevel).
+					Locator(availableConditionChange.Locator).
+					Message(monitorapi.NewMessage().Reason(reason).
+						Constructed(monitorapi.ConstructionOwnerAPIServiceLifecycle).
+						HumanMessage(previousHumanMesage)).
+					Display().
+					Build(previousChangeTime, availableConditionChange.From),
+			)
+			previousChangeTime = availableConditionChange.From
+			lastAvailableStatus = availableConditionChange.Message.Annotations[monitorapi.AnnotationStatus]
+			previousHumanMesage = availableConditionChange.Message.HumanMessage
+			apiserviceLocator = availableConditionChange.Locator
+		}
+
+		deletionTime := time.Now()
+		deletedIntervals := monitorapi.Intervals(allAPIServiceChanges).Filter(func(eventInterval monitorapi.Interval) bool {
+			return eventInterval.Message.Reason == monitorapi.APIServiceDeletedInAPI
+		})
+		if len(deletedIntervals) > 0 {
+			deletionTime = deletedIntervals[0].To
+		}
+		if len(lastAvailableStatus) > 0 {
+			reason := monitorapi.APIServiceUnavailable
+			intervalLevel := monitorapi.Error
+			if lastAvailableStatus == "True" {
+				reason = monitorapi.APIServiceAvailable
+				intervalLevel = monitorapi.Info
+			} else if lastAvailableStatus != "False" {
+				reason = monitorapi.APIServiceUnknown
+				intervalLevel = monitorapi.Warning
+			}
+			constructedIntervals = append(constructedIntervals,
+				monitorapi.NewInterval(monitorapi.SourceAPIServiceMonitor, intervalLevel).
+					Locator(apiserviceLocator).
+					Message(monitorapi.NewMessage().Reason(reason).
+						Constructed(monitorapi.ConstructionOwnerAPIServiceLifecycle).
+						HumanMessage(previousHumanMesage)).
+					Display().
+					Build(previousChangeTime, deletionTime),
+			)
+		}
+	}
+
+	return constructedIntervals, nil
+}
+
+func (*machineWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	ret := []*junitapi.JUnitTestCase{}
+
+	allOpenShiftAPIServices := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		if eventInterval.Locator.Type != monitorapi.LocatorTypeAPIService {
+			return false
+		}
+		if !strings.HasPrefix(eventInterval.Locator.Keys[monitorapi.LocatorNamespaceKey], "openshift-") {
+			return false
+		}
+		return true
+	})
+	unavailableOpenShiftAPIServices := allOpenShiftAPIServices.Filter(func(eventInterval monitorapi.Interval) bool {
+		if eventInterval.Message.Reason != monitorapi.APIServiceUnavailable {
+			return false
+		}
+		return true
+	})
+
+	allOpenShiftAPIServiceNamespaces := sets.Set[string]{}
+	for _, apiserviceInterval := range allOpenShiftAPIServices {
+		allOpenShiftAPIServiceNamespaces.Insert(apiserviceInterval.Locator.Keys[monitorapi.LocatorNamespaceKey])
+	}
+
+	unavailableIntervalsByNamespace := map[string]monitorapi.Intervals{}
+	for _, unavailableInterval := range unavailableOpenShiftAPIServices {
+		namespace := unavailableInterval.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		unavailableIntervalsByNamespace[namespace] = append(unavailableIntervalsByNamespace[namespace], unavailableInterval)
+	}
+
+	for _, namespace := range sets.List(allOpenShiftAPIServiceNamespaces) {
+		testName := fmt.Sprintf("APIServices in ns/%s must always have endpoints", namespace)
+		failures := []string{}
+		unavailableIntervals := unavailableIntervalsByNamespace[namespace]
+		for _, unavailableInterval := range unavailableIntervals {
+			failures = append(failures, unavailableInterval.Message.HumanMessage)
+		}
+		if len(failures) > 0 {
+			ret = append(ret,
+				&junitapi.JUnitTestCase{
+					Name: testName,
+					FailureOutput: &junitapi.FailureOutput{
+						Message: fmt.Sprintf("went unavailable %d times", len(failures)),
+						Output:  strings.Join(failures, "\n"),
+					},
+					SystemOut: "sysout",
+					SystemErr: "syserr",
+				},
+			)
+		} else {
+			ret = append(ret,
+				&junitapi.JUnitTestCase{
+					Name: testName,
+				},
+			)
+		}
+
+	}
+
+	return ret, nil
+}
+
+func (*machineWatcher) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*machineWatcher) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}


### PR DESCRIPTION
Tests should fail when apiservices are unavailable.  The failure should be assigned to the component owning the namespace of the apiservice.