### PR TITLE
NO-JIRA: managed services: add known image check for gcp

### DIFF
--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -85,6 +85,8 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 
 		// ROSA
 		"default-route-openshift-image-registry.apps.ci-rosa",
+		// OSD GCP
+		"default-route-openshift-image-registry.apps.ci-osd-gcp",
 
 		// installed alongside OLM and managed externally
 		"registry.redhat.io/redhat/community-operator-index",


### PR DESCRIPTION
this was added for rosa in 12ab194e2ef15737f8cae7793b7eb6294f36ef31

Signed-off-by: Brady Pratt <bpratt@redhat.com>
