### PR TITLE
OCPBUGS-48629: Use max time for netpol pods curl requests

### DIFF
--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -140,12 +140,12 @@ func namespacePodShouldReach(oc *exutil.CLI, namespace, podName, address string)
 	o.EventuallyWithOffset(1, func() error {
 		var err error
 		if namespace == "" {
-			out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", address).Output()
+			out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", "--max-time", "5", address).Output()
 		} else {
-			out, err = oc.AsAdmin().Run("exec").Args(podName, "-n", namespace, "--", "curl", "--connect-timeout", "1", address).Output()
+			out, err = oc.AsAdmin().Run("exec").Args(podName, "-n", namespace, "--", "curl", "--connect-timeout", "1", "--max-time", "5", address).Output()
 		}
 		return err
-	}, "30s", "1s").ShouldNot(o.HaveOccurred(), "cmd output: %s", out)
+	}, "30s", "5s").ShouldNot(o.HaveOccurred(), "cmd output: %s", out)
 }
 
 func podShouldNotReach(oc *exutil.CLI, podName, address string) {
@@ -157,12 +157,12 @@ func namespacePodShouldNotReach(oc *exutil.CLI, namespace, podName, address stri
 	o.EventuallyWithOffset(1, func() error {
 		var err error
 		if namespace == "" {
-			out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", address).Output()
+			out, err = oc.AsAdmin().Run("exec").Args(podName, "--", "curl", "--connect-timeout", "1", "--max-time", "5", address).Output()
 		} else {
-			out, err = oc.AsAdmin().Run("exec").Args(podName, "-n", namespace, "--", "curl", "--connect-timeout", "1", address).Output()
+			out, err = oc.AsAdmin().Run("exec").Args(podName, "-n", namespace, "--", "curl", "--connect-timeout", "1", "--max-time", "5", address).Output()
 		}
 		return err
-	}, "30s", "1s").Should(o.HaveOccurred(), "cmd output: %s", out)
+	}, "30s", "5s").Should(o.HaveOccurred(), "cmd output: %s", out)
 }
 
 func mustParseIPAndMask(in string) *net.IPNet {


### PR DESCRIPTION
The curl request is seen as waiting indefinitely though connect time set to 1s, so using max time for connect reestablishment to happen upon a failure.

Flaky job link: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-metal-ipi-ovn-dualstack-techpreview/1879675595101573120