### PR TITLE
SDN-4168: Add IPsec resilience tests

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -55,6 +55,7 @@ var staticSuites = []ginkgo.TestSuite{
 		},
 		Parallelism:          30,
 		MaximumAllowedFlakes: 15,
+		TestTimeout:          20 * time.Minute,
 	},
 	{
 		Name: "openshift/conformance/serial",

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1391,15 +1391,6 @@ func (p *PortAllocator) allocatePort(port int) error {
 	return nil
 }
 
-// deleteDaemonSet deletes the Daemonset <namespace>/<dsName>.
-func deleteDaemonSet(clientset kubernetes.Interface, namespace, dsName string) error {
-	deleteOptions := metav1.DeleteOptions{}
-	if err := clientset.AppsV1().DaemonSets(namespace).Delete(context.TODO(), dsName, deleteOptions); err != nil {
-		return fmt.Errorf("Failed to delete DaemonSet %s/%s: %v", namespace, dsName, err)
-	}
-	return nil
-}
-
 // createHostNetworkedDaemonSetAndProbe creates a host networked pod in namespace <namespace> on
 // node <nodeName>. It will allocate a port to listen on and it will return
 // the DaemonSet or an error.

--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -166,14 +166,14 @@ var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 				}
 			}
 		}
-		errs := parallelTest(6, testFns)
+		errs := ParallelTest(6, testFns)
 		o.Expect(errs).To(o.Equal([]error(nil)))
 	})
 })
 
-// parallelTest runs the provided fns in parallel with at most workers and returns an array of all
+// ParallelTest runs the provided fns in parallel with at most workers and returns an array of all
 // non nil errors.
-func parallelTest(workers int, fns []func() error) []error {
+func ParallelTest(workers int, fns []func() error) []error {
 	var wg sync.WaitGroup
 	work := make(chan func() error, workers)
 	results := make(chan error, workers)

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1391,6 +1391,10 @@ var Annotations = map[string]string{
 
 	"[sig-network-edge][Feature:Idling] Unidling with Deployments [apigroup:route.openshift.io] should work with UDP": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network] IPsec resilience when using openshift ovn-kubernetes check pod traffic are working across nodes after ipsec daemonset restart": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network] IPsec resilience when using openshift ovn-kubernetes check pod traffic are working across nodes": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network] external gateway address when using openshift ovn-kubernetes should match the address family of the pod": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This PR adds required resilience e2e tests which ensures IPsec deployment and pod traffic are working in all such scenarios.