### PR TITLE
OCPBUGS-45363: Parse node logs also when encountered with standard html header

### DIFF
--- a/pkg/monitortestlibrary/nodeaccess/node_log.go
+++ b/pkg/monitortestlibrary/nodeaccess/node_log.go
@@ -20,7 +20,9 @@ func GetDirectoryListing(in io.Reader) ([]string, error) {
 
 	// turn href links into lines of output
 	content, _ := buf.Peek(bufferSize)
-	if bytes.HasPrefix(content, []byte("<pre>")) {
+	// Until Go 1.23, kubelet returned with the prefix <pre>, but now
+	// it returns with standard html prefix. We need to support both of them.
+	if bytes.HasPrefix(content, []byte("<pre>")) || bytes.HasPrefix(content, []byte("<!doctype html>")) {
 		reLink := regexp.MustCompile(`href="([^"]+)"`)
 		s := bufio.NewScanner(buf)
 		s.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {


### PR DESCRIPTION
This PR is complementary of https://github.com/openshift/oc/pull/1934. 