### PR TITLE
SDN-4168: Fix for nmstate deployment related failures

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -721,7 +721,7 @@ func deployNmstateHandler(oc *exutil.CLI) error {
 }
 
 func ensureNmstateHandlerRunning(oc *exutil.CLI) error {
-	err := wait.PollUntilContextTimeout(context.Background(), poll, 2*time.Minute, true,
+	err := wait.PollUntilContextTimeout(context.Background(), poll, 5*time.Minute, true,
 		func(ctx context.Context) (bool, error) {
 			// Ensure nmstate handler is running.
 			return isDaemonSetRunning(oc, nmstateNamespace, "nmstate-handler")

--- a/test/extended/util/managed_services.go
+++ b/test/extended/util/managed_services.go
@@ -35,6 +35,7 @@ var ManagedServiceNamespaces = sets.New[string](
 	"openshift-managed-upgrade-operator",
 	"openshift-marketplace",
 	"openshift-must-gather-operator",
+	"openshift-nmstate",
 	"openshift-observability-operator",
 	"openshift-ocm-agent-operator",
 	"openshift-operators-redhat",


### PR DESCRIPTION
This PR fixes recent test failures around nmstate deployment seen from CI runs.

1. [sig-auth] all workloads in ns/openshift-nmstate must set the 'openshift.io/required-scc' annotation

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29437/pull-ci-openshift-origin-master-e2e-aws-ovn-ipsec-serial/1879584910717489152

2. Wait enough to get nmstate-handler daemonset running state.

```
[sig-network][Feature:IPsec] when using openshift ovn-kubernetes [BeforeAll] check traffic [apigroup:config.openshift.io] [Suite:openshift/network/ipsec] with IPsec in full mode
  [BeforeAll] github.com/openshift/origin/test/extended/networking/ipsec.go:449
  [It] github.com/openshift/origin/test/extended/networking/ipsec.go:628

  [FAILED] Unexpected error:
      <*errors.errorString | 0xc0015847e0>:
      failed to get nmstate handler running: context deadline exceeded
      {
          s: "failed to get nmstate handler running: context deadline exceeded",
      }
  occurred
  In [BeforeAll] at: github.com/openshift/origin/test/extended/networking/ipsec.go:464 @ 01/16/25 11:12:58.598
```

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-cluster-network-operator-2606-openshift-origin-29437-e2e-aws-ovn-ipsec-serial/1879821657376296960