### PR TITLE
OCPBUGS-26603: e2e: Fix IPv6 handling in router tests.

### DIFF
--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -238,7 +238,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 				defer t.Close()
 				t.Within(
 					time.Minute,
-					exurl.Expect("GET", url).Through(routerIP).SkipTLSVerification().HasStatusCode(200),
+					exurl.Expect("GET", url).Through(exutil.IPUrl(routerIP)).SkipTLSVerification().HasStatusCode(200),
 				)
 			})
 		})
@@ -268,6 +268,10 @@ func createScopedRouterPod(routerImage, routerName, pemData, updateStatus string
 									FieldPath: "metadata.namespace",
 								},
 							},
+						},
+						{
+							Name:  "ROUTER_IP_V4_V6_MODE",
+							Value: "v4v6",
 						},
 						{
 							Name:  "DEFAULT_CERTIFICATE",

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -567,6 +567,8 @@ http {
 })
 
 func waitForRouteToRespond(ns, execPodName, proto, host, abspath, ipaddr string, port int) error {
+	// bracket IPv6 IPs when used as URI
+	host = exutil.IPUrl(host)
 	if port == 0 {
 		switch proto {
 		case "http":

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(metricsIP, "1936"))

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -165,7 +165,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 					}
 					// send a burst of traffic to the router
 					g.By("sending traffic to a weighted route")
-					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", host), routeHost, http.StatusOK, times, proxyProtocol)
+					err = expectRouteStatusCodeRepeatedExec(ns, execPodName, fmt.Sprintf("http://%s", exutil.IPUrl(host)), routeHost, http.StatusOK, times, proxyProtocol)
 					o.Expect(err).NotTo(o.HaveOccurred())
 				}
 				g.By("retrying metrics until all backend servers appear")

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should support reencrypt to services backed by a serving certificate automatically", func() {
-			routerURL := fmt.Sprintf("https://%s", ip)
+			routerURL := fmt.Sprintf("https://%s", exutil.IPUrl(ip))
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -22,6 +22,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	defer g.GinkgoRecover()
 	var (
 		host, ns string
+		ipUrl    string
 		oc       *exutil.CLI
 
 		configPath = exutil.FixturePath("testdata", "router", "ingress.yaml")
@@ -52,6 +53,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	g.BeforeEach(func() {
 		var err error
 		host, err = exutil.WaitForRouterServiceIP(oc)
+		// bracket IPv6
+		ipUrl = exutil.IPUrl(host)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		ns = oc.KubeFramework().Namespace.Name
@@ -63,8 +66,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			defer t.Close()
 			t.Within(
 				time.Minute,
-				url.Expect("GET", "https://www.google.com").Through(host).SkipTLSVerification().HasStatusCode(503),
-				url.Expect("GET", "http://www.google.com").Through(host).HasStatusCode(503),
+				url.Expect("GET", "https://www.google.com").Through(ipUrl).SkipTLSVerification().HasStatusCode(503),
+				url.Expect("GET", "http://www.google.com").Through(ipUrl).HasStatusCode(503),
 			)
 		})
 
@@ -89,12 +92,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			defer t.Close()
 			t.Within(
 				3*time.Minute,
-				url.Expect("GET", "http://1.ingress-test.com/test").Through(host).HasStatusCode(200),
-				url.Expect("GET", "http://1.ingress-test.com/other/deep").Through(host).HasStatusCode(200),
-				url.Expect("GET", "http://1.ingress-test.com/").Through(host).HasStatusCode(503),
-				url.Expect("GET", "http://2.ingress-test.com/").Through(host).HasStatusCode(200),
-				url.Expect("GET", "https://3.ingress-test.com/").Through(host).SkipTLSVerification().HasStatusCode(200),
-				url.Expect("GET", "http://3.ingress-test.com/").Through(host).RedirectsTo("https://3.ingress-test.com/", http.StatusFound),
+				url.Expect("GET", "http://1.ingress-test.com/test").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "http://1.ingress-test.com/other/deep").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "http://1.ingress-test.com/").Through(ipUrl).HasStatusCode(503),
+				url.Expect("GET", "http://2.ingress-test.com/").Through(ipUrl).HasStatusCode(200),
+				url.Expect("GET", "https://3.ingress-test.com/").Through(ipUrl).SkipTLSVerification().HasStatusCode(200),
+				url.Expect("GET", "http://3.ingress-test.com/").Through(ipUrl).RedirectsTo("https://3.ingress-test.com/", http.StatusFound),
 			)
 		})
 	})

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))
@@ -137,7 +137,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 			pattern := "%s-%s.myapps.mycompany.com"
 
 			g.By("waiting for the healthz endpoint to respond")
@@ -203,7 +203,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 			pattern := "%s-%s.apps.veto.test"
 
 			g.By("waiting for the healthz endpoint to respond")
@@ -241,6 +241,8 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 })
 
 func waitForRouterOKResponseExec(ns, execPodName, url, host string, timeoutSeconds int) error {
+	// bracket IPv6 IPs when used as URI
+	host = exutil.IPUrl(host)
 	cmd := fmt.Sprintf(`
 		set -e
 		pass=%[4]d
@@ -364,6 +366,10 @@ func createOverrideRouterPod(routerImage string) *corev1.Pod {
 							},
 						},
 						{
+							Name:  "ROUTER_IP_V4_V6_MODE",
+							Value: "v4v6",
+						},
+						{
 							Name:  "DEFAULT_CERTIFICATE",
 							Value: defaultPemData,
 						},
@@ -428,6 +434,10 @@ func createOverrideDomainRouterPod(routerImage string) *corev1.Pod {
 									FieldPath: "metadata.namespace",
 								},
 							},
+						},
+						{
+							Name:  "ROUTER_IP_V4_V6_MODE",
+							Value: "v4v6",
 						},
 						{
 							Name:  "DEFAULT_CERTIFICATE",

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -199,6 +199,10 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 									},
 								},
 								{
+									Name:  "ROUTER_IP_V4_V6_MODE",
+									Value: "v4v6",
+								},
+								{
 									Name:  "DEFAULT_CERTIFICATE",
 									Value: defaultPemData,
 								},
@@ -359,7 +363,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			// router expected to listen on port 80
-			routerURL := fmt.Sprintf("http://%s", routerIP)
+			routerURL := fmt.Sprintf("http://%s", exutil.IPUrl(routerIP))
 
 			g.By("waiting for the healthz endpoint to respond")
 			healthzURI := fmt.Sprintf("http://%s/healthz", net.JoinHostPort(routerIP, "1936"))

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50721,6 +50721,7 @@ items:
       http {
         server {
             listen 8443;
+            listen [::]:8443 ipv6only=on;
             ssl    on;
             ssl_certificate     /etc/serving-cert/tls.crt;
             ssl_certificate_key    /etc/serving-cert/tls.key;

--- a/test/extended/testdata/router/reencrypt-serving-cert.yaml
+++ b/test/extended/testdata/router/reencrypt-serving-cert.yaml
@@ -50,6 +50,7 @@ items:
       http {
         server {
             listen 8443;
+            listen [::]:8443 ipv6only=on;
             ssl    on;
             ssl_certificate     /etc/serving-cert/tls.crt;
             ssl_certificate_key    /etc/serving-cert/tls.key;

--- a/test/extended/util/net.go
+++ b/test/extended/util/net.go
@@ -1,0 +1,26 @@
+package util
+
+// This is copied from go/src/internal/bytealg, which includes versions
+// optimized for various platforms.  Those optimizations are elided here so we
+// don't have to maintain them.
+func IndexByteString(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// IPUrl safely converts a bare IPv4 or IPv6 into URL form with brackets
+//
+// This is copied from net.JoinHostPort, but without the port
+// Use  net.JoinHostPort if you have host and port.
+func IPUrl(host string) string {
+	// We assume that host is a literal IPv6 address if host has
+	// colons, and isn't already bracketed.
+	if len(host) > 0 && !(host[0] == '[' && host[len(host)-1] == ']') && IndexByteString(host, ':') >= 0 {
+		return "[" + host + "]"
+	}
+	return host
+}


### PR DESCRIPTION
curl requires that ipv6 addresses are in brackets. This change adds the IPUrl function to handle adding those brackets when necessary.

Several tests also create router pods directly, and thus require that the environment variable ROUTER_IP_V4_V6_MODE is set. Setting it to "v4v6" should allow the router to work in all environments.

This is part of the fix for OCPBUGS-26603.