### PR TITLE
OPRUN-3606: Add diagnostics to olmv1 tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50082,30 +50082,30 @@ func testExtendedTestdataOlmv1InstallCatalogYaml() (*asset, error) {
 var _testExtendedTestdataOlmv1InstallOperatorYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: install-test-sa
+  name: install-test-sa-{PACKAGENAME}
   namespace: {NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: crb-{NAMESPACE}
+  name: install-test-crb-{PACKAGENAME}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: install-test-sa
+  name: install-test-sa-{PACKAGENAME}
   namespace: {NAMESPACE}
 ---
 apiVersion: olm.operatorframework.io/v1
 kind: ClusterExtension
 metadata:
-  name: install-test-ce
+  name: install-test-ce-{PACKAGENAME}
 spec:
   namespace: {NAMESPACE}
   serviceAccount:
-    name: install-test-sa
+    name: install-test-sa-{PACKAGENAME}
   source:
     catalog:
       packageName: {PACKAGENAME}

--- a/test/extended/testdata/olmv1/install-operator.yaml
+++ b/test/extended/testdata/olmv1/install-operator.yaml
@@ -1,30 +1,30 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: install-test-sa
+  name: install-test-sa-{PACKAGENAME}
   namespace: {NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: crb-{NAMESPACE}
+  name: install-test-crb-{PACKAGENAME}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: install-test-sa
+  name: install-test-sa-{PACKAGENAME}
   namespace: {NAMESPACE}
 ---
 apiVersion: olm.operatorframework.io/v1
 kind: ClusterExtension
 metadata:
-  name: install-test-ce
+  name: install-test-ce-{PACKAGENAME}
 spec:
   namespace: {NAMESPACE}
   serviceAccount:
-    name: install-test-sa
+    name: install-test-sa-{PACKAGENAME}
   source:
     catalog:
       packageName: {PACKAGENAME}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1707,15 +1707,15 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/serial]",
-
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension": " [Suite:openshift/conformance/serial]",
-
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/serial]",
-
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install should fail to install if it has an invalid reference": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -247,18 +247,17 @@ spec:
   - featureGate: NewOLM
     tests:
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
-        OLMv1 operator installation should block cluster upgrades if an incompatible
-        operator is installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
-        OLMv1 operator installation should fail to install a non-existing cluster
-        extension'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Serial][Skipped:Disconnected]
-        OLMv1 operator installation should install a cluster extension'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs
         should be installed'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New
         Catalog Install should fail to install if it has an invalid reference'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
+        installation should block cluster upgrades if an incompatible operator is
+        installed'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
+        installation should fail to install a non-existing cluster extension'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
+        installation should install a cluster extension'
   - featureGate: PersistentIPsForVirtualization
     tests:
     - testName: '[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][Feature:Layer2LiveMigration]


### PR DESCRIPTION
* Add diagnostics to figure out what happened when context timeout occurs
* Remove [Serial] requirements, the install tests can now happen in parallel