### PR TITLE
add a separate pod reflector to more accurately track resourceversion and cache drift

### DIFF
--- a/pkg/monitortests/node/watchpods/monitortest.go
+++ b/pkg/monitortests/node/watchpods/monitortest.go
@@ -2,8 +2,16 @@ package watchpods
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -17,6 +25,12 @@ import (
 type podWatcher struct {
 	kubeClient  kubernetes.Interface
 	podInformer coreinformers.PodInformer
+
+	blockDeltas          sync.Mutex
+	collectionCtxCancel  context.CancelFunc
+	collectionPodLister  listerscorev1.PodLister
+	collectionIndexer    cache.Indexer
+	collectionController cache.Controller
 }
 
 func NewPodWatcher() monitortestframework.MonitorTest {
@@ -32,11 +46,71 @@ func (w *podWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.
 
 	w.podInformer = startPodMonitoring(ctx, recorder, w.kubeClient)
 
+	collectionCtx, collectionCtxCancel := context.WithCancel(ctx)
+	w.collectionCtxCancel = collectionCtxCancel
+	// copy/pasted from the construction of sharedinformers
+	w.collectionIndexer = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{})
+	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
+		KnownObjects:          w.collectionIndexer,
+		EmitDeltaTypeReplaced: true,
+	})
+	listWatch := cache.NewListWatchFromClient(w.kubeClient.CoreV1().RESTClient(), "pods", "", fields.Everything())
+
+	cfg := &cache.Config{
+		Queue:             fifo,
+		ListerWatcher:     listWatch,
+		ObjectType:        &corev1.Pod{},
+		ObjectDescription: "pods",
+		FullResyncPeriod:  0,
+		RetryOnError:      false,
+		ShouldResync:      func() bool { return false },
+
+		Process:           w.handleDeltas,
+		WatchErrorHandler: func(r *cache.Reflector, err error) {},
+	}
+	w.collectionController = cache.New(cfg)
+	go w.collectionController.Run(collectionCtx.Done())
+
+	w.collectionPodLister = listerscorev1.NewPodLister(w.collectionIndexer)
+
 	return nil
+}
+
+// copied from the shared_informer in upstream.  It's a simplified version for the one collectionIndexer that we have.
+func (w *podWatcher) handleDeltas(obj interface{}, isInInitialList bool) error {
+	w.blockDeltas.Lock()
+	defer w.blockDeltas.Unlock()
+
+	if deltas, ok := obj.(cache.Deltas); ok {
+		// from oldest to newest
+		for _, d := range deltas {
+			obj := d.Object
+
+			switch d.Type {
+			case cache.Sync, cache.Replaced, cache.Added, cache.Updated:
+				if _, exists, err := w.collectionIndexer.Get(obj); err == nil && exists {
+					if err := w.collectionIndexer.Update(obj); err != nil {
+						return err
+					}
+				} else {
+					if err := w.collectionIndexer.Add(obj); err != nil {
+						return err
+					}
+				}
+			case cache.Deleted:
+				if err := w.collectionIndexer.Delete(obj); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return errors.New("object given as Process argument is not Deltas")
 }
 
 func (w *podWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
 	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	w.collectionCtxCancel()
+
 	return nil, nil, nil
 }
 
@@ -52,6 +126,7 @@ func (w *podWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, 
 	if w.podInformer == nil {
 		return nil, nil
 	}
+	ret := []*junitapi.JUnitTestCase{}
 
 	cacheFailures, err := checkCacheState(ctx, w.kubeClient, w.podInformer)
 	if err != nil {
@@ -59,7 +134,6 @@ func (w *podWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, 
 	}
 
 	testName := "[sig-apimachinery] informers must match live results at the same resource version"
-	ret := []*junitapi.JUnitTestCase{}
 	if len(cacheFailures) > 0 {
 		ret = append(ret,
 			&junitapi.JUnitTestCase{
@@ -80,6 +154,44 @@ func (w *podWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, 
 		ret = append(ret,
 			&junitapi.JUnitTestCase{
 				Name: testName,
+			},
+		)
+	}
+
+	actualResourceVersion, err := strconv.Atoi(w.collectionController.LastSyncResourceVersion())
+	if err != nil {
+		return nil, fmt.Errorf("error getting last RV %v: %w", w.collectionController.LastSyncResourceVersion(), err)
+	}
+	actualCachedPods, err := w.collectionPodLister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing cached pods: %w", err)
+	}
+
+	reflectorCachedFailures, err := checkCacheStateFromList(ctx, w.kubeClient, actualCachedPods, actualResourceVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error determining cache failures: %w", err)
+	}
+	reflectorCachedTestName := "[sig-apimachinery] reflector must match live results at the same resource version"
+	if len(reflectorCachedFailures) > 0 {
+		ret = append(ret,
+			&junitapi.JUnitTestCase{
+				Name: reflectorCachedTestName,
+				FailureOutput: &junitapi.FailureOutput{
+					Message: strings.Join(reflectorCachedFailures, "\n"),
+					Output:  "abandon all hope",
+				},
+			},
+		)
+		// start as a flake
+		ret = append(ret,
+			&junitapi.JUnitTestCase{
+				Name: reflectorCachedTestName,
+			},
+		)
+	} else {
+		ret = append(ret,
+			&junitapi.JUnitTestCase{
+				Name: reflectorCachedTestName,
 			},
 		)
 	}


### PR DESCRIPTION
building on https://github.com/openshift/origin/pull/29115 to wire a reflector to pull the actual resourceversion to test more often.

/assign @benluddy @p0lyn0mial 