### PR TITLE
NO-JIRA: update-tls-artifacts: set owner to unknown if unset

### DIFF
--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/annotation_requirement.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/annotation_requirement.go
@@ -117,7 +117,12 @@ func (o annotationRequirement) generateInspectionMarkdown(pkiInfo *certs.PKIRegi
 		violatingOwners := sets.StringKeySet(violatingCertsByOwner)
 		violatingOwners.Insert(sets.StringKeySet(violatingCABundlesByOwner).UnsortedList()...)
 		for _, owner := range violatingOwners.List() {
-			md.Title(3, fmt.Sprintf("%s (%d)", owner, len(violatingCertsByOwner[owner])+len(violatingCABundlesByOwner[owner])))
+			// Show custom label if owner is unset
+			ownerLabel := owner
+			if len(owner) == 0 {
+				ownerLabel = UnknownOwner
+			}
+			md.Title(3, fmt.Sprintf("%s (%d)", ownerLabel, len(violatingCertsByOwner[owner])+len(violatingCABundlesByOwner[owner])))
 			violatingCerts := violatingCertsByOwner[owner]
 			if len(violatingCerts) > 0 {
 				md.Title(4, fmt.Sprintf("Certificates (%d)", len(violatingCerts)))

--- a/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/helpers.go
+++ b/pkg/cmd/update-tls-artifacts/generate-owners/tlsmetadatainterfaces/helpers.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-const UnknownOwner = "Unknown"
+const UnknownOwner = "Unknown Owner"
 
 var (
 	onDiskCertKeyPairs = certs.CertKeyPairInfoByOnDiskLocation{

--- a/tls/autoregenerate-after-expiry/autoregenerate-after-expiry.md
+++ b/tls/autoregenerate-after-expiry/autoregenerate-after-expiry.md
@@ -3,7 +3,7 @@
 ## Table of Contents
   - [How to meet the requirement](#How-to-meet-the-requirement)
   - [Items Do NOT Meet the Requirement (258)](#Items-Do-NOT-Meet-the-Requirement-258)
-    - [ (4)](#-4)
+    - [Unknown Owner (4)](#Unknown-Owner-4)
       - [Certificates (2)](#Certificates-2)
       - [Certificate Authority Bundles (2)](#Certificate-Authority-Bundles-2)
     - [Bare Metal Hardware Provisioning / cluster-baremetal-operator (1)](#Bare-Metal-Hardware-Provisioning-/-cluster-baremetal-operator-1)
@@ -70,7 +70,7 @@ This assertion means that you have
 If you have not done this, you should not merge the annotation.
 
 ## Items Do NOT Meet the Requirement (258)
-###  (4)
+### Unknown Owner (4)
 #### Certificates (2)
 1. ns/openshift-ingress secret/router-certs-default
 

--- a/tls/descriptions/descriptions.md
+++ b/tls/descriptions/descriptions.md
@@ -3,7 +3,7 @@
 ## Table of Contents
   - [How to meet the requirement](#How-to-meet-the-requirement)
   - [Items Do NOT Meet the Requirement (127)](#Items-Do-NOT-Meet-the-Requirement-127)
-    - [ (4)](#-4)
+    - [Unknown Owner (4)](#Unknown-Owner-4)
       - [Certificates (2)](#Certificates-2)
       - [Certificate Authority Bundles (2)](#Certificate-Authority-Bundles-2)
     - [Bare Metal Hardware Provisioning / cluster-baremetal-operator (1)](#Bare-Metal-Hardware-Provisioning-/-cluster-baremetal-operator-1)
@@ -63,7 +63,7 @@ These descriptions must be in the style of API documentation and must include
 To create a description, set the `openshift.io/description` annotation to the markdown formatted string describing your TLS artifact. 
 
 ## Items Do NOT Meet the Requirement (127)
-###  (4)
+### Unknown Owner (4)
 #### Certificates (2)
 1. ns/openshift-ingress secret/router-certs-default
 


### PR DESCRIPTION
Avoid empty string in some markdown reports for TLS registry, instead sets the label as "Unknown"