### PR TITLE
[release-4.17] OCPBUGS-39606: Add image registry capability check

### DIFF
--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -224,7 +224,7 @@ func createNamespace(oc *exutil.CLI, name string, annotations map[string]string)
 	if err != nil {
 		return err
 	}
-	return exutil.WaitForServiceAccountWithSecret(oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
+	return exutil.WaitForServiceAccountWithSecret(oc.AdminConfigClient().ConfigV1().ClusterVersions(), oc.AdminKubeClient().CoreV1().ServiceAccounts(name), "builder")
 }
 
 func createDeployment(oc *exutil.CLI, name, namespace string, depLabels map[string]string, podAnnotations map[string]string) error {

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -340,6 +340,7 @@ func createTestBed(ctx context.Context, oc *exutil.CLI) {
 	err = callRBAC(ctx, oc, true)
 	Expect(err).NotTo(HaveOccurred())
 	err = exutil.WaitForServiceAccountWithSecret(
+		oc.AdminConfigClient().ConfigV1().ClusterVersions(),
 		oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace),
 		serviceAccountName)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1150,8 +1150,24 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 }
 
 // WaitForServiceAccountWithSecret waits until the named service account gets fully
-// provisioned, including dockercfg secrets
-func WaitForServiceAccountWithSecret(c corev1client.ServiceAccountInterface, name string) error {
+// provisioned, including dockercfg secrets. We also check if image registry is not enabled,
+// the SA will not contain the docker secret and we simply return nil.
+func WaitForServiceAccountWithSecret(config configclient.ClusterVersionInterface, c corev1client.ServiceAccountInterface, name string) error {
+	cv, err := config.Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var found bool
+	for _, capability := range cv.Status.Capabilities.EnabledCapabilities {
+		if capability == configv1.ClusterVersionCapabilityImageRegistry {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
 	waitFn := func() (bool, error) {
 		sa, err := c.Get(context.Background(), name, metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
Backport check for image registry capability to fix for `[sig-network] can collect pod-to-host poller pod logs`

8ab8b41c0adfcf999c6535031348d85a9fc663da
44824bbc69b3f3f56a34344c7cc8d05af02e5f45

https://github.com/openshift/origin/pull/29018
https://github.com/openshift/origin/pull/29077