### PR TITLE
TRT-1761: Allow the test for kubelet DiskPressure to fail job runs

### DIFF
--- a/pkg/monitortests/node/watchnodes/monitortest.go
+++ b/pkg/monitortests/node/watchnodes/monitortest.go
@@ -142,9 +142,9 @@ func nodeDiskPressure(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTest
 				Output: fmt.Sprintf("found %d intervals where a node began reporting DiskPressure:\n\n%v", len(failures), strings.Join(failures, "\n")),
 			},
 		})
+	} else {
+		tests = append(tests, &junitapi.JUnitTestCase{Name: testName})
 	}
 
-	// until we know how widespread this is, mark this as a flake
-	tests = append(tests, &junitapi.JUnitTestCase{Name: testName})
 	return tests
 }


### PR DESCRIPTION
Only metal jobs were showing up, rarely at that, and a fix just went in.

https://sippy.dptools.openshift.org/sippy-ng/jobs/4.18/runs?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522flaked_test_names%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522%255BJira%253A%255C%2522Test%2520Framework%255C%2522%255D%2520kubelet%2520should%2520not%2520report%2520DiskPressure%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=desc&sortField=timestamp
