### PR TITLE
OCPBUGS-42316: exclude must gather and debug from platform force delete

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/types.go
+++ b/pkg/monitortestlibrary/platformidentification/types.go
@@ -283,3 +283,21 @@ func getArchitecture(clientConfig *rest.Config) (string, error) {
 
 	return "amd64", errors.New("could not determine architecture from master nodes")
 }
+
+// IsPlatformNamespace is a utility to detect if the namespace is considered platform
+func IsPlatformNamespace(nsName string) bool {
+	switch {
+	case nsName == "default" || nsName == "kubernetes" || nsName == "openshift":
+		return true
+
+	case strings.HasPrefix(nsName, "openshift-must-gather-") || strings.HasPrefix(nsName, "openshift-debug-"):
+		// we skip these namespaces because the names vary by run and produce problems
+		return false
+	case strings.HasPrefix(nsName, "openshift-"):
+		return true
+	case strings.HasPrefix(nsName, "kube-"):
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/monitortests/node/legacynodemonitortests/kubelet.go
+++ b/pkg/monitortests/node/legacynodemonitortests/kubelet.go
@@ -332,7 +332,7 @@ func testDeleteGracePeriodZero(events monitorapi.Intervals) []*junitapi.JUnitTes
 		if event.Message.Reason != "ForceDelete" {
 			continue
 		}
-		if !strings.Contains(event.Locator.Keys[monitorapi.LocatorNamespaceKey], "openshift-") {
+		if !platformidentification.IsPlatformNamespace(event.Locator.Keys[monitorapi.LocatorNamespaceKey]) {
 			continue
 		}
 		if event.Message.Annotations["mirrored"] == "true" {

--- a/pkg/monitortests/testframework/watchnamespaces/namespaces.go
+++ b/pkg/monitortests/testframework/watchnamespaces/namespaces.go
@@ -2,10 +2,10 @@ package watchnamespaces
 
 import (
 	"context"
-	"strings"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -16,24 +16,6 @@ import (
 // allObservedPlatformNamespaces contains a list of namespaces observed
 var allObservedPlatformNamespaces = sets.Set[string]{}
 
-func isPlatformNamespace(nsName string) bool {
-	switch {
-	case nsName == "default" || nsName == "kubernetes" || nsName == "openshift":
-		return true
-
-	case strings.HasPrefix(nsName, "openshift-must-gather-"):
-		// we skip must-gather namespaces because the names vary by run and produce problems
-		return false
-
-	case strings.HasPrefix(nsName, "openshift-"):
-		return true
-	case strings.HasPrefix(nsName, "kube-"):
-		return true
-	default:
-		return false
-	}
-}
-
 func startNamespaceMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client kubernetes.Interface) {
 	namespaceChangeFns := []func(namespace, oldNamespace *corev1.Namespace) []monitorapi.Interval{
 		// this is first so namespace created shows up first when queried
@@ -42,7 +24,7 @@ func startNamespaceMonitoring(ctx context.Context, m monitorapi.RecorderWriter, 
 			if oldNamespace != nil {
 				return nil
 			}
-			if isPlatformNamespace(namespace.Name) {
+			if platformidentification.IsPlatformNamespace(namespace.Name) {
 				allObservedPlatformNamespaces.Insert(namespace.Name)
 			}
 			return nil


### PR DESCRIPTION
I am seeing a lot of flakes due to must-gathers.

```
amespace/openshift-must-gather-tqw22 node/control-1 pod/must-gather-v28rc uid/69848c84-2b1a-4b08-9018-deaf9faf6434
namespace/openshift-must-gather-9zxhj node/control-2 pod/must-gather-7tljn uid/c7dd24ab-47f5-48e5-81be-addfe70ceaca
namespace/openshift-must-gather-5ssnz node/control-0 pod/must-gather-gw7q6 uid/0793b22d-63df-41c1-a5b4-411836271ee8
namespace/openshift-must-gather-hxjcm node/compute-0 pod/perf-node-gather-daemonset-vcbmg uid/7fb7f233-6493-41f3-b547-1df416b357d3
namespace/openshift-must-gather-hxjcm node/compute-1 pod/perf-node-gather-daemonset-xm4pd uid/41cecd3b-d0d8-40f7-be44-ad226ce537c0
namespace/openshift-must-gather-hxjcm node/control-1 pod/perf-node-gather-daemonset-2kprz uid/15850d2b-cc8a-40fe-a60a-a1f13dc69d50
namespace/openshift-must-gather-hxjcm node/control-0 pod/perf-node-gather-daemonset-rp79k uid/ff924705-7cfc-4624-9a05-2c40b947b222
namespace/openshift-must-gather-hxjcm node/control-2 pod/perf-node-gather-daemonset-wr2vb uid/d59d62a1-60eb-4734-b0c5-3876b9d5fe82
namespace/openshift-must-gather-hxjcm node/control-1 pod/must-gather-mccdz uid/323e8d7f-621e-4c9b-9112-ce9532486edb
namespace/openshift-must-gather-4ln88 node/control-2 pod/must-gather-d2wjx uid/ef64d180-8e40-4f28-9c55-c2b22187819b}
```

Must gathers are not considered to be a platform namespace so I want to exclude this from test.