### PR TITLE
OCPBUGS-42610: filter out pod events during vsphere snapshot options

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -445,19 +445,6 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 		neverAllow:        true,
 	})
 
-	// Repeating events about pod creation are expected for snapshot options tests in vsphere csi driver.
-	// The tests change clusterCSIDriver object and have to rollout new pods to load new configuration.
-	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
-		name: "VsphereConfigurationTestsRollOutTooOften",
-		locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
-			monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
-			monitorapi.LocatorE2ETestKey:   regexp.MustCompile(`.*snapshot options in clusterCSIDriver.*`),
-		},
-		messageReasonRegex: regexp.MustCompile(`(^SuccessfulCreate$|^SuccessfulDelete$)`),
-		messageHumanRegex:  regexp.MustCompile(`(^Created pod.*vmware-vsphere-csi-driver.*|^Deleted pod.*vmware-vsphere-csi-driver.*)`),
-		jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
-	})
-
 	registry.AddPathologicalEventMatcherOrDie(AllowBackOffRestartingFailedContainer)
 
 	registry.AddPathologicalEventMatcherOrDie(AllowOVNReadiness)
@@ -496,6 +483,9 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	singleNodeKubeAPIServerProgressingMatcher := newSingleNodeKubeAPIProgressingEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(singleNodeConnectionRefusedMatcher)
 	registry.AddPathologicalEventMatcherOrDie(singleNodeKubeAPIServerProgressingMatcher)
+
+	vsphereConfigurationTestsRollOutTooOftenMatcher := newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals)
+	registry.AddPathologicalEventMatcherOrDie(vsphereConfigurationTestsRollOutTooOftenMatcher)
 
 	return registry
 }
@@ -946,6 +936,32 @@ func newTopologyAwareHintsDisabledDuringTaintTestsPathologicalEventMatcher(final
 	}
 
 	return matcher
+}
+
+// Repeating events about pod creation are expected for snapshot options tests in vsphere csi driver.
+// The tests change clusterCSIDriver object and have to rollout new pods to load new configuration.
+func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
+	configurationTestIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Source == monitorapi.SourceE2ETest &&
+			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "snapshot options in clusterCSIDriver")
+	})
+	for i := range configurationTestIntervals {
+		configurationTestIntervals[i].To = configurationTestIntervals[i].To.Add(time.Minute * 10)
+		configurationTestIntervals[i].From = configurationTestIntervals[i].From.Add(time.Minute * -10)
+	}
+
+	return &OverlapOtherIntervalsPathologicalEventMatcher{
+		delegate: &SimplePathologicalEventMatcher{
+			name: "VsphereConfigurationTestsRollOutTooOften",
+			locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
+				monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
+			},
+			messageReasonRegex: regexp.MustCompile(`(^SuccessfulCreate$|^SuccessfulDelete$)`),
+			messageHumanRegex:  regexp.MustCompile(`(Created pod.*vmware-vsphere-csi-driver.*|Deleted pod.*vmware-vsphere-csi-driver.*)`),
+			jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
+		},
+		allowIfWithinIntervals: configurationTestIntervals,
+	}
 }
 
 // Ignore connection refused events during OCP APIServer or OAuth APIServer being down


### PR DESCRIPTION
This is a fixup for previous patch https://github.com/openshift/origin/pull/29151 which does not seem to work well: 

https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?Aggregation=none&Architecture=amd64&FeatureSet=default&Installer=upi&LayeredProduct=none&Network=ovn&NetworkAccess=default&Platform=vsphere&Procedure=none&Scheduler=default&SecurityMode=default&Suite=serial&Topology=ha&Upgrade=none&baseEndTime=2024-10-01%2023%3A59%3A59&baseRelease=4.17&baseStartTime=2024-09-01%2000%3A00%3A00&capability=Other&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Storage&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20upi%20ovn%20vsphere%20serial%20ha%20none&ignoreDisruption=true&ignoreMissing=false&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2024-11-18%2023%3A59%3A59&sampleRelease=4.18&sampleStartTime=2024-11-11%2000%3A00%3A00&testId=openshift-tests%3A30ac23dcd7037e581ed41a85fad97ecf&testName=%5Bsig-arch%5D%20events%20should%20not%20repeat%20pathologically%20for%20ns%2Fopenshift-cluster-csi-drivers

cc @openshift/storage 