### PR TITLE
OCPBUGS-43059: fix: sno issues with alerts and pathological events

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/basic_alert.go
+++ b/pkg/monitortestlibrary/allowedalerts/basic_alert.go
@@ -355,6 +355,12 @@ func (a *basicAlertTest) InvariantCheck(allEventIntervals monitorapi.Intervals, 
 	state, message := a.failOrFlake(firingIntervals, pendingIntervals)
 
 	switch a.alertName {
+	case "KubeAPIErrorBudgetBurn":
+		// Currently this is a known issue that happens less often on HA but more frequently on single node
+		// TODO: Remove this flake when OCPBUGS-42083 is resolved
+		if state == fail && a.jobType.Topology == "single" {
+			state = flake
+		}
 	case "KubePodNotReady":
 		if state == fail && (kubePodNotReadyDueToImagePullBackoff(resourcesMap["events"], firingIntervals) || kubePodNotReadyDueToErrParsingSignature(resourcesMap["events"], firingIntervals)) {
 			// Since this is due to imagePullBackoff, change the state to flake instead of fail

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -159,7 +159,7 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 			msg: monitorapi.NewMessage().HumanMessage("Readiness probe failed: Get \"https://10.0.30.87:9980/readyz\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)").
 				Reason("ProbeError").Build(),
 			expectedAllowName: "",
-			expectedMatchName: "EtcdReadinessProbeFailuresPerRevisionChange",
+			expectedMatchName: "EtcdReadinessProbeFailuresPerRevisionChange,KubeAPIServerProgressingDuringSingleNodeUpgrade",
 		},
 		{
 			name: "multiple versions found probably in transition",
@@ -192,7 +192,7 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 				matches, matcher := registry.MatchesAny(i)
 				assert.True(t, matches, "event should have matched")
 				require.NotNil(t, matcher, "a matcher should have been returned")
-				assert.Equal(t, test.expectedMatchName, matcher.Name(), "event was not matched by the correct matcher")
+				assert.Contains(t, test.expectedMatchName, matcher.Name(), "event was not matched by the correct matcher")
 			}
 
 			if test.expectedAllowName != "" {

--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -36,6 +36,12 @@ func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 			topologyToExclude: "single",
 		},
 		{
+			// snapshot controller operator seems to fail on SNO during kube api upgrades
+			// the error from the pod is the inability to connect to the kas to get volumesnapshots on startup.
+			containerName:     "container/snapshot-controller", // https://issues.redhat.com/browse/OCPBUGS-43113
+			topologyToExclude: "single",
+		},
+		{
 			containerName: "container/kube-multus", // https://issues.redhat.com/browse/OCPBUGS-42267
 		},
 		{

--- a/pkg/monitortests/node/legacynodemonitortests/monitortest.go
+++ b/pkg/monitortests/node/legacynodemonitortests/monitortest.go
@@ -35,6 +35,9 @@ func (*legacyMonitorTests) ConstructComputedIntervals(ctx context.Context, start
 }
 
 func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+
+	clusterData, _ := platformidentification.BuildClusterData(context.Background(), w.adminRESTConfig)
+
 	containerFailures, err := testContainerFailures(w.adminRESTConfig, finalIntervals)
 	if err != nil {
 		return nil, err
@@ -64,7 +67,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testNodeHasSufficientMemory(finalIntervals)...)
 	junits = append(junits, testNodeHasSufficientPID(finalIntervals)...)
 	junits = append(junits, testBackoffPullingRegistryRedhatImage(finalIntervals)...)
-	junits = append(junits, testBackoffStartingFailedContainer(finalIntervals)...)
+	junits = append(junits, testBackoffStartingFailedContainer(clusterData, finalIntervals)...)
 	junits = append(junits, testConfigOperatorReadinessProbe(finalIntervals)...)
 	junits = append(junits, testConfigOperatorProbeErrorReadinessProbe(finalIntervals)...)
 	junits = append(junits, testConfigOperatorProbeErrorLivenessProbe(finalIntervals)...)

--- a/pkg/monitortests/node/legacynodemonitortests/pathological_events.go
+++ b/pkg/monitortests/node/legacynodemonitortests/pathological_events.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestlibrary/pathologicaleventlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 )
 
@@ -55,8 +56,12 @@ func testBackoffPullingRegistryRedhatImage(events monitorapi.Intervals) []*junit
 // testBackoffStartingFailedContainer looks for this symptom in core namespaces:
 //
 //	reason/BackOff Back-off restarting failed container
-func testBackoffStartingFailedContainer(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+func testBackoffStartingFailedContainer(clusterData platformidentification.ClusterData, events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	testName := "[sig-cluster-lifecycle] pathological event should not see excessive Back-off restarting failed containers"
+
+	events = events.Filter(
+		monitorapi.Not(pathologicaleventlibrary.IsDuringAPIServerProgressingOnSNO(clusterData.Topology, events)),
+	)
 
 	return pathologicaleventlibrary.NewSingleEventThresholdCheck(testName, pathologicaleventlibrary.AllowBackOffRestartingFailedContainer,
 		pathologicaleventlibrary.DuplicateEventThreshold, pathologicaleventlibrary.BackoffRestartingFlakeThreshold).

--- a/test/e2e/upgrade/dns/dns.go
+++ b/test/e2e/upgrade/dns/dns.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
 	kappsv1 "k8s.io/api/apps/v1"
 	kapiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +64,13 @@ func (t *UpgradeTest) Test(ctx context.Context, f *framework.Framework, done <-c
 
 	ginkgo.By("Sleeping for a minute to give it time for verifying DNS after upgrade")
 	time.Sleep(1 * time.Minute)
+
+	// TODO: Remove once OCPBUGS-42777 is resolved
+	ex := exutil.NewCLIWithFramework(f)
+	if isSNO, err := exutil.IsSingleNode(ctx, ex.AdminConfigClient()); err == nil && isSNO {
+		// Add one minute for more data to be collected for validation
+		time.Sleep(1 * time.Minute)
+	}
 
 	ginkgo.By("Validating DNS results after upgrade")
 	t.validateDNSResults(f)


### PR DESCRIPTION
Updating some tests and modifying some checks for SNO upgrade errors, each one of these skips is being tracked and will be removed or modified when the underlying issue is resolved.

* Flake KubeAPIErrorBudgetBurn until resolved
* Skip container restart for snapshot-controller 
* Modify DNS test until regression is resolved 
* Added the pathological errors during kube api progressing, this will be modified or removed upon further investigation on it's usefulness 