### PR TITLE
OCPBUGS-48569,SDN-4930: ovn-k,net-seg: Use the right IP family according to env

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -701,7 +701,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				topology:    "layer3",
 				name:        primaryNadName,
 				networkName: primaryNadName,
-				cidr:        "10.10.100.0/24",
+				cidr:        correctCIDRFamily(oc, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 			}))
 			_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), primaryNetNad, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -961,7 +961,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				topology:    "layer3",
 				name:        primaryNadName,
 				networkName: primaryNadName,
-				cidr:        "10.10.100.0/24",
+				cidr:        correctCIDRFamily(oc, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet),
 			}))
 			_, err := nadClient.NetworkAttachmentDefinitions(primaryNetTenantNs).Create(context.Background(), primaryNetNad, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This PR should fix flakes related to using work IP family CIDR in IPv6 lanes for the following tests:
```
[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes when primary network exist, ClusterUserDefinedNetwork status should report not-ready [Suite:openshift/conformance/parallel]
[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:UserDefinedPrimaryNetworks] when using openshift ovn-kubernetes when primary network exist, UserDefinedNetwork status should report not-ready [Suite:openshift/conformance/parallel]
```