### PR TITLE
OCPBUGS-48634: Revert "[release-4.17] OCPBUGS-48459, SDN-4930: ovn-k, udn crd e2e: Fix status report consumer assertion"

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -840,7 +840,7 @@ func assertUDNStatusReportsConsumers(udnNamesapce, udnName, expectedPodName stri
 	var conditions []metav1.Condition
 	Expect(json.Unmarshal([]byte(conditionsRaw), &conditions)).To(Succeed())
 	conditions = normalizeConditions(conditions)
-	expectedMsg := fmt.Sprintf("failed to delete NetworkAttachmentDefinition [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
+	expectedMsg := fmt.Sprintf("failed to verify NAD not in use [%[1]s/%[2]s]: network in use by the following pods: [%[1]s/%[3]s]",
 		udnNamesapce, udnName, expectedPodName)
 	found := false
 	for _, condition := range conditions {


### PR DESCRIPTION
Reverts openshift/origin#29301
This test change shouldn't have landed till the corresponding code change was brought in

see the 4.17 v/s 4.18 code diff:
https://github.com/openshift/ovn-kubernetes/blob/d60fad7b368831724701ebc90f6581a554eb673f/go-controller/pkg/clustermanager/userdefinednetwork/controller.go#L173
v/s
https://github.com/openshift/ovn-kubernetes/blob/930d8645c00fd2273c4cbb6e1d3c057e0967f0a1/go-controller/pkg/clustermanager/userdefinednetwork/controller.go#L390

