### PR TITLE
Revert "NO-ISSUE: Add Capability and FeatureGate checks to OLMv1 tests"

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -23,26 +23,31 @@ const (
 	typeIncompatibelOperatorsUpgradeable = "InstalledOLMOperatorsUpgradeable"
 )
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
+var _ = g.Describe("[sig-olmv1] OLMv1 CRDs", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("default")
 
 	g.It("should be installed", func(ctx g.SpecContext) {
-		checkFeatureCapability(ctx, oc)
+		g.Skip("Test is temporarily disabled while we make anticipated, breaking changes.")
+		// Check for tech preview, if this is not tech preview, bail
+		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
+			g.Skip("Test only runs in tech-preview")
+		}
 
+		// supports multiple versions during transision
 		providedAPIs := []struct {
 			group   string
-			version string
+			version []string
 			plural  string
 		}{
 			{
 				group:   olmv1GroupName,
-				version: "v1",
+				version: []string{"v1alpha1", "v1"},
 				plural:  "clusterextensions",
 			},
 			{
 				group:   olmv1GroupName,
-				version: "v1",
+				version: []string{"v1alpha1", "v1"},
 				plural:  "clustercatalogs",
 			},
 		}
@@ -50,7 +55,14 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
 		for _, api := range providedAPIs {
 			g.By(fmt.Sprintf("checking %s at version %s [apigroup:%s]", api.plural, api.version, api.group))
 			// Ensure expected version exists in spec.versions and is both served and stored
-			raw, err := oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==%q)]}", api.version)).Output()
+			var err error
+			var raw string
+			for _, ver := range api.version {
+				raw, err = oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==%q)]}", ver)).Output()
+				if err == nil {
+					break
+				}
+			}
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(raw).To(o.MatchRegexp(`served.?:true`))
 			o.Expect(raw).To(o.MatchRegexp(`storage.?:true`))
@@ -58,12 +70,16 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
 	})
 })
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs", func() {
+var _ = g.Describe("[sig-olmv1] OLMv1 Catalogs", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("default")
 
 	g.It("should be installed", func(ctx g.SpecContext) {
-		checkFeatureCapability(ctx, oc)
+		g.Skip("Test is temporarily disabled while we make anticipated, breaking changes.")
+		// Check for tech preview, if this is not tech preview, bail
+		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
+			g.Skip("Test only runs in tech-preview")
+		}
 
 		providedCatalogs := []string{
 			"openshift-certified-operators",
@@ -86,7 +102,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs", func() {
 	})
 })
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation", func() {
+var _ = g.Describe("[sig-olmv1][Serial] OLMv1 operator installation", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -109,12 +125,15 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator in
 	})
 
 	g.It("should install a cluster extension", func(ctx g.SpecContext) {
-		checkFeatureCapability(ctx, oc)
-
+		g.Skip("Test is temporarily disabled while we make anticipated, breaking changes.")
 		const (
 			packageName = "quay-operator"
 			version     = "3.13.0"
 		)
+		// Check for tech preview, if this is not tech preview, bail
+		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
+			g.Skip("Test only runs in tech-preview")
+		}
 
 		ns := oc.Namespace()
 		g.By(fmt.Sprintf("Updating the namespace to: %q", ns))
@@ -145,12 +164,15 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator in
 	})
 
 	g.It("should block cluster upgrades if an incompatible operator is installed", func(ctx g.SpecContext) {
-		checkFeatureCapability(ctx, oc)
-
+		g.Skip("Test is temporarily disabled while we make anticipated, breaking changes.")
 		const (
 			packageName = "elasticsearch-operator"
 			version     = "5.8.13"
 		)
+		// Check for tech preview, if this is not tech preview, bail
+		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
+			g.Skip("Test only runs in tech-preview")
+		}
 
 		ns := oc.Namespace()
 		g.By(fmt.Sprintf("Updating the namespace to: %q", ns))
@@ -183,7 +205,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator in
 
 func updateCe(b []byte, args ...string) string {
 	s := string(b)
-	s = strings.ReplaceAll(s, "{NAMESPACE}", args[0])
+	s = strings.ReplaceAll(s, "{REPLACE}", args[0])
 	s = strings.ReplaceAll(s, "{PACKAGENAME}", args[1])
 	s = strings.ReplaceAll(s, "{VERSION}", args[2])
 	return s
@@ -230,15 +252,4 @@ func WaitForCondition(oc *exutil.CLI, status bool) (done bool, err error) {
 		return false, nil
 	}
 	return true, nil
-}
-
-func checkFeatureCapability(ctx context.Context, oc *exutil.CLI) {
-	// Hardcoded until openshift/api is updated:
-	// import (	configv1 "github.com/openshift/api/config/v1" )
-	// configv1.ClusterVersionCapabilityOperatorLifecycleManagerV1
-	cap, err := exutil.IsCapabilityEnabled(oc, "OperatorLifecycleManagerV1")
-	o.Expect(err).NotTo(o.HaveOccurred())
-	if !cap {
-		g.Skip("Test only runs with OperatorLifecycleManagerV1 capability")
-	}
 }

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50056,12 +50056,12 @@ var _testExtendedTestdataOlmv1InstallOperatorYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: install-test-sa
-  namespace: {NAMESPACE}
+  namespace: {REPLACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: crb-{NAMESPACE}
+  name: crb-{REPLACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -50069,16 +50069,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: install-test-sa
-  namespace: {NAMESPACE}
+  namespace: {REPLACE}
 ---
-apiVersion: olm.operatorframework.io/v1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterExtension
 metadata:
   name: install-test-ce
 spec:
-  namespace: {NAMESPACE}
-  serviceAccount:
-    name: install-test-sa
+  install:
+    namespace: {REPLACE}
+    serviceAccount:
+      name: install-test-sa
   source:
     catalog:
       packageName: {PACKAGENAME}

--- a/test/extended/testdata/olmv1/install-operator.yaml
+++ b/test/extended/testdata/olmv1/install-operator.yaml
@@ -2,12 +2,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: install-test-sa
-  namespace: {NAMESPACE}
+  namespace: {REPLACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: crb-{NAMESPACE}
+  name: crb-{REPLACE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -15,16 +15,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: install-test-sa
-  namespace: {NAMESPACE}
+  namespace: {REPLACE}
 ---
-apiVersion: olm.operatorframework.io/v1
+apiVersion: olm.operatorframework.io/v1alpha1
 kind: ClusterExtension
 metadata:
   name: install-test-ce
 spec:
-  namespace: {NAMESPACE}
-  serviceAccount:
-    name: install-test-sa
+  install:
+    namespace: {REPLACE}
+    serviceAccount:
+      name: install-test-sa
   source:
     catalog:
       packageName: {PACKAGENAME}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1705,13 +1705,13 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io] CPU Partitioning node validation should have correct cpuset and cpushare set in crio containers": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
+	"[sig-olmv1] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
+	"[sig-olmv1] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/serial]",
+	"[sig-olmv1][Serial] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/serial]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/serial]",
+	"[sig-olmv1][Serial] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/serial]",
 
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -244,14 +244,6 @@ spec:
     - testName: '[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks]
         when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork
         status should report not-ready'
-  - featureGate: NewOLM
-    tests:
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs should be installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation
-        should block cluster upgrades if an incompatible operator is installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation
-        should install a cluster extension'
   - featureGate: PersistentIPsForVirtualization
     tests:
     - testName: '[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][Feature:Layer2LiveMigration]


### PR DESCRIPTION
Reverts https://github.com/openshift/origin/pull/29290 ; tracked by https://issues.redhat.com/browse/OCPBUGS-44662

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This change is breaking 4.18 nightly. First payload failure https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.nightly/release/4.18.0-0.nightly-2024-11-16-132904

See thread for more details: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1731937499008099?thread_ts=1731522911.671799&cid=C01CQA76KMX

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

/payload-job periodic-ci-openshift-release-master-ci-4.18-e2e-aws-ovn-techpreview-serial


CC: @tmshort @joelanford 