### PR TITLE
OPRUN-3576: Add OLMv1 origin tests

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -1,0 +1,60 @@
+package operators
+
+import (
+	"fmt"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	olmv1GroupName = "olm.operatorframework.io"
+)
+
+var _ = g.Describe("[sig-olmv1] OLMv1 CRDs", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should be installed", func(ctx g.SpecContext) {
+		// Check for tech preview, if this is not tech preview, bail
+		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
+			g.Skip("Test only runs in tech-preview")
+		}
+
+		// supports multiple versions during transision
+		providedAPIs := []struct {
+			group   string
+			version []string
+			plural  string
+		}{
+			{
+				group:   olmv1GroupName,
+				version: []string{"v1alpha1", "v1"},
+				plural:  "clusterextensions",
+			},
+			{
+				group:   olmv1GroupName,
+				version: []string{"v1alpha1", "v1"},
+				plural:  "clustercatalogs",
+			},
+		}
+
+		for _, api := range providedAPIs {
+			g.By(fmt.Sprintf("checking %s at version %s [apigroup:%s]", api.plural, api.version, api.group))
+			// Ensure expected version exists in spec.versions and is both served and stored
+			var err error
+			var raw string
+			for _, ver := range api.version {
+				raw, err = oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==%q)]}", ver)).Output()
+				if err == nil {
+					break
+				}
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(raw).To(o.MatchRegexp(`served.?:true`))
+			o.Expect(raw).To(o.MatchRegexp(`storage.?:true`))
+		}
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1665,6 +1665,8 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation should have correct cpuset and cpushare set in crio containers": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-olmv1] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should be installed with catalogsources at version v1alpha1 [apigroup:operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This is the initial test. Only works on tech-preview. Checks for presence of OLMv1 CRDs.