### PR TITLE
SDN-4930: networksegmentation, udn: Wait for NetworkCreated or NetworkReady condition

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -3,6 +3,7 @@ package networking
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -676,7 +677,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			var actualConditions []metav1.Condition
 			Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
 
-			Expect(actualConditions[0].Type).To(Equal("NetworkReady"))
+			Expect(actualConditions[0].Type).To(SatisfyAny(Equal("NetworkReady"), Equal("NetworkCreated")))
 			Expect(actualConditions[0].Status).To(Equal(metav1.ConditionFalse))
 			Expect(actualConditions[0].Reason).To(Equal("SyncError"))
 			expectedMessage := fmt.Sprintf("primary network already exist in namespace %q: %q", f.Namespace.Name, primaryNadName)
@@ -768,8 +769,15 @@ func applyManifest(namespace, manifest string) error {
 }
 
 func waitForUserDefinedNetworkReady(namespace, name string, timeout time.Duration) error {
-	_, err := e2ekubectl.RunKubectl(namespace, "wait", "userdefinednetwork", name, "--for", "condition=NetworkReady=True", "--timeout", timeout.String())
-	return err
+	_, errNetReady := e2ekubectl.RunKubectl(namespace, "wait", "userdefinednetwork", name, "--for", "condition=NetworkReady=True", "--timeout", timeout.String())
+	netReady := errNetReady == nil
+	_, errNetCreated := e2ekubectl.RunKubectl(namespace, "wait", "userdefinednetwork", name, "--for", "condition=NetworkCreated=True", "--timeout", timeout.String())
+	netCreated := errNetCreated == nil
+
+	if netReady || netCreated {
+		return nil
+	}
+	return errors.Join(errNetReady, errNetCreated)
 }
 
 func newPrimaryUserDefinedNetworkManifest(oc *exutil.CLI, name string) string {
@@ -859,6 +867,14 @@ func assertUDNStatusReportsConsumers(udnNamesapce, udnName, expectedPodName stri
 	for _, condition := range conditions {
 		if found, _ = Equal(metav1.Condition{
 			Type:    "NetworkReady",
+			Status:  "False",
+			Reason:  "SyncError",
+			Message: expectedMsg,
+		}).Match(condition); found {
+			break
+		}
+		if found, _ = Equal(metav1.Condition{
+			Type:    "NetworkCreated",
 			Status:  "False",
 			Reason:  "SyncError",
 			Message: expectedMsg,


### PR DESCRIPTION
Following the incoming changes of UserDefinedNetwork CRD condition type [1], tests that assert on the NetworkReady condition type should take in account the renamed type NetworkCreated to avoid CI breakage in the following scenarios:
- Production code changes reached D/S before tests code changes: Having the UDN CRD produce the new condition type (NetworkCreated), while e2e tests assert on the old condition type (NetworkReady).
- Tests code changes reached D/S before production code changes: Having the UDN CRD produce the old condition type (NetworkReady), while tests assert on the new condition type (NetworkCreated).

Change assertions on UDN condition type NetworkReady, expect condition type NetworkReady or NetworkCreated.

[1] https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4884