### PR TITLE
SDN-4930: Verify that a UDN pod can reach the kapi service in the default network

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -314,6 +314,22 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							}, 4*time.Second).Should(BeFalse())
 						}
 
+						By("asserting UDN pod can reach the kapi service in the default network")
+						// Use the service name to get test the DNS access
+						Consistently(func() bool {
+							_, err := e2ekubectl.RunKubectl(
+								udnPodConfig.namespace,
+								"exec",
+								udnPodConfig.name,
+								"--",
+								"curl",
+								"--connect-timeout",
+								"2",
+								"--insecure",
+								"https://kubernetes.default/healthz")
+							return err == nil
+						}, 5*time.Second).Should(BeTrue())
+
 						By("asserting UDN pod can't reach default services via default network interface")
 						// route setup is already done, get kapi IPs
 						kapi, err := cs.CoreV1().Services("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})


### PR DESCRIPTION
Ported from: https://github.com/ovn-org/ovn-kubernetes/blob/a68ef49d9441ed0f938f99ff2d605506572b7b78/test/e2e/network_segmentation.go#L343-L358

Depends on: 
 - https://github.com/ovn-org/ovn-kubernetes/pull/4805 in downstream.
 - https://github.com/openshift/cluster-network-operator/pull/2492