### PR TITLE
CNTRLPLANE-1: Update etcd test data for 1.32 release

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -282,11 +282,27 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 	// Apply output of git diff origin/release-1.XY origin/release-1.X(Y+1) test/integration/etcd/data.go. This is needed
 	// to apply the right data depending on the kube version of the running server. Replace this with the next current
 	// and rebase version next time. Don't pile them up.
-	if strings.HasPrefix(version.Minor, "31") {
+	if strings.HasPrefix(version.Minor, "32") {
 		for k, a := range map[schema.GroupVersionResource]etcddata.StorageData{
 			// Added etcd data.
 			// TODO: When rebase has started, add etcd storage data has been added to
-			//       k8s.io/kubernetes/test/integration/etcd/data.go in the 1.30 release.
+			//       k8s.io/kubernetes/test/integration/etcd/data.go in the 1.32 release.
+			gvr("resource.k8s.io", "v1beta1", "deviceclasses"): {
+				Stub:             `{"metadata": {"name": "class2name"}}`,
+				ExpectedEtcdPath: "/registry/deviceclasses/class2name",
+			},
+			gvr("resource.k8s.io", "v1beta1", "resourceclaims"): {
+				Stub:             `{"metadata": {"name": "claim2name"}, "spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}`,
+				ExpectedEtcdPath: "/registry/resourceclaims/" + oc.Namespace() + "/claim2name",
+			},
+			gvr("resource.k8s.io", "v1beta1", "resourceclaimtemplates"): {
+				Stub:             `{"metadata": {"name": "claimtemplate2name"}, "spec": {"spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}}`,
+				ExpectedEtcdPath: "/registry/resourceclaimtemplates/" + oc.Namespace() + "/claimtemplate2name",
+			},
+			gvr("resource.k8s.io", "v1beta1", "resourceslices"): {
+				Stub:             `{"metadata": {"name": "node2slice"}, "spec": {"nodeName": "worker1", "driver": "dra.example.com", "pool": {"name": "worker1", "resourceSliceCount": 1}}}`,
+				ExpectedEtcdPath: "/registry/resourceslices/node2slice",
+			},
 		} {
 			if _, preexisting := etcdStorageData[k]; preexisting {
 				t.Errorf("upstream etcd storage data already has data for %v. Update current and rebase version diff to next rebase version", k)
@@ -296,7 +312,34 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 
 		// Modified etcd data.
 		// TODO: When rebase has started, fixup etcd storage data that has been modified
-		//       in k8s.io/kubernetes/test/integration/etcd/data.go in the 1.30 release.
+		//       in k8s.io/kubernetes/test/integration/etcd/data.go in the 1.32 release.
+
+		// compare https://github.com/kubernetes/kubernetes/pull/127511
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "deviceclasses")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "class1name"}}`,
+			ExpectedEtcdPath: "/registry/deviceclasses/class1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1beta1", "DeviceClass"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceclaims")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "claim1name"}, "spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}`,
+			ExpectedEtcdPath: "/registry/resourceclaims/" + oc.Namespace() + "/claim1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1beta1", "ResourceClaim"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceclaimtemplates")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "claimtemplate1name"}, "spec": {"spec": {"devices": {"requests": [{"name": "req-0", "deviceClassName": "example-class", "allocationMode": "ExactCount", "count": 1}]}}}}`,
+			ExpectedEtcdPath: "/registry/resourceclaimtemplates/" + oc.Namespace() + "/claimtemplate1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1beta1", "ResourceClaimTemplate"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "podschedulingcontexts")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "pod1name"}, "spec": {"selectedNode": "node1name", "potentialNodes": ["node1name", "node2name"]}}`,
+			ExpectedEtcdPath: "/registry/podschedulingcontexts/" + oc.Namespace() + "/pod1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1beta1", "PodSchedulingContext"),
+		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "resourceslices")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "node1slice"}, "spec": {"nodeName": "worker1", "driver": "dra.example.com", "pool": {"name": "worker1", "resourceSliceCount": 1}}}`,
+			ExpectedEtcdPath: "/registry/resourceslices/node1slice",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1beta1", "ResourceSlice"),
+		}
 
 		// Removed etcd data.
 		// TODO: When rebase has started, remove etcd storage data that has been removed


### PR DESCRIPTION
This is intended to fix:

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-kubernetes-2147-ci-4.19-e2e-aws-ovn-techpreview-serial/1867506662982553600

```
[sig-api-machinery] API data in etcd should be stored at the correct location and version for all resources [Serial] [Suite:openshift/conformance/serial] expand_less 	15s
{  fail [github.com/openshift/origin/test/extended/etcd/etcd_storage_path.go:482]: test failed:
no test data for resource.k8s.io/v1beta1, Kind=DeviceClass.  Please add a test for your new type to etcdStorageData.
no test data for resource.k8s.io/v1beta1, Kind=ResourceClaim.  Please add a test for your new type to etcdStorageData.
no test data for resource.k8s.io/v1beta1, Kind=ResourceClaimTemplate.  Please add a test for your new type to etcdStorageData.
no test data for resource.k8s.io/v1beta1, Kind=ResourceSlice.  Please add a test for your new type to etcdStorageData.
GVK for resource.k8s.io/v1alpha3, Kind=DeviceClass does not match, expected resource.k8s.io/v1alpha3, Kind=DeviceClass got resource.k8s.io/v1beta1, Kind=DeviceClass
GVK for resource.k8s.io/v1alpha3, Kind=ResourceClaim does not match, expected resource.k8s.io/v1alpha3, Kind=ResourceClaim got resource.k8s.io/v1beta1, Kind=ResourceClaim
GVK for resource.k8s.io/v1alpha3, Kind=ResourceClaimTemplate does not match, expected resource.k8s.io/v1alpha3, Kind=ResourceClaimTemplate got resource.k8s.io/v1beta1, Kind=ResourceClaimTemplate
GVK for resource.k8s.io/v1alpha3, Kind=ResourceSlice does not match, expected resource.k8s.io/v1alpha3, Kind=ResourceSlice got resource.k8s.io/v1beta1, Kind=ResourceSlice
etcd data does not match the types we saw:
seen but not in etcd data:
[
	resource.k8s.io/v1beta1, Resource=resourceslices 
	resource.k8s.io/v1beta1, Resource=resourceclaims 
	resource.k8s.io/v1beta1, Resource=resourceclaimtemplates 
	resource.k8s.io/v1beta1, Resource=deviceclasses]
Ginkgo exit error 1: exit with code 1}
```
/assign @dusk125 