### PR TITLE
MCO-1370: Add boot image configmap test to openshift/origin

### DIFF
--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -50,4 +50,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
 		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
 	})
+
+	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", func() {
+		EnsureConfigMapStampTest(oc, allMachineSetFixture)
+	})
 })

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -50,4 +50,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
 		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
 	})
+
+	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", func() {
+		EnsureConfigMapStampTest(oc, allMachineSetFixture)
+	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1325,6 +1325,8 @@ var Annotations = map[string]string{
 
 	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
 
+	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
 	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
 
 	"[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
@@ -1332,6 +1334,8 @@ var Annotations = map[string]string{
 	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
 
 	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
+
+	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
 
 	"[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/serial]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -87,6 +87,8 @@ spec:
         on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should not update
         boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should stamp
+        coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update
         boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImages][Serial] Should update
@@ -97,6 +99,8 @@ spec:
         on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should not
         update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should stamp
+        coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update
         boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]'
     - testName: '[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial] Should update


### PR DESCRIPTION
This adds one more boot image update test to the MCO's test suite. This test ensures that the boot image configmap "stamp" action by the operator is always done, as long as at least one master node is up to date.