### PR TITLE
OCPBUGS-44244: use node node in deleted machine phases

### DIFF
--- a/pkg/monitortestlibrary/utility/utility.go
+++ b/pkg/monitortestlibrary/utility/utility.go
@@ -1,0 +1,44 @@
+package utility
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+)
+
+// SystemdJournalLogTime returns Now if there is trouble reading the time.  This will stack the event intervals without
+// parsable times at the end of the run, which will be more clearly visible as a problem than not reporting them.
+func SystemdJournalLogTime(logLine string) time.Time {
+	var kubeletTimeRegex = regexp.MustCompile(`^(?P<MONTH>\S+)\s(?P<DAY>\S+)\s(?P<TIME>\S+)`)
+	kubeletTimeRegex.MatchString(logLine)
+	if !kubeletTimeRegex.MatchString(logLine) {
+		return time.Now()
+	}
+
+	month := ""
+	day := ""
+	year := fmt.Sprintf("%d", time.Now().Year())
+	timeOfDay := ""
+	subMatches := kubeletTimeRegex.FindStringSubmatch(logLine)
+	subNames := kubeletTimeRegex.SubexpNames()
+	for i, name := range subNames {
+		switch name {
+		case "MONTH":
+			month = subMatches[i]
+		case "DAY":
+			day = subMatches[i]
+		case "TIME":
+			timeOfDay = subMatches[i]
+		}
+	}
+
+	timeString := fmt.Sprintf("%s %s %s %s UTC", day, month, year, timeOfDay)
+	ret, err := time.Parse("02 Jan 2006 15:04:05.999999999 MST", timeString)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failure parsing time format: %v for %q\n", err, timeString)
+		return time.Now()
+	}
+
+	return ret
+}

--- a/pkg/monitortests/node/kubeletlogcollector/node_test.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,8 +45,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Sep 27 08:59:59.857303"),
-				To:   systemdJournalLogTime("Sep 27 08:59:59.857303"),
+				From: utility.SystemdJournalLogTime("Sep 27 08:59:59.857303"),
+				To:   utility.SystemdJournalLogTime("Sep 27 08:59:59.857303"),
 			},
 		},
 		{
@@ -72,8 +73,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Sep 27 08:59:59.853216"),
-				To:   systemdJournalLogTime("Sep 27 08:59:59.853216"),
+				From: utility.SystemdJournalLogTime("Sep 27 08:59:59.853216"),
+				To:   utility.SystemdJournalLogTime("Sep 27 08:59:59.853216"),
 			},
 		},
 		{
@@ -98,8 +99,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Sep 27 08:59:59.853216"),
-				To:   systemdJournalLogTime("Sep 27 08:59:59.853216"),
+				From: utility.SystemdJournalLogTime("Sep 27 08:59:59.853216"),
+				To:   utility.SystemdJournalLogTime("Sep 27 08:59:59.853216"),
 			},
 		},
 		{
@@ -123,8 +124,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("May 19 19:10:03.753983"),
-				To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+				From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+				To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 			},
 		},
 		{
@@ -148,8 +149,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Jun 29 05:16:54.197389"),
-				To:   systemdJournalLogTime("Jun 29 05:16:55.197389"),
+				From: utility.SystemdJournalLogTime("Jun 29 05:16:54.197389"),
+				To:   utility.SystemdJournalLogTime("Jun 29 05:16:55.197389"),
 			},
 		},
 		{
@@ -173,8 +174,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Jun 29 05:16:54.197389"),
-				To:   systemdJournalLogTime("Jun 29 05:16:55.197389"),
+				From: utility.SystemdJournalLogTime("Jun 29 05:16:54.197389"),
+				To:   utility.SystemdJournalLogTime("Jun 29 05:16:55.197389"),
 			},
 		},
 		{
@@ -202,8 +203,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Jul 05 17:47:52.807876"),
-				To:   systemdJournalLogTime("Jul 05 17:47:52.807876"),
+				From: utility.SystemdJournalLogTime("Jul 05 17:47:52.807876"),
+				To:   utility.SystemdJournalLogTime("Jul 05 17:47:52.807876"),
 			},
 		},
 		{
@@ -231,8 +232,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Jul 05 17:43:12.908344"),
-				To:   systemdJournalLogTime("Jul 05 17:43:12.908344"),
+				From: utility.SystemdJournalLogTime("Jul 05 17:43:12.908344"),
+				To:   utility.SystemdJournalLogTime("Jul 05 17:43:12.908344"),
 			},
 		},
 		{
@@ -262,8 +263,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						},
 					},
 				},
-				From: systemdJournalLogTime("Feb 01 05:37:45.731611"),
-				To:   systemdJournalLogTime("Feb 01 05:37:45.731611"),
+				From: utility.SystemdJournalLogTime("Feb 01 05:37:45.731611"),
+				To:   utility.SystemdJournalLogTime("Feb 01 05:37:45.731611"),
 			},
 		},
 		{
@@ -286,8 +287,8 @@ func TestMonitorApiIntervals(t *testing.T) {
 						Annotations:  map[monitorapi.AnnotationKey]string{},
 					},
 				},
-				From: systemdJournalLogTime("Apr 12 11:49:49.188086"),
-				To:   systemdJournalLogTime("Apr 12 11:49:50.188086"),
+				From: utility.SystemdJournalLogTime("Apr 12 11:49:49.188086"),
+				To:   utility.SystemdJournalLogTime("Apr 12 11:49:50.188086"),
 			},
 		},
 	}
@@ -514,8 +515,8 @@ func Test_messageTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := systemdJournalLogTime(tt.args.logLine); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("systemdJournalLogTime() = %v, want %v", got, tt.want)
+			if got := utility.SystemdJournalLogTime(tt.args.logLine); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("utility.SystemdJournalLogTime() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -611,8 +612,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("Sep 27 08:59:59.857303"),
-					To:   systemdJournalLogTime("Sep 27 08:59:59.857303"),
+					From: utility.SystemdJournalLogTime("Sep 27 08:59:59.857303"),
+					To:   utility.SystemdJournalLogTime("Sep 27 08:59:59.857303"),
 				},
 			},
 			want: monitorapi.Intervals(nil),
@@ -637,8 +638,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 			},
 			want: monitorapi.Intervals(nil),
@@ -663,8 +664,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -683,8 +684,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:13.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:14.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:13.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:14.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -703,8 +704,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:13:17.753983"),
-					To:   systemdJournalLogTime("May 19 19:13:18.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:13:17.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:13:18.753983"),
 				},
 			},
 			want: monitorapi.Intervals{
@@ -725,8 +726,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 			},
 		},
@@ -750,8 +751,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -770,8 +771,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:13.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:14.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:13.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:14.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -790,8 +791,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:13:17.753983"),
-					To:   systemdJournalLogTime("May 19 19:13:18.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:13:17.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:13:18.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -810,8 +811,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -830,8 +831,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:17.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:18.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:17.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:18.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -850,8 +851,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:13:17.753983"),
-					To:   systemdJournalLogTime("May 19 19:13:18.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:13:17.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:13:18.753983"),
 				},
 			},
 			want: monitorapi.Intervals{
@@ -872,8 +873,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -892,8 +893,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:03.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:04.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:03.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:04.753983"),
 				},
 			},
 		},
@@ -917,8 +918,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:13.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:14.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:13.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:14.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -937,8 +938,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:13.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:14.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:13.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:14.753983"),
 				},
 				{
 					Condition: monitorapi.Condition{
@@ -957,8 +958,8 @@ func TestNodeLeaseClusters(t *testing.T) {
 							},
 						},
 					},
-					From: systemdJournalLogTime("May 19 19:10:13.753983"),
-					To:   systemdJournalLogTime("May 19 19:10:14.753983"),
+					From: utility.SystemdJournalLogTime("May 19 19:10:13.753983"),
+					To:   utility.SystemdJournalLogTime("May 19 19:10:14.753983"),
 				},
 			},
 			want: monitorapi.Intervals(nil),

--- a/pkg/monitortests/node/watchnodes/monitortest.go
+++ b/pkg/monitortests/node/watchnodes/monitortest.go
@@ -44,29 +44,10 @@ func (*nodeWatcher) ConstructComputedIntervals(ctx context.Context, startingInte
 }
 
 func (*nodeWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
-	machineDeletePhases := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		if eventInterval.Message.Reason != monitorapi.MachinePhase {
-			return false
-		}
-		if eventInterval.Message.Annotations[monitorapi.AnnotationPhase] == "Deleting" {
-			return true
-		}
-		return false
-	})
 
-	nodeNameToMachineName := map[string]string{}
-	machineNameToDeletePhases := map[string][]monitorapi.Interval{}
-	for _, machineDeletePhase := range machineDeletePhases {
-		machineName := machineDeletePhase.Locator.Keys[monitorapi.LocatorMachineKey]
-		nodeName := machineDeletePhase.Message.Annotations[monitorapi.AnnotationNode]
-		machineNameToDeletePhases[machineName] = append(machineNameToDeletePhases[machineName], machineDeletePhase)
-		nodeNameToMachineName[nodeName] = machineName
-	}
-
-	// Fail tests when monitor test flags this as an error
 	junits := []*junitapi.JUnitTestCase{}
-	junits = append(junits, unexpectedNodeNotReadyJunit(finalIntervals, nodeNameToMachineName, machineNameToDeletePhases)...)
-	junits = append(junits, unreachableNodeTaint(finalIntervals, nodeNameToMachineName, machineNameToDeletePhases)...)
+	junits = append(junits, unexpectedNodeNotReadyJunit(finalIntervals)...)
+	junits = append(junits, unreachableNodeTaint(finalIntervals)...)
 	return junits, nil
 }
 
@@ -79,27 +60,10 @@ func (*nodeWatcher) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals, nodeNameToMachineName map[string]string, machinesToDeletePhases map[string][]monitorapi.Interval) []*junitapi.JUnitTestCase {
+func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] node-lifecycle detects unexpected not ready node"
 
-	unexpectedNodeUnreadies := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		if eventInterval.Message.Reason == monitorapi.NodeUnexpectedReadyReason {
-			return true
-		}
-		return false
-	})
-
-	var failures []string
-	for _, unexpectedNodeUnready := range unexpectedNodeUnreadies {
-		nodeName := unexpectedNodeUnready.Locator.Keys[monitorapi.LocatorNodeKey]
-		machineNameForNode := nodeNameToMachineName[nodeName]
-		machineDeletingIntervals := machinesToDeletePhases[machineNameForNode]
-
-		if intervalStartDuring(unexpectedNodeUnready, machineDeletingIntervals) {
-			failures = append(failures, fmt.Sprintf("%v - %v at from: %v - to: %v", unexpectedNodeUnready.Locator.OldLocator(), unexpectedNodeUnready.Message.OldMessage(), unexpectedNodeUnready.From, unexpectedNodeUnready.To))
-		}
-	}
-
+	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedReadyReason)
 	// failures during a run always fail the test suite
 	var tests []*junitapi.JUnitTestCase
 	if len(failures) > 0 {
@@ -118,23 +82,9 @@ func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals, nodeNameTo
 	return tests
 }
 
-func unreachableNodeTaint(finalIntervals monitorapi.Intervals, nodeNameToMachineName map[string]string, machinesToDeletePhases map[string][]monitorapi.Interval) []*junitapi.JUnitTestCase {
+func unreachableNodeTaint(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] node-lifecycle detects unreachable state on node"
-	var failures []string
-
-	unexpectedNodeUnreachables := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Message.Reason == monitorapi.NodeUnexpectedUnreachableReason
-	})
-
-	for _, unexpectedNodeUnreachable := range unexpectedNodeUnreachables {
-		nodeName := unexpectedNodeUnreachable.Locator.Keys[monitorapi.LocatorNodeKey]
-		machineNameForNode := nodeNameToMachineName[nodeName]
-		machineDeletingIntervals := machinesToDeletePhases[machineNameForNode]
-
-		if intervalStartDuring(unexpectedNodeUnreachable, machineDeletingIntervals) {
-			failures = append(failures, fmt.Sprintf("%v - %v from %v to %v", unexpectedNodeUnreachable.Locator.OldLocator(), unexpectedNodeUnreachable.Message.OldMessage(), unexpectedNodeUnreachable.From, unexpectedNodeUnreachable.To))
-		}
-	}
+	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedUnreachableReason)
 
 	// failures during a run always fail the test suite
 	var tests []*junitapi.JUnitTestCase
@@ -158,7 +108,7 @@ func intervalStartDuring(needle monitorapi.Interval, haystack monitorapi.Interva
 	if len(haystack) == 0 {
 		// If there are no deleted intervals
 		// we can assume that the unexpected event is significant.
-		return true
+		return false
 	}
 	for _, curr := range haystack {
 		needleStartEqualOrAfterFrom := needle.From.Equal(curr.From) || needle.From.After(curr.From)

--- a/pkg/monitortests/node/watchnodes/node_test.go
+++ b/pkg/monitortests/node/watchnodes/node_test.go
@@ -3,6 +3,8 @@ package watchnodes
 import (
 	"testing"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,5 +55,285 @@ func TestNodeRoles(t *testing.T) {
 		if actual := nodeRoles(tc.node); tc.expected != actual {
 			t.Errorf("mismatch roles. expected: %s, actual: %s", tc.expected, actual)
 		}
+	}
+}
+
+func TestReportUnexpectedNodeDownFailures(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		rawIntervals     monitorapi.Intervals
+		unexpectedReason monitorapi.IntervalReason
+		expected         []string
+	}{
+		{
+			name: "node unexpected ready reason with no deleted machines",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedReadyReason,
+							HumanMessage: "unexpected node not ready",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedNotReady",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+			},
+			expected:         []string{"node/node1 - reason/UnexpectedNotReady unexpected node not ready at from: 2024-11-11 19:46:00 +0000 UTC - to: 2024-11-11 19:46:00 +0000 UTC"},
+			unexpectedReason: monitorapi.NodeUnexpectedReadyReason,
+		},
+		{
+			// OCPBUG-44244: if machine phase interval does not have node name than we will get a failure
+			name: "node unexpected ready reason with a deleted machine but missing node",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedReadyReason,
+							HumanMessage: "unexpected node not ready",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedNotReady",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Info,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeMachine,
+							Keys: map[monitorapi.LocatorKey]string{
+								"machine": "machine1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.MachinePhase,
+							HumanMessage: "Machine is in deleted",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationConstructed: "machine-lifecycle-constructor",
+								monitorapi.AnnotationPhase:       "Deleting",
+								monitorapi.AnnotationReason:      "MachinePhase",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:45:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:47:00"),
+				},
+			},
+			expected:         []string{"node/node1 - reason/UnexpectedNotReady unexpected node not ready at from: 2024-11-11 19:46:00 +0000 UTC - to: 2024-11-11 19:46:00 +0000 UTC"},
+			unexpectedReason: monitorapi.NodeUnexpectedReadyReason,
+		},
+		{
+			// OCPBUG-44244: if deleted machine exists for that node than we will get no failures
+			name: "node unexpected ready reason with a deleted machine and a node annotation",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedReadyReason,
+							HumanMessage: "unexpected node not ready",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedNotReady",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Info,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeMachine,
+							Keys: map[monitorapi.LocatorKey]string{
+								"machine": "machine1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.MachinePhase,
+							HumanMessage: "Machine is in deleted",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationConstructed: "machine-lifecycle-constructor",
+								monitorapi.AnnotationNode:        "node1",
+								monitorapi.AnnotationPhase:       "Deleting",
+								monitorapi.AnnotationReason:      "MachinePhase",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:45:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:47:00"),
+				},
+			},
+			expected:         []string{},
+			unexpectedReason: monitorapi.NodeUnexpectedReadyReason,
+		},
+		{
+			name: "node unexpected unreachable reason with no deleted machines",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedUnreachableReason,
+							HumanMessage: "unexpected node unreachable",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedUnreachable",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+			},
+			expected:         []string{"node/node1 - reason/UnexpectedUnreachable unexpected node unreachable at from: 2024-11-11 19:46:00 +0000 UTC - to: 2024-11-11 19:46:00 +0000 UTC"},
+			unexpectedReason: monitorapi.NodeUnexpectedUnreachableReason,
+		},
+		{
+			// OCPBUG-44244: if machine phase interval does not have node name than we will get a failure
+			name: "node unexpected unreachable reason with a deleted machine but missing node",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedUnreachableReason,
+							HumanMessage: "unexpected node unreachable",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedUnreachable",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Info,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeMachine,
+							Keys: map[monitorapi.LocatorKey]string{
+								"machine": "machine1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.MachinePhase,
+							HumanMessage: "Machine is in deleted",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationConstructed: "machine-lifecycle-constructor",
+								monitorapi.AnnotationPhase:       "Deleting",
+								monitorapi.AnnotationReason:      "MachinePhase",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:45:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:47:00"),
+				},
+			},
+			expected:         []string{"node/node1 - reason/UnexpectedUnreachable unexpected node unreachable at from: 2024-11-11 19:46:00 +0000 UTC - to: 2024-11-11 19:46:00 +0000 UTC"},
+			unexpectedReason: monitorapi.NodeUnexpectedUnreachableReason,
+		},
+		{
+			// OCPBUG-44244: if deleted machine exists for that node than we will get no failures
+			name: "node unexpected unreachable reason with a deleted machine and a node annotation",
+			rawIntervals: monitorapi.Intervals{
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Error,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeNode,
+							Keys: map[monitorapi.LocatorKey]string{
+								"node": "node1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.NodeUnexpectedUnreachableReason,
+							HumanMessage: "unexpected node not ready",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationReason: "UnexpectedUnreachable",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:46:00"),
+				},
+				{
+					Condition: monitorapi.Condition{
+						Level: monitorapi.Info,
+						Locator: monitorapi.Locator{
+							Type: monitorapi.LocatorTypeMachine,
+							Keys: map[monitorapi.LocatorKey]string{
+								"machine": "machine1",
+							},
+						},
+						Message: monitorapi.Message{
+							Reason:       monitorapi.MachinePhase,
+							HumanMessage: "Machine is in deleted",
+							Annotations: map[monitorapi.AnnotationKey]string{
+								monitorapi.AnnotationConstructed: "machine-lifecycle-constructor",
+								monitorapi.AnnotationNode:        "node1",
+								monitorapi.AnnotationPhase:       "Deleting",
+								monitorapi.AnnotationReason:      "MachinePhase",
+							},
+						},
+					},
+					From: utility.SystemdJournalLogTime("Nov 11 19:45:00"),
+					To:   utility.SystemdJournalLogTime("Nov 11 19:47:00"),
+				},
+			},
+			expected:         []string{},
+			unexpectedReason: monitorapi.NodeUnexpectedUnreachableReason,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := reportUnexpectedNodeDownFailures(tc.rawIntervals, tc.unexpectedReason)
+			if len(actual) != len(tc.expected) {
+				t.Fatalf("mismatch of length from actual to expected")
+			}
+			for i := range actual {
+				if actual[i] != tc.expected[i] {
+					t.Errorf("mismatch failures. expected: %s, actual: %s", tc.expected[i], actual[i])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR makes sure to add a node name to the DeletedMachine monitor.

Once that is added, we also added some unit tests to this code to make sure that we are correctly detecting UnexpectedNodeNotReady / UnexpectedUnreachable.

The main edge case we had to work around was when Machines get deleted and that node goes not ready. This is correct behavior but our test was flagging this as this code path does not go through a Machine Config change.