### PR TITLE
OCPEDGE-1266: fix: adding oslat updates and outputting test results to the artifacts

### DIFF
--- a/test/extended/kernel/common.go
+++ b/test/extended/kernel/common.go
@@ -2,6 +2,8 @@ package kernel
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"regexp"
 	"time"
 
@@ -97,4 +99,15 @@ func cleanupRtTestPod(oc *exutil.CLI) {
 	// Wait for the container to be ready to go
 	err = exutil.WaitForNoPodsRunning(oc.SetNamespace(rtNamespace))
 	o.Expect(err).NotTo(o.HaveOccurred(), "test pod for rt-tests never became ready")
+}
+
+// Write out test artifacts
+func writeTestArtifacts(fname string, content string) {
+	// Create the artifact dir for rt-tests if it does not exist
+	artifactDir := filepath.Join(exutil.ArtifactDirPath(), "rt-tests")
+	err := os.MkdirAll(artifactDir, 0755)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = os.WriteFile(filepath.Join(artifactDir, fname), []byte(content), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
 }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -45794,7 +45794,6 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
   annotations:
     workload.openshift.io/allowed: management
-    openshift.io/node-selector: "node-role.kubernetes.io/worker="
 spec: {}
 
 ---

--- a/test/extended/testdata/kernel/rt-tests-environment.yaml
+++ b/test/extended/testdata/kernel/rt-tests-environment.yaml
@@ -9,7 +9,6 @@ metadata:
     pod-security.kubernetes.io/warn: privileged
   annotations:
     workload.openshift.io/allowed: management
-    openshift.io/node-selector: "node-role.kubernetes.io/worker="
 spec: {}
 
 ---


### PR DESCRIPTION
- Pins the oslat main thread to the first thread under test to accommodate workload partitioning
- Writes the outputs of oslat, cyclictest and rteval to the artifacts dir 