### PR TITLE
ETCD-674: Add E2E test for scaling when an unhealthy member is present

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1141,6 +1141,8 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery][Timeout:30m] [Feature:EtcdRecovery][Disruptive] Restore snapshot from node on another single unhealthy node": " [Serial]",
 
+	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to vertically scale down when a member is unhealthy [apigroup:machine.openshift.io]": "",
+
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]": "",
 
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",


### PR DESCRIPTION
 The following test covers a vertical scaling scenario when a member is unhealthy.This test validates that scale down happens before scale up if the deleted member is unhealthy.CPMS is disabled to observe that scale-down happens first in this case.

1. If the CPMS is active, first disable it by deleting the CPMS custom resource.
2. Remove the static pod manifest from a node and stop the kubelet on the node. This makes the member unhealthy.
3. Delete the machine hosting the node in step 2.
4. Verify the member removal and the total voting member count of 2 to ensure scale-down happens first when a member is unhealthy.
5. Restore the initial cluster state by creating a new machine(scale-up) and re-enabling CPMS