### PR TITLE
OCPBUGS-48340: skip OperatorHubSourceError metric checking when disableAllDefaultSources is true

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -747,6 +747,10 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			if isManagedService {
 				allowedAlertNames = append(allowedAlertNames, "KubeDaemonSetMisScheduled")
 			}
+			// https://issues.redhat.com/browse/OCPBUGS-48340
+			if SkipOperatorHubMetricsCheck(oc) {
+				allowedAlertNames = append(allowedAlertNames, "OperatorHubSourceError")
+			}
 
 			tests := map[string]bool{
 				// openshift-e2e-loki alerts should never fail this test, we've seen this happen on daemon set rollout stuck when CI loki was down.
@@ -1013,4 +1017,12 @@ func hasTelemeterClient(client clientset.Interface) bool {
 		e2e.Failf("could not list pods: %v", err)
 	}
 	return true
+}
+
+func SkipOperatorHubMetricsCheck(oc *exutil.CLI) bool {
+	stdout, stderr, err := oc.AsAdmin().Run("get").Args("operatorhub", "cluster", "-o=jsonpath={.spec.disableAllDefaultSources}").Outputs()
+	if err != nil {
+		fmt.Printf("command failed: %v\nstderr: %s\nstdout:%s", err, stderr, stdout)
+	}
+	return stdout == "true"
 }


### PR DESCRIPTION
When disableAllDefaultSources is true, all default catalogSource are disabled, so there is no metric.
```console
    [
      {
        "metric": {
          "__name__": "ALERTS",
          "alertname": "OperatorHubSourceError",
          "alertstate": "firing",
          "container": "catalog-operator",
          "endpoint": "https-metrics",
          "exported_namespace": "openshift-marketplace",
          "instance": "[fd01:0:0:1::1a]:8443",
          "job": "catalog-operator-metrics",
          "name": "community-operators",
          "namespace": "openshift-operator-lifecycle-manager",
          "pod": "catalog-operator-6c446dcbbb-sxvjz",
          "prometheus": "openshift-monitoring/k8s",
          "service": "catalog-operator-metrics",
          "severity": "warning"
        },
        "value": [
          1736751753.045,
          "1"
        ]
      }
    ]
```