### PR TITLE
STOR-2136: Remove CSI snapshot webhook conditions checks

### DIFF
--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -3,6 +3,8 @@ package operators
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -12,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"strings"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
@@ -159,11 +160,7 @@ var (
 			"CSISnapshotControllerUpgradeable",
 			"CSISnapshotGuestStaticResourceControllerDegraded",
 			"CSISnapshotStaticResourceControllerDegraded",
-			"CSISnapshotWebhookControllerAvailable",
-			"CSISnapshotWebhookControllerDegraded",
-			"CSISnapshotWebhookControllerProgressing",
 			"ManagementStateDegraded",
-			"WebhookControllerDegraded",
 		},
 		//{Group: "operator.openshift.io", Version: "v1", Resource: "dnses"}:                       {}, // different name
 		{Group: "operator.openshift.io", Version: "v1", Resource: "etcds"}: {


### PR DESCRIPTION
We don't need these conditions, because we are no longer deploying snapshot webhook stuff in OCP.

See - https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/219 