### PR TITLE
DNM/SPLAT-1854: fix: setup platform external as none

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -103,7 +103,7 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		"clusterState": clusterState,
 	}).Info("Decoding provider")
 	switch providerTypeOrJSON {
-	case "none":
+	case "none", "external":
 		config := &ClusterConfiguration{
 			ProviderName: "skeleton",
 		}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -4,11 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
-	"github.com/openshift/origin/test/extended/util"
 	"io/ioutil"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"math/rand"
 	"os"
@@ -19,6 +15,11 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/test/extended/util"
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sirupsen/logrus"
 
@@ -223,7 +224,8 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 		// 3. Use openshift-config secret/pull-secret from the cluster-under-test, if it exists
 		//    (Microshift does not).
 		// 4. Use unauthenticated access to the payload image and component images.
-		registryAuthFilePath := os.Getenv("REGISTRY_AUTH_FILE")
+		// registryAuthFilePath := os.Getenv("REGISTRY_AUTH_FILE")
+		registryAuthFilePath := fmt.Sprintf("%s/pull-secret-with-ci", os.Getenv("SHARED_DIR"))
 
 		// if the environment variable is not set, extract the target cluster's
 		// platform pull secret.


### PR DESCRIPTION

This PR is investigating changes affecting platform external clusters making presubmit jobs with permanent failures.

release repo PR: https://github.com/openshift/release/pull/57954

Example of failed job: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/57954/rehearse-57954-pull-ci-openshift-installer-master-e2e-external-aws-ccm/1847341737333231616#1:build-log.txt%3A175-179