### PR TITLE
OCPBUGS-48569,SDN-4930: e2e,ovn-k,net-seg: Wait for UDN condition populate

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -690,16 +690,27 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			DeferCleanup(cleanup)
 			Expect(err).NotTo(HaveOccurred())
 
-			conditionsJSON, err := e2ekubectl.RunKubectl(f.Namespace.Name, "get", "userdefinednetwork", primaryUdnName, "-o", "jsonpath={.status.conditions}")
-			Expect(err).NotTo(HaveOccurred())
-			var actualConditions []metav1.Condition
-			Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
-
-			Expect(actualConditions[0].Type).To(SatisfyAny(Equal("NetworkReady"), Equal("NetworkCreated")))
-			Expect(actualConditions[0].Status).To(Equal(metav1.ConditionFalse))
-			Expect(actualConditions[0].Reason).To(Equal("SyncError"))
 			expectedMessage := fmt.Sprintf("primary network already exist in namespace %q: %q", f.Namespace.Name, primaryNadName)
-			Expect(actualConditions[0].Message).To(Equal(expectedMessage))
+			Eventually(func(g Gomega) []metav1.Condition {
+				conditionsJSON, err := e2ekubectl.RunKubectl(f.Namespace.Name, "get", "userdefinednetwork", primaryUdnName, "-o", "jsonpath={.status.conditions}")
+				g.Expect(err).NotTo(HaveOccurred())
+				var actualConditions []metav1.Condition
+				g.Expect(json.Unmarshal([]byte(conditionsJSON), &actualConditions)).To(Succeed())
+				return normalizeConditions(actualConditions)
+			}, 5*time.Second, 1*time.Second).Should(SatisfyAny(
+				ConsistOf(metav1.Condition{
+					Type:    "NetworkCreated",
+					Status:  metav1.ConditionFalse,
+					Reason:  "SyncError",
+					Message: expectedMessage,
+				}),
+				ConsistOf(metav1.Condition{
+					Type:    "NetworkReady",
+					Status:  metav1.ConditionFalse,
+					Reason:  "SyncError",
+					Message: expectedMessage,
+				}),
+			))
 		})
 
 		Context("UDN Pod", func() {


### PR DESCRIPTION
The test "Network Segmentation when primary network exist, UserDefinedNetwork status should report not-ready" may flake in case the tested UserDefinedNetwork instance conditions are not populated on the expected time.

This PR stabilize the test by wrapping the failing assertion with Eventually, so that the test wait for conditions to populate.

Note to reviewer:
This PR port the changes introduced on U/S https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4959 
- The test asserts for one of NetworkReady/Created conditions since the relevant bits has not been reached D/S yet.

