### PR TITLE
OCPBUGS-45153: address malformed configmap post-test

### DIFF
--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -33,8 +33,9 @@ const (
 	operatorName              = "cluster-monitoring-operator"
 	operatorNamespaceName     = "openshift-monitoring"
 	operatorConfigurationName = "cluster-monitoring-config"
-	pollTimeout               = 15 * time.Minute
-	pollInterval              = 5 * time.Second
+
+	pollTimeout  = 15 * time.Minute
+	pollInterval = 5 * time.Second
 )
 
 var (
@@ -56,7 +57,7 @@ type runner struct {
 // NOTE: The containers themselves are guaranteed to run in the order in which they appear.
 var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
-	
+
 	r := &runner{}
 	oc := exutil.NewCLI(projectName)
 	tctx := context.Background()
@@ -119,7 +120,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			}
 
 			return nil
-		}).Should(o.BeNil())
+		}, pollTimeout, pollInterval).Should(o.BeNil())
 	})
 
 	g.Context("initially, in a homogeneous default environment,", func() {
@@ -294,7 +295,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				wantCount := int(queryResponse.Data.Result[0].Value)
 
 				kubeStateMetricsMainMetricsString := strings.Join(kubeStateMetricsMainMetrics, "")
-				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */ ])
+				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */])
 				queryResponse, err = helper.RunQuery(tctx, r.pclient, kubeStateMetricsMainMetricsCountQuery)
 				if err != nil {
 					return err

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -54,7 +54,7 @@ type runner struct {
 // NOTE: The nested `Context` containers inside the following `Describe` container are used to group certain tests based on the environments they demand.
 // NOTE: When adding a test-case, ensure that the test-case is placed in the appropriate `Context` container.
 // NOTE: The containers themselves are guaranteed to run in the order in which they appear.
-var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set", g.Ordered, func() {
+var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
 	r := &runner{}

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -95,6 +95,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 	})
 
 	g.AfterAll(func() {
+		shouldDeleteConfiguration := false
 		currentConfiguration, err := r.kclient.CoreV1().ConfigMaps(operatorNamespaceName).Get(tctx, operatorConfigurationName, metav1.GetOptions{})
 		o.Expect(err).To(o.BeNil())
 		if r.originalOperatorConfiguration != nil {
@@ -102,17 +103,22 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			g.By("restoring the original configuration for the operator")
 			_, err = r.kclient.CoreV1().ConfigMaps(operatorNamespaceName).Update(tctx, currentConfiguration, metav1.UpdateOptions{})
 		} else {
+			shouldDeleteConfiguration = true
 			g.By("cleaning up the configuration for the operator as it did not exist pre-job")
 			err = r.kclient.CoreV1().ConfigMaps(operatorNamespaceName).Delete(tctx, operatorConfigurationName, metav1.DeleteOptions{})
 		}
 		o.Expect(err).To(o.BeNil())
 
 		o.Eventually(func() error {
-			_, err := r.kclient.CoreV1().ConfigMaps(operatorNamespaceName).Get(tctx, operatorConfigurationName, metav1.GetOptions{})
-			if errors.IsNotFound(err) {
-				return nil
+			if shouldDeleteConfiguration {
+				_, err := r.kclient.CoreV1().ConfigMaps(operatorNamespaceName).Get(tctx, operatorConfigurationName, metav1.GetOptions{})
+				if errors.IsNotFound(err) {
+					return nil
+				}
+				return fmt.Errorf("ConfigMap %q still exists after deletion attempt", operatorConfigurationName)
 			}
-			return fmt.Errorf("ConfigMap %q still exists after deletion attempt", operatorConfigurationName)
+
+			return nil
 		}).Should(o.BeNil())
 	})
 

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -56,7 +56,7 @@ type runner struct {
 // NOTE: The containers themselves are guaranteed to run in the order in which they appear.
 var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
-
+	
 	r := &runner{}
 	oc := exutil.NewCLI(projectName)
 	tctx := context.Background()

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1315,15 +1315,15 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to an HTTP(S) location if the runbook_url annotation is defined": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should expose information about the applied collection profile using meta-metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should expose information about the applied collection profile using meta-metrics": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should have at least one implementation for each collection profile": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should have at least one implementation for each collection profile": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should revert to default collection profile when an empty collection profile value is specified": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should revert to default collection profile when an empty collection profile value is specified": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a homogeneous minimal environment, should hide default metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a homogeneous minimal environment, should hide default metrics": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set initially, in a homogeneous default environment, should expose default metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set initially, in a homogeneous default environment, should expose default metrics": " [Suite:openshift/conformance/serial]",
 
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -107,20 +107,21 @@ spec:
         boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]'
   - featureGate: MetricsCollectionProfiles
     tests:
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should expose
-        information about the applied collection profile using meta-metrics'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should have
-        at least one implementation for each collection profile'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should revert
-        to default collection profile when an empty collection profile value is specified'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a homogeneous minimal environment, should
-        hide default metrics'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set initially, in a homogeneous default environment,
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        expose information about the applied collection profile using meta-metrics'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        have at least one implementation for each collection profile'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        revert to default collection profile when an empty collection profile value
+        is specified'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a homogeneous minimal environment,
+        should hide default metrics'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set initially, in a homogeneous default environment,
         should expose default metrics'
   - featureGate: NetworkDiagnosticsConfig
     tests:


### PR DESCRIPTION
- [[Prow]](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29307-nightly-4.18-e2e-metal-ipi-ovn-dualstack-techpreview/1858916202634547200) After merging https://github.com/openshift/origin/pull/28889, we found out that the tests were failing on bare-metal, due to the absence of a configmap, and the fact that the tests were "leaving" a new configmap in a malformed state (without a `config.yaml` key).
```
{  fail [github.com/openshift/origin/test/extended/prometheus/prometheus.go:405]: could not determine if Telemetry is enabled: openshift-monitoring/cluster-monitoring-config data lacks a config.yaml key: map[]
Ginkgo exit error 1: exit with code 1}
```
- To address this, https://github.com/openshift/origin/pull/29309 was merged that seemed to [resolve](https://github.com/openshift/origin/pull/29309#issuecomment-2491074917) the issue on bare-metal. Note that with this patch, the configmap was [deleted successfully](https://github.com/openshift/origin/pull/29309#issuecomment-2491074917) upon tests' completion.
- [[Prow]](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29309-ci-4.19-e2e-aws-ovn-techpreview/1861901510435147776) Shortly after that, TRT team found out that this introduced a bug for at-least `aws-ovn-techpreview`, stemming from this [snippet](https://github.com/openshift/origin/blob/master/test/extended/prometheus/collection_profiles.go#L100-L105) owing to which the patch was reverted and merged: https://github.com/openshift/origin/pull/29330. However, that snippet is unchanged in the (original and) revert PR, and thus hints towards it being caused due to multiple specs modifying the configmap at the same time.
```
{  fail [github.com/openshift/origin/test/extended/prometheus/collection_profiles.go:180]: Expected
    <*errors.StatusError | 0xc0065a3360>: 
    Operation cannot be fulfilled on configmaps "cluster-monitoring-config": the object has been modified; please apply your changes to the latest version and try again
```
- [[Prow]](https://pr-payload-tests.ci.openshift.org/runs/ci/ead857a0-adb4-11ef-847d-a7a19d6ffba0-0) However, post-revert, on the latest bare-metal must-gathers (for `ipv6` and `dualstack` so far), the CMO configmap collected after the tests are completed has an unpredictable `collectionProfiles` definition (I ran the tests on both 4.18 and 4.19 today, and it seems to be `minimal` and `full`, respectively). Note that earlier, an absence of this patch would have caused the same issue seen in the first point above on bare-metal, but not anymore.
```
apiVersion: v1
data:
  config.yaml: |
    prometheusK8s:
        collectionProfile: "minimal"
kind: ConfigMap
metadata:
  name: cluster-monitoring-config
  namespace: openshift-monitoring
```
***
### [tl;dr](https://github.com/openshift/origin/pull/29331#issuecomment-2508671844)
- Even though the tests may pass post-revert, there's a lingering `collectionProfiles` definition may cause a reduced metrics throughput in general (if set to `minimal`) causing other tests to fail that depend on them.
- Serializing these tests means slightly lesser plaforms to run them on (no bare-metal, for instance).