### PR TITLE
NO-JIRA: managed services: centralize definition of namespaces

### DIFF
--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -34,37 +34,19 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 			e2e.Failf("unable to list pods: %v", err)
 		}
 
-		exemptNamespaces := []string{
+		exemptNamespaces := append([]string{
 			// Must-gather runs are excluded from this rule
 			"openshift-must-gather",
-
+		},
 			// Managed service namespaces - https://issues.redhat.com/browse/OSD-21708
-			"openshift-addon-operator",
-			"openshift-backplane",
-			"openshift-backplane-srep",
-			"openshift-custom-domains-operator",
-			"openshift-deployment-validation-operator",
-			"openshift-managed-node-metadata-operator",
-			"openshift-managed-upgrade-operator",
-			"openshift-marketplace",
-			"openshift-must-gather-operator",
-			"openshift-observability-operator",
-			"openshift-ocm-agent-operator",
-			"openshift-osd-metrics",
-			"openshift-package-operator",
-			"openshift-rbac-permissions",
-			"openshift-route-monitor-operator",
-			"openshift-security",
-			"openshift-splunk-forwarder-operator",
-			"openshift-sre-pruning",
-			"openshift-validation-webhook",
-		}
+			exutil.ManagedServiceNamespaces.UnsortedList()...,
+		)
 
 		// pods that have a bug opened, every entry here must have a bug associated
 		knownBrokenPods := map[string]string{
 			//"<apiVersion>/<kind>/<namespace>/<name>/(initContainer|container)/<container_name>/<violation_type>": "<url to bug>",
 
-			// Managed service pods that have limits but not requests
+			// Managed service pods that have limits but not requests, that are in platform namespaces
 			"apps/v1/Deployment/openshift-monitoring/configure-alertmanager-operator/container/configure-alertmanager-operator/limit[cpu]":      "https://issues.redhat.com/browse/OSD-21708",
 			"apps/v1/Deployment/openshift-monitoring/configure-alertmanager-operator/container/configure-alertmanager-operator/request[cpu]":    "https://issues.redhat.com/browse/OSD-21708",
 			"apps/v1/Deployment/openshift-monitoring/configure-alertmanager-operator/container/configure-alertmanager-operator/limit[memory]":   "https://issues.redhat.com/browse/OSD-21708",

--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -13,85 +13,22 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var excludedPriorityClassNamespaces = []string{
+var excludedPriorityClassNamespaces = append([]string{
 	// OpenShift marketplace can have workloads pods that are created from Jobs which just have hashes
 	// They can be safely ignored as they're not part of core platform.
-	// In future, if this assumption changes, we can revisit it.
-	"openshift-marketplace",
+	// In the future, if this assumption changes, we can revisit it.
+	"openshift-marketplace"},
 
-	// Managed service namespaces
-	"openshift-deployment-validation-operator",
-	"openshift-observability-operator",
-}
+	// Managed services namespaces
+	exutil.ManagedServiceNamespaces.UnsortedList()...,
+)
 
 var excludedPriorityClassPods = map[string][]string{
-	// Managed service pods
-	"openshift-addon-operator": {
-		"addon-operator-catalog",
-		"addon-operator-manager",
-		"addon-operator-webhooks",
-	},
-	"openshift-backplane-srep": {
-		"osd-delete-ownerrefs-serviceaccounts",
-	},
-	"openshift-backplane": {
-		"osd-delete-backplane-serviceaccounts",
-	},
-	"openshift-custom-domains-operator": {
-		"custom-domains-operator",
-		"custom-domains-operator-registry",
-	},
-	"openshift-managed-node-metadata-operator": {
-		"managed-node-metadata-operator",
-		"managed-node-metadata-operator-registry",
-	},
-	"openshift-managed-upgrade-operator": {
-		"managed-upgrade-operator",
-		"managed-upgrade-operator-catalog",
-	},
+	// Managed services pods running in platform namespaces
 	"openshift-monitoring": {
 		"osd-rebalance-infra-nodes",
 		"configure-alertmanager-operator",
 		"osd-cluster-ready",
-	},
-	"openshift-must-gather-operator": {
-		"must-gather-operator",
-		"must-gather-operator-registry",
-	},
-	"openshift-ocm-agent-operator": {
-		"ocm-agent",
-		"ocm-agent-operator",
-	},
-	"openshift-osd-metrics": {
-		"osd-metrics-exporter",
-		"osd-metrics-exporter-registry",
-	},
-	"openshift-package-operator": {
-		"package-operator-manager",
-	},
-	"openshift-rbac-permissions": {
-		"rbac-permissions-operator",
-		"rbac-permissions-operator-registry",
-	},
-	"openshift-route-monitor-operator": {
-		"route-monitor-operator-controller-manager",
-		"blackbox-exporter",
-		"route-monitor-operator-registry",
-	},
-	"openshift-security": {
-		"audit-exporter",
-		"splunkforwarder-ds",
-	},
-	"openshift-splunk-forwarder-operator": {
-		"splunk-forwarder-operator",
-		"splunk-forwarder-operator-catalog",
-	},
-	"openshift-sre-pruning": {
-		"deployments-pruner",
-		"builds-pruner",
-	},
-	"openshift-validation-webhook": {
-		"validation-webhook",
 	},
 }
 

--- a/test/extended/util/managed_services.go
+++ b/test/extended/util/managed_services.go
@@ -1,0 +1,28 @@
+package util
+
+import "k8s.io/apimachinery/pkg/util/sets"
+
+// ManagedServiceNamespaces is the set of namespaces used by managed service platforms
+// like ROSA, ARO, etc. These are typically exempt from the requirements we impose on
+// core platform namespaces.
+var ManagedServiceNamespaces = sets.New[string](
+	"openshift-addon-operator",
+	"openshift-backplane",
+	"openshift-backplane-srep",
+	"openshift-custom-domains-operator",
+	"openshift-deployment-validation-operator",
+	"openshift-managed-node-metadata-operator",
+	"openshift-managed-upgrade-operator",
+	"openshift-marketplace",
+	"openshift-must-gather-operator",
+	"openshift-observability-operator",
+	"openshift-ocm-agent-operator",
+	"openshift-osd-metrics",
+	"openshift-package-operator",
+	"openshift-rbac-permissions",
+	"openshift-route-monitor-operator",
+	"openshift-security",
+	"openshift-splunk-forwarder-operator",
+	"openshift-sre-pruning",
+	"openshift-validation-webhook",
+)


### PR DESCRIPTION
Some ephemeral pods in rosa namespaces like openshift-sre-pruning are triggering failures that didn't have per-pod exceptions, just skip examining these namespaces alltogether.

Example:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-rosa-sts-ovn/1856870032659714048