### PR TITLE
SDN-4930: Set startup probe for UDN tests

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -202,6 +202,17 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 								PeriodSeconds:       1,
 								FailureThreshold:    1,
 							}
+							pod.Spec.Containers[0].StartupProbe = &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.FromInt32(port),
+									},
+								},
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+								FailureThreshold:    3,
+							}
 							// add NET_ADMIN to change pod routes
 							pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
 								Capabilities: &v1.Capabilities{


### PR DESCRIPTION
Hit downstream:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2314/pull-ci-openshift-ovn-kubernetes-master-e2e-gcp-ovn-techpreview/1849904878739001344

Taken from upstream:
https://github.com/ovn-org/ovn-kubernetes/pull/4811