### PR TITLE
4.18, virt: Skip operator unhealthy alarm

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -47,4 +47,5 @@ var AllowedAlertNames = []string{
 	"CDIDefaultStorageClassDegraded", // Installing openshift virt with RWX storage fire an alarm, that is not relevant for most of the tests.
 	"VirtHandlerRESTErrorsHigh",      // https://issues.redhat.com/browse/CNV-50418
 	"VirtControllerRESTErrorsHigh",   // https://issues.redhat.com/browse/CNV-50418
+	"OperatorConditionsUnhealthy",    // When installing openshift virt, unhealty alert fires until operator is ready.
 }


### PR DESCRIPTION
During openshift virt the operator emits an alarm until all the sub components are not healthy, this change skip that alarm so monitor test do not fail.