### PR TITLE
OCPBUGS-44970: Excluding loki prod-bearer-token container from excessive restarts test in SNO

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -35,6 +35,14 @@ func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 			topologyToExclude: "single",
 		},
 		{
+			// prod-bearer-token is part of the opeshift-e2e-loki deployment
+			// (see https://github.com/openshift/release/tree/master/ci-operator/step-registry/ipi/install/hosted-loki)
+			// the error from the pod is the inability to resolve sso.redhat.com due to dns being unavailable
+			// briefly during the upgrade
+			containerName:     "container/prod-bearer-token", // https://issues.redhat.com/browse/OCPBUGS-44970
+			topologyToExclude: "single",
+		},
+		{
 			containerName: "container/kube-multus", // https://issues.redhat.com/browse/OCPBUGS-42267
 		},
 		{


### PR DESCRIPTION
This container is deployed by https://github.com/openshift/release/tree/master/ci-operator/step-registry/ipi/install/hosted-loki and is sensitive to resolving sso.redhat.com. During an SNO upgrade, there is a brief period of time where dns is unavailable because the only instance of the pod has been killed and the new pod is starting up. The goal of this change is to exclude this container from the excessive restart checks since, depending on the exact timing, it can restart enough times to trigger a failed test.