### PR TITLE
Remove the references to ruby:3.0-ubi8 from the builds tests.

### DIFF
--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -26,7 +26,7 @@ FROM %s
 USER 1001
 `, image.ShellImage())
 		testDockerfile2 = `
-FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+FROM image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 USER 1001
 `
 		testDockerfile3 = `
@@ -37,7 +37,6 @@ USER 1001
 	)
 
 	g.Context("", func() {
-
 		g.BeforeEach(func() {
 			exutil.PreTestDump()
 		})
@@ -110,7 +109,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 
 				g.By("checking for the imported tag")
-				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:3.0-ubi8", metav1.GetOptions{})
+				_, err = oc.ImageClient().ImageV1().ImageStreamTags(oc.Namespace()).Get(context.Background(), "ruby:3.1-ubi8", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -17865,7 +17865,7 @@ var _testExtendedTestdataBuildsBuildSecretsTestS2iBuildJson = []byte(`{
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         },
         "env": [
           {
@@ -19196,7 +19196,7 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailBadcontextdirs2iYamlBytes() ([]byte, error) {
@@ -19296,7 +19296,7 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchimagecontentdockerYamlBytes() ([]byte, error) {
@@ -19330,7 +19330,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsourcedockerYamlBytes() ([]byte, error) {
@@ -19364,7 +19364,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
 `)
 
 func testExtendedTestdataBuildsStatusfailFetchsources2iYamlBytes() ([]byte, error) {
@@ -19396,7 +19396,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy
@@ -19439,7 +19439,7 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       forcePull: true
 `)
 
@@ -20165,7 +20165,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com
@@ -20354,7 +20354,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20383,7 +20383,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20411,7 +20411,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20440,7 +20440,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -20468,7 +20468,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue
@@ -21260,7 +21260,7 @@ var _testExtendedTestdataBuildsTestEnvBuildJson = []byte(`{
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         }
       }
     },
@@ -21609,7 +21609,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:3.0-ubi8
+          name: ruby:3.1-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig
@@ -51069,7 +51069,7 @@ var _testExtendedTestdataRun_policyParallelBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0
@@ -51115,7 +51115,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -51136,7 +51136,7 @@ var _testExtendedTestdataRun_policySerialBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
 `)
 
 func testExtendedTestdataRun_policySerialBcYamlBytes() ([]byte, error) {
@@ -51179,7 +51179,7 @@ var _testExtendedTestdataRun_policySerialLatestOnlyBcYaml = []byte(`---
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/builds/build-secrets/test-s2i-build.json
+++ b/test/extended/testdata/builds/build-secrets/test-s2i-build.json
@@ -45,7 +45,7 @@
       "sourceStrategy": {
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         },
         "env": [
           {

--- a/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
+++ b/test/extended/testdata/builds/statusfail-badcontextdirs2i.yaml
@@ -15,4 +15,4 @@ spec:
         value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchimagecontentdocker.yaml
@@ -19,4 +19,4 @@ spec:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsourcedocker.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
+++ b/test/extended/testdata/builds/statusfail-fetchsources2i.yaml
@@ -14,4 +14,4 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8

--- a/test/extended/testdata/builds/statusfail-genericreason.yaml
+++ b/test/extended/testdata/builds/statusfail-genericreason.yaml
@@ -12,7 +12,7 @@ spec:
 
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       scripts: "http://example.org/scripts"
       env:
         - name: http_proxy

--- a/test/extended/testdata/builds/statusfail-oomkilled.yaml
+++ b/test/extended/testdata/builds/statusfail-oomkilled.yaml
@@ -17,5 +17,5 @@ spec:
           value: "2"
       from:
         kind: DockerImage
-        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+        name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
       forcePull: true

--- a/test/extended/testdata/builds/test-build-proxy.yaml
+++ b/test/extended/testdata/builds/test-build-proxy.yaml
@@ -88,7 +88,7 @@ items:
       dockerStrategy:
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
         env:
         - name: SOME_HTTP_PROXY
           value: https://envuser:password@proxy3.com

--- a/test/extended/testdata/builds/test-build.yaml
+++ b/test/extended/testdata/builds/test-build.yaml
@@ -48,7 +48,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -77,7 +77,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -105,7 +105,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -134,7 +134,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
   status:
     lastVersion: 0
@@ -162,7 +162,7 @@ items:
           value: '5'
         from:
           kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8
+          name: image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8
     resources: {}
     nodeSelector:
       nodelabelkey: nodelabelvalue

--- a/test/extended/testdata/builds/test-env-build.json
+++ b/test/extended/testdata/builds/test-env-build.json
@@ -23,7 +23,7 @@
         ],
         "from": {
           "kind": "DockerImage",
-          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+          "name": "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         }
       }
     },

--- a/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
+++ b/test/extended/testdata/builds/test-imagesource-buildconfig.yaml
@@ -26,7 +26,7 @@ items:
             value: "2"
         from:
           kind: ImageStreamTag
-          name: ruby:3.0-ubi8
+          name: ruby:3.1-ubi8
           namespace: openshift
 - apiVersion: build.openshift.io/v1
   kind: BuildConfig

--- a/test/extended/testdata/run_policy/parallel-bc.yaml
+++ b/test/extended/testdata/run_policy/parallel-bc.yaml
@@ -32,7 +32,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0

--- a/test/extended/testdata/run_policy/serial-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
     -
       kind: "BuildConfig"
       apiVersion: "build.openshift.io/v1"
@@ -44,4 +44,4 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"

--- a/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
+++ b/test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -23,7 +23,7 @@
           sourceStrategy:
             from:
               kind: "DockerImage"
-              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.0-ubi8"
+              name: "image-registry.openshift-image-registry.svc:5000/openshift/ruby:3.1-ubi8"
         resources: {}
       status:
         lastVersion: 0


### PR DESCRIPTION
The image is not available anymore.

I'm not assigning this PR to an issue (https://issues.redhat.com/browse/OCPBUGS-42237) yet, because I'm not part of the builds team and I'm not sure the changes actually fix the problem. I'm opening this PR just to check if it helps at all.