### PR TITLE
OCPBUGS-38713: Adjust createDNSPod() to support hypershift dual-stack test

### DIFF
--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -27,12 +27,12 @@ import (
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
+	ocpv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
 )
 
-func createDNSPod(namespace, probeCmd string) *kapiv1.Pod {
-	nodeSelector := map[string]string{"node-role.kubernetes.io/master": ""}
+func createDNSPod(namespace, probeCmd string, nodeSelector map[string]string) *kapiv1.Pod {
 	pod := &kapiv1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -411,6 +411,15 @@ func validateLocalDNSPodPreference(queryPodExec *exutil.PodExecutor, localDNSPod
 var _ = Describe("[sig-network-edge] DNS", func() {
 	f := e2e.NewDefaultFramework("dns")
 	oc := exutil.NewCLI("dns-dualstack")
+	nodeSelector := make(map[string]string)
+
+	BeforeEach(func() {
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if *controlPlaneTopology != ocpv1.ExternalTopologyMode {
+			nodeSelector["node-role.kubernetes.io/master"] = ""
+		}
+	})
 
 	It("should answer endpoint and wildcard queries for the cluster", func() {
 		ctx := context.Background()
@@ -492,7 +501,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 
 		// Run a pod which probes DNS and exposes the results by HTTP.
 		By("creating a pod to probe DNS")
-		pod := createDNSPod(f.Namespace.Name, cmd)
+		pod := createDNSPod(f.Namespace.Name, cmd, nodeSelector)
 		validateDNSResults(f, pod, expect, times)
 	})
 
@@ -580,7 +589,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 
 		// Run a pod which probes DNS and exposes the results.
 		By("creating a pod to probe DNS")
-		pod := createDNSPod(f.Namespace.Name, cmd)
+		pod := createDNSPod(f.Namespace.Name, cmd, nodeSelector)
 		validateDNSResults(f, pod, expect, times)
 	})
 


### PR DESCRIPTION
For HyperShift, since master nodes are not visible in the HostedCluster, adjust createDNSPod() to support dual-stack testing in HyperShift.

test job: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29228/pull-ci-openshift-origin-release-4.16-e2e-agent-connected-ovn-dualstack-metal3/1849379580285030400
```
passed: (20.9s) 2024-10-24T12:00:01 "[sig-network-edge] DNS should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io] [Suite:openshift/conformance/parallel]"
```