### PR TITLE
NO-JIRA: images.sh: Do not rely on the tag order

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -34156,9 +34156,8 @@ os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/delete-istag"
 # test deleting a tag using oc delete
-os::cmd::expect_success_and_text "oc get is perl --template '{{(index .spec.tags 0).name}}'" '5.32-'
-os::cmd::expect_success_and_text "oc get is perl --template '{{(index .status.tags 0).tag}}'" '5.32-'
-os::cmd::expect_success_and_text "oc describe is perl | sed -n -e '0,/^Tags:/d' -e '/^\s\+/d' -e '/./p' | head -n 1" '5.32-'
+os::cmd::expect_success_and_text "oc get is perl --template={{.spec.tags}}" 'name:5.32-el8'
+os::cmd::expect_success_and_text "oc get is perl --template={{.status.tags}}" 'tag:5.32-el8'
 os::cmd::expect_success "oc delete istag/perl:5.32-el8 --context='${cluster_admin_context}'"
 os::cmd::expect_success_and_not_text 'oc get is/perl --template={{.spec.tags}}' 'name:5.32-el8'
 os::cmd::expect_success_and_not_text 'oc get is/perl --template={{.status.tags}}' 'tag:5.32-el8'

--- a/test/extended/testdata/cmd/test/cmd/images.sh
+++ b/test/extended/testdata/cmd/test/cmd/images.sh
@@ -290,9 +290,8 @@ os::test::junit::declare_suite_end
 
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/delete-istag"
 # test deleting a tag using oc delete
-os::cmd::expect_success_and_text "oc get is perl --template '{{(index .spec.tags 0).name}}'" '5.32-'
-os::cmd::expect_success_and_text "oc get is perl --template '{{(index .status.tags 0).tag}}'" '5.32-'
-os::cmd::expect_success_and_text "oc describe is perl | sed -n -e '0,/^Tags:/d' -e '/^\s\+/d' -e '/./p' | head -n 1" '5.32-'
+os::cmd::expect_success_and_text "oc get is perl --template={{.spec.tags}}" 'name:5.32-el8'
+os::cmd::expect_success_and_text "oc get is perl --template={{.status.tags}}" 'tag:5.32-el8'
 os::cmd::expect_success "oc delete istag/perl:5.32-el8 --context='${cluster_admin_context}'"
 os::cmd::expect_success_and_not_text 'oc get is/perl --template={{.spec.tags}}' 'name:5.32-el8'
 os::cmd::expect_success_and_not_text 'oc get is/perl --template={{.status.tags}}' 'tag:5.32-el8'


### PR DESCRIPTION
ImageStreams object's tag order seems to be changed and this test fully relies on the first object of the tag list and it is perma-failing https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_oc/1877/pull-ci-openshift-oc-master-e2e-agnostic-ovn-cmd/1834521049262198784. This PR modifies the test by searching for the perl 5.32 image in the list instead of checking the first item.