### PR TITLE
SDN-5768: virt, udn: use l2bridge binding

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -56,7 +56,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 		Context("with user defined networks and persistent ips configured", func() {
 			const (
 				nadName           = "blue"
-				bindingName       = "passt"
+				bindingName       = "l2bridge"
 				udnCrReadyTimeout = 60 * time.Second
 				// TODO(trozet): lower this timeout once https://issues.redhat.com/browse/OCPBUGS-49727 is fixed
 				udnNetworkReadyTimeout = 5 * time.Minute


### PR DESCRIPTION
This - l2bridge - is the binding which we will use on 4.18 and 4.19.

In later releases we expect passt to replace it, but, its shortcomings (unable to preserve TCP connections during live migration) make it a bad candidate for the binding of the primary network attachment.