### PR TITLE
daemon sets: use standardized tolerations for platform ds

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -205,6 +205,8 @@ var Annotations = map[string]string{
 
 	"[sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable or maxSurge update of 10 percent or maxUnavailable of 33 percent": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-arch] Managed cluster should only include daemon sets with proper tolerations": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-arch] Managed cluster should recover when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]": " [Serial]",
 
 	"[sig-arch] Managed cluster should set requests but not limits": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Managed OpenShift has an issue with platform daemon sets and infra nodes. The infra nodes are tainted as NoSchedule, to avoid customer workloads on them. However, platform workloads should run there, but two daemon sets (iptables-alerter and dns-default) don't tolerate all taints, unlike most daemon sets, which use:

```yaml
tolerations:
- operator: Exists
```

Instead, they use:

```yaml
tolerations:
- key: "node-role.kubernetes.io/master"
  operator: "Exists"
```

This prevents these pods from running on infra nodes. However, these DS are also marked `PreferredDuringScheduling` which can cause the tolerations to be ignored (why do we use this?) triggering frequent KubeDaemonSetMisScheduled alerts, disrupting SREs and CI, and blocking ROSA payload readiness.

PRs to fix this:

- https://github.com/openshift/cluster-network-operator/pull/2581
- https://github.com/openshift/cluster-dns-operator/pull/424
 
This PR enforces the first style.

/hold
Pending discussion
