### PR TITLE
TRT-1809: refine early E2E disruption test

### DIFF
--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/monitortest.go
@@ -37,7 +37,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testPodNodeNameIsImmutable(finalIntervals)...)
 	junits = append(junits, testStaticPodLifecycleFailure(finalIntervals, w.adminRESTConfig)...)
 	junits = append(junits, testAPIServerIPTablesAccessDisruption(finalIntervals)...)
-	junits = append(junits, testEarlyE2EAPIServerDisruption(finalIntervals)...)
+	junits = append(junits, testEarlyE2EAPIServerDisruption(finalIntervals, w.adminRESTConfig)...)
 
 	return junits, nil
 }


### PR DESCRIPTION
Tighten the conditions for failure a bit.
Skip single-node.