### PR TITLE
NO-JIRA: only count 500s for resource requests

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_count_tracking.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_count_tracking.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -85,6 +86,9 @@ func (c *CountsForRun) countIndexesFromAuditTime(in *auditv1.Event) (int, int, i
 		return -1, -1, -1, false
 	}
 	if in.Verb == "watch" {
+		return -1, -1, -1, false
+	}
+	if !strings.HasPrefix(in.RequestURI, "/api/") && !strings.HasPrefix(in.RequestURI, "/apis/") {
 		return -1, -1, -1, false
 	}
 	if in.RequestReceivedTimestamp.BeforeTime(&c.EstimatedStartOfCluster) {


### PR DESCRIPTION
I *think* this is already covered by our audit policy, but just making sure.