### PR TITLE
NO-JIRA: Revert #29108 "NO-JIRA: revert restart tests and skip must gathers"

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/kubelet.go
+++ b/pkg/monitortests/node/legacynodemonitortests/kubelet.go
@@ -224,20 +224,12 @@ func testKubeAPIServerGracefulTermination(events monitorapi.Intervals) []*junita
 }
 
 func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	openshiftNamespaces := sets.Set[string]{}
-	containerExitsByNamespace := map[string]map[string][]string{}
-	failuresByNamespace := map[string][]string{}
+	containerExits := make(map[string][]string)
+	failures := []string{}
 	for _, event := range events {
-		namespace := event.Locator.Keys[monitorapi.LocatorNamespaceKey]
-		if !strings.Contains(namespace, "openshift-") {
+		if !strings.Contains(event.Locator.Keys[monitorapi.LocatorNamespaceKey], "openshift-") {
 			continue
 		}
-		// mustgather caused problems due to dynamic namespace
-		if strings.Contains(namespace, "openshift-must-gather-") {
-			continue
-		}
-		openshiftNamespaces.Insert(namespace)
-
 		reason := event.Message.Reason
 		code := event.Message.Annotations[monitorapi.AnnotationContainerExitCode]
 		switch {
@@ -246,69 +238,47 @@ func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Inter
 			if event.Message.Annotations[monitorapi.AnnotationCause] == "ContainerCreating" {
 				continue
 			}
-			failuresByNamespace[namespace] = append(failuresByNamespace[namespace], fmt.Sprintf("container failed to start at %v: %v - %v", event.From, event.Locator.OldLocator(), event.Message.OldMessage()))
+			failures = append(failures, fmt.Sprintf("container failed to start at %v: %v - %v", event.From, event.Locator.OldLocator(), event.Message.OldMessage()))
 
 		// workload containers should never exit non-zero during normal operations
 		case reason == monitorapi.ContainerReasonContainerExit && code != "0":
-			containerExits, ok := containerExitsByNamespace[namespace]
-			if !ok {
-				containerExits = map[string][]string{}
-			}
 			containerExits[event.Locator.OldLocator()] = append(containerExits[event.Locator.OldLocator()], fmt.Sprintf("non-zero exit at %v: %v", event.From, event.Message.OldMessage()))
-			containerExitsByNamespace[namespace] = containerExits
 		}
 	}
-	// This is a map of the tests we want to fail on
-	// In this case, this is any container that restarts more than 3 times
-	excessiveExitsByNamespaceForFailedTests := map[string][]string{}
-	// We want to report restarts of openshift containers as flakes
-	excessiveExitsByNamespaceForFlakeTests := map[string][]string{}
 
-	maxRestartCountForFailures := 3
-	maxRestartCountForFlakes := 2
+	var excessiveExits []string
+	maxRestartCount := 3
+
+	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(events, time.Time{}, time.Time{})
 
 	clusterDataPlatform, _ := platformidentification.BuildClusterData(context.Background(), adminRestConfig)
 
-	exclusions := Exclusion{clusterData: clusterDataPlatform}
-	for namespace, containerExits := range containerExitsByNamespace {
-		for locator, messages := range containerExits {
-			if len(messages) > 0 {
-				messageSet := sets.NewString(messages...)
-				// Blanket fail for restarts over maxRestartCount
-				if !isThisContainerRestartExcluded(locator, exclusions) && len(messages) > maxRestartCountForFailures {
-					excessiveExitsByNamespaceForFailedTests[namespace] = append(excessiveExitsByNamespaceForFailedTests[namespace], fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
-				} else if len(messages) >= maxRestartCountForFlakes {
-					excessiveExitsByNamespaceForFlakeTests[namespace] = append(excessiveExitsByNamespaceForFlakeTests[namespace], fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
-				}
+	exclusions := Exclusion{upgradeJob: isUpgrade, clusterData: clusterDataPlatform}
+	for locator, messages := range containerExits {
+		if len(messages) > 0 {
+			messageSet := sets.NewString(messages...)
+			// Blanket fail for restarts over maxRestartCount
+			if !isThisContainerRestartExcluded(locator, exclusions) && len(messages) > maxRestartCount {
+				excessiveExits = append(excessiveExits, fmt.Sprintf("%s restarted %d times at:\n%s", locator, len(messages), strings.Join(messageSet.List(), "\n")))
 			}
 		}
 	}
-	for namespace, excessiveExitsFails := range excessiveExitsByNamespaceForFailedTests {
-		sort.Strings(excessiveExitsFails)
-		excessiveExitsByNamespaceForFailedTests[namespace] = excessiveExitsFails
-	}
-	for namespace, excessiveExitsFlakes := range excessiveExitsByNamespaceForFlakeTests {
-		sort.Strings(excessiveExitsFlakes)
-		excessiveExitsByNamespaceForFlakeTests[namespace] = excessiveExitsFlakes
-	}
+	sort.Strings(excessiveExits)
 
 	var testCases []*junitapi.JUnitTestCase
 
-	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
-		failures := failuresByNamespace[namespace]
-		failToStartTestName := fmt.Sprintf("[sig-architecture] platform pods in ns/%s should not fail to start", namespace)
-		if len(failures) > 0 {
-			testCases = append(testCases, &junitapi.JUnitTestCase{
-				Name:      failToStartTestName,
-				SystemOut: strings.Join(failures, "\n"),
-				FailureOutput: &junitapi.FailureOutput{
-					Output: fmt.Sprintf("%d container starts had issues\n\n%s", len(failures), strings.Join(failures, "\n")),
-				},
-			})
-		}
-		// mark flaky for now while we debug
-		testCases = append(testCases, &junitapi.JUnitTestCase{Name: failToStartTestName})
+	const failToStartTestName = "[sig-architecture] platform pods should not fail to start"
+	if len(failures) > 0 {
+		testCases = append(testCases, &junitapi.JUnitTestCase{
+			Name:      failToStartTestName,
+			SystemOut: strings.Join(failures, "\n"),
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("%d container starts had issues\n\n%s", len(failures), strings.Join(failures, "\n")),
+			},
+		})
 	}
+	// mark flaky for now while we debug
+	testCases = append(testCases, &junitapi.JUnitTestCase{Name: failToStartTestName})
 
 	// We want to deflake this test.
 	// Plan is to release this test and report any failures for pods
@@ -316,34 +286,16 @@ func testContainerFailures(adminRestConfig *rest.Config, events monitorapi.Inter
 	// We will then build exclusion rules for those that we see
 	// and then make this test fail for any case that doesn't match the rules
 	// we have.
-	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
-		excessiveExits := excessiveExitsByNamespaceForFailedTests[namespace]
-		excessiveRestartTestName := fmt.Sprintf("[sig-architecture] platform pods in ns/%s should not exit more than %d with a non-zero exit code", namespace, maxRestartCountForFailures)
-		if len(excessiveExits) > 0 {
-			testCases = append(testCases, &junitapi.JUnitTestCase{
-				Name:      excessiveRestartTestName,
-				SystemOut: strings.Join(excessiveExits, "\n"),
-				FailureOutput: &junitapi.FailureOutput{
-					Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
-				},
-			})
-		}
+	const excessiveRestartTestName = "[sig-architecture] platform pods should not exit more than once with a non-zero exit code"
+	if len(excessiveExits) > 0 {
+		testCases = append(testCases, &junitapi.JUnitTestCase{
+			Name:      excessiveRestartTestName,
+			SystemOut: strings.Join(excessiveExits, "\n"),
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
+			},
+		})
 	}
-	for _, namespace := range sets.List(openshiftNamespaces) { // this ensures we create test case for every namespace, even in success cases
-		excessiveExits := excessiveExitsByNamespaceForFlakeTests[namespace]
-		excessiveRestartTestNameForFlakes := fmt.Sprintf("[sig-architecture] platform pods in ns/%s that restart more than %d is considered a flake for now", namespace, maxRestartCountForFlakes)
-		if len(excessiveExits) > 0 {
-			testCases = append(testCases, &junitapi.JUnitTestCase{
-				Name:      excessiveRestartTestNameForFlakes,
-				SystemOut: strings.Join(excessiveExits, "\n"),
-				FailureOutput: &junitapi.FailureOutput{
-					Output: fmt.Sprintf("%d containers with multiple restarts\n\n%s", len(excessiveExits), strings.Join(excessiveExits, "\n\n")),
-				},
-			})
-		}
-		testCases = append(testCases, &junitapi.JUnitTestCase{Name: excessiveRestartTestNameForFlakes})
-	}
-
 	return testCases
 }
 


### PR DESCRIPTION

Reverts #29108 ; tracked by NO-JIRA

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

From what we can tell, these tests are having a high failure rate and likely to reject a payload

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Run /payload blocking jobs to verify aggregation passes
```

CC: @kannon92

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
