### PR TITLE
OPRUN-3605: sig-olmv1: update all but one of the olmv1 tests to be skipped in disconnected testing

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -65,7 +65,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
 	})
 })
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs", func() {
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("default")
 
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs", func() {
 	})
 })
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 New Catalog Install", func() {
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -132,7 +132,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 New Catalog Install
 	})
 })
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation", func() {
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1707,15 +1707,15 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/serial]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 New Catalog Install should fail to install if it has an invalid reference": " [Suite:openshift/conformance/parallel]",
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension": " [Suite:openshift/conformance/serial]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/serial]",
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/serial]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation should fail to install a non-existing cluster extension": " [Suite:openshift/conformance/serial]",
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/serial]",
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install should fail to install if it has an invalid reference": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -247,15 +247,18 @@ spec:
   - featureGate: NewOLM
     tests:
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 Catalogs should be installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 New Catalog Install should
-        fail to install if it has an invalid reference'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation
-        should block cluster upgrades if an incompatible operator is installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation
-        should fail to install a non-existing cluster extension'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial] OLMv1 operator installation
-        should install a cluster extension'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
+        OLMv1 operator installation should block cluster upgrades if an incompatible
+        operator is installed'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
+        OLMv1 operator installation should fail to install a non-existing cluster
+        extension'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
+        OLMv1 operator installation should install a cluster extension'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs
+        should be installed'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New
+        Catalog Install should fail to install if it has an invalid reference'
   - featureGate: PersistentIPsForVirtualization
     tests:
     - testName: '[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][Feature:Layer2LiveMigration]


### PR DESCRIPTION
as all the skipped tests expect some level of internet access or a specific disconnected environment configuration.