### PR TITLE
NO-JIRA: add test that ensures our informer cache matches the live results

### DIFF
--- a/pkg/monitortests/node/watchpods/cache_check.go
+++ b/pkg/monitortests/node/watchpods/cache_check.go
@@ -1,0 +1,99 @@
+package watchpods
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func checkCacheState(ctx context.Context, kubeClient kubernetes.Interface, podInformer coreinformers.PodInformer) ([]string, error) {
+	// We are running into problems where the cached list of pods contains pods that don't exist in the kube-apiserver.
+	// Let's try to check exactly.
+	cachedPods, err := podInformer.Lister().List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing cached pods: %w", err)
+	}
+
+	return checkCacheStateFromList(ctx, kubeClient, cachedPods)
+}
+
+func checkCacheStateFromList(ctx context.Context, kubeClient kubernetes.Interface, cachedPods []*corev1.Pod) ([]string, error) {
+	if len(cachedPods) == 0 {
+		return nil, fmt.Errorf("somehow the lister is missing pods")
+	}
+
+	biggestResourceVersion := -1
+	for _, cachedPod := range cachedPods {
+		if len(cachedPod.ResourceVersion) == 0 {
+			return nil, fmt.Errorf("encounted cached pod/%s -n %s without a resourceversion", cachedPod.Namespace, cachedPod.Name)
+		}
+		currRV, err := strconv.Atoi(cachedPod.ResourceVersion)
+		if err != nil {
+			return nil, fmt.Errorf("cached pod/%s -n %s has a non-integer RV %q: %w", cachedPod.Namespace, cachedPod.Name, cachedPod.ResourceVersion, err)
+		}
+		if currRV > biggestResourceVersion {
+			biggestResourceVersion = currRV
+		}
+	}
+
+	livePodsAtSameRV, err := kubeClient.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+		ResourceVersion:      strconv.Itoa(biggestResourceVersion),
+		ResourceVersionMatch: metav1.ResourceVersionMatchExact,
+	})
+	if err != nil && strings.Contains(err.Error(), "The resourceVersion for the provided list is too old") {
+		// if the resourceversion is too old (this happened a bunch), just skip the test.
+		// Again, we'll write a better test with a reflector that isn't vulnerable to this, but to gain some insight early we'll skip this case.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods resourceVersion=%v: %w", biggestResourceVersion, err)
+	}
+
+	failures := []string{}
+	for _, livePod := range livePodsAtSameRV.Items {
+		found := false
+		for _, cachedPod := range cachedPods {
+			if cachedPod.Namespace == livePod.Namespace && cachedPod.Name == livePod.Name {
+				found = true
+				if cachedPod.ResourceVersion != livePod.ResourceVersion {
+					failures = append(failures, fmt.Sprintf("matching pod/%s -n %s has different resourceVersions: live=%v cached=%v", livePod.Name, livePod.Namespace, livePod.ResourceVersion, cachedPod.ResourceVersion))
+				}
+			}
+		}
+		if !found {
+			// We cannot fail in this case because of a scenario like this
+			/*
+				rv-1: create a
+				rv-2: create b
+				rv-3: create c
+				rv-4: delete a
+				rv-5: delete b
+
+				In this scenario, the biggest RV is 3.  When we live list RV 3, the live list has [a, b, c].  The cache only has [c].
+				To get this test off the ground and check the case where the cache has more items than the live list (the current failure
+				we're checking), we will exclude this case from the inital check.
+			*/
+			//failures = append(failures, "live pod/%s -n %s RV=%v is not present in the cached results", livePod.Name, livePod.Namespace, livePod.ResourceVersion)
+		}
+	}
+	for _, cachedPod := range cachedPods {
+		found := false
+		for _, livePod := range livePodsAtSameRV.Items {
+			if cachedPod.Namespace == livePod.Namespace && cachedPod.Name == livePod.Name {
+				found = true
+			}
+		}
+		if !found {
+			failures = append(failures, fmt.Sprintf("cached pod/%s -n %s RV=%v is not present in the live results", cachedPod.Name, cachedPod.Namespace, cachedPod.ResourceVersion))
+		}
+	}
+
+	return failures, nil
+}

--- a/pkg/monitortests/node/watchpods/collection.go
+++ b/pkg/monitortests/node/watchpods/collection.go
@@ -10,11 +10,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
 
-func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderWriter, client kubernetes.Interface) {
+func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderWriter, client kubernetes.Interface) coreinformers.PodInformer {
 	podPendingFn := func(pod, oldPod *corev1.Pod) []monitorapi.Interval {
 		isCreate := oldPod == nil
 		oldPodIsPending := oldPod != nil && oldPod.Status.Phase == "Pending"
@@ -543,6 +544,7 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 	go podIPController.Run(ctx)
 	go sharedInformers.Start(ctx.Done())
 
+	return sharedInformers.Core().V1().Pods()
 }
 
 func toCreateFns(podCreateFns []func(pod *corev1.Pod) []monitorapi.Interval) []monitortestlibrary.ObjCreateFunc {


### PR DESCRIPTION
Trying to figure out why pods that were deleted in job runs like https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-upgrade-from-stable-4.17-e2e-metal-ipi-ovn-upgrade-cgroupsv1/1832612917804011520 (we very rarely catch the condition because pod IPs have to collide) were still present in our caches.

Reminder to self that some analysis is in https://gist.github.com/deads2k/5f9b725894bdb7ba03011889c06b2127

In this case
1. pods/pod-network-to-service-disruption-poller-565f9f69c4-nqjgl was deleted 05:18:52 (see audit log for delete and a get that 404'd)
2. pod-network-to-host-network-disruption-poller-794dd9846-9sc9m was created at 05:18:52
3. at 2024-09-08T05:18:59, the lister in the pod_ip_controller returned a list that contained *both* 565f9f69c4-nqjgl and 794dd9846-9sc9m with the same IP

even if the watch was latent, the delete (lower resourceversion) should have happened before the create and pod IP assignment.


@trozet ptal