### PR TITLE
[release-4.17] OCPBUGS-43576: Porting testing for netConfig and UDN and CIDR overlapping tests from upstream

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -519,7 +519,9 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 								"2",
 								net.JoinHostPort(ip, fmt.Sprintf("%d", port)),
 							)
-							Expect(strings.Contains(err.Error(), "Connection timeout")).To(Equal(true))
+							if err == nil {
+								framework.Failf("connection succeeded but expected timeout")
+							}
 						}
 					},
 					// can completely fill the L2 topology because it does not depend on the size of the clusters hostsubnet

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	admissionapi "k8s.io/pod-security-admission/api"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
@@ -78,9 +77,6 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						clientPodConfig podConfiguration,
 						serverPodConfig podConfiguration,
 					) {
-						if netConfig.topology == "layer3" {
-							e2eskipper.Skipf("IPv6 routes are not configured on the tech-preview lane since the cluster config is single-stack IPv4")
-						}
 						var err error
 
 						netConfig.namespace = f.Namespace.Name

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -369,201 +369,194 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						})),
 					),
 				)
+				DescribeTable(
+					"isolates overlapping CIDRs",
+					func(
+						topology string,
+						numberOfPods int,
+						userDefinedv4Subnet string,
+						userDefinedv6Subnet string,
+
+					) {
+
+						red := "red"
+						blue := "blue"
+
+						namespaceRed := f.Namespace.Name + "-" + red
+						namespaceBlue := f.Namespace.Name + "-" + blue
+
+						netConfig := networkAttachmentConfigParams{
+							topology: topology,
+							cidr:     correctCIDRFamily(oc, userDefinedv4Subnet, userDefinedv6Subnet),
+							role:     "primary",
+						}
+						for _, namespace := range []string{namespaceRed, namespaceBlue} {
+							By("Creating namespace " + namespace)
+							_, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
+								ObjectMeta: metav1.ObjectMeta{
+									Name: namespace,
+								},
+							}, metav1.CreateOptions{})
+							Expect(err).NotTo(HaveOccurred())
+							defer func() {
+								Expect(cs.CoreV1().Namespaces().Delete(
+									context.Background(),
+									namespace,
+									metav1.DeleteOptions{},
+								)).To(Succeed())
+							}()
+						}
+						networkNamespaceMap := map[string]string{namespaceRed: red, namespaceBlue: blue}
+						for namespace, network := range networkNamespaceMap {
+							By("creating the network " + network + " in namespace " + namespace)
+							netConfig.namespace = namespace
+							netConfig.name = network
+
+							Expect(createNetworkFn(netConfig)).To(Succeed())
+						}
+						workerNodes, err := getWorkerNodesOrdered(cs)
+						Expect(err).NotTo(HaveOccurred())
+						pods := []*v1.Pod{}
+						redIPs := []string{}
+						blueIPs := []string{}
+						for namespace, network := range networkNamespaceMap {
+							for i := 0; i < numberOfPods; i++ {
+								podConfig := *podConfig(
+									fmt.Sprintf("%s-pod-%d", network, i),
+									withCommand(func() []string {
+										return httpServerContainerCmd(port)
+									}),
+								)
+								podConfig.namespace = namespace
+								//ensure testing accross nodes
+								if i%2 == 0 {
+									podConfig.nodeSelector = map[string]string{nodeHostnameKey: workerNodes[0].Name}
+
+								} else {
+
+									podConfig.nodeSelector = map[string]string{nodeHostnameKey: workerNodes[len(workerNodes)-1].Name}
+								}
+								By("creating pod " + podConfig.name + " in " + podConfig.namespace)
+								pod := runUDNPod(
+									cs,
+									podConfig.namespace,
+									podConfig,
+									func(pod *v1.Pod) {
+										setRuntimeDefaultPSA(pod)
+									})
+								pods = append(pods, pod)
+								podIP, err := podIPsForUserDefinedPrimaryNetwork(
+									cs,
+									pod.Namespace,
+									pod.Name,
+									namespacedName(namespace, network),
+									0,
+								)
+								Expect(err).NotTo(HaveOccurred())
+								if network == red {
+									redIPs = append(redIPs, podIP)
+								} else {
+									blueIPs = append(blueIPs, podIP)
+								}
+							}
+						}
+
+						By("ensuring pods only communicate with pods in their network")
+						for _, pod := range pods {
+							isRedPod := strings.Contains(pod.Name, red)
+							ips := redIPs
+							if !isRedPod {
+								ips = blueIPs
+							}
+							for _, ip := range ips {
+								result, err := e2ekubectl.RunKubectl(
+									pod.Namespace,
+									"exec",
+									pod.Name,
+									"--",
+									"curl",
+									"--connect-timeout",
+									"2",
+									net.JoinHostPort(ip, fmt.Sprintf("%d", port)+"/hostname"),
+								)
+								Expect(err).NotTo(HaveOccurred())
+								if isRedPod {
+									Expect(strings.Contains(result, red)).To(BeTrue())
+								} else {
+									Expect(strings.Contains(result, blue)).To(BeTrue())
+								}
+							}
+						}
+
+						By("Deleting pods in network blue except " + fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1))
+						for i := 0; i < numberOfPods-1; i++ {
+							err := cs.CoreV1().Pods(namespaceBlue).Delete(
+								context.Background(),
+								fmt.Sprintf("%s-pod-%d", blue, i),
+								metav1.DeleteOptions{},
+							)
+							Expect(err).NotTo(HaveOccurred())
+						}
+
+						podIP, err := podIPsForUserDefinedPrimaryNetwork(
+							cs,
+							namespaceBlue,
+							fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1),
+							namespacedName(namespaceBlue, blue),
+							0,
+						)
+						Expect(err).NotTo(HaveOccurred())
+
+						By("Remaining blue pod cannot communicate with red networks overlapping CIDR")
+						for _, ip := range redIPs {
+							if podIP == ip {
+								//don't try with your own IP
+								continue
+							}
+							_, err := e2ekubectl.RunKubectl(
+								namespaceBlue,
+								"exec",
+								fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1),
+								"--",
+								"curl",
+								"--connect-timeout",
+								"2",
+								net.JoinHostPort(ip, fmt.Sprintf("%d", port)),
+							)
+							Expect(strings.Contains(err.Error(), "Connection timeout")).To(Equal(true))
+						}
+					},
+					// can completely fill the L2 topology because it does not depend on the size of the clusters hostsubnet
+					Entry(
+						"with L2 primary UDN",
+						"layer2",
+						4,
+						"203.203.0.0/29",
+						"2014:100:200::0/125",
+					),
+					// limit the number of pods to 10
+					Entry(
+						"with L3 primary UDN",
+						"layer3",
+						10,
+						userDefinedNetworkIPv4Subnet,
+						userDefinedNetworkIPv6Subnet,
+					),
+				)
 			},
 			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(c)
 				nad := generateNAD(netConfig)
-				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), nad, metav1.CreateOptions{})
+				_, err := nadClient.NetworkAttachmentDefinitions(c.namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
 				udnManifest := generateUserDefinedNetworkManifest(&c)
-				cleanup, err := createManifest(f.Namespace.Name, udnManifest)
+				cleanup, err := createManifest(c.namespace, udnManifest)
 				DeferCleanup(cleanup)
-				Expect(waitForUserDefinedNetworkReady(f.Namespace.Name, c.name, udnCrReadyTimeout)).To(Succeed())
+				Expect(waitForUserDefinedNetworkReady(c.namespace, c.name, udnCrReadyTimeout)).To(Succeed())
 				return err
 			}),
-		)
-
-		DescribeTable(
-			"isolates overlapping CIDRs",
-			func(
-				topology string,
-				numberOfPods int,
-				userDefinedSubnet string,
-
-			) {
-
-				nadClient, err := nadclient.NewForConfig(f.ClientConfig())
-				Expect(err).NotTo(HaveOccurred())
-
-				red := "red"
-				blue := "blue"
-
-				namespaceRed := f.Namespace.Name + "-" + red
-				namespaceBlue := f.Namespace.Name + "-" + blue
-
-				nad := networkAttachmentConfigParams{
-					topology: topology,
-					cidr:     fmt.Sprintf("%s,%s", userDefinedSubnet, userDefinedNetworkIPv6Subnet),
-					role:     "primary",
-				}
-				for _, namespace := range []string{namespaceRed, namespaceBlue} {
-					By("Creating namespace " + namespace)
-					_, err = cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: namespace,
-						},
-					}, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-					defer func() {
-						Expect(cs.CoreV1().Namespaces().Delete(
-							context.Background(),
-							namespace,
-							metav1.DeleteOptions{},
-						)).To(Succeed())
-					}()
-				}
-				networkNamespaceMap := map[string]string{namespaceRed: red, namespaceBlue: blue}
-				for namespace, network := range networkNamespaceMap {
-					By("creating the attachment configuration for network " + network + " in namespace " + namespace)
-					netConfig := newNetworkAttachmentConfig(nad)
-					netConfig.namespace = namespace
-					netConfig.name = network
-
-					_, err = nadClient.NetworkAttachmentDefinitions(namespace).Create(
-						context.Background(),
-						generateNAD(netConfig),
-						metav1.CreateOptions{},
-					)
-					Expect(err).NotTo(HaveOccurred())
-				}
-				workerNodes, err := getWorkerNodesOrdered(cs)
-				Expect(err).NotTo(HaveOccurred())
-				pods := []*v1.Pod{}
-				redIPs := []string{}
-				blueIPs := []string{}
-				for namespace, network := range networkNamespaceMap {
-					for i := 0; i < numberOfPods; i++ {
-						podConfig := *podConfig(
-							fmt.Sprintf("%s-pod-%d", network, i),
-							withCommand(func() []string {
-								return httpServerContainerCmd(port)
-							}),
-						)
-						podConfig.namespace = namespace
-						//ensure testing accross nodes
-						if i%2 == 0 {
-							podConfig.nodeSelector = map[string]string{nodeHostnameKey: workerNodes[0].Name}
-
-						} else {
-
-							podConfig.nodeSelector = map[string]string{nodeHostnameKey: workerNodes[len(workerNodes)-1].Name}
-						}
-						By("creating pod " + podConfig.name + " in " + podConfig.namespace)
-						pod := runUDNPod(
-							cs,
-							podConfig.namespace,
-							podConfig,
-							func(pod *v1.Pod) {
-								setRuntimeDefaultPSA(pod)
-							})
-						pods = append(pods, pod)
-						podIP, err := podIPsForUserDefinedPrimaryNetwork(
-							cs,
-							pod.Namespace,
-							pod.Name,
-							namespacedName(namespace, network),
-							0,
-						)
-						Expect(err).NotTo(HaveOccurred())
-						if network == red {
-							redIPs = append(redIPs, podIP)
-						} else {
-							blueIPs = append(blueIPs, podIP)
-						}
-					}
-				}
-
-				By("ensuring pods only communicate with pods in their network")
-				for _, pod := range pods {
-					isRedPod := strings.Contains(pod.Name, red)
-					ips := redIPs
-					if !isRedPod {
-						ips = blueIPs
-					}
-					for _, ip := range ips {
-						result, err := e2ekubectl.RunKubectl(
-							pod.Namespace,
-							"exec",
-							pod.Name,
-							"--",
-							"curl",
-							"--connect-timeout",
-							"2",
-							net.JoinHostPort(ip, fmt.Sprintf("%d", port)+"/hostname"),
-						)
-						Expect(err).NotTo(HaveOccurred())
-						if isRedPod {
-							Expect(strings.Contains(result, red)).To(BeTrue())
-						} else {
-							Expect(strings.Contains(result, blue)).To(BeTrue())
-						}
-					}
-				}
-
-				By("Deleting pods in network blue except " + fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1))
-				for i := 0; i < numberOfPods-1; i++ {
-					err := cs.CoreV1().Pods(namespaceBlue).Delete(
-						context.Background(),
-						fmt.Sprintf("%s-pod-%d", blue, i),
-						metav1.DeleteOptions{},
-					)
-					Expect(err).NotTo(HaveOccurred())
-				}
-
-				podIP, err := podIPsForUserDefinedPrimaryNetwork(
-					cs,
-					namespaceBlue,
-					fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1),
-					namespacedName(namespaceBlue, blue),
-					0,
-				)
-				Expect(err).NotTo(HaveOccurred())
-
-				By("Remaining blue pod cannot communicate with red networks overlapping CIDR")
-				for _, ip := range redIPs {
-					if podIP == ip {
-						//don't try with your own IP
-						continue
-					}
-					_, err := e2ekubectl.RunKubectl(
-						namespaceBlue,
-						"exec",
-						fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1),
-						"--",
-						"curl",
-						"--connect-timeout",
-						"2",
-						net.JoinHostPort(ip, fmt.Sprintf("%d", port)),
-					)
-					Expect(strings.Contains(err.Error(), "Connection timeout")).To(Equal(true))
-				}
-			},
-			// can completely fill the L2 topology because it does not depend on the size of the clusters hostsubnet
-			Entry(
-				"with L2 primary UDN",
-				"layer2",
-				4,
-				"10.128.0.0/29",
-			),
-			// limit the number of pods to 10
-			Entry(
-				"with L3 primary UDN",
-				"layer3",
-				10,
-				userDefinedNetworkIPv4Subnet,
-			),
 		)
 
 		Context("UserDefinedNetwork", func() {
@@ -799,7 +792,7 @@ func generateCIDRforUDN(oc *exutil.CLI) string {
 `
 	} else if hasIPv6 {
 		cidr = `
-   - cidr: 2014:100:200::0/60
+    - cidr: 2014:100:200::0/60
 `
 	}
 	return cidr

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -60,6 +60,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						isHostNetwork bool,
 					) {
 						By("creating the network")
+						// correctCIDRFamily makes use of the ginkgo framework so it needs to be in the testcase
+						netConfig.cidr = correctCIDRFamily(oc, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
 						netConfig.namespace = f.Namespace.Name
 						Expect(createNetworkFn(netConfig)).To(Succeed())
 
@@ -119,41 +121,37 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 
 					},
 					Entry(
-						"L2 dualstack primary UDN, cluster-networked pods",
+						"L2 primary UDN, cluster-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
 					),
 					Entry(
-						"L3 dualstack primary UDN, cluster-networked pods",
+						"L3 primary UDN, cluster-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						false,
 					),
 					Entry(
-						"L2 dualstack primary UDN, host-networked pods",
+						"L2 primary UDN, host-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer2",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,
 					),
 					Entry(
-						"L3 dualstack primary UDN, host-networked pods",
+						"L3 primary UDN, host-networked pods",
 						networkAttachmentConfigParams{
 							name:     nadName,
 							topology: "layer3",
-							cidr:     fmt.Sprintf("%s,%s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 							role:     "primary",
 						},
 						true,

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1515,13 +1515,21 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of EndpointSlices pointing to the cluster or service network": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1503,17 +1503,29 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Serial] Should set the condition to false if there are no nodes able to host the source pods": " [Suite:openshift/conformance/serial]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes does not mirror EndpointSlices in namespaces not using user defined primary networks L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions does not mirror EndpointSlices in namespaces not using user defined primary networks L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes does not mirror EndpointSlices in namespaces not using user defined primary networks L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions does not mirror EndpointSlices in namespaces not using user defined primary networks L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork does not mirror EndpointSlices in namespaces not using user defined primary networks L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork does not mirror EndpointSlices in namespaces not using user defined primary networks L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork cannot be deleted when being used": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1515,6 +1515,12 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork cannot be deleted when being used": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork should create NetworkAttachmentDefinition according to spec": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork should delete NetworkAttachmentDefinition when UserDefinedNetwork is deleted": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
@@ -1530,6 +1536,8 @@ var Annotations = map[string]string{
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork status should report not-ready": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of EndpointSlices pointing to the cluster or service network": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1541,6 +1541,10 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions isolates overlapping CIDRs with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions isolates overlapping CIDRs with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes for two pods connected over a L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 primary UDN": " [Suite:openshift/conformance/parallel]",
@@ -1549,9 +1553,9 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork isolates overlapping CIDRs with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes isolates overlapping CIDRs with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork isolates overlapping CIDRs with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork status should report not-ready": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1507,25 +1507,25 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions does not mirror EndpointSlices in namespaces not using user defined primary networks L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork does not mirror EndpointSlices in namespaces not using user defined primary networks L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork does not mirror EndpointSlices in namespaces not using user defined primary networks L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L2 primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 primary UDN, cluster-networked pods": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 dualstack primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] EndpointSlices mirroring when using openshift ovn-kubernetes created using UserDefinedNetwork mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks L3 primary UDN, host-networked pods": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork cannot be deleted when being used": " [Suite:openshift/conformance/parallel]",
 
@@ -1533,21 +1533,21 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes UserDefinedNetwork should delete NetworkAttachmentDefinition when UserDefinedNetwork is deleted": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes for two pods connected over a L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions can perform east/west traffic between nodes two pods connected over a L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes for two pods connected over a L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes for two pods connected over a L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork can perform east/west traffic between nodes two pods connected over a L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L2 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1549,6 +1549,10 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated from the default network with L3 dualstack primary UDN": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary UDN": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes isolates overlapping CIDRs with L3 primary UDN": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork status should report not-ready": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][endpoints] admission [apigroup:config.openshift.io] blocks manual creation of EndpointSlices pointing to the cluster or service network": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -103,17 +103,33 @@ spec:
         managed by the default controller for namespaces with user defined primary
         networks L3 dualstack primary UDN, host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes can perform east/west traffic between
-        nodes for two pods connected over a L2 dualstack primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes can perform east/west traffic between
-        nodes two pods connected over a L3 dualstack primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes is isolated from the default network with
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        can perform east/west traffic between nodes for two pods connected over a
         L2 dualstack primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes is isolated from the default network with
-        L3 dualstack primary UDN'
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        can perform east/west traffic between nodes two pods connected over a L3 dualstack
+        primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        is isolated from the default network with L2 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        is isolated from the default network with L3 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
+        east/west traffic between nodes for two pods connected over a L2 dualstack
+        primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
+        east/west traffic between nodes two pods connected over a L3 dualstack primary
+        UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
+        from the default network with L2 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
+        from the default network with L3 dualstack primary UDN'
   - featureGate: SELinuxMount
     tests:
     - testName: '[sig-storage] CSI Mock selinux on mount SELinuxMount [LinuxOnly]

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -79,29 +79,61 @@ spec:
   - featureGate: NetworkSegmentation
     tests:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes does not mirror
-        EndpointSlices in namespaces not using user defined primary networks L2 dualstack
-        primary UDN'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions does not mirror EndpointSlices in namespaces
+        not using user defined primary networks L2 dualstack primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes does not mirror
-        EndpointSlices in namespaces not using user defined primary networks L3 dualstack
-        primary UDN'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions does not mirror EndpointSlices in namespaces
+        not using user defined primary networks L3 dualstack primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices
-        managed by the default controller for namespaces with user defined primary
-        networks L2 dualstack primary UDN, cluster-networked pods'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
+        controller for namespaces with user defined primary networks L2 dualstack
+        primary UDN, cluster-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices
-        managed by the default controller for namespaces with user defined primary
-        networks L2 dualstack primary UDN, host-networked pods'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
+        controller for namespaces with user defined primary networks L2 dualstack
+        primary UDN, host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices
-        managed by the default controller for namespaces with user defined primary
-        networks L3 dualstack primary UDN, cluster-networked pods'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
+        controller for namespaces with user defined primary networks L3 dualstack
+        primary UDN, cluster-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        EndpointSlices mirroring when using openshift ovn-kubernetes mirrors EndpointSlices
-        managed by the default controller for namespaces with user defined primary
-        networks L3 dualstack primary UDN, host-networked pods'
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
+        controller for namespaces with user defined primary networks L3 dualstack
+        primary UDN, host-networked pods'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork does not mirror EndpointSlices in namespaces not using
+        user defined primary networks L2 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork does not mirror EndpointSlices in namespaces not using
+        user defined primary networks L3 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork mirrors EndpointSlices managed by the default controller
+        for namespaces with user defined primary networks L2 dualstack primary UDN,
+        cluster-networked pods'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork mirrors EndpointSlices managed by the default controller
+        for namespaces with user defined primary networks L2 dualstack primary UDN,
+        host-networked pods'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork mirrors EndpointSlices managed by the default controller
+        for namespaces with user defined primary networks L3 dualstack primary UDN,
+        cluster-networked pods'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        EndpointSlices mirroring when using openshift ovn-kubernetes created using
+        UserDefinedNetwork mirrors EndpointSlices managed by the default controller
+        for namespaces with user defined primary networks L3 dualstack primary UDN,
+        host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork
         cannot be deleted when being used'

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -158,6 +158,12 @@ spec:
         when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
         is isolated from the default network with L3 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        isolates overlapping CIDRs with L2 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        isolates overlapping CIDRs with L3 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
         east/west traffic between nodes for two pods connected over a L2 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
@@ -170,11 +176,11 @@ spec:
         when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
         from the default network with L3 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary
-        UDN'
+        when using openshift ovn-kubernetes created using UserDefinedNetwork isolates
+        overlapping CIDRs with L2 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes isolates overlapping CIDRs with L3 primary
-        UDN'
+        when using openshift ovn-kubernetes created using UserDefinedNetwork isolates
+        overlapping CIDRs with L3 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork
         status should report not-ready'

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -103,6 +103,15 @@ spec:
         managed by the default controller for namespaces with user defined primary
         networks L3 dualstack primary UDN, host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork
+        cannot be deleted when being used'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes UserDefinedNetwork should create NetworkAttachmentDefinition
+        according to spec'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes UserDefinedNetwork should delete NetworkAttachmentDefinition
+        when UserDefinedNetwork is deleted'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
         can perform east/west traffic between nodes for two pods connected over a
         L2 dualstack primary UDN'
@@ -130,6 +139,9 @@ spec:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
         from the default network with L3 dualstack primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork
+        status should report not-ready'
   - featureGate: SELinuxMount
     tests:
     - testName: '[sig-storage] CSI Mock selinux on mount SELinuxMount [LinuxOnly]

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -89,23 +89,23 @@ spec:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
-        controller for namespaces with user defined primary networks L2 dualstack
-        primary UDN, cluster-networked pods'
+        controller for namespaces with user defined primary networks L2 primary UDN,
+        cluster-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
-        controller for namespaces with user defined primary networks L2 dualstack
-        primary UDN, host-networked pods'
+        controller for namespaces with user defined primary networks L2 primary UDN,
+        host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
-        controller for namespaces with user defined primary networks L3 dualstack
-        primary UDN, cluster-networked pods'
+        controller for namespaces with user defined primary networks L3 primary UDN,
+        cluster-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         NetworkAttachmentDefinitions mirrors EndpointSlices managed by the default
-        controller for namespaces with user defined primary networks L3 dualstack
-        primary UDN, host-networked pods'
+        controller for namespaces with user defined primary networks L3 primary UDN,
+        host-networked pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         UserDefinedNetwork does not mirror EndpointSlices in namespaces not using
@@ -117,23 +117,23 @@ spec:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         UserDefinedNetwork mirrors EndpointSlices managed by the default controller
-        for namespaces with user defined primary networks L2 dualstack primary UDN,
-        cluster-networked pods'
+        for namespaces with user defined primary networks L2 primary UDN, cluster-networked
+        pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         UserDefinedNetwork mirrors EndpointSlices managed by the default controller
-        for namespaces with user defined primary networks L2 dualstack primary UDN,
-        host-networked pods'
+        for namespaces with user defined primary networks L2 primary UDN, host-networked
+        pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         UserDefinedNetwork mirrors EndpointSlices managed by the default controller
-        for namespaces with user defined primary networks L3 dualstack primary UDN,
-        cluster-networked pods'
+        for namespaces with user defined primary networks L3 primary UDN, cluster-networked
+        pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         EndpointSlices mirroring when using openshift ovn-kubernetes created using
         UserDefinedNetwork mirrors EndpointSlices managed by the default controller
-        for namespaces with user defined primary networks L3 dualstack primary UDN,
-        host-networked pods'
+        for namespaces with user defined primary networks L3 primary UDN, host-networked
+        pods'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes UserDefinedNetwork pod connected to UserDefinedNetwork
         cannot be deleted when being used'
@@ -146,31 +146,29 @@ spec:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
         can perform east/west traffic between nodes for two pods connected over a
-        L2 dualstack primary UDN'
+        L2 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
-        can perform east/west traffic between nodes two pods connected over a L3 dualstack
-        primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
-        is isolated from the default network with L2 dualstack primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
-        is isolated from the default network with L3 dualstack primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
-        east/west traffic between nodes for two pods connected over a L2 dualstack
-        primary UDN'
-    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
-        east/west traffic between nodes two pods connected over a L3 dualstack primary
+        can perform east/west traffic between nodes two pods connected over a L3 primary
         UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
-        when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
-        from the default network with L2 dualstack primary UDN'
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        is isolated from the default network with L2 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions
+        is isolated from the default network with L3 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
+        east/west traffic between nodes for two pods connected over a L2 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork can perform
+        east/west traffic between nodes two pods connected over a L3 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
-        from the default network with L3 dualstack primary UDN'
+        from the default network with L2 primary UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
+        from the default network with L3 primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary
         UDN'

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -172,6 +172,12 @@ spec:
         when using openshift ovn-kubernetes created using UserDefinedNetwork is isolated
         from the default network with L3 dualstack primary UDN'
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes isolates overlapping CIDRs with L2 primary
+        UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
+        when using openshift ovn-kubernetes isolates overlapping CIDRs with L3 primary
+        UDN'
+    - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork
         status should report not-ready'
   - featureGate: SELinuxMount


### PR DESCRIPTION
This PR ports using a correct primary network configuration for all user defined networking tests, using both netConfig and UDN crd for all currently ported tests, and overlapping CIDR tests from upstream ovn-kubernetes