### PR TITLE
NE-1870: Fix the Network Ingress & DNS OWNERS files and add aliases to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -54,3 +54,25 @@ aliases:
   - umohnani8 # Container Engine Tools
   - davidvossel # HyperShift on KubeVirt Platform
   - orenc1 # HyperShift on KubeVirt Platform
+  network-ingress-dns-test-case-approvers:
+  - frobware
+  - knobunc
+  - Miciah
+  - miheer
+  - alebedev87
+  - candita
+  - gcs278
+  - rfredette
+  - Thealisyed
+  - grzpiotrowski
+  network-ingress-dns-test-case-reviewers:
+  - frobware
+  - knobunc
+  - Miciah
+  - miheer
+  - alebedev87
+  - candita
+  - gcs278
+  - rfredette
+  - Thealisyed
+  - grzpiotrowski

--- a/test/extended/dns/OWNERS
+++ b/test/extended/dns/OWNERS
@@ -4,6 +4,3 @@ approvers:
 - network-ingress-dns-test-case-approvers
 reviewers:
 - network-ingress-dns-test-case-reviewers
-emeritus_approvers:
-  - danehans
-  - sgreene570


### PR DESCRIPTION
 Fix the Network Ingress & DNS OWNERS files and add aliases to OWNERS_ALIASES.

modified:   OWNERS_ALIASES
new file:   test/extended/dns/OWNERS
modified:   test/extended/router/OWNERS