### PR TITLE
OCPBUGS-42536: Trying to reduce the flakiness of the samples smoke tests

### DIFF
--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -70,7 +70,7 @@ func NewSampleRepoTest(c sampleRepoConfig) func() {
 					buildName := c.buildConfigName + "-1"
 
 					g.By("expecting the build is in the Complete phase")
-					err = exutil.WaitForABuild(oc.BuildClient().BuildV1().Builds(oc.Namespace()), buildName, nil, nil, nil)
+					err = exutil.WaitForABuildWithTimeout(oc.BuildClient().BuildV1().Builds(oc.Namespace()), buildName, 5*time.Minute, 15*time.Minute, nil, nil, nil)
 					if err != nil {
 						exutil.DumpBuildLogs(c.buildConfigName, oc)
 					}


### PR DESCRIPTION
Trying to reduce the flakiness of the samples smoke tests by increasing the timeout for the build of the app.

Especially the rails example tends to take forever to build.