### PR TITLE
NO-JIRA: test for checking the healthz endpoints for the openshift-apiserver

### DIFF
--- a/test/extended/apiserver/health_endpoints.go
+++ b/test/extended/apiserver/health_endpoints.go
@@ -1,0 +1,114 @@
+package apiserver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = ginkgo.Describe("[sig-api-machinery] API health endpoints", func() {
+	f := framework.NewDefaultFramework("api-health-endpoints")
+	f.SkipNamespaceCreation = true
+
+	oc := exutil.NewCLIWithoutNamespace("api-health-endpoints").AsAdmin()
+
+	ginkgo.It("should contain the required checks for the openshift-apiserver APIs", func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		framework.ExpectNoError(err)
+		if isMicroShift {
+			ginkgo.Skip("MicroShift does not have the openshift-apiserver")
+		}
+
+		ctx := context.Background()
+		requiredReadyzChecks := sets.New[string](
+			"[+]ping ok",
+			"[+]log ok",
+			"[+]etcd ok",
+			"[+]etcd-readiness ok",
+			"[+]informer-sync ok",
+			"[+]poststarthook/generic-apiserver-start-informers ok",
+			"[+]poststarthook/max-in-flight-filter ok",
+			"[+]poststarthook/storage-object-count-tracker-hook ok",
+			"[+]poststarthook/image.openshift.io-apiserver-caches ok",
+			"[+]poststarthook/authorization.openshift.io-bootstrapclusterroles ok",
+			"[+]poststarthook/authorization.openshift.io-ensurenodebootstrap-sa ok",
+			"[+]poststarthook/project.openshift.io-projectcache ok",
+			"[+]poststarthook/project.openshift.io-projectauthorizationcache ok",
+			"[+]poststarthook/openshift.io-startinformers ok",
+			"[+]poststarthook/openshift.io-restmapperupdater ok",
+			"[+]poststarthook/quota.openshift.io-clusterquotamapping ok",
+			"[+]shutdown ok",
+		)
+		requiredLivezChecks := sets.New[string](
+			"[+]ping ok",
+			"[+]log ok",
+			"[+]etcd ok",
+			"[+]poststarthook/generic-apiserver-start-informers ok",
+			"[+]poststarthook/max-in-flight-filter ok",
+			"[+]poststarthook/storage-object-count-tracker-hook ok",
+			"[+]poststarthook/image.openshift.io-apiserver-caches ok",
+			"[+]poststarthook/authorization.openshift.io-bootstrapclusterroles ok",
+			"[+]poststarthook/authorization.openshift.io-ensurenodebootstrap-sa ok",
+			"[+]poststarthook/project.openshift.io-projectcache ok",
+			"[+]poststarthook/project.openshift.io-projectauthorizationcache ok",
+			"[+]poststarthook/openshift.io-startinformers ok",
+			"[+]poststarthook/openshift.io-restmapperupdater ok",
+			"[+]poststarthook/quota.openshift.io-clusterquotamapping ok",
+		)
+
+		// ensure the service exists and hit the well-known endpoint
+		_, err = f.ClientSet.CoreV1().Services("openshift-apiserver").Get(ctx, "api", metav1.GetOptions{})
+		framework.ExpectNoError(err)
+
+		transport, err := restclient.TransportFor(oc.AdminConfig())
+		framework.ExpectNoError(err)
+		basePath := oc.AdminConfig().Host + "/api/v1/namespaces/openshift-apiserver/services/https:api:443/proxy/"
+
+		readyzPath := basePath + "readyz?verbose=true"
+		ginkgo.By(readyzPath)
+		err = testPath(transport, readyzPath, requiredReadyzChecks)
+		framework.ExpectNoError(err)
+
+		livezPath := basePath + "livez?verbose=true"
+		ginkgo.By(livezPath)
+		err = testPath(transport, livezPath, requiredLivezChecks)
+		framework.ExpectNoError(err)
+		return
+	})
+})
+
+func testPath(transport http.RoundTripper, path string, requiredChecks sets.Set[string]) error {
+	request, err := http.NewRequest("GET", path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := transport.RoundTrip(request)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected response statusCode=%v", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	checks := sets.New[string](strings.Split(string(rawBody), "\n")...)
+	if missing := requiredChecks.Difference(checks); missing.Len() > 0 {
+		return fmt.Errorf("missing required checks: %s, for path: %s in: %s", missing, path, string(rawBody))
+	}
+	return nil
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -23,6 +23,8 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial]": " [Suite:openshift/conformance/serial]",
 
+	"[sig-api-machinery] API health endpoints should contain the required checks for the openshift-apiserver APIs": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-api-machinery] APIServer CR fields validation additionalCORSAllowedOrigins [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-api-machinery][Feature:APIServer] TestTLSDefaults": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
The test could be defined in the operand repo, but since the operand repo doesn't have any CI job defined, I decided to add the test directly to the origin.

This might cause minor issues during rebases when the output changes, but this shouldn't happen frequently.

Also we should add test cases for the remaining aggregated APIs.

Required for https://github.com/openshift/openshift-apiserver/pull/452