### PR TITLE
NO-JIRA: fix: increase watch count for monitoring operator

### DIFF
--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -340,7 +340,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 				"cluster-autoscaler-operator":            44,
 				"cluster-baremetal-operator":             125.0,
 				"cluster-image-registry-operator":        119,
-				"cluster-monitoring-operator":            88,
+				"cluster-monitoring-operator":            101,
 				"cluster-node-tuning-operator":           97,
 				"cluster-samples-operator":               27,
 				"cluster-storage-operator":               202,


### PR DESCRIPTION
Increasing watch count for monitoring operator 110% above p95 for SNO 4.19 runs

(P95 * 1.1)/2 =~ 101

```
SELECT
  APPROX_QUANTILES(WatchRequestCount, 100)[OFFSET(50)] AS Median,
  APPROX_QUANTILES(WatchRequestCount, 100)[OFFSET(95)] AS Percentile_95,
  APPROX_QUANTILES(WatchRequestCount, 100)[OFFSET(99)] AS Percentile_99
FROM `openshift-ci-data-analysis.ci_data_autodl.operator_watch_requests` AS Watches
  INNER JOIN openshift-gce-devel.ci_analysis_us.jobs AS JobRuns
    ON JobRuns.prowjob_build_id = Watches.JobRunName
  INNER JOIN openshift-ci-data-analysis.ci_data.JobsWithVariants AS Jobs
    ON Jobs.JobName = JobRuns.prowjob_job_name
WHERE
JobRuns.prowjob_job_name LIKE "%4.19%"
AND Watches.Operator = "cluster-monitoring-operator"
AND Watches.ControlPlaneTopology = "SingleReplica"
AND Watches.PlatformType = "AWS"
```