### PR TITLE
TRT-1871: Revert #29266 "NO-JIRA: Additional ROSA exceptions"

### DIFF
--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -56,15 +56,13 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// These shouldn't be DaemonSets as they end up being scheduled to all nodes because contrary to selfhosted OCP
-		// there are no master nodes. Today it is unclear how networking will look like in the future so it isn't worth
-		// chaning yet. Future work and removal of these exceptions is tracked in https://issues.redhat.com/browse/HOSTEDCP-279
-		hyperShiftExceptions := sets.NewString(
+		exceptions := sets.NewString(
+			// These shouldn't be DaemonSets as they end up being scheduled to all nodes because contrary to selfhosted OCP
+			// there are no master nodes. Today it is unclear how networking will look like in the future so it isn't worth
+			// chaning yet. Future work and removal of these exceptions is tracked in https://issues.redhat.com/browse/HOSTEDCP-279
 			"openshift-multus/multus-admission-controller",
 			"openshift-sdn/sdn-controller",
-		)
 
-		exceptions := sets.NewString(
 			// Managed service exceptions https://issues.redhat.com/browse/OSD-26323
 			"openshift-security/splunkforwarder-ds",
 			"openshift-validation-webhook/validation-webhook",
@@ -82,10 +80,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 					continue
 				}
 			}
-			if *controlPlaneTopology == configv1.ExternalTopologyMode && hyperShiftExceptions.Has(ds.Namespace+"/"+ds.Name) {
-				continue
-			}
-			if exceptions.Has(ds.Namespace + "/" + ds.Name) {
+			if *controlPlaneTopology == configv1.ExternalTopologyMode && exceptions.Has(ds.Namespace+"/"+ds.Name) {
 				continue
 			}
 

--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -7,13 +7,12 @@ import (
 	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
+	exutil "github.com/openshift/origin/test/extended/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kube-openapi/pkg/util/sets"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
-
-	"github.com/openshift/origin/pkg/test/ginkgo/result"
-	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-arch] Managed cluster", func() {
@@ -34,38 +33,9 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 			e2e.Failf("unable to list pods: %v", err)
 		}
 
-		exemptNamespaces := []string{
-			// Must-gather runs are excluded from this rule
-			"openshift-must-gather",
-
-			// Managed service namespaces - https://issues.redhat.com/browse/OSD-21708
-			"openshift-addon-operator",
-			"openshift-backplane",
-			"openshift-backplane-srep",
-			"openshift-custom-domains-operator",
-			"openshift-deployment-validation-operator",
-			"openshift-managed-node-metadata-operator",
-			"openshift-managed-upgrade-operator",
-			"openshift-marketplace",
-			"openshift-observability-operator",
-			"openshift-ocm-agent-operator",
-			"openshift-osd-metrics",
-			"openshift-package-operator",
-			"openshift-rbac-permissions",
-			"openshift-route-monitor-operator",
-			"openshift-security",
-			"openshift-splunk-forwarder-operator",
-			"openshift-sre-pruning",
-			"openshift-validation-webhook",
-		}
-
 		// pods that have a bug opened, every entry here must have a bug associated
 		knownBrokenPods := map[string]string{
 			//"<apiVersion>/<kind>/<namespace>/<name>/(initContainer|container)/<container_name>/<violation_type>": "<url to bug>",
-
-			// Managed service pods that have limits but not requests
-			"apps/v1/Deployment/openshift-monitoring/configure-alertmanager-operator/container/configure-alertmanager-operator/limit[cpu]":    "https://issues.redhat.com/browse/OSD-21708",
-			"apps/v1/Deployment/openshift-monitoring/configure-alertmanager-operator/container/configure-alertmanager-operator/limit[memory]": "https://issues.redhat.com/browse/OSD-21708",
 		}
 
 		// pods with an exception granted, the value should be the justification and the approver (a release architect)
@@ -101,17 +71,14 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		waitingForFix := sets.NewString()
 		notAllowed := sets.NewString()
 		possibleFuture := sets.NewString()
-	podLoop:
 		for _, pod := range pods.Items {
 			// Only pods in the openshift-*, kube-*, and default namespaces are considered
 			if !strings.HasPrefix(pod.Namespace, "openshift-") && !strings.HasPrefix(pod.Namespace, "kube-") && pod.Namespace != "default" {
 				continue
 			}
-
-			for _, ns := range exemptNamespaces {
-				if pod.Namespace == ns {
-					continue podLoop
-				}
+			// Must-gather runs are excluded from this rule
+			if strings.HasPrefix(pod.Namespace, "openshift-must-gather") {
+				continue
 			}
 			// var controlPlaneTarget bool
 			// selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
@@ -137,7 +104,9 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 						}
 					}
 				case "Job":
-					ref.Name = "<batch_job>"
+					if pod.Namespace == "openshift-marketplace" {
+						ref.Name = "<batch_job>"
+					}
 				case "Node":
 					continue
 				}


### PR DESCRIPTION

Reverts #29266 ; tracked by https://issues.redhat.com/browse/TRT-1871

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

While we suspect the test is now finding a legit issue, payloads have blocked. We're going to revert and test a fix with an exception and a jira to address adding the pod requests for the network team.

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-aggregate periodic-ci-openshift-release-master-ci-4.18-upgrade-from-stable-4.17-e2e-aws-ovn-upgrade
```

CC: @stbenjam

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
