### PR TITLE
NO-JIRA: Revert "Enforce the required-scc monitor test and validate usage of non-standard OCP SCCs

### DIFF
--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -31,24 +31,6 @@ var defaultSCCs = sets.NewString(
 	"restricted-v2",
 )
 
-var nonStandardSCCNamespaces = map[string]sets.Set[string]{
-	"node-exporter":                   sets.New("openshift-monitoring"),
-	"machine-api-termination-handler": sets.New("openshift-machine-api"),
-}
-
-var namespacesWithPendingSCCPinning = sets.NewString(
-	"openshift-cluster-csi-drivers",
-	"openshift-cluster-version",
-	"openshift-image-registry",
-	"openshift-ingress",
-	"openshift-ingress-canary",
-	"openshift-ingress-operator",
-	"openshift-insights",
-	"openshift-machine-api",
-	"openshift-marketplace",
-	"openshift-monitoring",
-)
-
 type requiredSCCAnnotationChecker struct {
 	kubeClient kubernetes.Interface
 }
@@ -86,11 +68,6 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 			continue
 		}
 
-		// check if the namespace should be treated as flaking when failed
-		flakeWhenFailed := ns.Labels["openshift.io/run-level"] == "0" ||
-			ns.Labels["openshift.io/run-level"] == "1" ||
-			namespacesWithPendingSCCPinning.Has(ns.Name)
-
 		pods, err := w.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, nil, err
@@ -98,47 +75,13 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 
 		failures := make([]string, 0)
 		for _, pod := range pods.Items {
-			validatedSCC := pod.Annotations[securityv1.ValidatedSCCAnnotation]
-			allowedNamespaces, isNonStandard := nonStandardSCCNamespaces[validatedSCC]
-
 			if _, exists := pod.Annotations[securityv1.RequiredSCCAnnotation]; exists {
-				if isNonStandard && !allowedNamespaces.Has(ns.Name) {
-					failures = append(failures, fmt.Sprintf(
-						"pod '%s' has a non-standard SCC '%s' not allowed in namespace '%s'; allowed namespaces are: %s",
-						pod.Name, validatedSCC, ns.Name, strings.Join(allowedNamespaces.UnsortedList(), ", ")))
-				}
 				continue
 			}
 
+			suggestedSCC := suggestSCC(&pod)
 			owners := ownerReferences(&pod)
-
-			switch {
-			case len(validatedSCC) == 0:
-				failures = append(failures, fmt.Sprintf(
-					"annotation missing from pod '%s'%s; cannot suggest required-scc, no validated SCC on pod",
-					pod.Name, owners))
-
-			case defaultSCCs.Has(validatedSCC):
-				failures = append(failures, fmt.Sprintf(
-					"annotation missing from pod '%s'%s; suggested required-scc: '%s'",
-					pod.Name, owners, validatedSCC))
-
-			case isNonStandard:
-				if allowedNamespaces.Has(ns.Name) {
-					failures = append(failures, fmt.Sprintf(
-						"annotation missing from pod '%s'%s; suggested required-scc: '%s', this is a non-standard SCC",
-						pod.Name, owners, validatedSCC))
-				} else {
-					failures = append(failures, fmt.Sprintf(
-						"annotation missing from pod '%s'%s; pod is using non-standard SCC '%s' not allowed in namespace '%s'; allowed namespaces are: %s",
-						pod.Name, owners, validatedSCC, ns.Name, strings.Join(allowedNamespaces.UnsortedList(), ", ")))
-				}
-
-			default:
-				failures = append(failures, fmt.Sprintf(
-					"annotation missing from pod '%s'%s; cannot suggest required-scc, validated SCC '%s' is a custom SCC",
-					pod.Name, owners, validatedSCC))
-			}
+			failures = append(failures, fmt.Sprintf("annotation missing from pod '%s'%s; %s", pod.Name, owners, suggestedSCC))
 		}
 
 		testName := fmt.Sprintf("[sig-auth] all workloads in ns/%s must set the '%s' annotation", ns.Name, securityv1.RequiredSCCAnnotation)
@@ -148,21 +91,18 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 		}
 
 		failureMsg := strings.Join(failures, "\n")
-
 		junits = append(junits,
 			&junitapi.JUnitTestCase{
 				Name:          testName,
 				SystemOut:     failureMsg,
 				FailureOutput: &junitapi.FailureOutput{Output: failureMsg},
-			})
+			},
 
-		// add a successful test with the same name to cause a flake
-		if flakeWhenFailed {
-			junits = append(junits,
-				&junitapi.JUnitTestCase{
-					Name: testName,
-				})
-		}
+			// add a successful test with the same name to cause a flake
+			&junitapi.JUnitTestCase{
+				Name: testName,
+			},
+		)
 	}
 
 	return nil, junits, nil
@@ -182,6 +122,20 @@ func (w *requiredSCCAnnotationChecker) WriteContentToStorage(ctx context.Context
 
 func (w *requiredSCCAnnotationChecker) Cleanup(ctx context.Context) error {
 	return nil
+}
+
+// suggestSCC suggests the assigned SCC only if it belongs to the default set of SCCs
+// pods in runlevel 0/1 namespaces won't have any assigned SCC as SCC admission is disabled
+func suggestSCC(pod *v1.Pod) string {
+	if len(pod.Annotations[securityv1.ValidatedSCCAnnotation]) == 0 {
+		return "cannot suggest required-scc, no validated SCC on pod"
+	}
+
+	if defaultSCCs.Has(pod.Annotations[securityv1.ValidatedSCCAnnotation]) {
+		return fmt.Sprintf("suggested required-scc: '%s'", pod.Annotations[securityv1.ValidatedSCCAnnotation])
+	}
+
+	return "cannot suggest required-scc, validated SCC is custom"
 }
 
 func ownerReferences(pod *v1.Pod) string {


### PR DESCRIPTION
Reverts openshift/origin#29135

Observing permafailures in 4.19 Nightly payloads (haven't had a 4.18 recently) for hypershift starting with [4.19.0-0.nightly-2024-11-23-092733](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.19.0-0.nightly/release/4.19.0-0.nightly-2024-11-23-092733)

Due to:
```
: [sig-auth] all workloads in ns/kube-system must set the 'openshift.io/required-scc' annotation expand_less 	0s
{  annotation missing from pod 'konnectivity-agent-6rwjl' (owners: daemonset/konnectivity-agent); cannot suggest required-scc, no validated SCC on pod
annotation missing from pod 'konnectivity-agent-88sdg' (owners: daemonset/konnectivity-agent); cannot suggest required-scc, no validated SCC on pod
annotation missing from pod 'konnectivity-agent-ktcw5' (owners: daemonset/konnectivity-agent); cannot suggest required-scc, no validated SCC on pod
annotation missing from pod 'kube-apiserver-proxy-ip-10-0-128-121.ec2.internal' (owners: node/ip-10-0-128-121.ec2.internal); cannot suggest required-scc, no validated SCC on pod
annotation missing from pod 'kube-apiserver-proxy-ip-10-0-132-203.ec2.internal' (owners: node/ip-10-0-132-203.ec2.internal); cannot suggest required-scc, no validated SCC on pod
annotation missing from pod 'kube-apiserver-proxy-ip-10-0-141-250.ec2.internal' (owners: node/ip-10-0-141-250.ec2.internal); cannot suggest required-scc, no validated SCC on pod}
```

Starting the revert to validate via `/payload-job periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-aws-ovn-conformance`