### PR TITLE
NO-JIRA: Create an `openshift/conformance/ocp-flaky` test suite

### DIFF
--- a/pkg/testsuites/flaky.go
+++ b/pkg/testsuites/flaky.go
@@ -1,0 +1,8 @@
+package testsuites
+
+// This file is not yet updated from an official query
+var (
+	flakyTestNames = map[string]struct{}{
+		//`[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions isolates overlapping CIDRs with L3 primary UDN [Suite:openshift/conformance/parallel]`: {},
+	}
+)

--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -48,6 +48,10 @@ var staticSuites = []ginkgo.TestSuite{
 		Only the portion of the openshift/conformance test suite that run in parallel.
 		`),
 		Matches: func(name string) bool {
+			_, isFlaky := flakyTestNames[name]
+			if isFlaky {
+				return false
+			}
 			if isDisabled(name) {
 				return false
 			}
@@ -55,6 +59,21 @@ var staticSuites = []ginkgo.TestSuite{
 		},
 		Parallelism:          30,
 		MaximumAllowedFlakes: 15,
+	},
+	{
+		Name: "openshift/conformance/ocp-flaky",
+		Description: templates.LongDesc(`
+		Our flaky tests plus the portion of the openshift/conformance test suite that run in parallel.
+		`),
+		// same as Matches from "openshift/conformance/parallel" without the flakyTestName check
+		Matches: func(name string) bool {
+			if isDisabled(name) {
+				return false
+			}
+			return strings.Contains(name, "[Suite:openshift/conformance/parallel")
+		},
+		Parallelism:          30,
+		MaximumAllowedFlakes: 0,
 	},
 	{
 		Name: "openshift/conformance/serial",


### PR DESCRIPTION
Nearly all of our tests are reliable enough to not need a retry. Let's eliminate the retry and make flaky tests obvious.  The new periodic jobs we create based on this test will still show up in component readiness and sippy results.