### PR TITLE
OCPBUGS-42044: Minimize `git-clone` Privileges

### DIFF
--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -54,17 +54,17 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					continue
 				}
 				o.Expect(initContainer.SecurityContext).NotTo(o.BeNil(), "git-clone container should have a security context")
-				o.Expect(initContainer.SecurityContext.Privileged).NotTo(o.BeTrue(), "git-clone container should not be privileged")
-				o.Expect(initContainer.SecurityContext.SeccompProfile).To(o.Or(o.BeNil(), o.Equal(corev1.SeccompProfileRuntimeDefault)),
+				o.Expect(initContainer.SecurityContext.Privileged).To(o.Or(o.BeNil(), o.BeEquivalentTo(false)), "git-clone container should not be privileged")
+				o.Expect(initContainer.SecurityContext.SeccompProfile).To(o.Or(o.BeNil(), o.BeEquivalentTo(corev1.SeccompProfileRuntimeDefault)),
 					"git-clone container should have the runtime default seccomp profile")
 				capabilities := initContainer.SecurityContext.Capabilities
 				o.Expect(capabilities).NotTo(o.BeNil(), "git-clone container should have capabilities defined")
 				o.Expect(capabilities.Drop).NotTo(o.BeEmpty(), "git-clone container should drop ALL capabilities")
 				for _, cap := range capabilities.Drop {
-					o.Expect(cap).To(o.Equal("ALL"), "git-clone container should only drop the ALL capability")
+					o.Expect(cap).To(o.BeEquivalentTo("ALL"), "git-clone container should only drop the ALL capability")
 				}
 				for _, cap := range capabilities.Add {
-					o.Expect(cap).To(o.Or(o.Equal("CHOWN"), o.Equal("DAC_OVERRIDE")),
+					o.Expect(cap).To(o.Or(o.BeEquivalentTo("CHOWN"), o.BeEquivalentTo("DAC_OVERRIDE")),
 						"git-clone is only allowed to have the following capabilities: %s",
 						[]string{"CHOWN", "DAC_OVERRIDE"})
 				}

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -31,20 +31,46 @@ import (
 var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CLI", func() {
 	defer g.GinkgoRecover()
 	var (
-		buildFixture       = exutil.FixturePath("testdata", "builds", "test-build.yaml")
-		bcWithPRRef        = exutil.FixturePath("testdata", "builds", "test-bc-with-pr-ref.yaml")
-		exampleGemfile     = exutil.FixturePath("testdata", "builds", "test-build-app", "Gemfile")
-		exampleBuild       = exutil.FixturePath("testdata", "builds", "test-build-app")
-		symlinkFixture     = exutil.FixturePath("testdata", "builds", "test-symlink-build.yaml")
-		exampleGemfileURL  = "https://raw.githubusercontent.com/openshift/ruby-hello-world/master/Gemfile"
-		exampleArchiveURL  = "https://github.com/openshift/ruby-hello-world/archive/master.zip"
-		oc                 = exutil.NewCLIWithPodSecurityLevel("cli-start-build", admissionapi.LevelBaseline)
-		verifyNodeSelector = func(oc *exutil.CLI, name string) {
+		buildFixture      = exutil.FixturePath("testdata", "builds", "test-build.yaml")
+		bcWithPRRef       = exutil.FixturePath("testdata", "builds", "test-bc-with-pr-ref.yaml")
+		exampleGemfile    = exutil.FixturePath("testdata", "builds", "test-build-app", "Gemfile")
+		exampleBuild      = exutil.FixturePath("testdata", "builds", "test-build-app")
+		symlinkFixture    = exutil.FixturePath("testdata", "builds", "test-symlink-build.yaml")
+		exampleGemfileURL = "https://raw.githubusercontent.com/openshift/ruby-hello-world/master/Gemfile"
+		exampleArchiveURL = "https://github.com/openshift/ruby-hello-world/archive/master.zip"
+		oc                = exutil.NewCLIWithPodSecurityLevel("cli-start-build", admissionapi.LevelBaseline)
+		verifyBuildPod    = func(oc *exutil.CLI, name string) {
+			// Check the build ran on a linux node
 			pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), name+"-build", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 			os, ok := pod.Spec.NodeSelector[corev1.LabelOSStable]
 			o.Expect(ok).To(o.BeTrue())
 			o.Expect(os).To(o.Equal("linux"))
+
+			// CVE-2024-45496: .gitconfig can be abused to run aritrary commands.
+			// Ensure the git-clone container does not run privileged and with minimum capabilities enabled.
+			for _, initContainer := range pod.Spec.InitContainers {
+				if initContainer.Name != "git-clone" {
+					continue
+				}
+				o.Expect(initContainer.SecurityContext).NotTo(o.BeNil(), "git-clone container should have a security context")
+				o.Expect(initContainer.SecurityContext.Privileged).NotTo(o.BeTrue(), "git-clone container should not be privileged")
+				o.Expect(initContainer.SecurityContext.SeccompProfile).To(o.Or(o.BeNil(), o.Equal(corev1.SeccompProfileRuntimeDefault)),
+					"git-clone container should have the runtime default seccomp profile")
+				capabilities := initContainer.SecurityContext.Capabilities
+				o.Expect(capabilities).NotTo(o.BeNil(), "git-clone container should have capabilities defined")
+				o.Expect(capabilities.Drop).NotTo(o.BeEmpty(), "git-clone container should drop ALL capabilities")
+				for _, cap := range capabilities.Drop {
+					o.Expect(cap).To(o.Equal("ALL"), "git-clone container should only drop the ALL capability")
+				}
+				for _, cap := range capabilities.Add {
+					o.Expect(cap).To(o.Or(o.Equal("CHOWN"), o.Equal("DAC_OVERRIDE")),
+						"git-clone is only allowed to have the following capabilities: %s",
+						[]string{"CHOWN", "DAC_OVERRIDE"})
+				}
+
+			}
+
 		}
 	)
 
@@ -71,7 +97,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "--wait")
 					o.Expect(err).NotTo(o.HaveOccurred())
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 				})
 
 				g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", func() {
@@ -80,7 +106,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					br.AssertFailure()
 					o.Expect(br.StartBuildErr).To(o.HaveOccurred()) // start-build should detect the build error with --wait flag
 					o.Expect(br.StartBuildStdErr).Should(o.ContainSubstring(`status is "Failed"`))
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 				})
 			})
 
@@ -98,11 +124,11 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					br, err := exutil.StartBuildAndWait(oc, "bc-with-pr-ref-docker")
 					o.Expect(err).NotTo(o.HaveOccurred())
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					br, err = exutil.StartBuildAndWait(oc, "bc-with-pr-ref")
 					o.Expect(err).NotTo(o.HaveOccurred())
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					out, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -134,7 +160,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with -e FOO=bar,-e VAR=test")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "-e", "FOO=bar", "-e", "VAR=test")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -151,7 +177,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build output is verbose"))
@@ -166,7 +192,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5 but build-loglevel=1")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build", "--build-loglevel=1")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build output is not verbose"))
@@ -189,7 +215,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with a Dockerfile")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfile))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build %q status", br.BuildPath))
@@ -203,7 +229,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-dir=%s", exampleBuild))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("verifying the build %q status", br.BuildPath))
@@ -217,7 +243,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					tryRepoInit(exampleBuild)
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-repo=%s", exampleBuild))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -237,7 +263,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(err).NotTo(o.HaveOccurred())
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--commit=%s", commit), fmt.Sprintf("--from-repo=%s", exampleBuild))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -254,7 +280,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting a valid build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-binary", "--follow", fmt.Sprintf("--from-dir=%s", exampleBuild))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("Uploading directory"))
@@ -276,7 +302,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting a valid build with input file served by https")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfileURL))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(fmt.Sprintf("Uploading file from %q as binary input for the build", exampleGemfileURL)))
@@ -288,7 +314,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					// can't use sample-build-binary because we need contextDir due to github archives containing the top-level directory
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-github-archive", fmt.Sprintf("--from-archive=%s", exampleArchiveURL))
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring(fmt.Sprintf("Uploading archive from %q as binary input for the build", exampleArchiveURL)))
@@ -363,7 +389,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build without --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By("verifying the build output contains the build args from the BuildConfig.")
@@ -373,7 +399,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=foofoo=bar")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By("verifying the build output contains the changes.")
@@ -383,7 +409,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=bar=foo")
 					br.AssertSuccess()
-					verifyNodeSelector(oc, br.BuildName)
+					verifyBuildPod(oc, br.BuildName)
 					buildLog, err := br.Logs()
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By("verifying the build completed with a warning.")


### PR DESCRIPTION
As part of the mitigation for CVE-2024-45496, the `git-clone` container for builds was updated to run unprivileged and a minimal set of Linux capabilities enabled. This update ensures that we do not regress and elevate the permissions granted to the `git-clone` container in builds.