### PR TITLE
OCPBUGS-44381: ovn-k, udn crd e2e: Fix status report consumer assertion

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -853,7 +853,7 @@ func assertUDNStatusReportsConsumers(udnNamesapce, udnName, expectedPodName stri
 	var conditions []metav1.Condition
 	Expect(json.Unmarshal([]byte(conditionsRaw), &conditions)).To(Succeed())
 	conditions = normalizeConditions(conditions)
-	expectedMsg := fmt.Sprintf("failed to verify NAD not in use [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
+	expectedMsg := fmt.Sprintf("failed to delete NetworkAttachmentDefinition [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
 		udnNamesapce, udnName, expectedPodName)
 	found := false
 	for _, condition := range conditions {


### PR DESCRIPTION
Following the incoming changes of the CUDN controller, the assertion on the UDN status is no longer valid.

Fix the assertion with the expected condition message.