### PR TITLE
API-1835: Add a generation analyzer monitortest

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionlegacyapiservers"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/disruptionnewapiserver"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/faultyloadbalancer"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/generationanalyzer"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
 	"github.com/openshift/origin/pkg/monitortests/machines/watchmachines"
 	"github.com/openshift/origin/pkg/monitortests/monitoring/disruptionmetricsapi"
@@ -173,6 +174,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("pod-lifecycle", "Node / Kubelet", watchpods.NewPodWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("node-lifecycle", "Node / Kubelet", watchnodes.NewNodeWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("machine-lifecycle", "Cluster-Lifecycle / machine-api", watchmachines.NewMachineWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("generation-analyzer", "kube-apiserver", generationanalyzer.NewGenerationAnalyzer())
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-storage-invariants", "Storage", legacystoragemonitortests.NewLegacyTests())
 

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -109,6 +109,30 @@ func (b *LocatorBuilder) NodeFromName(nodeName string) Locator {
 		Build()
 }
 
+func (b *LocatorBuilder) DeploymentFromName(namespace, deploymentName string) Locator {
+	return b.
+		withTargetType(LocatorTypeDeployment).
+		withNamespace(namespace).
+		withDeployment(deploymentName).
+		Build()
+}
+
+func (b *LocatorBuilder) DaemonSetFromName(namespace, daemonSetName string) Locator {
+	return b.
+		withTargetType(LocatorTypeDaemonSet).
+		withNamespace(namespace).
+		withDaemonSet(daemonSetName).
+		Build()
+}
+
+func (b *LocatorBuilder) StatefulSetFromName(namespace, statefulSetName string) Locator {
+	return b.
+		withTargetType(LocatorTypeStatefulSet).
+		withNamespace(namespace).
+		withStatefuulSet(statefulSetName).
+		Build()
+}
+
 func (b *LocatorBuilder) MachineFromName(machineName string) Locator {
 	return b.
 		withTargetType(LocatorTypeMachine).
@@ -249,6 +273,20 @@ func (b *LocatorBuilder) withNamespace(namespace string) *LocatorBuilder {
 
 func (b *LocatorBuilder) withNode(nodeName string) *LocatorBuilder {
 	b.annotations[LocatorNodeKey] = nodeName
+	return b
+}
+
+func (b *LocatorBuilder) withDeployment(deploymentName string) *LocatorBuilder {
+	b.annotations[LocatorDeploymentKey] = deploymentName
+	return b
+}
+
+func (b *LocatorBuilder) withDaemonSet(daemonSetName string) *LocatorBuilder {
+	b.annotations[LocatorDaemonSetKey] = daemonSetName
+	return b
+}
+func (b *LocatorBuilder) withStatefuulSet(statefulSetName string) *LocatorBuilder {
+	b.annotations[LocatorStatefulSetKey] = statefulSetName
 	return b
 }
 

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -109,6 +109,9 @@ const (
 	LocatorTypeClusterVersion  LocatorType = "ClusterVersion"
 	LocatorTypeKind            LocatorType = "Kind"
 	LocatorTypeCloudMetrics    LocatorType = "CloudMetrics"
+	LocatorTypeDeployment      LocatorType = "Deployment"
+	LocatorTypeDaemonSet       LocatorType = "DaemonSet"
+	LocatorTypeStatefulSet     LocatorType = "StatefulSet"
 
 	LocatorTypeAPIUnreachableFromClient LocatorType = "APIUnreachableFromClient"
 )
@@ -120,6 +123,8 @@ const (
 	LocatorClusterVersionKey  LocatorKey = "clusterversion"
 	LocatorNamespaceKey       LocatorKey = "namespace"
 	LocatorDeploymentKey      LocatorKey = "deployment"
+	LocatorDaemonSetKey       LocatorKey = "daemonset"
+	LocatorStatefulSetKey     LocatorKey = "statefulset"
 	LocatorNodeKey            LocatorKey = "node"
 	LocatorMachineKey         LocatorKey = "machine"
 	LocatorEtcdMemberKey      LocatorKey = "etcd-member"
@@ -238,6 +243,9 @@ const (
 
 	ReasonBadOperatorApply  IntervalReason = "BadOperatorApply"
 	ReasonKubeAPIServer500s IntervalReason = "KubeAPIServer500s"
+
+	ReasonHighGeneration    IntervalReason = "HighGeneration"
+	ReasonInvalidGeneration IntervalReason = "GenerationViolation"
 )
 
 type AnnotationKey string
@@ -336,6 +344,8 @@ const (
 
 	SourceAPIUnreachableFromClient IntervalSource = "APIUnreachableFromClient"
 	SourceMachine                  IntervalSource = "MachineMonitor"
+
+	SourceGenerationMonitor IntervalSource = "GenerationMonitor"
 )
 
 type Interval struct {

--- a/pkg/monitortests/kubeapiserver/generationanalyzer/generation.go
+++ b/pkg/monitortests/kubeapiserver/generationanalyzer/generation.go
@@ -1,0 +1,202 @@
+package generationanalyzer
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary"
+	"k8s.io/apimachinery/pkg/fields"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Workload interface {
+	GetData() *WorkloadData
+}
+
+type WorkloadWrapper struct {
+	obj interface{}
+}
+
+type WorkloadData struct {
+	Kind               string
+	Name               string
+	Namespace          string
+	Generation         int64
+	ObservedGeneration int64
+	Locator            monitorapi.Locator
+}
+
+func (w *WorkloadWrapper) GetData() *WorkloadData {
+	switch o := w.obj.(type) {
+	case *appsv1.Deployment:
+		return &WorkloadData{
+			Kind:               o.Kind,
+			Name:               o.Name,
+			Namespace:          o.Namespace,
+			Generation:         o.Generation,
+			ObservedGeneration: o.Status.ObservedGeneration,
+			Locator:            monitorapi.NewLocator().DeploymentFromName(o.Namespace, o.Name),
+		}
+	case *appsv1.DaemonSet:
+		return &WorkloadData{
+			Kind:               o.Kind,
+			Name:               o.Name,
+			Namespace:          o.Namespace,
+			Generation:         o.Generation,
+			ObservedGeneration: o.Status.ObservedGeneration,
+			Locator:            monitorapi.NewLocator().DaemonSetFromName(o.Namespace, o.Name),
+		}
+	case *appsv1.StatefulSet:
+		return &WorkloadData{
+			Kind:               o.Kind,
+			Name:               o.Name,
+			Namespace:          o.Namespace,
+			Generation:         o.Generation,
+			ObservedGeneration: o.Status.ObservedGeneration,
+			Locator:            monitorapi.NewLocator().StatefulSetFromName(o.Namespace, o.Name),
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", o))
+	}
+}
+
+func startGenerationMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client kubernetes.Interface) {
+	objChangeFns := []func(obj, oldObj Workload) []monitorapi.Interval{
+		func(obj, oldObj Workload) []monitorapi.Interval {
+			var intervals []monitorapi.Interval
+
+			var objData *WorkloadData
+			if obj != nil {
+				objData = obj.GetData()
+			} else {
+				objData = oldObj.GetData()
+			}
+
+			// Regardless if this is a creation, deletion or update, check if the generation is too high
+			if objData.Generation > maxGenerationAllowed {
+				intervals = append(intervals, highGenerationInterval(objData.Locator, objData.Kind, objData.Generation))
+			}
+
+			// If this is an update, check if generation is increasing monotonically
+			if oldObj != nil && obj != nil {
+				objData := obj.GetData()
+				oldObjData := oldObj.GetData()
+				if objData.ObservedGeneration < oldObjData.ObservedGeneration {
+					intervals = append(intervals, invalidGenerationInterval(
+						objData.Locator,
+						objData.Kind,
+						objData.ObservedGeneration,
+						oldObjData.ObservedGeneration,
+					))
+				}
+			}
+
+			return intervals
+		},
+	}
+
+	listWatchDeployment := cache.NewListWatchFromClient(client.AppsV1().RESTClient(), "deployments", "", fields.Everything())
+	listWatchDaemonSet := cache.NewListWatchFromClient(client.AppsV1().RESTClient(), "daemonsets", "", fields.Everything())
+	listWatchStatefulSet := cache.NewListWatchFromClient(client.AppsV1().RESTClient(), "statefulsets", "", fields.Everything())
+
+	customStoreDeployments := monitortestlibrary.NewMonitoringStore(
+		"deployments",
+		toCreateFns(objChangeFns),
+		toUpdateFns(objChangeFns),
+		toDeleteFns(objChangeFns),
+		m,
+		m,
+	)
+
+	customStoreDaemonSets := monitortestlibrary.NewMonitoringStore(
+		"daemonsets",
+		toCreateFns(objChangeFns),
+		toUpdateFns(objChangeFns),
+		toDeleteFns(objChangeFns),
+		m,
+		m,
+	)
+
+	customStoreStatefulSets := monitortestlibrary.NewMonitoringStore(
+		"statefulsets",
+		toCreateFns(objChangeFns),
+		toUpdateFns(objChangeFns),
+		toDeleteFns(objChangeFns),
+		m,
+		m,
+	)
+
+	reflectorDeployment := cache.NewReflector(listWatchDeployment, &appsv1.Deployment{}, customStoreDeployments, 0)
+	reflectorDaemonSet := cache.NewReflector(listWatchDaemonSet, &appsv1.DaemonSet{}, customStoreDaemonSets, 0)
+	reflectorStatefulSet := cache.NewReflector(listWatchStatefulSet, &appsv1.StatefulSet{}, customStoreStatefulSets, 0)
+
+	go reflectorDeployment.Run(ctx.Done())
+	go reflectorDaemonSet.Run(ctx.Done())
+	go reflectorStatefulSet.Run(ctx.Done())
+}
+
+func toCreateFns(objUpdateFns []func(obj, oldObj Workload) []monitorapi.Interval) []monitortestlibrary.ObjCreateFunc {
+	ret := []monitortestlibrary.ObjCreateFunc{}
+
+	for i := range objUpdateFns {
+		fn := objUpdateFns[i]
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
+			return fn(&WorkloadWrapper{obj: obj}, nil)
+		})
+	}
+
+	return ret
+}
+
+func toUpdateFns(objUpdateFns []func(obj, oldObj Workload) []monitorapi.Interval) []monitortestlibrary.ObjUpdateFunc {
+	ret := []monitortestlibrary.ObjUpdateFunc{}
+
+	for i := range objUpdateFns {
+		fn := objUpdateFns[i]
+		ret = append(ret, func(obj, oldObj interface{}) []monitorapi.Interval {
+			if oldObj == nil {
+				return fn(obj.(Workload), nil)
+			}
+			return fn(&WorkloadWrapper{obj: obj}, &WorkloadWrapper{obj: oldObj})
+		})
+	}
+
+	return ret
+}
+
+func toDeleteFns(objUpdateFns []func(obj, oldObj Workload) []monitorapi.Interval) []monitortestlibrary.ObjDeleteFunc {
+	ret := []monitortestlibrary.ObjDeleteFunc{}
+
+	for i := range objUpdateFns {
+		fn := objUpdateFns[i]
+		ret = append(ret, func(obj interface{}) []monitorapi.Interval {
+			return fn(nil, &WorkloadWrapper{obj: obj})
+		})
+	}
+	return ret
+}
+
+func highGenerationInterval(locator monitorapi.Locator, kind string, generation int64) monitorapi.Interval {
+	now := time.Now()
+	return monitorapi.NewInterval(monitorapi.SourceGenerationMonitor, monitorapi.Info).
+		Locator(locator).
+		Message(monitorapi.NewMessage().
+			Reason(monitorapi.ReasonHighGeneration).
+			HumanMessage(fmt.Sprintf("%s generation too high: %d", kind, generation)),
+		).Build(now, now)
+}
+
+func invalidGenerationInterval(locator monitorapi.Locator, kind string, newGeneration, previousGeneration int64) monitorapi.Interval {
+	now := time.Now()
+	return monitorapi.NewInterval(monitorapi.SourceGenerationMonitor, monitorapi.Info).
+		Locator(locator).
+		Message(monitorapi.NewMessage().
+			Reason(monitorapi.ReasonInvalidGeneration).
+			HumanMessage(fmt.Sprintf("new %s generation (%d) is higher than previous generation (%d)", kind, newGeneration, previousGeneration)),
+		).Build(now, now)
+}

--- a/pkg/monitortests/kubeapiserver/generationanalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/generationanalyzer/monitortest.go
@@ -1,0 +1,128 @@
+package generationanalyzer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortests/testframework/watchnamespaces"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const maxGenerationAllowed = 50
+
+type generationWatcher struct {
+	kubeClient kubernetes.Interface
+}
+
+func NewGenerationAnalyzer() monitortestframework.MonitorTest {
+	return &generationWatcher{}
+}
+
+func (w *generationWatcher) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	kubeClient, err := kubernetes.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+	w.kubeClient = kubeClient
+	startGenerationMonitoring(ctx, recorder, kubeClient)
+	return nil
+}
+
+func (w *generationWatcher) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	// because we are sharing a recorder that we're streaming into, we don't need to have a separate data collection step.
+	return nil, nil, nil
+}
+
+func (w *generationWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (w *generationWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	platformNamespaces, err := watchnamespaces.GetAllPlatformNamespaces()
+	if err != nil {
+		return nil, err
+	}
+
+	intervalHighGenerationFailures := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Message.Reason == monitorapi.ReasonHighGeneration
+	})
+
+	namespaceToHighGenerationFailure := map[string][]string{}
+	for _, failure := range intervalHighGenerationFailures {
+		namespace := failure.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		namespaceToHighGenerationFailure[namespace] = append(namespaceToHighGenerationFailure[namespace], failure.String())
+	}
+
+	intervalInvalidGenerationFailures := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Message.Reason == monitorapi.ReasonInvalidGeneration
+	})
+
+	namespaceToInvalidGenerationFailure := map[string][]string{}
+	for _, failure := range intervalInvalidGenerationFailures {
+		namespace := failure.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		namespaceToInvalidGenerationFailure[namespace] = append(namespaceToInvalidGenerationFailure[namespace], failure.String())
+	}
+
+	ret := []*junitapi.JUnitTestCase{}
+	for _, namespace := range platformNamespaces {
+		// Generation should not be too high
+		testNameHighGeneration := fmt.Sprintf("objects in ns/%s should not have too many generations", namespace)
+		nsFailuresHighGeneration := namespaceToHighGenerationFailure[namespace]
+		if len(nsFailuresHighGeneration) > 0 {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameHighGeneration,
+				FailureOutput: &junitapi.FailureOutput{
+					Message: strings.Join(nsFailuresHighGeneration, "\n"),
+					Output:  fmt.Sprintf("objects had a metadata.Generation higher than %d", maxGenerationAllowed),
+				},
+			})
+			// Flake for now
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameHighGeneration,
+			})
+		} else {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameHighGeneration,
+			})
+		}
+
+		// ObservedGeneration should increase monotonically
+		testNameInvalidGeneration := fmt.Sprintf("objects in ns/%s should have generation increasing monotonically", namespace)
+		nsFailuresInvalidGeneration := namespaceToInvalidGenerationFailure[namespace]
+		if len(nsFailuresInvalidGeneration) > 0 {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameInvalidGeneration,
+				FailureOutput: &junitapi.FailureOutput{
+					Message: strings.Join(nsFailuresInvalidGeneration, "\n"),
+					Output:  "objects had observed generation increasing non-monotonically",
+				},
+			})
+			// Flake for now
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameInvalidGeneration,
+			})
+		} else {
+			ret = append(ret, &junitapi.JUnitTestCase{
+				Name: testNameInvalidGeneration,
+			})
+		}
+
+	}
+
+	return ret, nil
+}
+
+func (w *generationWatcher) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (w *generationWatcher) Cleanup(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Example CI run where the max allowed generation is 3 (for testing only) from [this job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29168/pull-ci-openshift-origin-master-e2e-aws-csi/1844711431623151616):

```
objects in ns/openshift-apiserver should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.664 I namespace/openshift-apiserver deployment/apiserver reason/HighGeneration Deployment generation too high: 7  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-authentication should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.665 I namespace/openshift-authentication deployment/oauth-openshift reason/HighGeneration Deployment generation too high: 4  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-cluster-csi-drivers should not have a generation greater than 3 expand_less
Run #0: Failed expand_less 	0s
{Oct 11 13:13:27.665 I namespace/openshift-cluster-csi-drivers deployment/aws-ebs-csi-driver-controller reason/HighGeneration Deployment generation too high: 4  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-console should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.665 I namespace/openshift-console deployment/console reason/HighGeneration Deployment generation too high: 5  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-controller-manager should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.665 I namespace/openshift-controller-manager deployment/controller-manager reason/HighGeneration Deployment generation too high: 7  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-oauth-apiserver should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.665 I namespace/openshift-oauth-apiserver deployment/apiserver reason/HighGeneration Deployment generation too high: 5  objects had a metadata.Generation higher than 3}
Run #1: Passed

objects in ns/openshift-route-controller-manager should not have a generation greater than 3 expand_less
Run #0: Failed
{Oct 11 13:13:27.665 I namespace/openshift-route-controller-manager deployment/route-controller-manager reason/HighGeneration Deployment generation too high: 5  objects had a metadata.Generation higher than 3}
Run #1: Passed
```