### PR TITLE
API-1835: add test to prevent invalid apply statements

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -235,6 +235,8 @@ const (
 	LeaseAcquiring        IntervalReason = "Acquiring"
 	LeaseAcquiringStarted IntervalReason = "StartedAcquiring"
 	LeaseAcquired         IntervalReason = "Acquired"
+
+	ReasonBadOperatorApply IntervalReason = "BadOperatorApply"
 )
 
 type AnnotationKey string

--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/origin/pkg/monitor"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/openshift/origin/pkg/monitortests/testframework/watchnamespaces"
 	"strings"
 	"time"
 
+	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/podaccess"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -85,7 +86,47 @@ func (*operatorLogAnalyzer) ConstructComputedIntervals(ctx context.Context, star
 }
 
 func (*operatorLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
-	return nil, nil
+	platformNamespaces, err := watchnamespaces.GetAllPlatformNamespaces()
+	if err != nil {
+		return nil, err
+	}
+
+	ret := []*junitapi.JUnitTestCase{}
+
+	applyFailures := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Message.Reason == monitorapi.ReasonBadOperatorApply
+	})
+
+	namespaceToApplyFailures := map[string][]string{}
+	for _, applyFailure := range applyFailures {
+		namespace := applyFailure.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		namespaceToApplyFailures[namespace] = append(namespaceToApplyFailures[namespace], applyFailure.String())
+	}
+
+	for _, nsName := range platformNamespaces {
+		testName := fmt.Sprintf("operators in in ns/%s should not submit invalid apply statements", nsName)
+		nsFailures := namespaceToApplyFailures[nsName]
+		if len(nsFailures) > 0 {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testName,
+				FailureOutput: &junitapi.FailureOutput{
+					Message: strings.Join(nsFailures, "\n"),
+					Output:  fmt.Sprintf("found %d invalid applies in the log", len(nsFailures)),
+				},
+			})
+			// flake because Stephen will want it that way this week.
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testName,
+			})
+		} else {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testName,
+			})
+		}
+
+	}
+
+	return ret, nil
 }
 
 func (w *operatorLogAnalyzer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
@@ -140,6 +181,28 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 				Locator(logLine.Locator).
 				Message(monitorapi.NewMessage().
 					Reason(monitorapi.LeaseAcquired).
+					HumanMessage(logLine.Line),
+				).
+				Build(logLine.Instant, logLine.Instant),
+		)
+	case strings.Contains(logLine.Line, "unable to ApplyStatus for operator") &&
+		strings.Contains(logLine.Line, "is invalid"): // apply failures
+		g.recorder.AddIntervals(
+			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Error).
+				Locator(logLine.Locator).
+				Message(monitorapi.NewMessage().
+					Reason(monitorapi.ReasonBadOperatorApply).
+					HumanMessage(logLine.Line),
+				).
+				Build(logLine.Instant, logLine.Instant),
+		)
+	case strings.Contains(logLine.Line, "unable to Apply for operator") &&
+		strings.Contains(logLine.Line, "is invalid"): // apply failures
+		g.recorder.AddIntervals(
+			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Error).
+				Locator(logLine.Locator).
+				Message(monitorapi.NewMessage().
+					Reason(monitorapi.ReasonBadOperatorApply).
 					HumanMessage(logLine.Line),
 				).
 				Build(logLine.Instant, logLine.Instant),


### PR DESCRIPTION
To catch things like

> 2024-09-26T09:00:24.282667248Z E0926 09:00:24.282588       1 base_controller.go:271] OAuthAPIServerControllerWorkloadController reconciliation failed: Authentication.operator.openshift.io "cluster" is invalid: [conditions[55].type: Invalid value: "": conditions[55].type in body should match '^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$', conditions[55].status: Unsupported value: "": supported values: "True", "False", "Unknown", <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]

in our operator logs.  It would be better to track client metic invalid request rates, but I don't know how at the moment.