### PR TITLE
API-1802: chart template: show cert rotation events

### DIFF
--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -254,6 +254,7 @@
                         <option value="e2e_test_failed">e2e Test Failed</option>
                         <option value="e2e_test_flaked">e2e Test Flaked</option>
                         <option value="interesting_events">Interesting Events</option>
+                        <option value="certificate_rotation">Certificate Rotation</option>
                     </select>
 `
 
@@ -296,6 +297,7 @@
         eventInterval.categories.e2e_test_flaked = isE2EFlaked(eventInterval);
         eventInterval.categories.e2e_test_passed = isE2EPassed(eventInterval);
         eventInterval.categories.endpoint_availability = isEndpointConnectivity(eventInterval);
+        eventInterval.categories.certificate_rotation = isCertificateRotation(eventInterval);
         eventInterval.categories.uncategorized = !_.some(eventInterval.categories); // will save time later during filtering and re-rendering since we don't render any uncategorized events
     });
 
@@ -436,6 +438,52 @@
 
     function isAlert(eventInterval) {
         return eventInterval.source === "Alert"
+    }
+
+
+    function isCertificateRotation(eventInterval) {
+        if (eventInterval.source != 'KubeEvent') {
+            return false
+        }
+        if (eventInterval.message.reason === "CertificateUpdated") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateRemoved") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateUpdateFailed") {
+            return true
+        };
+        if (eventInterval.message.reason === "ConfigMapUpdated") {
+            return true
+        };
+        if (eventInterval.message.reason === "SignerUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "CABundleUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "TargetUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "CSRCreated") {
+            return true
+        };
+        if (eventInterval.message.reason === "CSRApproved") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateRotationStarted") {
+            return true
+        };
+        if (eventInterval.message.reason === "ClientCertificateCreated") {
+            return true
+        };
+        if (eventInterval.message.reason === "NoValidCertificateFound") {
+            return true
+        };
+        
+                
+        return false;
     }
 
     function interestingEvents(item) {
@@ -865,6 +913,9 @@
 
         timelineGroups.push({group: "interesting-events", data: []});
         createTimelineData(interestingEvents, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "interesting_events");
+
+        timelineGroups.push({group: "certificate-rotation", data: []})
+        createTimelineData("CertificateRotation", timelineGroups[timelineGroups.length - 1].data, filteredEvents, "certificate_rotation")
 
         var segmentFunc = function (segment) {
             // Copy label to clipboard

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -710,7 +710,7 @@ var KubeAPIServerAvoids500s = &SimplePathologicalEventMatcher{
 
 var CertificateRotation = &SimplePathologicalEventMatcher{
 	name:               "CertificateRotation",
-	messageReasonRegex: regexp.MustCompile(`^(CABundleUpdateRequired|SignerUpdateRequired|TargetUpdateRequired|CertificateUpdated|CertificateRemoved|CertificateUpdateFailed)$`),
+	messageReasonRegex: regexp.MustCompile(`^(CABundleUpdateRequired|SignerUpdateRequired|TargetUpdateRequired|CertificateUpdated|CertificateRemoved|CertificateUpdateFailed|CSRCreated|CSRApproved|CertificateRotationStarted|ClientCertificateCreated|NoValidCertificateFound)$`),
 }
 
 // IsEventAfterInstallation returns true if the monitorEvent represents an event that happened after installation.

--- a/pkg/monitortests/testframework/watchevents/event.go
+++ b/pkg/monitortests/testframework/watchevents/event.go
@@ -150,7 +150,7 @@ func recordAddOrUpdateEvent(
 				}
 			}
 		}
-	case "CABundleUpdateRequired", "SignerUpdateRequired", "TargetUpdateRequired", "CertificateUpdated", "CertificateRemoved", "CertificateUpdateFailed":
+	case "CABundleUpdateRequired", "SignerUpdateRequired", "TargetUpdateRequired", "CertificateUpdated", "CertificateRemoved", "CertificateUpdateFailed", "CSRCreated", "CSRApproved", "CertificateRotationStarted", "ClientCertificateCreated", "NoValidCertificateFound":
 		message = message.WithAnnotation(monitorapi.AnnotationInteresting, "true")
 	default:
 	}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -54302,6 +54302,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
                         <option value="e2e_test_failed">e2e Test Failed</option>
                         <option value="e2e_test_flaked">e2e Test Flaked</option>
                         <option value="interesting_events">Interesting Events</option>
+                        <option value="certificate_rotation">Certificate Rotation</option>
                     </select>
 ` + "`" + `
 
@@ -54344,6 +54345,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         eventInterval.categories.e2e_test_flaked = isE2EFlaked(eventInterval);
         eventInterval.categories.e2e_test_passed = isE2EPassed(eventInterval);
         eventInterval.categories.endpoint_availability = isEndpointConnectivity(eventInterval);
+        eventInterval.categories.certificate_rotation = isCertificateRotation(eventInterval);
         eventInterval.categories.uncategorized = !_.some(eventInterval.categories); // will save time later during filtering and re-rendering since we don't render any uncategorized events
     });
 
@@ -54484,6 +54486,52 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
 
     function isAlert(eventInterval) {
         return eventInterval.source === "Alert"
+    }
+
+
+    function isCertificateRotation(eventInterval) {
+        if (eventInterval.source != 'KubeEvent') {
+            return false
+        }
+        if (eventInterval.message.reason === "CertificateUpdated") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateRemoved") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateUpdateFailed") {
+            return true
+        };
+        if (eventInterval.message.reason === "ConfigMapUpdated") {
+            return true
+        };
+        if (eventInterval.message.reason === "SignerUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "CABundleUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "TargetUpdateRequired") {
+            return true
+        };
+        if (eventInterval.message.reason === "CSRCreated") {
+            return true
+        };
+        if (eventInterval.message.reason === "CSRApproved") {
+            return true
+        };
+        if (eventInterval.message.reason === "CertificateRotationStarted") {
+            return true
+        };
+        if (eventInterval.message.reason === "ClientCertificateCreated") {
+            return true
+        };
+        if (eventInterval.message.reason === "NoValidCertificateFound") {
+            return true
+        };
+        
+                
+        return false;
     }
 
     function interestingEvents(item) {
@@ -54913,6 +54961,9 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "interesting-events", data: []});
         createTimelineData(interestingEvents, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "interesting_events");
+
+        timelineGroups.push({group: "certificate-rotation", data: []})
+        createTimelineData("CertificateRotation", timelineGroups[timelineGroups.length - 1].data, filteredEvents, "certificate_rotation")
 
         var segmentFunc = function (segment) {
             // Copy label to clipboard


### PR DESCRIPTION
Followup for https://github.com/openshift/origin/pull/28639:
* Add "Certificate Rotation" section to e2e-chart-everything.html
* Show cert rotation events from certrotationcontroller, csrapprover and ingress controller