### PR TITLE
OCPBUGS-43512: New ManagedBootImages test appears to be failing too often

### DIFF
--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -107,7 +107,7 @@ func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
 			return false
 		}
 		return true
-	}, 30*time.Second, 2*time.Second).Should(o.BeTrue())
+	}, 2*time.Minute, 5*time.Second).Should(o.BeTrue())
 	framework.Logf("Succesfully verified that the cluster operator is degraded")
 
 	// Remove the owner reference from this machineset
@@ -126,6 +126,6 @@ func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
 			return false
 		}
 		return true
-	}, 30*time.Second, 2*time.Second).Should(o.BeTrue())
+	}, 2*time.Minute, 5*time.Second).Should(o.BeTrue())
 	framework.Logf("Succesfully verified that the cluster operator is no longer degraded")
 }


### PR DESCRIPTION
This test extends the timeout for the following test to 2 minutes, as 30 seconds seems to be too short.
```
[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/serial]
```