### PR TITLE
ovn-k, udn crd e2e: Fix status report consumer assertion

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -853,7 +853,7 @@ func assertUDNStatusReportsConsumers(udnNamesapce, udnName, expectedPodName stri
 	var conditions []metav1.Condition
 	Expect(json.Unmarshal([]byte(conditionsRaw), &conditions)).To(Succeed())
 	conditions = normalizeConditions(conditions)
-	expectedMsg := fmt.Sprintf("failed to verify NAD not in use [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
+	expectedMsg := fmt.Sprintf("failed to delete NetworkAttachmentDefinition [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
 		udnNamesapce, udnName, expectedPodName)
 	found := false
 	for _, condition := range conditions {


### PR DESCRIPTION
Following the incoming changes of the CUDN controller by [origin/ovn-kubernetes#2345](https://github.com/openshift/ovn-kubernetes/pull/2345), the assertion on the UDN status is no longer valid.

This PR fix the assertion with the expected condition message.

Note to reviewer:
Merging this PR means there might be intermediate time where techpreview lane will fail due to missing bits of https://github.com/openshift/ovn-kubernetes/pull/2345
Or if https://github.com/openshift/ovn-kubernetes/pull/2345 merged without this PR changes.

PR converted to draft state to avoid burning CI time