### PR TITLE
NO-JIRA: Fix Network segmentation test for detecting timeout

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -519,7 +519,9 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 								"2",
 								net.JoinHostPort(ip, fmt.Sprintf("%d", port)),
 							)
-							Expect(strings.Contains(err.Error(), "Connection timeout")).To(Equal(true))
+							if err == nil {
+								framework.Failf("connection succeeded but expected timeout")
+							}
 						}
 					},
 					// can completely fill the L2 topology because it does not depend on the size of the clusters hostsubnet


### PR DESCRIPTION
Sample test failure signature:

```
STEP: Remaining blue pod cannot communicate with red networks overlapping CIDR @ 10/09/24 01:54:08.744
  I1009 01:54:08.744310 63202 builder.go:121] Running '/usr/bin/kubectl --server=https://api.ci-op-5vlfjmrg-64ca1.origin-ci-int-aws.dev.rhcloud.com:6443/ --kubeconfig=/tmp/kubeconfig-3159918400 --namespace=e2e-test-network-segmentation-e2e-jkxkx-blue exec blue-pod-3 -- curl --connect-timeout 2 203.203.0.4:9000'
  I1009 01:54:11.246120 63202 builder.go:135] rc: 28
    [FAILED] in [It] - github.com/openshift/origin/test/extended/networking/network_segmentation.go:522 @ 10/09/24 01:54:11.29
```


The objective of the test is that the connection does not succeed and I think thats sufficient instead of trying to play whackamole with timeouts and string detection.
