### PR TITLE
NO-JIRA: managed services: bump series limit

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -420,7 +420,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		var averageSeriesLimit int
 		switch {
 		case isManagedServiceCluster:
-			averageSeriesLimit = 800
+			averageSeriesLimit = 850
 		default:
 			averageSeriesLimit = 760
 		}


### PR DESCRIPTION
it was 807 in the latest GCP run

Signed-off-by: Brady Pratt <bpratt@redhat.com>
