### PR TITLE
TRT-1851: Revert "NO-JIRA: external binary registry"

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
-	"github.com/openshift/origin/test/extended/util"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -125,36 +122,6 @@ func max(a, b int) int {
 	return b
 }
 
-type RunMatchFunc func(run *RunInformation) bool
-
-type RunInformation struct {
-	// jobType may be nil for topologies without
-	// platform identification.
-	*platformidentification.JobType
-	suite *TestSuite
-}
-
-type externalBinaryStruct struct {
-	// The payload image tag in which an external binary path can be found
-	imageTag string
-	// The binary path to extract from the image
-	binaryPath string
-
-	// nil, nil - run for all suites
-	// (), nil, - run for only those matched by include
-	// nil, () - run for all except excluded
-	// (), () - include overridden by exclude
-	includeForRun RunMatchFunc
-	excludeForRun RunMatchFunc
-}
-
-type externalBinaryResult struct {
-	err            error
-	skipReason     string
-	externalBinary *externalBinaryStruct
-	externalTests  []*testCase
-}
-
 func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, monitorTestInfo monitortestframework.MonitorTestInitializationInfo, upgrade bool) error {
 	ctx := context.Background()
 
@@ -163,95 +130,17 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 		return fmt.Errorf("failed reading origin test suites: %w", err)
 	}
 
-	fmt.Fprintf(o.Out, "Found %d tests for in openshift-tests binary for suite %q\n", len(tests), suite.Name)
+	fmt.Fprintf(o.Out, "found %d tests for suite\n", len(tests))
 
 	var fallbackSyntheticTestResult []*junitapi.JUnitTestCase
 	if len(os.Getenv("OPENSHIFT_SKIP_EXTERNAL_TESTS")) == 0 {
-		// A registry of available external binaries and in which image
-		// they reside in the payload.
-		externalBinaries := []externalBinaryStruct{
-			{
-				imageTag:   "hyperkube",
-				binaryPath: "/usr/bin/k8s-tests",
-			},
-		}
-
-		var (
-			externalTests []*testCase
-			wg            sync.WaitGroup
-			resultCh      = make(chan externalBinaryResult, len(externalBinaries))
-			err           error
-		)
-
-		// Lines logged to this logger will be included in the junit output for the
-		// external binary usage synthetic.
-		var extractDetailsBuffer bytes.Buffer
-		extractLogger := log.New(&extractDetailsBuffer, "", log.LstdFlags|log.Lmicroseconds)
-
-		oc := util.NewCLIWithoutNamespace("default")
-		jobType, err := platformidentification.GetJobType(context.Background(), oc.AdminConfig())
-		if err != nil {
-			// Microshift does not permit identification. External binaries must
-			// tolerate nil jobType.
-			extractLogger.Printf("Failed determining job type: %v", err)
-		}
-
-		runInformation := &RunInformation{
-			JobType: jobType,
-			suite:   suite,
-		}
-
-		releaseImageReferences, err := extractReleaseImageStream(extractLogger)
-		if err != nil {
-			return fmt.Errorf("unable to extract image references from release payload: %w", err)
-		}
-
-		for _, externalBinary := range externalBinaries {
-			wg.Add(1)
-			go func(externalBinary externalBinaryStruct) {
-				defer wg.Done()
-
-				var skipReason string
-				if (externalBinary.includeForRun != nil && !externalBinary.includeForRun(runInformation)) ||
-					(externalBinary.excludeForRun != nil && externalBinary.excludeForRun(runInformation)) {
-					skipReason = "excluded by suite selection functions"
-				}
-
-				var tagTestSet []*testCase
-				var tagErr error
-				if len(skipReason) == 0 {
-					tagTestSet, tagErr = externalTestsForSuite(ctx, extractLogger, releaseImageReferences, externalBinary.imageTag, externalBinary.binaryPath)
-				}
-
-				resultCh <- externalBinaryResult{
-					err:            tagErr,
-					skipReason:     skipReason,
-					externalBinary: &externalBinary,
-					externalTests:  tagTestSet,
-				}
-
-			}(externalBinary)
-		}
-
-		wg.Wait()
-		close(resultCh)
-
-		for result := range resultCh {
-			if result.skipReason != "" {
-				extractLogger.Printf("Skipping test discovery for image %q and binary %q: %v\n", result.externalBinary.imageTag, result.externalBinary.binaryPath, result.skipReason)
-			} else if result.err != nil {
-				extractLogger.Printf("Error during test discovery for image %q and binary %q: %v\n", result.externalBinary.imageTag, result.externalBinary.binaryPath, result.err)
-				err = result.err
-			} else {
-				extractLogger.Printf("Discovered %v tests from image %q and binary %q\n", len(result.externalTests), result.externalBinary.imageTag, result.externalBinary.binaryPath)
-				externalTests = append(externalTests, result.externalTests...)
-			}
-		}
-
+		buf := &bytes.Buffer{}
+		fmt.Fprintf(buf, "Attempting to pull tests from external binary...\n")
+		externalTests, err := externalTestsForSuite(ctx)
 		if err == nil {
-			var filteredTests []*testCase
+			filteredTests := []*testCase{}
 			for _, test := range tests {
-				// tests contains all the tests "registered" in openshift-tests binary,
+				// tests contains all the tests "registered" in openshif-tests binary,
 				// this also includes vendored k8s tests, since this path assumes we're
 				// using external binary to run these tests we need to remove them
 				// from the final lists, which contains:
@@ -262,29 +151,29 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 				}
 			}
 			tests = append(filteredTests, externalTests...)
-			extractLogger.Printf("Discovered a total of %v external tests and will run a total of %v\n", len(externalTests), len(tests))
+			fmt.Fprintf(buf, "Got %d tests from external binary\n", len(externalTests))
 		} else {
-			extractLogger.Printf("Errors encountered while extracting one or more external test suites; Falling back to built-in suite: %v\n", err)
+			fmt.Fprintf(buf, "Falling back to built-in suite, failed reading external test suites: %v\n", err)
 			// adding this test twice (one failure here, and success below) will
 			// ensure it gets picked as flake further down in synthetic tests processing
 			fallbackSyntheticTestResult = append(fallbackSyntheticTestResult, &junitapi.JUnitTestCase{
 				Name:      "[sig-arch] External binary usage",
-				SystemOut: extractDetailsBuffer.String(),
+				SystemOut: buf.String(),
 				FailureOutput: &junitapi.FailureOutput{
-					Output: extractDetailsBuffer.String(),
+					Output: buf.String(),
 				},
 			})
 		}
-		fmt.Fprintf(o.Out, extractDetailsBuffer.String())
+		fmt.Fprintf(o.Out, buf.String())
 		fallbackSyntheticTestResult = append(fallbackSyntheticTestResult, &junitapi.JUnitTestCase{
 			Name:      "[sig-arch] External binary usage",
-			SystemOut: extractDetailsBuffer.String(),
+			SystemOut: buf.String(),
 		})
 	} else {
 		fmt.Fprintf(o.Out, "Using built-in tests only due to OPENSHIFT_SKIP_EXTERNAL_TESTS being set\n")
 	}
 
-	fmt.Fprintf(o.Out, "Found %d tests (including externals)\n", len(tests))
+	fmt.Fprintf(o.Out, "found %d tests (incl externals)\n", len(tests))
 
 	// this ensures the tests are always run in random order to avoid
 	// any intra-tests dependencies

--- a/pkg/test/ginkgo/external.go
+++ b/pkg/test/ginkgo/external.go
@@ -2,18 +2,14 @@ package ginkgo
 
 import (
 	"bytes"
-	"compress/gzip"
 	"context"
-	"debug/elf"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -28,23 +24,15 @@ type serializedTest struct {
 	Labels string
 }
 
-// externalTestsForSuite extracts extension binaries from the release payload and
-// reads which tests it advertises.
-func externalTestsForSuite(ctx context.Context, logger *log.Logger, releaseReferences *imagev1.ImageStream, tag string, binaryPath string) ([]*testCase, error) {
+// externalTestsForSuite reads tests from external binary, currently only
+// k8s-tests is supported
+func externalTestsForSuite(ctx context.Context) ([]*testCase, error) {
 	var tests []*testCase
 
-	testBinary, err := extractBinaryFromReleaseImage(logger, releaseReferences, tag, binaryPath)
+	// TODO: add support for binaries from other images
+	testBinary, err := extractBinaryFromReleaseImage("hyperkube", "/usr/bin/k8s-tests")
 	if err != nil {
-		return nil, fmt.Errorf("unable to extract %q binary from tag %q: %w", binaryPath, tag, err)
-	}
-
-	compat, err := checkCompatibleArchitecture(testBinary)
-	if err != nil {
-		return nil, fmt.Errorf("unable to check compatibility external binary %q from tag %q: %w", binaryPath, tag, err)
-	}
-
-	if !compat {
-		return nil, fmt.Errorf("external binary %q from tag %q was compiled for incompatible architecture", binaryPath, tag)
+		return nil, fmt.Errorf("unable to extract k8s-tests binary: %w", err)
 	}
 
 	command := exec.Command(testBinary, "list")
@@ -61,8 +49,7 @@ func externalTestsForSuite(ctx context.Context, logger *log.Logger, releaseRefer
 		if !strings.HasPrefix(line, "[{") {
 			continue
 		}
-
-		var serializedTests []serializedTest
+		serializedTests := []serializedTest{}
 		err = json.Unmarshal([]byte(line), &serializedTests)
 		if err != nil {
 			return nil, err
@@ -78,101 +65,51 @@ func externalTestsForSuite(ctx context.Context, logger *log.Logger, releaseRefer
 	return tests, nil
 }
 
-// extractReleaseImageStream extracts image references from the current
-// cluster's release payload (or image specified by EXTENSIONS_PAYLOAD_OVERRIDE
-// or RELEASE_IMAGE_LATEST which is used in OpenShift Test Platform CI) and returns
-// an ImageStream object with tags associated with image-references from that payload.
-func extractReleaseImageStream(logger *log.Logger) (*imagev1.ImageStream, error) {
+// extractBinaryFromReleaseImage is responsible for resolving the tag from
+// release image and extracting binary, returns path to the binary or error
+func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
 	tmpDir, err := os.MkdirTemp("", "release")
 	if err != nil {
-		return nil, fmt.Errorf("cannot create temporary directory for extracted binary: %w", err)
+		return "", fmt.Errorf("cannot create temporary directory for extracted binary: %w", err)
 	}
 
 	oc := util.NewCLIWithoutNamespace("default")
-
-	var releaseImage string
-
-	// Highest priority override is EXTENSIONS_PAYLOAD_OVERRIDE
-	overrideReleaseImage := os.Getenv("EXTENSIONS_PAYLOAD_OVERRIDE")
-	if len(overrideReleaseImage) != 0 {
-		// if "cluster" is specified, prefer target cluster payload even if RELEASE_IMAGE_LATEST is set.
-		if overrideReleaseImage != "cluster" {
-			releaseImage = overrideReleaseImage
-			logger.Printf("Using env EXTENSIONS_PAYLOAD_OVERRIDE for release image %q", releaseImage)
-		}
-	} else {
-		// Allow testing using an overridden source for external tests.
-		envReleaseImage := os.Getenv("RELEASE_IMAGE_LATEST")
-		if len(envReleaseImage) != 0 {
-			releaseImage = envReleaseImage
-			logger.Printf("Using env RELEASE_IMAGE_LATEST for release image %q", releaseImage)
-		}
+	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed reading ClusterVersion/version: %w", err)
 	}
-
+	releaseImage := cv.Status.Desired.Image
 	if len(releaseImage) == 0 {
-		// Note that MicroShift does not have this resource. The test driver must use ENV vars.
-		cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("failed reading ClusterVersion/version: %w", err)
-		}
-
-		releaseImage = cv.Status.Desired.Image
-		if len(releaseImage) == 0 {
-			return nil, fmt.Errorf("cannot determine release image from ClusterVersion resource")
-		}
-		logger.Printf("Using target cluster release image %q", releaseImage)
+		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
 	}
 
 	if err := runImageExtract(releaseImage, "/release-manifests/image-references", tmpDir, ""); err != nil {
-		return nil, fmt.Errorf("failed extracting image-references from %q: %w", releaseImage, err)
+		return "", fmt.Errorf("failed extracting image-references: %w", err)
 	}
 	jsonFile, err := os.Open(filepath.Join(tmpDir, "image-references"))
 	if err != nil {
-		return nil, fmt.Errorf("failed reading image-references from %q: %w", releaseImage, err)
+		return "", fmt.Errorf("failed reading image-references: %w", err)
 	}
 	defer jsonFile.Close()
 	data, err := ioutil.ReadAll(jsonFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to load release image-references from %q: %w", releaseImage, err)
+		return "", fmt.Errorf("unable to load release image-references: %w", err)
 	}
 	is := &imagev1.ImageStream{}
 	if err := json.Unmarshal(data, &is); err != nil {
-		return nil, fmt.Errorf("unable to load release image-references from %q: %w", releaseImage, err)
+		return "", fmt.Errorf("unable to load release image-references: %w", err)
 	}
 	if is.Kind != "ImageStream" || is.APIVersion != "image.openshift.io/v1" {
-		return nil, fmt.Errorf("unrecognized image-references in release payload %q", releaseImage)
+		return "", fmt.Errorf("unrecognized image-references in release payload")
 	}
-
-	logger.Printf("Targeting release image %q for default external binaries", releaseImage)
-
-	// Allow environmental overrides for individual component images.
-	for _, tag := range is.Spec.Tags {
-		componentEnvName := "EXTENSIONS_PAYLOAD_OVERRIDE_" + tag.Name
-		componentOverrideImage := os.Getenv(componentEnvName)
-		if len(componentOverrideImage) != 0 {
-			tag.From.Name = componentOverrideImage
-			logger.Printf("Overrode release image tag %q for with env %s value %q", tag.Name, componentEnvName, componentOverrideImage)
-		}
-	}
-
-	return is, nil
-}
-
-// extractBinaryFromReleaseImage is responsible for resolving the tag from
-// release image and extracting binary, returns path to the binary or error
-func extractBinaryFromReleaseImage(logger *log.Logger, releaseImageReferences *imagev1.ImageStream, tag, binary string) (string, error) {
-
-	tmpDir, err := os.MkdirTemp("", "external-binary")
 
 	image := ""
-	for _, t := range releaseImageReferences.Spec.Tags {
+	for _, t := range is.Spec.Tags {
 		if t.Name == tag {
 			image = t.From.Name
 			break
 		}
 	}
-
-	oc := util.NewCLIWithoutNamespace("default")
 
 	// The preceding runImageExtract was against a release payload that was created in the local
 	// ci-operator namespace. Our process was free to access it. The release payload, however,
@@ -183,44 +120,27 @@ func extractBinaryFromReleaseImage(logger *log.Logger, releaseImageReferences *i
 	// from images referenced by the release payload.
 	clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("unable to read ephemeral cluster pull secret: %w", err)
+		return "", fmt.Errorf("unable to read ephemeral cluster pull secret: %v", err)
 	}
 
 	clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
 	dockerConfigJsonPath := filepath.Join(tmpDir, ".dockerconfigjson")
 	err = os.WriteFile(dockerConfigJsonPath, clusterDockerConfig, 0644)
 	if err != nil {
-		return "", fmt.Errorf("unable to serialize ephemeral cluster pull secret locally: %w", err)
+		return "", fmt.Errorf("unable to serialize ephemeral cluster pull secret locally: %v", err)
 	}
 
 	if len(image) == 0 {
 		return "", fmt.Errorf("%s not found", tag)
 	}
-
-	startTime := time.Now()
 	if err := runImageExtract(image, binary, tmpDir, dockerConfigJsonPath); err != nil {
 		return "", fmt.Errorf("failed extracting %q from %q: %w", binary, image, err)
 	}
-	extractDuration := time.Since(startTime)
 
 	extractedBinary := filepath.Join(tmpDir, filepath.Base(binary))
-	// Support gzipped external binaries as they will not be flagged by FIPS scan
-	// for being statically compiled.
-	extractedBinary, err = ungzipFile(extractedBinary)
-	if err != nil {
-		return "", fmt.Errorf("failed to decompress external binary %q: %w", binary, err)
-	}
-
 	if err := os.Chmod(extractedBinary, 0755); err != nil {
-		return "", fmt.Errorf("failed making the extracted binary %q executable: %w", extractedBinary, err)
+		return "", fmt.Errorf("failed making the extracted binary executable: %w", err)
 	}
-
-	fileInfo, err := os.Stat(extractedBinary)
-	if err != nil {
-		return "", fmt.Errorf("failed stat on extracted binary %q: %w", extractedBinary, err)
-	}
-
-	logger.Printf("Extracted %q for tag %q from %q (disk size %v, extraction duration %v)", binary, tag, image, fileInfo.Size(), extractDuration)
 	return extractedBinary, nil
 }
 
@@ -236,85 +156,4 @@ func runImageExtract(image, src, dst string, dockerConfigJsonPath string) error 
 		return fmt.Errorf("error during image extract: %w (%v)", err, string(out))
 	}
 	return nil
-}
-
-// ungzipFile checks if a binary is gzipped (ends with .gz) and decompresses it.
-// Returns the new filename of the decompressed file (original is deleted), or original filename if it was not gzipped.
-func ungzipFile(extractedBinary string) (string, error) {
-
-	if strings.HasSuffix(extractedBinary, ".gz") {
-
-		gzFile, err := os.Open(extractedBinary)
-		if err != nil {
-			return "", fmt.Errorf("failed to open gzip file: %w", err)
-		}
-		defer gzFile.Close()
-
-		gzipReader, err := gzip.NewReader(gzFile)
-		if err != nil {
-			return "", fmt.Errorf("failed to create gzip reader: %w", err)
-		}
-		defer gzipReader.Close()
-
-		newFilePath := strings.TrimSuffix(extractedBinary, ".gz")
-		outFile, err := os.Create(newFilePath)
-		if err != nil {
-			return "", fmt.Errorf("failed to create output file: %w", err)
-		}
-		defer outFile.Close()
-
-		if _, err := io.Copy(outFile, gzipReader); err != nil {
-			return "", fmt.Errorf("failed to write to output file: %w", err)
-		}
-
-		// Attempt to delete the original .gz file
-		if err := os.Remove(extractedBinary); err != nil {
-			return "", fmt.Errorf("failed to delete original .gz file: %w", err)
-		}
-
-		return newFilePath, nil
-	}
-
-	// Return the original path if the file was not decompressed
-	return extractedBinary, nil
-}
-
-// Checks whether the binary has a compatible CPU architecture  to the
-// host.
-func checkCompatibleArchitecture(executablePath string) (bool, error) {
-
-	file, err := os.Open(executablePath)
-	if err != nil {
-		return false, fmt.Errorf("failed to open ELF file: %w", err)
-	}
-	defer file.Close()
-
-	elfFile, err := elf.NewFile(file)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse ELF file: %w", err)
-	}
-
-	// Determine the architecture of the ELF file
-	elfArch := elfFile.Machine
-	var expectedArch elf.Machine
-
-	// Determine the host architecture
-	switch runtime.GOARCH {
-	case "amd64":
-		expectedArch = elf.EM_X86_64
-	case "arm64":
-		expectedArch = elf.EM_AARCH64
-	case "s390x":
-		expectedArch = elf.EM_S390
-	case "ppc64le":
-		expectedArch = elf.EM_PPC64
-	default:
-		return false, fmt.Errorf("unsupported host architecture: %s", runtime.GOARCH)
-	}
-
-	if elfArch == expectedArch {
-		return true, nil
-	}
-
-	return false, nil
 }


### PR DESCRIPTION
Reverts openshift/origin#29025

Failures beginning in [4.18.0-0.ci-2024-10-08-185524](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.ci/release/4.18.0-0.ci-2024-10-08-185524)

```
 Suite run returned error: unable to extract image references from release payload: failed extracting image-references from "registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524": error during image extract: exit status 1 (error: unable to read image registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524: unauthorized: authentication required
)
error running options: unable to extract image references from release payload: failed extracting image-references from "registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524": error during image extract: exit status 1 (error: unable to read image registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524: unauthorized: authentication required
)error: unable to extract image references from release payload: failed extracting image-references from "registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524": error during image extract: exit status 1 (error: unable to read image registry.ci.openshift.org/ocp/release:4.18.0-0.ci-2024-10-08-185524: unauthorized: authentication required
) 
```