### PR TITLE
OCPEDGE-1265: removing rteval from the realtime test suite

### DIFF
--- a/test/extended/kernel/kernel_rt_latency.go
+++ b/test/extended/kernel/kernel_rt_latency.go
@@ -42,11 +42,6 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running cyclictest")
 	})
 
-	g.It("rteval", func() {
-		err := runRteval(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running rteval")
-	})
-
 	g.AfterEach(func() {
 		cleanupRtTestPod(oc)
 	})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1633,8 +1633,6 @@ var Annotations = map[string]string{
 
 	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with oslat": " [Serial]",
 
-	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with rteval": " [Serial]",
-
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow deadline_test to run successfully": " [Serial]",
 
 	"[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real time kernel should allow pi_stress to run successfully with the fifo algorithm": " [Serial]",


### PR DESCRIPTION
We are removing rteval from the realtime test suite. After switching to a metal host it was exposed that this test overruns container limits when creating system load and the only logical fix is to run rteval on the host rather than containerized. That approach is beyond the scope of what this test suite is intended for. In addition, this test is primarily useful when testing hardware being used in production systems to provide platform readiness by putting the CPU under load and then evaluating with cyclictest. We are not validating the hardware with this test suite and as such rteval is a bad fit for this suite.

In our situation we are really trying to just test that there are no obvious underlying issues with the kernel or with Openshift running on top of the real-time kernel which is exposed by just running cyclictest (which we do separately of rteval). 