### PR TITLE
print the error result from UDN test failure

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -504,7 +504,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 								//don't try with your own IP
 								continue
 							}
-							_, err := e2ekubectl.RunKubectl(
+							result, err := e2ekubectl.RunKubectl(
 								namespaceBlue,
 								"exec",
 								fmt.Sprintf("%s-pod-%d", blue, numberOfPods-1),
@@ -515,7 +515,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 								net.JoinHostPort(ip, fmt.Sprintf("%d", port)),
 							)
 							if err == nil {
-								framework.Failf("connection succeeded but expected timeout")
+								framework.Failf("connection succeeded but expected timeout: result=%s", result)
 							}
 						}
 					},


### PR DESCRIPTION
currently we do not print out the result if the connection does not isolate traffic for UDN tests. This does not show us what the pod is connecting to and as such don't know if there are artifacts of the old pods around or if the traffic is not isolated.

Print out the result of the query so that we have more insight as to how the test failed.