### PR TITLE
OCPBUGS-42237: bump ruby-3.0-ubi8 image to ruby-3.1-ubi8

### DIFF
--- a/examples/quickstarts/rails-postgresql-persistent.json
+++ b/examples/quickstarts/rails-postgresql-persistent.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/examples/quickstarts/rails-postgresql.json
+++ b/examples/quickstarts/rails-postgresql.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -26,7 +26,7 @@ FROM %s
 USER 1001
 `, image.ShellImage())
 		testDockerfile2 = `
-FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 USER 1001
 `
 		testDockerfile3 = `
@@ -110,7 +110,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 
 				g.By("checking for the imported tag")
-				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:3.0-ubi8", metav1.GetOptions{})
+				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:3.1-ubi8", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -40,28 +40,28 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("waiting for created resources to be ready for testing")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "ruby:3.0-ubi8").Execute()
+			err := oc.Run("get").Args("imagestreamtags", "ruby:3.1-ubi8").Execute()
 			return err == nil, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("testing --local flag validation")
-		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--local").Output()
+		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.1-ubi8", "--local").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
 
 		g.By("testing --dry-run=client with -o flags")
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag", "--dry-run=client").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("test-deployment-config"))
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config image updated (dry run)"))
 
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config"))
 
 		g.By("testing basic image updates")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -70,7 +70,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
 
 		g.By("repeating basic image updates to ensure nothing changed")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -110,7 +110,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("setting a different, valid image on multiple resources")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("set").Args("image", "pods,dc", "*=ruby:3.0-ubi8", "--all", "--source=imagestreamtag").Execute()
+			err := oc.Run("set").Args("image", "pods,dc", "*=ruby:3.1-ubi8", "--all", "--source=imagestreamtag").Execute()
 			if err != nil {
 				klog.Warningf("one of pods failed when setting image %v", err)
 				return false, nil
@@ -146,28 +146,28 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("waiting for created resources to be ready for testing")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "ruby:3.0-ubi8").Execute()
+			err := oc.Run("get").Args("imagestreamtags", "ruby:3.1-ubi8").Execute()
 			return err == nil, nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("testing --local flag validation")
-		out, err := oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--local").Output()
+		out, err := oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.1-ubi8", "--local").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
 
 		g.By("testing --dry-run=client with -o flags")
-		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client").Output()
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag", "--dry-run=client").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("test-deployment"))
 		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment image updated (dry run)"))
 
-		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment"))
 
 		g.By("testing basic image updates")
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -176,7 +176,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
 
 		g.By("repeating basic image updates to ensure nothing changed")
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.0-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.1-ubi8", "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -216,7 +216,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 
 		g.By("setting a different, valid image on multiple resources")
 		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("set").Args("image", "pods,deployments", "*=ruby:3.0-ubi8", "--all", "--source=imagestreamtag").Execute()
+			err := oc.Run("set").Args("image", "pods,deployments", "*=ruby:3.1-ubi8", "--all", "--source=imagestreamtag").Execute()
 			if err != nil {
 				klog.Warningf("one of pods failed when setting image %v", err)
 				return false, nil

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -11819,7 +11819,7 @@ var _examplesQuickstartsRailsPostgresqlPersistentJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -12446,7 +12446,7 @@ var _examplesQuickstartsRailsPostgresqlJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -17865,7 +17865,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         },
         "env": [
           {
@@ -19196,7 +19196,7 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailBadcontextdirs2iYamlBytes() ([]byte, error) {
@@ -19296,7 +19296,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchimagecontentdockerYamlBytes() ([]byte, error) {
@@ -19330,7 +19330,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsourcedockerYamlBytes() ([]byte, error) {
@@ -19364,7 +19364,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsources2iYamlBytes() ([]byte, error) {
@@ -19396,7 +19396,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
@@ -19439,7 +19439,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       forcePull: true
 `)
 
@@ -20165,7 +20165,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -20354,7 +20354,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20383,7 +20383,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20411,7 +20411,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20440,7 +20440,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20468,7 +20468,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -21260,7 +21260,7 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         }
       }
     },
@@ -21609,7 +21609,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:3.0-ubi8
+          name: ruby:3.1-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -30053,7 +30053,7 @@ var _testExtendedTestdataClusterQuickstartsRailsPostgresqlJson = []byte(`{
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},
@@ -34169,9 +34169,10 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi9 3.1-ubi8 latest'
+
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi9 3.1-ubi8 latest newtag'
 os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"
@@ -37526,20 +37527,20 @@ var _testExtendedTestdataCmdTestCmdTestdataImageStreamsImageStreamsCentos7Json =
             }
           },
           {
-            "name": "3.0-ubi8",
+            "name": "3.1-ubi8",
             "annotations": {
-              "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "description": "Build and run Ruby 3.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+              "openshift.io/display-name": "Ruby 3.1 (UBI 8)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:3.0,ruby",
+              "supports": "ruby:3.1,ruby",
               "tags": "builder,ruby",
-              "version": "3.0"
+              "version": "3.1"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-30:latest"
+              "name": "registry.redhat.io/ubi8/ruby-31:latest"
             },
             "generation": null,
             "importPolicy": {},
@@ -38297,12 +38298,12 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "3.0"
+      name: "3.1"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:3.0-ubi8
-    name: "3.0"
+      name: ruby:3.1-ubi8
+    name: "3.1"
 `)
 
 func testExtendedTestdataCmdTestCmdTestdataNewAppImagestreamRefYamlBytes() ([]byte, error) {
@@ -45293,7 +45294,7 @@ var _testExtendedTestdataImageTestImageJson = []byte(`{
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",
@@ -48943,7 +48944,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
                         }
                     }
                 }
@@ -48972,7 +48973,7 @@ var _testExtendedTestdataLong_namesFixtureJson = []byte(`{
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
                         }
                     }
                 }
@@ -51069,7 +51070,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0
@@ -51115,7 +51116,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -51136,7 +51137,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -51179,7 +51180,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -15,4 +15,4 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
@@ -19,4 +19,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -12,7 +12,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -17,5 +17,5 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       forcePull: true

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -88,7 +88,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -23,7 +23,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         }
       }
     },

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -26,7 +26,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:3.0-ubi8
+          name: ruby:3.1-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
+++ b/test/extended/testdata/cluster/quickstarts/rails-postgresql.json
@@ -117,7 +117,7 @@
 						],
 						"from": {
 							"kind": "ImageStreamTag",
-							"name": "ruby:3.0-ubi8",
+							"name": "ruby:3.1-ubi8",
 							"namespace": "${NAMESPACE}"
 						}
 					},

--- a/test/extended/testdata/cmd/test/cmd/images.sh
+++ b/test/extended/testdata/cmd/test/cmd/images.sh
@@ -304,9 +304,10 @@ os::test::junit::declare_suite_end
 os::test::junit::declare_suite_start "cmd/images${IMAGES_TESTS_POSTFIX:-}/merge-tags-on-apply"
 os::cmd::expect_success 'oc new-project merge-tags'
 os::cmd::expect_success 'oc create -f ${TEST_DATA}/image-streams/image-streams-centos7.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi9 3.1-ubi8 latest'
+
 os::cmd::expect_success 'oc apply -f ${TEST_DATA}/modified-ruby-imagestream.json'
-os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi8 3.0-ubi9 latest newtag'
+os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[*].name}' '2.7-ubi8 3.0-ubi7 3.0-ubi9 3.1-ubi8 latest newtag'
 os::cmd::expect_success_and_text 'oc get is ruby -o jsonpath={.spec.tags[0].annotations.version}' '2.7 patched'
 os::cmd::expect_success 'oc delete project merge-tags'
 echo "apply new imagestream tags: ok"

--- a/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
+++ b/test/extended/testdata/cmd/test/cmd/testdata/image-streams/image-streams-centos7.json
@@ -843,20 +843,20 @@
             }
           },
           {
-            "name": "3.0-ubi8",
+            "name": "3.1-ubi8",
             "annotations": {
-              "description": "Build and run Ruby 3.0 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.0/README.md.",
+              "description": "Build and run Ruby 3.1 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-ruby-container/blob/master/3.1/README.md.",
               "iconClass": "icon-ruby",
-              "openshift.io/display-name": "Ruby 3.0 (UBI 8)",
+              "openshift.io/display-name": "Ruby 3.1 (UBI 8)",
               "openshift.io/provider-display-name": "Red Hat, Inc.",
               "sampleRepo": "https://github.com/sclorg/ruby-ex.git",
-              "supports": "ruby:3.0,ruby",
+              "supports": "ruby:3.1,ruby",
               "tags": "builder,ruby",
-              "version": "3.0"
+              "version": "3.1"
             },
             "from": {
               "kind": "DockerImage",
-              "name": "registry.access.redhat.com/ubi8/ruby-30:latest"
+              "name": "registry.redhat.io/ubi8/ruby-31:latest"
             },
             "generation": null,
             "importPolicy": {},

--- a/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
+++ b/test/extended/testdata/cmd/test/cmd/testdata/new-app/imagestream-ref.yaml
@@ -6,9 +6,9 @@ spec:
   tags:
   - from:
       kind: ImageStreamTag
-      name: "3.0"
+      name: "3.1"
     name: "latest"
   - from:
       kind: ImageStreamTag
-      name: ruby:3.0-ubi8
-    name: "3.0"
+      name: ruby:3.1-ubi8
+    name: "3.1"

--- a/test/extended/testdata/image/test-image.json
+++ b/test/extended/testdata/image/test-image.json
@@ -5,7 +5,7 @@
     "name": "test",
     "creationTimestamp": null
   },
-  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8",
+  "dockerImageReference": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8",
   "dockerImageMetadata": {
     "kind": "DockerImage",
     "apiVersion": "1.0",

--- a/test/extended/testdata/long_names/fixture.json
+++ b/test/extended/testdata/long_names/fixture.json
@@ -26,7 +26,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
                         }
                     }
                 }
@@ -55,7 +55,7 @@
                     "sourceStrategy": {
                         "from": {
                             "kind": "DockerImage",
-                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+                            "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
                         }
                     }
                 }

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -32,7 +32,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -44,4 +44,4 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0


### PR DESCRIPTION
Fix tests that fail due to not finding ruby-3.0-ubi8 images.