### PR TITLE
OCPBUGS-48076: external binary: in-line registry auth file fetching

### DIFF
--- a/pkg/test/externalbinary/util.go
+++ b/pkg/test/externalbinary/util.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	imagev1 "github.com/openshift/api/image/v1"
-	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/origin/test/extended/util"
@@ -191,68 +190,6 @@ func determineReleasePayloadImage(logger *log.Logger) (string, error) {
 	return releaseImage, nil
 }
 
-func getRegistryAuthFilePath(logger *log.Logger, oc *util.CLI) (string, error) {
-	// To extract binaries bearing external tests, we must inspect the release
-	// payload under tests as well as extract content from component images
-	// referenced by that payload.
-	// openshift-tests is frequently run in the context of a CI job, within a pod.
-	// CI sets $RELEASE_IMAGE_LATEST to a pullspec for the release payload under test. This
-	// pull spec resolve to:
-	// 1. A build farm ci-op-* namespace / imagestream location (anonymous access permitted).
-	// 2. A quay.io/openshift-release-dev location (for tests against promoted ART payloads -- anonymous access permitted).
-	// 3. A registry.ci.openshift.org/ocp-<arch>/release:<tag> (request registry.ci.openshift.org token).
-	// Within the pod, we don't necessarily have a pull-secret for #3 OR the component images
-	// a payload references (which are private, unless in a ci-op-* imagestream).
-	// We try the following options:
-	// 1. If set, use the REGISTRY_AUTH_FILE environment variable to an auths file with
-	//    pull secrets capable of reading appropriate payload & component image
-	//    information.
-	// 2. If it exists, use a file /run/secrets/ci.openshift.io/cluster-profile/pull-secret
-	//    (conventional location for pull-secret information for CI cluster profile).
-	// 3. Use openshift-config secret/pull-secret from the cluster-under-test, if it exists
-	//    (Microshift does not).
-	// 4. Use unauthenticated access to the payload image and component images.
-	registryAuthFilePath := os.Getenv("REGISTRY_AUTH_FILE")
-
-	// if the environment variable is not set, extract the target cluster's
-	// platform pull secret.
-	if len(registryAuthFilePath) != 0 {
-		logger.Printf("Using REGISTRY_AUTH_FILE environment variable: %v", registryAuthFilePath)
-	} else {
-
-		// See if the cluster-profile has stored a pull-secret at the conventional location.
-		ciProfilePullSecretPath := "/run/secrets/ci.openshift.io/cluster-profile/pull-secret"
-		_, err := os.Stat(ciProfilePullSecretPath)
-		if !os.IsNotExist(err) {
-			logger.Printf("Detected %v; using cluster profile for image access", ciProfilePullSecretPath)
-			registryAuthFilePath = ciProfilePullSecretPath
-		} else {
-			// Inspect the cluster-under-test and read its cluster pull-secret dockerconfigjson value.
-			clusterPullSecret, err := oc.AdminKubeClient().CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
-			if err != nil {
-				if kapierrs.IsNotFound(err) {
-					logger.Printf("Cluster has no openshift-config secret/pull-secret; falling back to unauthenticated image access")
-				} else {
-					return "", fmt.Errorf("unable to read ephemeral cluster pull secret: %w", err)
-				}
-			} else {
-				tmpDir, err := os.MkdirTemp("", "external-binary")
-				clusterDockerConfig := clusterPullSecret.Data[".dockerconfigjson"]
-				registryAuthFilePath = filepath.Join(tmpDir, ".dockerconfigjson")
-				err = os.WriteFile(registryAuthFilePath, clusterDockerConfig, 0600)
-				if err != nil {
-					return "", fmt.Errorf("unable to serialize target cluster pull-secret locally: %w", err)
-				}
-
-				defer os.Remove(registryAuthFilePath)
-				logger.Printf("Using target cluster pull-secrets for registry auth")
-			}
-		}
-	}
-
-	return registryAuthFilePath, nil
-}
-
 // createBinPath ensures the given path exists, is writable, and allows executing binaries.
 func createBinPath(path string) error {
 	// Create the directory if it doesn't exist.
@@ -288,9 +225,7 @@ func createBinPath(path string) error {
 // extractReleaseImageStream extracts image references from the given releaseImage and returns
 // an ImageStream object with tags associated with image-references from that payload.
 func extractReleaseImageStream(logger *log.Logger, extractPath, releaseImage string,
-	registryAuthFilePath string) (*imagev1.
-	ImageStream,
-	string, error) {
+	registryAuthFilePath string) (*imagev1.ImageStream, string, error) {
 
 	if _, err := os.Stat(path.Join(extractPath, "image-references")); err != nil {
 		if err := runImageExtract(releaseImage, "/release-manifests/image-references", extractPath, registryAuthFilePath,


### PR DESCRIPTION
I had extracted this code, but I broke the case where we're getting the pull secret from the cluster -- because it was immediately getting deleted on return.  In-line the code instead to prevent that, so it gets deleted when we're done using it.

The error you get when this happens looks like:

```
error running options: could not create external binary provider: couldn't extract release payload image stream: failed extracting image-references from "quay.io/openshift-release-dev/ocp-release-nightly@sha256:856d044a4f97813fb31bc4edda39b05b2b7c02de1327b9b297bdf93edc08fa95": error during image extract: exit status 1 (error: unable to load --registry-config: stat /tmp/external-binary2166428580/.dockerconfigjson: no such file or directory
```