### PR TITLE
fix for image signature workflow end to end test

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51636,15 +51636,10 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-cli:latest
+        FROM image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         WORKDIR /var/lib/origin
-        RUN source /etc/os-release \
-            && rhel_major=${VERSION_ID%.*} \
-            && yum config-manager \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
-        RUN yum install -y skopeo && \
-            yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
+        RUN yum install -y skopeo
+        RUN mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: RSA \n\
             Key-Length: 2048 \n\
@@ -51663,9 +51658,6 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
-        from:
-          kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -16,15 +16,10 @@ items:
       - type: ConfigChange
     source:
       dockerfile: |
-        FROM quay.io/openshift/origin-cli:latest
+        FROM image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
         WORKDIR /var/lib/origin
-        RUN source /etc/os-release \
-            && rhel_major=${VERSION_ID%.*} \
-            && yum config-manager \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
-        RUN yum install -y skopeo && \
-            yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
+        RUN yum install -y skopeo
+        RUN mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: RSA \n\
             Key-Length: 2048 \n\
@@ -43,9 +38,6 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
-        from:
-          kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
The following e2e test is flaky in our CI:

```
[sig-imageregistry][Serial] Image signature workflow can push a signedimage to openshift registry and verify it
```

After some investigations it seems like what is failing is the build config [here](https://github.com/openshift/origin/blob/release-4.18/test/extended/testdata/signer-buildconfig.yaml)

The image build fails with:

```
STEP 4/8: RUN source /etc/os-release     && rhel_major=${VERSION_ID%.*}     && yum config-manager     --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/"     --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
ART yum/dnf wrapper [1]: Checking for CI build pod repo definitions...
ART yum/dnf wrapper [1]: Did not detect that this script is running in a CI build pod. Will not install CI repositories.
error: build error: building at STEP "RUN source /etc/os-release     && rhel_major=${VERSION_ID%.*}     && yum config-manager     --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/"     --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"": while running runtime: exit status 6
```

You can see a failure sample [here](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/29428/pull-ci-openshift-origin-master-e2e-aws-ovn-serial/1879630839508111360/artifacts/e2e-aws-ovn-serial/openshift-e2e-test/artifacts/junit/e2e-test-registry-signing-dpqk9/signer-1-build/docker-build/logs.txt)

This PR replaces the base image `quay.io/openshift/origin-cli:latest` with `image-registry.openshift-image-registry.svc:5000/openshift/cli:latest`, by replacing the image we can avoid running the `yum config-manager` command.