### PR TITLE
OCPBUGS-43936: disable fsync degraded check

### DIFF
--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -184,7 +184,7 @@ var (
 			"EtcdMembersProgressing",
 			"EtcdRunningInCluster",
 			"EtcdStaticResourcesDegraded",
-			"FSyncControllerDegraded",
+			//"FSyncControllerDegraded", // this is flaky and depends on the environment
 			"GuardControllerDegraded",
 			"InstallerControllerDegraded",
 			"InstallerPodContainerWaitingDegraded",


### PR DESCRIPTION
This can appear and disappear at any time, depending on the fsync metric in the environment. That does not indicate a bug in the operator.