### PR TITLE
NO-ISSUE: skip boot image tests on single node tests

### DIFF
--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -27,6 +27,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		skipUnlessTargetPlatform(oc, osconfigv1.AWSPlatformType)
 		//skip this test if the cluster is not using MachineAPI
 		skipUnlessFunctionalMachineAPI(oc)
+		//skip this test on single node platforms
+		skipOnSingleNodeTopology(oc)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -27,6 +27,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 		skipUnlessTargetPlatform(oc, osconfigv1.GCPPlatformType)
 		//skip this test if the cluster is not using MachineAPI
 		skipUnlessFunctionalMachineAPI(oc)
+		//skip this test on single node platforms
+		skipOnSingleNodeTopology(oc)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -72,6 +72,15 @@ func skipUnlessFunctionalMachineAPI(oc *exutil.CLI) {
 	e2eskipper.Skipf("haven't found a machine in running state, this test can be run on a platform that supports functional MachineAPI")
 }
 
+// skipOnSingleNodeTopology skips the test if the cluster is using single-node topology
+func skipOnSingleNodeTopology(oc *exutil.CLI) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.ControlPlaneTopology == osconfigv1.SingleReplicaTopologyMode {
+		e2eskipper.Skipf("This test does not apply to single-node topologies")
+	}
+}
+
 // getRandomMachineSet picks a random machineset present on the cluster
 func getRandomMachineSet(machineClient *machineclient.Clientset) machinev1beta1.MachineSet {
 	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
The [last set of timeout failures are isolated to SNO](https://sippy.dptools.openshift.org/sippy-ng/tests/4.18/analysis?test=%5Bsig-mco%5D%5BOCPFeatureGate%3AManagedBootImagesAWS%5D%5BSerial%5D%20Should%20update%20boot%20images%20on%20all%20MachineSets%20when%20configured%20%5Bapigroup%3Amachineconfiguration.openshift.io%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D&filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22%5Bsig-mco%5D%5BOCPFeatureGate%3AManagedBootImagesAWS%5D%5BSerial%5D%20Should%20update%20boot%20images%20on%20all%20MachineSets%20when%20configured%20%5Bapigroup%3Amachineconfiguration.openshift.io%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fserial%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D), I suspect this is because the controller waits for "one" control plane node to be up-to date. This can take an unpredicatable amount of time, depending on other cluster variables. Increasing [the timeout helped a bit](https://github.com/openshift/origin/pull/29210), but whenever SNO goes through a "slow" patch, these failures will creep up again. Further, boot images updates are not applicable for SNO, as they are never scaled up after installation - so updating the machineset in such a case is moot. Let's skip these tests for the SNO cases. 