### PR TITLE
NO-JIRA: managed services: skip JSON patch tests

### DIFF
--- a/test/extended/apiserver/patch.go
+++ b/test/extended/apiserver/patch.go
@@ -6,7 +6,6 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -20,6 +19,7 @@ import (
 	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
 	"github.com/openshift/library-go/pkg/apiserver/jsonpatch"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+
 	"github.com/openshift/origin/test/extended/testdata"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -29,6 +29,14 @@ var _ = g.Describe("[sig-api-machinery] JSON Patch [apigroup:operator.openshift.
 	gvr := operatorv1.GroupVersion.WithResource("kubeapiservers")
 	gvk := operatorv1.GroupVersion.WithKind("KubeAPIServer")
 	oc := exutil.NewCLIWithoutNamespace("json-patch")
+
+	g.BeforeEach(func() {
+		isManagedServiceCluster, err := exutil.IsManagedServiceCluster(ctx, oc.AdminKubeClient())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		if isManagedServiceCluster {
+			g.Skip("skipping JSON Patch tests on managed service cluster")
+		}
+	})
 
 	g.It("should delete an entry from an array with a test precondition provided", func() {
 		g.By("Creating KubeAPIServerOperator CR for the test")

--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -45,6 +45,7 @@ var excludedPriorityClassPods = map[string][]string{
 	"openshift-monitoring": {
 		"osd-rebalance-infra-nodes",
 		"configure-alertmanager-operator",
+		"osd-cluster-ready",
 	},
 	"openshift-must-gather-operator": {
 		"must-gather-operator",
@@ -73,6 +74,7 @@ var excludedPriorityClassPods = map[string][]string{
 	"openshift-route-monitor-operator": {
 		"route-monitor-operator-controller-manager",
 		"blackbox-exporter",
+		"route-monitor-operator-registry",
 	},
 	"openshift-security": {
 		"audit-exporter",

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -61,6 +61,7 @@ import (
 	"github.com/openshift/library-go/pkg/build/naming"
 	"github.com/openshift/library-go/pkg/git"
 	"github.com/openshift/library-go/pkg/image/imageutil"
+
 	"github.com/openshift/origin/test/extended/testdata"
 	utilimage "github.com/openshift/origin/test/extended/util/image"
 )
@@ -2261,6 +2262,19 @@ func IsSelfManagedHA(ctx context.Context, configClient clientconfigv1.Interface)
 	}
 
 	return infrastructure.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode, nil
+}
+
+func IsManagedServiceCluster(ctx context.Context, adminClient kubernetes.Interface) (bool, error) {
+	_, err := adminClient.CoreV1().Namespaces().Get(ctx, "openshift-backplane", metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+
+	if !kapierrs.IsNotFound(err) {
+		return false, err
+	}
+
+	return false, nil
 }
 
 func IsSingleNode(ctx context.Context, configClient clientconfigv1.Interface) (bool, error) {


### PR DESCRIPTION
These tests are prevented from working on managed clusters:

```
    admission webhook "regular-user-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed resources. This is in an effort to prevent harmful actions that may cause unintended consequences or affect the stability of the cluster. If you have any questions about this, please reach out to Red Hat support at https://access.redhat.com/support
```