### PR TITLE
OCPBUGS-41787: Ignore infra nodes on tap cni tests

### DIFF
--- a/test/extended/networking/tap.go
+++ b/test/extended/networking/tap.go
@@ -17,7 +17,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-const nodeLabelSelectorWorker = "node-role.kubernetes.io/worker,!node-role.kubernetes.io/edge"
+const nodeLabelSelectorWorker = "node-role.kubernetes.io/worker,!node-role.kubernetes.io/edge,!node-role.kubernetes.io/infra"
 
 var _ = g.Describe("[sig-network][Feature:tap]", func() {
 	oc := exutil.NewCLI("tap")


### PR DESCRIPTION
The tests fails to schedule on infra nodes. These nodes should be ignored.