### PR TITLE
OCPBUGS-26601: Re-enable AWS for router HTTP/2 test

### DIFF
--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strconv"
@@ -470,7 +471,7 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 				return
 			}
 
-			testSuites, err := runConformanceTests(oc, host, "h2spec", 5*time.Minute)
+			testSuites, err := runConformanceTests(oc, host, "h2spec", 10*time.Minute)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(testSuites).ShouldNot(o.BeEmpty())
 
@@ -546,7 +547,14 @@ func failingTests(testSuites []*h2spec.JUnitTestSuite) []h2specFailingTest {
 func runConformanceTests(oc *exutil.CLI, host, podName string, timeout time.Duration) ([]*h2spec.JUnitTestSuite, error) {
 	var testSuites []*h2spec.JUnitTestSuite
 
-	if err := wait.Poll(time.Second, timeout, func() (bool, error) {
+	if err := wait.Poll(2*time.Second, timeout, func() (bool, error) {
+		// Error message will read as:
+		//   <date>: INFO: lookup <host>: no such host, retrying...
+		if _, err := net.LookupHost(host); err != nil {
+			e2e.Logf("%v, retrying...", err)
+			return false, nil
+		}
+
 		g.By("Running the h2spec CLI test")
 
 		// this is the output file in the pod
@@ -613,7 +621,7 @@ func runConformanceTestsAndLogAggregateFailures(oc *exutil.CLI, host, podName st
 	failuresByTestCaseID := map[string]int{}
 
 	for i := 1; i <= iterations; i++ {
-		testResults, err := runConformanceTests(oc, host, podName, 5*time.Minute)
+		testResults, err := runConformanceTests(oc, host, podName, 10*time.Minute)
 		if err != nil {
 			e2e.Logf(err.Error())
 			continue

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -592,11 +592,8 @@ func resolveHost(oc *exutil.CLI, interval, timeout time.Duration, host string) (
 // clients.
 func platformHasHTTP2LoadBalancerService(platformType configv1.PlatformType) bool {
 	switch platformType {
-	case configv1.AzurePlatformType, configv1.GCPPlatformType:
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
 		return true
-	case configv1.AWSPlatformType:
-		e2e.Logf("AWS support waiting on https://bugzilla.redhat.com/show_bug.cgi?id=1912413")
-		fallthrough
 	default:
 		return false
 	}


### PR DESCRIPTION
After local tests on an AWS cluster, I don't see the limitation for the HTTP/2 support on AWS CLB (default LB type) anymore. This PR re-introduces https://github.com/openshift/origin/pull/28515 which was reverted by https://github.com/openshift/origin/pull/28905.