### PR TITLE
SDN-4930:  Fix pods cleanup in ClusterUserDefinedNetwork test

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -395,11 +395,6 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						namespaceRed := f.Namespace.Name + "-" + red
 						namespaceBlue := f.Namespace.Name + "-" + blue
 
-						netConfig := &networkAttachmentConfigParams{
-							topology: topology,
-							cidr:     correctCIDRFamily(oc, userDefinedv4Subnet, userDefinedv6Subnet),
-							role:     "primary",
-						}
 						for _, namespace := range []string{namespaceRed, namespaceBlue} {
 							By("Creating namespace " + namespace)
 							_, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
@@ -409,6 +404,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							}, metav1.CreateOptions{})
 							Expect(err).NotTo(HaveOccurred())
 							defer func() {
+								By("Removing namespace " + namespace)
 								Expect(cs.CoreV1().Namespaces().Delete(
 									context.Background(),
 									namespace,
@@ -419,8 +415,13 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						networkNamespaceMap := map[string]string{namespaceRed: red, namespaceBlue: blue}
 						for namespace, network := range networkNamespaceMap {
 							By("creating the network " + network + " in namespace " + namespace)
-							netConfig.namespace = namespace
-							netConfig.name = network
+							netConfig := &networkAttachmentConfigParams{
+								topology:  topology,
+								cidr:      correctCIDRFamily(oc, userDefinedv4Subnet, userDefinedv6Subnet),
+								role:      "primary",
+								namespace: namespace,
+								name:      network,
+							}
 
 							Expect(createNetworkFn(netConfig)).To(Succeed())
 							// update the name because createNetworkFn may mutate the netConfig.name
@@ -582,7 +583,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				cleanup, err := createManifest("", cudnManifest)
 				DeferCleanup(func() {
 					cleanup()
-					By("delete pods in test namespace to unblock CUDN CR & associate NAD deletion")
+					By(fmt.Sprintf("delete pods in %s namespace to unblock CUDN CR & associate NAD deletion", c.namespace))
 					Expect(cs.CoreV1().Pods(c.namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
 					_, err := e2ekubectl.RunKubectl("", "delete", "clusteruserdefinednetwork", cudnName, "--wait", fmt.Sprintf("--timeout=%ds", 120))
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
`netConfig` pointer was being modified in a loop so pods were removed from only one namespace.
Upstream PR: https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4975.

/cc @ormergi @tssurya 