### PR TITLE
OCPBUGS-48053: auditLogAnalyzer: fix flake error message

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -234,7 +234,7 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 				&junitapi.JUnitTestCase{
 					Name: testName,
 					FailureOutput: &junitapi.FailureOutput{
-						Message: strings.Join(failures, "\n"),
+						Message: strings.Join(flakes, "\n"),
 						Output:  "details in audit log",
 					},
 				},


### PR DESCRIPTION
"users in ns/openshift-... must not produce too many applies" test should contain correct error message when it flakes. This fixes it to change from:
```
{  details in audit log}
```
to
```
{user system:serviceaccount:openshift-infra:serviceaccount-pull-secrets-controller had 43897 applies, check the audit log and operator log to figure out why
user system:serviceaccount:openshift-infra:podsecurity-admission-label-syncer-controller had 1034 applies, check the audit log and operator log to figure out why  details in audit log}
```