### PR TITLE
NO-JIRA: Introduce version annotation test for Windows nodes

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -56,4 +56,5 @@ import (
 	_ "github.com/openshift/origin/test/extended/tbr_health"
 	_ "github.com/openshift/origin/test/extended/templates"
 	_ "github.com/openshift/origin/test/extended/user"
+	_ "github.com/openshift/origin/test/extended/windows"
 )

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1754,6 +1754,8 @@ var Annotations = map[string]string{
 	"[sig-storage][Late] Metrics should report short attach times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
 	"[sig-storage][Late] Metrics should report short mount times": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
+
+	"[sig-windows] Nodes should fail with invalid version annotation": " [Suite:openshift/conformance/parallel]",
 }
 
 func init() {

--- a/test/extended/windows/OWNERS
+++ b/test/extended/windows/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+# Follows https://github.com/openshift/windows-machine-config-operator root OWNERS
+
+reviewers:
+  - sebsoto
+  - mansikulkarni96
+approvers:
+  - sebsoto
+  - mansikulkarni96

--- a/test/extended/windows/nodes.go
+++ b/test/extended/windows/nodes.go
@@ -1,0 +1,55 @@
+package windows
+
+import (
+	"context"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// NodeLabelSelector is a label selector that can be used to filter Windows nodes
+	NodeLabelSelector = corev1.LabelOSStable + "=windows"
+	// VersionAnnotation indicates the version of WMCO that configured the node
+	VersionAnnotation = "windowsmachineconfig.openshift.io/version"
+)
+
+var _ = g.Describe("[sig-windows] Nodes", func() {
+	defer g.GinkgoRecover()
+
+	var windowsNodes []corev1.Node
+
+	oc := exutil.NewCLIWithoutNamespace("windows")
+
+	g.BeforeEach(func() {
+		// fetch the list of Windows nodes
+		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(),
+			metav1.ListOptions{LabelSelector: NodeLabelSelector})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		// update the windowsNodes variable to the list of Windows nodes
+		windowsNodes = nodes.Items
+		// skip if no Windows nodes
+		if len(windowsNodes) < 1 {
+			g.Skip("Skip. No Windows node found on the test cluster.")
+		}
+	})
+
+	g.It("should fail with invalid version annotation", func() {
+		g.By("process version annotation")
+		for _, node := range windowsNodes {
+			annotations := node.GetAnnotations()
+			v, ok := annotations[VersionAnnotation]
+			if !ok {
+				e2e.Failf("missing version annotation on node %s", node.Name)
+			}
+			if strings.TrimSpace(v) == "" {
+				e2e.Failf("emtpy version annotation on node %s", node.Name)
+			}
+		}
+	})
+})


### PR DESCRIPTION
This PR proposes a new group of tests targeting Windows nodes in the test cluster and introduces a simple Windows-specific check as the first step in providing test coverage for Windows nodes.