### PR TITLE
NO-JIRA: Enable external binary registry

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -214,57 +214,50 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 		// 3. A registry.ci.openshift.org/ocp-<arch>/release:<tag> (request registry.ci.openshift.org token).
 		// Within the pod, we don't necessarily have a pull-secret for #3 OR the component images
 		// a payload references (which are private, unless in a ci-op-* imagestream).
-		// For CI runs, conventionally, the cluster under test will possess a pull-secret
-		// with access to both the payload and component images. While it is technically
-		// possible to circumvent this convention (CI steps which mirror the images to
-		// another private registry and alter the conventional secret used in the install-config),
-		// we assume that most jobs will follow the convention.
-		// The convention will also generally be true for human users running e2e tests
-		// on a cluster.
-		// For any situation in which the convention is violated (e.g. Microshift, which
-		// has no openshift-config/pull-secret object), they must have one of the following:
-		// 1. Set the REGISTRY_AUTH_FILE environment variable to an auths file with
+		// We try the following options:
+		// 1. If set, use the REGISTRY_AUTH_FILE environment variable to an auths file with
 		//    pull secrets capable of reading appropriate payload & component image
 		//    information.
-		// 2. A file /run/secrets/ci.openshift.io/cluster-profile/pull-secret file
+		// 2. If it exists, use a file /run/secrets/ci.openshift.io/cluster-profile/pull-secret
 		//    (conventional location for pull-secret information for CI cluster profile).
-		// 3. No authentication required to access the release payload / component images.
-
+		// 3. Use openshift-config secret/pull-secret from the cluster-under-test, if it exists
+		//    (Microshift does not).
+		// 4. Use unauthenticated access to the payload image and component images.
 		registryAuthFilePath := os.Getenv("REGISTRY_AUTH_FILE")
 
 		// if the environment variable is not set, extract the target cluster's
 		// platform pull secret.
 		if len(registryAuthFilePath) != 0 {
-			extractLogger.Printf("Using registry auth file: %v", registryAuthFilePath)
+			extractLogger.Printf("Using REGISTRY_AUTH_FILE environment variable: %v", registryAuthFilePath)
 		} else {
-			// Read its dockerconfigjson value and use it when extracting external test binaries
-			// from images referenced by the release payload.
-			clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
-			if err != nil {
-				if kapierrs.IsNotFound(err) {
-					extractLogger.Printf("Cluster has no openshift-config secret/pull-secret")
-					ciProfilePullSecretPath := "/run/secrets/ci.openshift.io/cluster-profile/pull-secret"
-					_, err = os.Stat(ciProfilePullSecretPath)
-					if os.IsNotExist(err) {
-						extractLogger.Printf("No %v; falling back to unauthenticated image access", ciProfilePullSecretPath)
+
+			// See if the cluster-profile has stored a pull-secret at the conventional location.
+			ciProfilePullSecretPath := "/run/secrets/ci.openshift.io/cluster-profile/pull-secret"
+			_, err = os.Stat(ciProfilePullSecretPath)
+			if !os.IsNotExist(err) {
+				extractLogger.Printf("Detected %v; using cluster profile for image access", ciProfilePullSecretPath)
+				registryAuthFilePath = ciProfilePullSecretPath
+			} else {
+				// Inspect the cluster-under-test and read its cluster pull-secret dockerconfigjson value.
+				clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
+				if err != nil {
+					if kapierrs.IsNotFound(err) {
+						extractLogger.Printf("Cluster has no openshift-config secret/pull-secret; falling back to unauthenticated image access")
 					} else {
-						extractLogger.Printf("Detected %v; using cluster profile for image access", ciProfilePullSecretPath)
-						registryAuthFilePath = ciProfilePullSecretPath
+						return fmt.Errorf("unable to read ephemeral cluster pull secret: %w", err)
 					}
 				} else {
-					return fmt.Errorf("unable to read ephemeral cluster pull secret: %w", err)
-				}
-			} else {
-				tmpDir, err := os.MkdirTemp("", "external-binary")
-				clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
-				registryAuthFilePath = filepath.Join(tmpDir, ".dockerconfigjson")
-				err = os.WriteFile(registryAuthFilePath, clusterDockerConfig, 0600)
-				if err != nil {
-					return fmt.Errorf("unable to serialize ephemeral cluster pull secret locally: %w", err)
-				}
+					tmpDir, err := os.MkdirTemp("", "external-binary")
+					clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
+					registryAuthFilePath = filepath.Join(tmpDir, ".dockerconfigjson")
+					err = os.WriteFile(registryAuthFilePath, clusterDockerConfig, 0600)
+					if err != nil {
+						return fmt.Errorf("unable to serialize target cluster pull-secret locally: %w", err)
+					}
 
-				defer os.Remove(registryAuthFilePath)
-				extractLogger.Printf("Using target cluster pull-secrets for registry auth")
+					defer os.Remove(registryAuthFilePath)
+					extractLogger.Printf("Using target cluster pull-secrets for registry auth")
+				}
 			}
 		}
 

--- a/pkg/test/ginkgo/external.go
+++ b/pkg/test/ginkgo/external.go
@@ -2,14 +2,18 @@ package ginkgo
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
+	"debug/elf"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -24,15 +28,23 @@ type serializedTest struct {
 	Labels string
 }
 
-// externalTestsForSuite reads tests from external binary, currently only
-// k8s-tests is supported
-func externalTestsForSuite(ctx context.Context) ([]*testCase, error) {
+// externalTestsForSuite extracts extension binaries from the release payload and
+// reads which tests it advertises.
+func externalTestsForSuite(ctx context.Context, logger *log.Logger, releaseReferences *imagev1.ImageStream, tag string, binaryPath string, registryAuthFilePath string) ([]*testCase, error) {
 	var tests []*testCase
 
-	// TODO: add support for binaries from other images
-	testBinary, err := extractBinaryFromReleaseImage("hyperkube", "/usr/bin/k8s-tests")
+	testBinary, err := extractBinaryFromReleaseImage(logger, releaseReferences, tag, binaryPath, registryAuthFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to extract k8s-tests binary: %w", err)
+		return nil, fmt.Errorf("unable to extract %q binary from tag %q: %w", binaryPath, tag, err)
+	}
+
+	compat, err := checkCompatibleArchitecture(testBinary)
+	if err != nil {
+		return nil, fmt.Errorf("unable to check compatibility external binary %q from tag %q: %w", binaryPath, tag, err)
+	}
+
+	if !compat {
+		return nil, fmt.Errorf("external binary %q from tag %q was compiled for incompatible architecture", binaryPath, tag)
 	}
 
 	command := exec.Command(testBinary, "list")
@@ -49,7 +61,8 @@ func externalTestsForSuite(ctx context.Context) ([]*testCase, error) {
 		if !strings.HasPrefix(line, "[{") {
 			continue
 		}
-		serializedTests := []serializedTest{}
+
+		var serializedTests []serializedTest
 		err = json.Unmarshal([]byte(line), &serializedTests)
 		if err != nil {
 			return nil, err
@@ -65,82 +78,128 @@ func externalTestsForSuite(ctx context.Context) ([]*testCase, error) {
 	return tests, nil
 }
 
-// extractBinaryFromReleaseImage is responsible for resolving the tag from
-// release image and extracting binary, returns path to the binary or error
-func extractBinaryFromReleaseImage(tag, binary string) (string, error) {
+// extractReleaseImageStream extracts image references from the current
+// cluster's release payload (or image specified by EXTENSIONS_PAYLOAD_OVERRIDE
+// or RELEASE_IMAGE_LATEST which is used in OpenShift Test Platform CI) and returns
+// an ImageStream object with tags associated with image-references from that payload.
+func extractReleaseImageStream(logger *log.Logger, registryAuthFilePath string) (*imagev1.ImageStream, error) {
 	tmpDir, err := os.MkdirTemp("", "release")
 	if err != nil {
-		return "", fmt.Errorf("cannot create temporary directory for extracted binary: %w", err)
+		return nil, fmt.Errorf("cannot create temporary directory for extracted binary: %w", err)
 	}
 
 	oc := util.NewCLIWithoutNamespace("default")
-	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("failed reading ClusterVersion/version: %w", err)
-	}
-	releaseImage := cv.Status.Desired.Image
-	if len(releaseImage) == 0 {
-		return "", fmt.Errorf("cannot determine release image from ClusterVersion resource")
+
+	var releaseImage string
+
+	// Highest priority override is EXTENSIONS_PAYLOAD_OVERRIDE
+	overrideReleaseImage := os.Getenv("EXTENSIONS_PAYLOAD_OVERRIDE")
+	if len(overrideReleaseImage) != 0 {
+		// if "cluster" is specified, prefer target cluster payload even if RELEASE_IMAGE_LATEST is set.
+		if overrideReleaseImage != "cluster" {
+			releaseImage = overrideReleaseImage
+			logger.Printf("Using env EXTENSIONS_PAYLOAD_OVERRIDE for release image %q", releaseImage)
+		}
+	} else {
+		// Allow testing using an overridden source for external tests.
+		envReleaseImage := os.Getenv("RELEASE_IMAGE_LATEST")
+		if len(envReleaseImage) != 0 {
+			releaseImage = envReleaseImage
+			logger.Printf("Using env RELEASE_IMAGE_LATEST for release image %q", releaseImage)
+		}
 	}
 
-	if err := runImageExtract(releaseImage, "/release-manifests/image-references", tmpDir, ""); err != nil {
-		return "", fmt.Errorf("failed extracting image-references: %w", err)
+	if len(releaseImage) == 0 {
+		// Note that MicroShift does not have this resource. The test driver must use ENV vars.
+		cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed reading ClusterVersion/version: %w", err)
+		}
+
+		releaseImage = cv.Status.Desired.Image
+		if len(releaseImage) == 0 {
+			return nil, fmt.Errorf("cannot determine release image from ClusterVersion resource")
+		}
+		logger.Printf("Using target cluster release image %q", releaseImage)
+	}
+
+	if err := runImageExtract(releaseImage, "/release-manifests/image-references", tmpDir, registryAuthFilePath); err != nil {
+		return nil, fmt.Errorf("failed extracting image-references from %q: %w", releaseImage, err)
 	}
 	jsonFile, err := os.Open(filepath.Join(tmpDir, "image-references"))
 	if err != nil {
-		return "", fmt.Errorf("failed reading image-references: %w", err)
+		return nil, fmt.Errorf("failed reading image-references from %q: %w", releaseImage, err)
 	}
 	defer jsonFile.Close()
 	data, err := ioutil.ReadAll(jsonFile)
 	if err != nil {
-		return "", fmt.Errorf("unable to load release image-references: %w", err)
+		return nil, fmt.Errorf("unable to load release image-references from %q: %w", releaseImage, err)
 	}
 	is := &imagev1.ImageStream{}
 	if err := json.Unmarshal(data, &is); err != nil {
-		return "", fmt.Errorf("unable to load release image-references: %w", err)
+		return nil, fmt.Errorf("unable to load release image-references from %q: %w", releaseImage, err)
 	}
 	if is.Kind != "ImageStream" || is.APIVersion != "image.openshift.io/v1" {
-		return "", fmt.Errorf("unrecognized image-references in release payload")
+		return nil, fmt.Errorf("unrecognized image-references in release payload %q", releaseImage)
 	}
 
+	logger.Printf("Targeting release image %q for default external binaries", releaseImage)
+
+	// Allow environmental overrides for individual component images.
+	for _, tag := range is.Spec.Tags {
+		componentEnvName := "EXTENSIONS_PAYLOAD_OVERRIDE_" + tag.Name
+		componentOverrideImage := os.Getenv(componentEnvName)
+		if len(componentOverrideImage) != 0 {
+			tag.From.Name = componentOverrideImage
+			logger.Printf("Overrode release image tag %q for with env %s value %q", tag.Name, componentEnvName, componentOverrideImage)
+		}
+	}
+
+	return is, nil
+}
+
+// extractBinaryFromReleaseImage is responsible for resolving the tag from
+// release image and extracting binary, returns path to the binary or error
+func extractBinaryFromReleaseImage(logger *log.Logger, releaseImageReferences *imagev1.ImageStream, tag, binary string, registryAuthFilePath string) (string, error) {
+
+	tmpDir, err := os.MkdirTemp("", "external-binary")
+
 	image := ""
-	for _, t := range is.Spec.Tags {
+	for _, t := range releaseImageReferences.Spec.Tags {
 		if t.Name == tag {
 			image = t.From.Name
 			break
 		}
 	}
 
-	// The preceding runImageExtract was against a release payload that was created in the local
-	// ci-operator namespace. Our process was free to access it. The release payload, however,
-	// may be referencing images in other registries that we don't have access to (e.g. quay.io,
-	// registry.ci.openshift.org). One location that does have access is in the cluster under test.
-	// The cluster-wide pull-secret must have pull access to these images in order for it to have
-	// installed. Read its dockerconfigjson value and use it when extracting external test binaries
-	// from images referenced by the release payload.
-	clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("unable to read ephemeral cluster pull secret: %v", err)
-	}
-
-	clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
-	dockerConfigJsonPath := filepath.Join(tmpDir, ".dockerconfigjson")
-	err = os.WriteFile(dockerConfigJsonPath, clusterDockerConfig, 0644)
-	if err != nil {
-		return "", fmt.Errorf("unable to serialize ephemeral cluster pull secret locally: %v", err)
-	}
-
 	if len(image) == 0 {
 		return "", fmt.Errorf("%s not found", tag)
 	}
-	if err := runImageExtract(image, binary, tmpDir, dockerConfigJsonPath); err != nil {
+
+	startTime := time.Now()
+	if err := runImageExtract(image, binary, tmpDir, registryAuthFilePath); err != nil {
 		return "", fmt.Errorf("failed extracting %q from %q: %w", binary, image, err)
 	}
+	extractDuration := time.Since(startTime)
 
 	extractedBinary := filepath.Join(tmpDir, filepath.Base(binary))
-	if err := os.Chmod(extractedBinary, 0755); err != nil {
-		return "", fmt.Errorf("failed making the extracted binary executable: %w", err)
+	// Support gzipped external binaries as they will not be flagged by FIPS scan
+	// for being statically compiled.
+	extractedBinary, err = ungzipFile(extractedBinary)
+	if err != nil {
+		return "", fmt.Errorf("failed to decompress external binary %q: %w", binary, err)
 	}
+
+	if err := os.Chmod(extractedBinary, 0755); err != nil {
+		return "", fmt.Errorf("failed making the extracted binary %q executable: %w", extractedBinary, err)
+	}
+
+	fileInfo, err := os.Stat(extractedBinary)
+	if err != nil {
+		return "", fmt.Errorf("failed stat on extracted binary %q: %w", extractedBinary, err)
+	}
+
+	logger.Printf("Extracted %q for tag %q from %q (disk size %v, extraction duration %v)", binary, tag, image, fileInfo.Size(), extractDuration)
 	return extractedBinary, nil
 }
 
@@ -156,4 +215,85 @@ func runImageExtract(image, src, dst string, dockerConfigJsonPath string) error 
 		return fmt.Errorf("error during image extract: %w (%v)", err, string(out))
 	}
 	return nil
+}
+
+// ungzipFile checks if a binary is gzipped (ends with .gz) and decompresses it.
+// Returns the new filename of the decompressed file (original is deleted), or original filename if it was not gzipped.
+func ungzipFile(extractedBinary string) (string, error) {
+
+	if strings.HasSuffix(extractedBinary, ".gz") {
+
+		gzFile, err := os.Open(extractedBinary)
+		if err != nil {
+			return "", fmt.Errorf("failed to open gzip file: %w", err)
+		}
+		defer gzFile.Close()
+
+		gzipReader, err := gzip.NewReader(gzFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to create gzip reader: %w", err)
+		}
+		defer gzipReader.Close()
+
+		newFilePath := strings.TrimSuffix(extractedBinary, ".gz")
+		outFile, err := os.Create(newFilePath)
+		if err != nil {
+			return "", fmt.Errorf("failed to create output file: %w", err)
+		}
+		defer outFile.Close()
+
+		if _, err := io.Copy(outFile, gzipReader); err != nil {
+			return "", fmt.Errorf("failed to write to output file: %w", err)
+		}
+
+		// Attempt to delete the original .gz file
+		if err := os.Remove(extractedBinary); err != nil {
+			return "", fmt.Errorf("failed to delete original .gz file: %w", err)
+		}
+
+		return newFilePath, nil
+	}
+
+	// Return the original path if the file was not decompressed
+	return extractedBinary, nil
+}
+
+// Checks whether the binary has a compatible CPU architecture  to the
+// host.
+func checkCompatibleArchitecture(executablePath string) (bool, error) {
+
+	file, err := os.Open(executablePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open ELF file: %w", err)
+	}
+	defer file.Close()
+
+	elfFile, err := elf.NewFile(file)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse ELF file: %w", err)
+	}
+
+	// Determine the architecture of the ELF file
+	elfArch := elfFile.Machine
+	var expectedArch elf.Machine
+
+	// Determine the host architecture
+	switch runtime.GOARCH {
+	case "amd64":
+		expectedArch = elf.EM_X86_64
+	case "arm64":
+		expectedArch = elf.EM_AARCH64
+	case "s390x":
+		expectedArch = elf.EM_S390
+	case "ppc64le":
+		expectedArch = elf.EM_PPC64
+	default:
+		return false, fmt.Errorf("unsupported host architecture: %s", runtime.GOARCH)
+	}
+
+	if elfArch == expectedArch {
+		return true, nil
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
https://github.com/openshift/origin/pull/29025 introduced an external binary registry. The code assumed that the release payload it analyzed could be accessed without authentication. This is true for every payload except release controller nightly & CI payloads (e.g. registry.ci.openshift.org/ocp/release:<tag>). RELEASE_IMAGE_LATEST, in contexts, like aggregated jobs, directly reference registry.ci instead of payloads in the `ci-op-*` namespace.
https://github.com/openshift/origin/pull/29025 was reverted because it could not access the release controller formulated payloads in these contexts. 
With this PR, the previous method of finding pull-secrets for the installed cluster in order to authorize access to component images is also leveraged to access the release payload image.
It also adds a fallback for clusters that lack a cluster pull-secret (MicroShift), which will check for `REGISTRY_AUTH_FILE` or a Test Platform cluster profile pull-secret file in its conventional location.