### PR TITLE
OCPBUGS-47529: Add team members to the OWNERS file for PR approvals

### DIFF
--- a/test/extended/builds/OWNERS
+++ b/test/extended/builds/OWNERS
@@ -1,5 +1,10 @@
 reviewers:
   - sayan-biswas
   - divyansh42
+  - prabhapa
+  - moebasim  
+
 approvers:
   - sayan-biswas
+  - prabhapa
+  - moebasim

--- a/test/extended/testdata/builds/OWNERS
+++ b/test/extended/testdata/builds/OWNERS
@@ -1,5 +1,10 @@
 reviewers:
   - coreydaley
   - divyansh42
+  - prabhapa
+  - moebasim
+  
 approvers:
   - coreydaley
+  - prabhapa
+  - moebasim


### PR DESCRIPTION
This PR updates the OWNERS file to include two additional members who can approve pull requests.