### PR TITLE
no-jira: add a monitor test to detect concurrent installer pod or static pod

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -142,6 +142,10 @@
         return (eventInterval.source === "APIUnreachableFromClient")
     }
 
+    function isStaticPodInstallMonitorActivity(eventInterval) {
+        return (eventInterval.source === "StaticPodInstallMonitor")
+    }
+
     function isEndpointConnectivity(eventInterval) {
         if (eventInterval.message.reason !== "DisruptionBegan" && eventInterval.message.reason !== "DisruptionSamplerOutageBegan") {
             return false
@@ -270,6 +274,10 @@
 
     function isAPIUnreachableFromClientValue(item) {
         return [buildLocatorDisplayString(item.locator), "", "APIUnreachableFromClientMetrics"]
+    }
+
+    function isStaticPodInstallMonitorValue(item) {
+        return [buildLocatorDisplayString(item.locator), "", item.message.reason]
     }
 
     function disruptionValue(item) {
@@ -486,6 +494,9 @@
 
         timelineGroups.push({group: "api-unreachable", data: []})
         createTimelineData(isAPIUnreachableFromClientValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIUnreachableFromClientActivity, regex)
+
+        timelineGroups.push({group: "staticpod-install", data: []})
+        createTimelineData(isStaticPodInstallMonitorValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isStaticPodInstallMonitorActivity, regex)
 
         timelineGroups.push({ group: "etcd-leaders", data: [] })
         createTimelineData(etcdLeadershipLogsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdLeadershipAndNotEmpty, regex)

--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/faultyloadbalancer"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/generationanalyzer"
 	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/staticpodinstall"
 	"github.com/openshift/origin/pkg/monitortests/machines/watchmachines"
 	"github.com/openshift/origin/pkg/monitortests/monitoring/disruptionmetricsapi"
 	"github.com/openshift/origin/pkg/monitortests/monitoring/statefulsetsrecreation"
@@ -133,6 +134,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie("metrics-api-availability", "Monitoring", disruptionmetricsapi.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie(apiunreachablefromclientmetrics.MonitorName, "kube-apiserver", apiunreachablefromclientmetrics.NewMonitorTest())
 	monitorTestRegistry.AddMonitorTestOrDie(faultyloadbalancer.MonitorName, "kube-apiserver", faultyloadbalancer.NewMonitorTest())
+	monitorTestRegistry.AddMonitorTestOrDie(staticpodinstall.MonitorName, "kube-apiserver", staticpodinstall.NewStaticPodInstallMonitorTest())
 
 	return monitorTestRegistry
 }

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -423,6 +423,27 @@ func (b *LocatorBuilder) KubeEvent(event *corev1.Event) Locator {
 	return b.Build()
 }
 
+// KubeletSyncLoopProbe constructs a locator from a Kubelet SyncLoop
+// probe event, typically kubelet log prints the events as follows:
+// "SyncLoop (probe)" probe="readiness" status="ready" pod="openshift-etcd/etcd-ci-op-bzbjn2bk-206af-gfdsw-master-2"
+func (b *LocatorBuilder) KubeletSyncLoopProbe(node, ns, podName, probeType string) Locator {
+	b.targetType = LocatorTypeKubeletSyncLoopProbe
+	b.withNode(node).
+		withNamespace(ns).
+		withPodName(podName)
+	b.annotations[LocatorTypeKubeletSyncLoopProbeType] = probeType
+	return b.Build()
+}
+
+func (b *LocatorBuilder) KubeletSyncLoopPLEG(node, ns, podName, eventType string) Locator {
+	b.targetType = LocatorTypeKubeletSyncLoopPLEG
+	b.withNode(node).
+		withNamespace(ns).
+		withPodName(podName)
+	b.annotations[LocatorTypeKubeletSyncLoopPLEGType] = eventType
+	return b.Build()
+}
+
 func (b *LocatorBuilder) ContainerFromPod(pod *corev1.Pod, containerName string) Locator {
 	b.PodFromPod(pod)
 	b.targetType = LocatorTypeContainer

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -444,6 +444,13 @@ func (b *LocatorBuilder) KubeletSyncLoopPLEG(node, ns, podName, eventType string
 	return b.Build()
 }
 
+func (b *LocatorBuilder) StaticPodInstall(node, podType string) Locator {
+	b.targetType = LocatorTypeStaticPodInstall
+	b.withNode(node)
+	b.annotations[LocatorStaticPodInstallType] = podType
+	return b.Build()
+}
+
 func (b *LocatorBuilder) ContainerFromPod(pod *corev1.Pod, containerName string) Locator {
 	b.PodFromPod(pod)
 	b.targetType = LocatorTypeContainer

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -117,6 +117,7 @@ const (
 
 	LocatorTypeKubeletSyncLoopProbe LocatorType = "KubeletSyncLoopProbe"
 	LocatorTypeKubeletSyncLoopPLEG  LocatorType = "KubeletSyncLoopPLEG"
+	LocatorTypeStaticPodInstall     LocatorType = "StaticPodInstall"
 )
 
 type LocatorKey string
@@ -363,6 +364,8 @@ const (
 	SourceMachine                  IntervalSource = "MachineMonitor"
 
 	SourceGenerationMonitor IntervalSource = "GenerationMonitor"
+
+	SourceStaticPodInstallMonitor IntervalSource = "StaticPodInstallMonitor"
 )
 
 type Interval struct {

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -114,6 +114,9 @@ const (
 	LocatorTypeStatefulSet     LocatorType = "StatefulSet"
 
 	LocatorTypeAPIUnreachableFromClient LocatorType = "APIUnreachableFromClient"
+
+	LocatorTypeKubeletSyncLoopProbe LocatorType = "KubeletSyncLoopProbe"
+	LocatorTypeKubeletSyncLoopPLEG  LocatorType = "KubeletSyncLoopPLEG"
 )
 
 type LocatorKey string
@@ -153,6 +156,10 @@ const (
 
 	LocatorAPIUnreachableHostKey                  LocatorKey = "host"
 	LocatorOnPremKubeapiUnreachableFromHaproxyKey LocatorKey = "onprem-haproxy"
+
+	LocatorTypeKubeletSyncLoopProbeType LocatorKey = "probe"
+	LocatorTypeKubeletSyncLoopPLEGType  LocatorKey = "plegType"
+	LocatorStaticPodInstallType         LocatorKey = "podType"
 )
 
 type Locator struct {
@@ -185,6 +192,8 @@ const (
 	PodReasonEvicted               IntervalReason = "Evicted"
 	PodReasonPreempted             IntervalReason = "Preempted"
 	PodReasonFailed                IntervalReason = "Failed"
+	PodReasonReady                 IntervalReason = "PodReady"
+	PodReasonNotReady              IntervalReason = "PodNotReady"
 
 	ContainerReasonContainerExit      IntervalReason = "ContainerExit"
 	ContainerReasonContainerStart     IntervalReason = "ContainerStart"

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/analyzer.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/analyzer.go
@@ -1,0 +1,216 @@
+package staticpodinstall
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+type podKey struct {
+	ns, name string
+}
+
+type podWindow struct {
+	podKey
+	node     string
+	from, to time.Time
+}
+
+func (w podWindow) isComplete() bool {
+	return !w.from.IsZero() && !w.to.IsZero() && w.from.Before(w.to)
+}
+
+type staticPodReadinessProbeEventAnalyzer struct {
+	// static pod unready window [from -> to]
+	windowsByPod map[podKey][]*podWindow
+}
+
+func (a staticPodReadinessProbeEventAnalyzer) want(interval monitorapi.Interval) bool {
+	return interval.Locator.Type == monitorapi.LocatorTypeKubeletSyncLoopProbe &&
+		interval.Locator.Keys[monitorapi.LocatorTypeKubeletSyncLoopProbeType] == "readiness"
+}
+
+func (a staticPodReadinessProbeEventAnalyzer) analyze(interval monitorapi.Interval) {
+	key := key(interval)
+	windows, ok := a.windowsByPod[key]
+	status := interval.Message.Annotations[monitorapi.AnnotationKey("status")]
+	if !ok || len(windows) == 0 ||
+		// we need to start a new window when we see an unready after a ready event
+		(windows[len(windows)-1].isComplete() && status != "ready") {
+		windows = append(windows, &podWindow{
+			podKey: key,
+			node:   interval.Locator.Keys[monitorapi.LocatorNodeKey],
+		})
+		a.windowsByPod[key] = windows
+	}
+	window := windows[len(windows)-1]
+
+	// NOTE: if a ready event goes missing:
+	//  unready unready ready(missing) unready ready
+	// these two unready windows will be reported as one
+	switch status {
+	case "ready":
+		if window.isComplete() {
+			// the last event we saw was a ready
+			// event, so we can ignore this one
+			break
+		}
+		// we will take the earliest ready event time, since there could be
+		// multiple ready events reported in sequence
+		if window.to.IsZero() {
+			window.to = interval.From
+		}
+	default:
+		// we will retain the earliest unready time, since there usually are
+		// multiple unready events before kubelet reports a ready event
+		if window.from.IsZero() {
+			window.from = interval.From
+		}
+	}
+}
+
+func (a staticPodReadinessProbeEventAnalyzer) result() monitorapi.Intervals {
+	sorted := sortedByFrom{}
+	for _, v := range a.windowsByPod {
+		sorted = append(sorted, v...)
+	}
+	sort.Sort(sorted)
+
+	intervals := monitorapi.Intervals{}
+	for i, this := range sorted {
+		level := monitorapi.Error
+		annotations := map[monitorapi.AnnotationKey]string{}
+		msg := fmt.Sprintf("static pod unready duration=%s", this.to.Sub(this.from))
+		if this.isComplete() {
+			level = monitorapi.Info
+			for _, other := range sorted[i+1:] {
+				if !other.isComplete() {
+					continue
+				}
+				if other.from.After(this.to) {
+					break
+				}
+				// a) we are on a different node
+				// b) is there any installer pod that is active?
+				if this.node != other.node {
+					level = monitorapi.Error
+					annotations["concurrent-node"] = other.node
+					annotations["concurrent-pod"] = other.name
+					msg = fmt.Sprintf("%s concurrent unready - pod: %s was unready after: %s", msg, other.name, other.from.Sub(this.from))
+					break
+				}
+			}
+		}
+
+		interval := monitorapi.NewInterval(monitorapi.SourceStaticPodInstallMonitor, level).
+			Locator(monitorapi.NewLocator().StaticPodInstall(this.node, "etcd")).
+			Message(monitorapi.NewMessage().
+				HumanMessage(msg).
+				WithAnnotations(annotations).
+				Reason(monitorapi.IntervalReason("StaticPodUnready")),
+			).
+			Display().
+			Build(this.from, this.to)
+		intervals = append(intervals, interval)
+	}
+
+	return intervals
+
+}
+
+type installerPodPLEGEventAnalyzer struct {
+	// installer pods run window [from -> to]
+	windows map[podKey]*podWindow
+}
+
+func (a installerPodPLEGEventAnalyzer) want(interval monitorapi.Interval) bool {
+	return interval.Locator.Type == monitorapi.LocatorTypeKubeletSyncLoopPLEG
+}
+
+func (a installerPodPLEGEventAnalyzer) analyze(interval monitorapi.Interval) {
+	key := key(interval)
+	window, ok := a.windows[key]
+	if !ok {
+		window = &podWindow{
+			podKey: key,
+			node:   interval.Locator.Keys[monitorapi.LocatorNodeKey],
+		}
+		a.windows[key] = window
+	}
+	event := interval.Locator.Keys[monitorapi.LocatorTypeKubeletSyncLoopPLEGType]
+	switch event {
+	case "ContainerStarted":
+		// we will take the earliest start time (due to multiple containers)
+		// TODO: container name is not provided in these events by kubelet
+		if window.from.IsZero() {
+			window.from = interval.From
+		}
+	case "ContainerDied":
+		// we will take the most recent died time (due to multiple containers)
+		// TODO: container name is not provided in these events by kubelet
+		window.to = interval.From
+	}
+}
+
+func (a installerPodPLEGEventAnalyzer) result() monitorapi.Intervals {
+	sorted := sortedByFrom{}
+	for _, v := range a.windows {
+		sorted = append(sorted, v)
+	}
+	sort.Sort(sorted)
+
+	intervals := monitorapi.Intervals{}
+	for i, this := range sorted {
+		level := monitorapi.Error
+		annotations := map[monitorapi.AnnotationKey]string{}
+		msg := fmt.Sprintf("pod=%s duration=%s", this.name, this.to.Sub(this.from))
+		if this.isComplete() {
+			level = monitorapi.Info
+			for _, other := range sorted[i+1:] {
+				if !other.isComplete() {
+					continue
+				}
+				if other.from.After(this.to) {
+					break
+				}
+				// a) we are on a different node
+				// b) is there any installer pod that is active?
+				if this.node != other.node {
+					level = monitorapi.Error
+					annotations["concurrent-node"] = other.node
+					annotations["concurrent-pod"] = other.name
+					msg = fmt.Sprintf("%s a concurrent pod started after: %s", msg, other.from.Sub(this.from))
+					break
+				}
+			}
+		}
+
+		interval := monitorapi.NewInterval(monitorapi.SourceStaticPodInstallMonitor, level).
+			Locator(monitorapi.NewLocator().StaticPodInstall(this.node, "installer")).
+			Message(monitorapi.NewMessage().
+				HumanMessage(msg).
+				WithAnnotations(annotations).
+				Reason(monitorapi.IntervalReason("InstallerPodCompleted")),
+			).
+			Display().
+			Build(this.from, this.to)
+		intervals = append(intervals, interval)
+	}
+
+	return intervals
+}
+
+func key(interval monitorapi.Interval) podKey {
+	return podKey{
+		ns:   interval.Locator.Keys[monitorapi.LocatorNamespaceKey],
+		name: interval.Locator.Keys[monitorapi.LocatorPodKey],
+	}
+}
+
+type sortedByFrom []*podWindow
+
+func (s sortedByFrom) Len() int           { return len(s) }
+func (s sortedByFrom) Less(i, j int) bool { return s[i].from.Before(s[j].from) }
+func (s sortedByFrom) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/analyzer_test.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/analyzer_test.go
@@ -1,0 +1,225 @@
+package staticpodinstall
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser"
+)
+
+func TestInstallerPodPLEGEventAnalyzer(t *testing.T) {
+	type entry struct {
+		node, line string
+	}
+	newProbeLine := func(ts time.Time, node, pod, eventType string) entry {
+		const template = `%s    2546 kubelet.go:2453] "SyncLoop (PLEG): event for pod" pod="openshift-etcd/%s-%s" event={"ID":"0d817ff9-f980-46f0-b046-57ee340e2d38","Type":"%s"}`
+		return entry{
+			node: node,
+			line: fmt.Sprintf(template, ts.Format("Jan 02 15:04:05.000000"), pod, node, eventType),
+		}
+	}
+	newInterval := func(from, to time.Time, level monitorapi.IntervalLevel, node, msg string, annotations map[monitorapi.AnnotationKey]string) monitorapi.Interval {
+		return monitorapi.NewInterval(monitorapi.SourceStaticPodInstallMonitor, level).
+			Locator(monitorapi.NewLocator().StaticPodInstall(node, "installer")).
+			Message(
+				monitorapi.NewMessage().
+					Reason("InstallerPodCompleted").
+					WithAnnotations(annotations).
+					HumanMessage(msg),
+			).
+			Display().
+			Build(from, to)
+	}
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T) ([]entry, monitorapi.Intervals)
+	}{
+		{
+			name: "two installer pod completed on the same node",
+			setup: func(t *testing.T) ([]entry, monitorapi.Intervals) {
+				now := getNow(t)
+				from1, to1 := now, now.Add(3*time.Second)
+				from2, to2 := to1.Add(time.Second), to1.Add(4*time.Second)
+				lines := []entry{
+					// installer-1 pod, with [ContainerStarted, ContainerDied]
+					newProbeLine(from1, "master-1", "installer-1", "ContainerStarted"),
+					newProbeLine(to1, "master-1", "installer-1", "ContainerDied"),
+					// installer-2 pod, with [ContainerStarted, ContainerStarted, ContainerDied, ContainerDied]
+					newProbeLine(from2, "master-1", "installer-2", "ContainerStarted"),
+					newProbeLine(from2.Add(time.Millisecond), "master-1", "installer-2", "ContainerStarted"),
+					newProbeLine(to2.Add(-time.Millisecond), "master-1", "installer-2", "ContainerDied"),
+					newProbeLine(to2, "master-1", "installer-2", "ContainerDied"),
+				}
+				intervals := monitorapi.Intervals{
+					newInterval(from1, to1, monitorapi.Info, "master-1", fmt.Sprintf("pod=%s duration=%s", "installer-1-master-1", to1.Sub(from1)), nil),
+					newInterval(from2, to2, monitorapi.Info, "master-1", fmt.Sprintf("pod=%s duration=%s", "installer-2-master-1", to2.Sub(from2)), nil),
+				}
+
+				return lines, intervals
+			},
+		},
+		{
+			name: "concurrent installer pods on two separate nodes",
+			setup: func(t *testing.T) ([]entry, monitorapi.Intervals) {
+				now := getNow(t)
+				from1, to1 := now, now.Add(11*time.Second)
+				from2, to2 := to1.Add(-time.Second), to1.Add(12*time.Second)
+				lines := []entry{
+					// pod=installer-1, node=master-1 events=[ContainerStarted, ContainerDied]
+					newProbeLine(from1, "master-1", "installer-1", "ContainerStarted"),
+					newProbeLine(to1, "master-1", "installer-1", "ContainerDied"),
+					// pod=installer-1, node=master-2 events=[ContainerStarted, ContainerDied]
+					newProbeLine(from2, "master-2", "installer-1", "ContainerStarted"),
+					newProbeLine(to2, "master-2", "installer-1", "ContainerDied"),
+				}
+				msg1 := fmt.Sprintf("pod=%s duration=%s a concurrent pod started after: %s", "installer-1-master-1", to1.Sub(from1), from2.Sub(from1))
+				annotations1 := map[monitorapi.AnnotationKey]string{
+					"concurrent-node": "master-2",
+					"concurrent-pod":  "installer-1-master-2",
+				}
+				intervals := monitorapi.Intervals{
+					newInterval(from1, to1, monitorapi.Error, "master-1", msg1, annotations1),
+					newInterval(from2, to2, monitorapi.Info, "master-2", fmt.Sprintf("pod=%s duration=%s", "installer-1-master-2", to2.Sub(from2)), nil),
+				}
+
+				return lines, intervals
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries, intervalsWant := test.setup(t)
+
+			// step 1: create initial intervals by parsing kubelet logs
+			parserFn := kubeletlogparser.NewEtcdStaticPodEventsFromKubelet()
+			initial := monitorapi.Intervals{}
+			for _, entry := range entries {
+				initial = append(initial, parserFn(entry.node, entry.line)...)
+			}
+
+			// step 2: feed the initial intervals to the analyzers
+			// and construct the computed intervals
+			mt := NewStaticPodInstallMonitorTest()
+			computed := mt.construct(initial)
+
+			if want, got := intervalsWant, computed; !cmp.Equal(want, got) {
+				t.Errorf("expected a match, diff: %s", cmp.Diff(want, got))
+			}
+
+		})
+	}
+}
+
+func TestStaticPodReadinessProbeEventAnalyzer(t *testing.T) {
+	type entry struct {
+		node, line string
+	}
+	newProbeLine := func(ts time.Time, node, probeType, status string) entry {
+		const template = `%s    2546 kubelet.go:2542] "SyncLoop (probe)" probe="%s" status="%s" pod="openshift-etcd/etcd-%s"`
+		return entry{
+			node: node,
+			line: fmt.Sprintf(template, ts.Format("Jan 02 15:04:05.000000"), probeType, status, node),
+		}
+	}
+	newInterval := func(from, to time.Time, level monitorapi.IntervalLevel, node, msg string, annotations map[monitorapi.AnnotationKey]string) monitorapi.Interval {
+		return monitorapi.NewInterval(monitorapi.SourceStaticPodInstallMonitor, level).
+			Locator(monitorapi.NewLocator().StaticPodInstall(node, "etcd")).
+			Message(
+				monitorapi.NewMessage().
+					HumanMessage(msg).
+					WithAnnotations(annotations).
+					Reason(monitorapi.IntervalReason("StaticPodUnready")),
+			).
+			Display().
+			Build(from, to)
+	}
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T) ([]entry, monitorapi.Intervals)
+	}{
+		{
+			name: "valid unready window, with repeating unready and ready events ",
+			setup: func(t *testing.T) ([]entry, monitorapi.Intervals) {
+				from := getNow(t)
+				to := from.Add(11 * time.Second)
+				lines := []entry{
+					newProbeLine(from, "master-1", "readiness", ""),
+					newProbeLine(from.Add(2*time.Second), "master-1", "readiness", "not ready"),
+					newProbeLine(from.Add(4*time.Second), "master-1", "readiness", "not ready"),
+					newProbeLine(from.Add(6*time.Second), "master-1", "liveness", "ready"),
+					newProbeLine(to, "master-1", "readiness", "ready"),
+					newProbeLine(to.Add(time.Second), "master-1", "readiness", "ready"),
+				}
+				intervals := monitorapi.Intervals{
+					newInterval(from, to, monitorapi.Info, "master-1", fmt.Sprintf("static pod unready duration=%s", to.Sub(from)), nil),
+				}
+
+				return lines, intervals
+			},
+		},
+		{
+			name: "concurrent unready window on separate nodes",
+			setup: func(t *testing.T) ([]entry, monitorapi.Intervals) {
+				from1 := getNow(t)
+				to1, from2, to2 := from1.Add(10*time.Second), from1.Add(time.Second), from1.Add(11*time.Second)
+				lines := []entry{
+					newProbeLine(from1, "master-1", "readiness", "not ready"),
+					newProbeLine(to1, "master-1", "readiness", "ready"),
+					newProbeLine(from2, "master-2", "readiness", "not ready"),
+					newProbeLine(to2, "master-2", "readiness", "ready"),
+				}
+				msg1 := fmt.Sprintf("static pod unready duration=%s concurrent unready - pod: %s was unready after: %s", to1.Sub(from1), "etcd-master-2", from2.Sub(from1))
+				annotations1 := map[monitorapi.AnnotationKey]string{
+					"concurrent-node": "master-2",
+					"concurrent-pod":  "etcd-master-2",
+				}
+				intervals := monitorapi.Intervals{
+					newInterval(from1, to1, monitorapi.Error, "master-1", msg1, annotations1),
+					newInterval(from2, to2, monitorapi.Info, "master-2", fmt.Sprintf("static pod unready duration=%s", to2.Sub(from2)), nil),
+				}
+
+				return lines, intervals
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entries, intervalsWant := test.setup(t)
+
+			// step 1: create initial intervals by parsing kubelet logs
+			parserFn := kubeletlogparser.NewEtcdStaticPodEventsFromKubelet()
+			initial := monitorapi.Intervals{}
+			for _, entry := range entries {
+				initial = append(initial, parserFn(entry.node, entry.line)...)
+			}
+
+			// step 2: feed the initial intervals to the analyzers
+			// and construct the computed intervals
+			mt := NewStaticPodInstallMonitorTest()
+			computed := mt.construct(initial)
+
+			if want, got := intervalsWant, computed; !cmp.Equal(want, got) {
+				t.Errorf("expected a match, diff: %s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func getNow(t *testing.T) time.Time {
+	// keep micro second precision, there may be a better way of doing it
+	layout := "Jan 02 2006 15:04:05.000000"
+	s := time.Now().Format(layout)
+	ts, err := time.Parse(layout, s)
+	if err != nil {
+		t.Fatalf("unexpected error while getting time - %v", err)
+	}
+	return ts
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/parser.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/parser.go
@@ -1,0 +1,51 @@
+package kubeletlogparser
+
+import (
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+// NewEtcdStaticPodEventsFromKubelet returns a parser that will parse kubelet
+// log for SyncLoop PLEG and probe events.
+// For now, we are interested in the etcd installer and the etcd static pod
+func NewEtcdStaticPodEventsFromKubelet() func(node, line string) monitorapi.Intervals {
+	filter := func(node, ns, podName string) bool {
+		return ns == "openshift-etcd" && (strings.HasPrefix(podName, "installer-") || podName == "etcd-"+node)
+	}
+	p := parsers{
+		// we want to observe the unready window for ectd static pods
+		&SyncLoopProbeParser{
+			source: monitorapi.SourceKubeletLog,
+			want:   filter,
+		},
+		// we want to observe the container start and exit pleg events for the etcd installer pods
+		&SyncLoopPLEGParser{
+			source: monitorapi.SourceKubeletLog,
+			filter: filter,
+		},
+	}
+	return p.parse
+}
+
+// interval is created only if the given filter func returns true
+type filterFunc func(node, ns, podName string) bool
+
+type parser interface {
+	Parse(node, line string) (monitorapi.Intervals, bool)
+}
+
+type parsers []parser
+
+// this complies with the signature the default node log parser in origin requires
+func (p parsers) parse(node, line string) monitorapi.Intervals {
+	accummulated := monitorapi.Intervals{}
+	for _, parser := range p {
+		intervals, handled := parser.Parse(node, line)
+		accummulated = append(accummulated, intervals...)
+		if handled {
+			return accummulated
+		}
+	}
+	return accummulated
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/pleg_parser.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/pleg_parser.go
@@ -1,0 +1,74 @@
+package kubeletlogparser
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
+)
+
+type SyncLoopPLEGParser struct {
+	source monitorapi.IntervalSource
+	filter filterFunc
+}
+
+var (
+	plegRegExp = regexp.MustCompile(`pod="(?P<NS>[a-z0-9.-]+)\/(?P<POD>[a-z0-9.-]+)" event={"ID":"[a-z0-9.-]+","Type":"(?P<TYPE>[a-zA-Z]+)"`)
+
+	//TODO:  using the well defined container reasons in use today will
+	// cause the following job to fail:
+	//  platform pods in ns/openshift-etcd should not exit an excessive amount of times
+	// so for now we will use the names reported by kubelet
+	plegToContainerReasons = map[string]monitorapi.IntervalReason{
+		"ContainerStarted": monitorapi.ContainerReasonContainerStart,
+		"ContainerDied":    monitorapi.ContainerReasonContainerExit,
+	}
+)
+
+// Parse parses a PLEG pod event from the kubelet log and generates an
+// appropriate interval for it, the format of a PLEG line is as follows:
+// "SyncLoop (PLEG): event for pod" pod="openshift-etcd/installer-4-ci-op-bzbjn2bk-206af-gfdsw-master-2" event={"ID":"0d817ff9-f980-46f0-b046-57ee340e2d38","Type":"ContainerStarted","Data":"f8d11fe0b65575141b38a7310faebaff0b287779bc27d3c635a144891a2304fa"}
+func (p SyncLoopPLEGParser) Parse(node, line string) (monitorapi.Intervals, bool) {
+	_, after, found := strings.Cut(line, `"SyncLoop (PLEG): event for pod"`)
+	if !found {
+		// not a probe event, let the other parsers inspect
+		return nil, false
+	}
+
+	subMatches := plegRegExp.FindStringSubmatch(after)
+	names := plegRegExp.SubexpNames()
+	if len(subMatches) == 0 || len(names) > len(subMatches) {
+		return nil, true
+	}
+
+	var podNamespace, podName, eventType string
+	for i, name := range names {
+		switch name {
+		case "NS":
+			podNamespace = subMatches[i]
+		case "POD":
+			podName = subMatches[i]
+		case "TYPE":
+			eventType = subMatches[i]
+		}
+	}
+
+	if p.filter != nil && !p.filter(node, podNamespace, podName) {
+		return nil, true
+	}
+
+	at := utility.SystemdJournalLogTime(line, time.Now().Year())
+	locator := monitorapi.NewLocator().KubeletSyncLoopPLEG(node, podNamespace, podName, eventType)
+	interval := monitorapi.NewInterval(p.source, monitorapi.Info).
+		Locator(locator).
+		Message(
+			monitorapi.NewMessage().
+				Reason(monitorapi.IntervalReason(eventType)).
+				Node(node).
+				WithAnnotation("type", eventType).
+				HumanMessage("kubelet PLEG event"),
+		).Build(at, at)
+	return monitorapi.Intervals{interval}, true
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/pleg_parser_test.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/pleg_parser_test.go
@@ -1,0 +1,84 @@
+package kubeletlogparser
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func TestSyncLoopPLEGParser(t *testing.T) {
+	type entry struct {
+		node, line string
+	}
+
+	newProbeLine := func(ts time.Time, node, pod, eventType string) entry {
+		const template = `%s 2546 kubelet.go:2453] "SyncLoop (PLEG): event for pod" pod="openshift-etcd/%s-%s" event={"ID":"0d817ff9-f980-46f0-b046-57ee340e2d38","Type":"%s","Data":"f8d11fe0b65575141b38a7310faebaff0b287779bc27d3c635a144891a2304fa"}`
+		return entry{
+			node: node,
+			line: fmt.Sprintf(template, ts.Format("Jan 02 15:04:05.000000"), pod, node, eventType),
+		}
+	}
+	newInterval := func(at time.Time, node, pod, eventType string) monitorapi.Interval {
+		return monitorapi.NewInterval(monitorapi.SourceKubeletLog, monitorapi.Info).
+			Locator(monitorapi.NewLocator().KubeletSyncLoopPLEG(node, "openshift-etcd", pod+"-"+node, eventType)).
+			Message(
+				monitorapi.NewMessage().
+					Reason(monitorapi.IntervalReason(eventType)).
+					Node(node).
+					WithAnnotation("type", eventType).
+					HumanMessage("kubelet PLEG event"),
+			).Build(at, at)
+
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) (entry, monitorapi.Intervals)
+	}{
+		{
+
+			name: "PLEG ContainerStarted event",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "installer-1", "ContainerStarted"),
+				}
+				return newProbeLine(at, "master-1", "installer-1", "ContainerStarted"), intervals
+			},
+		},
+		{
+
+			name: "PLEG ContainerDied event",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "installer-1", "ContainerDied"),
+				}
+				return newProbeLine(at, "master-1", "installer-1", "ContainerDied"), intervals
+			},
+		},
+		{
+
+			name: "unwanted PLEG event, should be ignored",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				return newProbeLine(at, "master-1", "foo-1", "ContainerDied"), monitorapi.Intervals{}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry, intervalsWant := test.setup(t)
+			parserFn := NewEtcdStaticPodEventsFromKubelet()
+
+			intervalsGot := parserFn(entry.node, entry.line)
+			if want, got := intervalsWant, intervalsGot; !cmp.Equal(want, got) {
+				t.Errorf("expected a match, diff: %s", cmp.Diff(want, got))
+			}
+		})
+	}
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/probe_parser.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/probe_parser.go
@@ -1,0 +1,69 @@
+package kubeletlogparser
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
+)
+
+type SyncLoopProbeParser struct {
+	source monitorapi.IntervalSource
+	want   filterFunc
+}
+
+var probeRegExp = regexp.MustCompile(`probe="(?P<PROBE>[a-z]+)" status="(?P<STATUS>[a-z\s]*)" pod="(?P<NS>[a-z0-9.-]+)\/(?P<POD>[a-z0-9.-]+)"`)
+
+// Parse parses a SyncLoop probe event line from kubelet log, the line has the followng format:
+// [kubelet.go:2542] "SyncLoop (probe)" probe="readiness" status="" pod="openshift-etcd/etcd-ci-op-bzbjn2bk-206af-gfdsw-master-2"
+func (p SyncLoopProbeParser) Parse(node, line string) (monitorapi.Intervals, bool) {
+	_, after, found := strings.Cut(line, `"SyncLoop (probe)"`)
+	if !found {
+		// not a probe event, let the other parsers inspect
+		return nil, false
+	}
+
+	// probe="readiness" status="not ready" pod="openshift-etcd/etcd-ci-op-bzbjn2bk-206af-gfdsw-master-2"
+	subMatches := probeRegExp.FindStringSubmatch(after)
+	names := probeRegExp.SubexpNames()
+	if len(subMatches) == 0 || len(names) > len(subMatches) {
+		return nil, true
+	}
+	var probeType, status, podNamespace, podName string
+	for i, name := range names {
+		switch name {
+		case "NS":
+			podNamespace = subMatches[i]
+		case "POD":
+			podName = subMatches[i]
+		case "PROBE":
+			probeType = subMatches[i]
+		case "STATUS":
+			status = subMatches[i]
+		}
+	}
+
+	if p.want != nil && !p.want(node, podNamespace, podName) {
+		return nil, true
+	}
+
+	// older version of kubelet uses empty string to denote not ready
+	if status == "" {
+		status = "not ready"
+	}
+	at := utility.SystemdJournalLogTime(line, time.Now().Year())
+	locator := monitorapi.NewLocator().KubeletSyncLoopProbe(node, podNamespace, podName, probeType)
+	interval := monitorapi.NewInterval(p.source, monitorapi.Info).
+		Locator(locator).
+		Message(
+			monitorapi.NewMessage().
+				Reason(monitorapi.IntervalReason(status)).
+				Node(node).
+				WithAnnotation("probe", probeType).
+				WithAnnotation("status", status).
+				HumanMessage("kubelet SyncLoop probe"),
+		).Build(at, at)
+	return monitorapi.Intervals{interval}, true
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/probe_parser_test.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser/probe_parser_test.go
@@ -1,0 +1,106 @@
+package kubeletlogparser
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func TestSyncLoopProbeParser(t *testing.T) {
+	type entry struct {
+		node, line string
+	}
+
+	newProbeLine := func(ts time.Time, node, probeType, status string) entry {
+		const template = `%s	2546 kubelet.go:2542] "SyncLoop (probe)" probe="%s" status="%s" pod="openshift-etcd/etcd-%s"`
+		return entry{
+			node: node,
+			line: fmt.Sprintf(template, ts.Format("Jan 02 15:04:05.000000"), probeType, status, node),
+		}
+	}
+	newInterval := func(at time.Time, node, probeType, status string) monitorapi.Interval {
+		return monitorapi.NewInterval(monitorapi.SourceKubeletLog, monitorapi.Info).
+			Locator(monitorapi.NewLocator().KubeletSyncLoopProbe(node, "openshift-etcd", "etcd-"+node, probeType)).
+			Message(
+				monitorapi.NewMessage().
+					Reason(monitorapi.IntervalReason(status)).
+					Node(node).
+					WithAnnotation("probe", probeType).
+					WithAnnotation("status", status).
+					HumanMessage("kubelet SyncLoop probe"),
+			).Build(at, at)
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) (entry, monitorapi.Intervals)
+	}{
+		{
+			name: "Pod not ready, status is empty (legacy case)",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "readiness", "not ready"),
+				}
+				return newProbeLine(at, "master-1", "readiness", ""), intervals
+			},
+		},
+		{
+			name: "Pod is not ready",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "readiness", "not ready"),
+				}
+				return newProbeLine(at, "master-1", "readiness", "not ready"), intervals
+			},
+		},
+		{
+			name: "Pod is ready",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "readiness", "ready"),
+				}
+				return newProbeLine(at, "master-1", "readiness", "ready"), intervals
+			},
+		},
+		{
+			name: "Pod is live",
+			setup: func(t *testing.T) (entry, monitorapi.Intervals) {
+				at := getNow(t)
+				intervals := monitorapi.Intervals{
+					newInterval(at, "master-1", "liveness", "healthy"),
+				}
+				return newProbeLine(at, "master-1", "liveness", "healthy"), intervals
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			entry, intervalsWant := test.setup(t)
+			parserFn := NewEtcdStaticPodEventsFromKubelet()
+
+			intervalsGot := parserFn(entry.node, entry.line)
+			if want, got := intervalsWant, intervalsGot; !cmp.Equal(want, got) {
+				t.Errorf("expected a match, diff: %s", cmp.Diff(want, got))
+			}
+		})
+	}
+}
+
+func getNow(t *testing.T) time.Time {
+	// keep micro second precision, there may be a better way of doing it
+	layout := "Jan 02 2006 15:04:05.000000"
+	s := time.Now().Format(layout)
+	ts, err := time.Parse(layout, s)
+	if err != nil {
+		t.Fatalf("unexpected error while getting time - %v", err)
+	}
+	return ts
+}

--- a/pkg/monitortests/kubeapiserver/staticpodinstall/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/staticpodinstall/monitortest.go
@@ -1,0 +1,155 @@
+package staticpodinstall
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	MonitorName = "staicpod-install-monitor"
+)
+
+func NewStaticPodInstallMonitorTest() *monitorTest {
+	analyzers := []analyzer{
+		&staticPodReadinessProbeEventAnalyzer{
+			windowsByPod: map[podKey][]*podWindow{},
+		},
+		&installerPodPLEGEventAnalyzer{
+			windows: map[podKey]*podWindow{},
+		},
+	}
+	return &monitorTest{analyzers: analyzers}
+}
+
+type monitorTest struct {
+	analyzers []analyzer
+	computed  monitorapi.Intervals
+}
+
+func (mt *monitorTest) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (mt *monitorTest) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	return nil, nil, nil
+}
+
+func (mt *monitorTest) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	mt.computed = mt.construct(startingIntervals)
+
+	return mt.computed, nil
+}
+
+func (mt *monitorTest) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	junitTest := &junitTest{
+		name:     "[sig-apimachinery] installer pods should not run concurrently on two or more nodes",
+		computed: mt.computed,
+	}
+
+	framework.Logf("monitor[%s]: found %d intervals of interest", MonitorName, len(junitTest.computed))
+
+	// the following constraints define pass/fail for this test:
+	// a) if we don't find any constructed/computed interval, then
+	// this test is a noop, so we mark the test as skipped
+	// b) we find constructed/computed intervals, but no occurrences of
+	// concurrent situation, this test is a pass
+	// c) otherwise, there is at least one incident of a
+	// concurrent situation, this test is a flake/fail
+	if len(junitTest.computed) == 0 {
+		// a) no constructed/computed interval observed, mark the test as skipped
+		return junitTest.Skip(), nil
+	}
+
+	// now check if there are any occurrences of concurrent interval
+	// and return either b,  or c
+	return junitTest.Result(), nil
+}
+
+func (*monitorTest) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*monitorTest) Cleanup(ctx context.Context) error {
+	// TODO wire up the start to a context we can kill here
+	return nil
+}
+
+type analyzer interface {
+	// want should return true if this analyzer is interested in this interval
+	want(interval monitorapi.Interval) bool
+	// analyze handles or processes the wanted interval
+	analyze(interval monitorapi.Interval)
+	// result returns a set of computed or constructed intervals
+	result() monitorapi.Intervals
+}
+
+func (mt *monitorTest) construct(starting monitorapi.Intervals) monitorapi.Intervals {
+	for _, interval := range starting {
+		for _, analyzer := range mt.analyzers {
+			if analyzer.want(interval) {
+				analyzer.analyze(interval)
+			}
+		}
+	}
+
+	computed := monitorapi.Intervals{}
+	for _, analyzer := range mt.analyzers {
+		computed = append(computed, analyzer.result()...)
+	}
+	return computed
+}
+
+type junitTest struct {
+	name     string
+	computed monitorapi.Intervals
+}
+
+func (jut *junitTest) Result() []*junitapi.JUnitTestCase {
+	passed := &junitapi.JUnitTestCase{
+		Name:      jut.name,
+		SystemOut: "",
+	}
+
+	concurrent := monitorapi.Intervals{}
+	for _, interval := range jut.computed {
+		if node, ok := interval.Message.Annotations["concurrent-node"]; ok && len(node) > 0 {
+			concurrent = append(concurrent, interval)
+		}
+	}
+
+	if len(concurrent) == 0 {
+		// passed
+		return []*junitapi.JUnitTestCase{passed}
+	}
+
+	// flake
+	failed := &junitapi.JUnitTestCase{
+		Name:          jut.name,
+		SystemOut:     fmt.Sprintf("installer pods running concurrently on two or more nodes"),
+		FailureOutput: &junitapi.FailureOutput{},
+	}
+	for _, interval := range concurrent {
+		failed.FailureOutput.Output = fmt.Sprintf("%s\n%s", failed.FailureOutput.Output, interval.String())
+	}
+
+	// TODO: for now, we flake the test, Once we know it's fully
+	// passing then we can remove the flake test case.
+	return []*junitapi.JUnitTestCase{failed, passed}
+}
+
+func (jut *junitTest) Skip() []*junitapi.JUnitTestCase {
+	skipped := &junitapi.JUnitTestCase{
+		Name: jut.name,
+		SkipMessage: &junitapi.SkipMessage{
+			Message: "No intervals of interest seen",
+		},
+	}
+	return []*junitapi.JUnitTestCase{skipped}
+}

--- a/pkg/monitortests/node/kubeletlogcollector/node.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
+	"github.com/openshift/origin/pkg/monitortests/kubeapiserver/staticpodinstall/kubeletlogparser"
+
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -90,6 +92,8 @@ func eventsFromKubeletLogs(nodeName string, kubeletLog []byte) monitorapi.Interv
 	nodeLocator := monitorapi.NewLocator().NodeFromName(nodeName)
 	ret := monitorapi.Intervals{}
 
+	parse := kubeletlogparser.NewEtcdStaticPodEventsFromKubelet()
+
 	scanner := bufio.NewScanner(bytes.NewBuffer(kubeletLog))
 	for scanner.Scan() {
 		currLine := scanner.Text()
@@ -104,6 +108,7 @@ func eventsFromKubeletLogs(nodeName string, kubeletLog []byte) monitorapi.Interv
 		ret = append(ret, anonymousCertConnectionError(nodeLocator, currLine)...)
 		ret = append(ret, leaseUpdateError(nodeLocator, currLine)...)
 		ret = append(ret, leaseFailBackOff(nodeLocator, currLine)...)
+		ret = append(ret, parse(nodeName, currLine)...)
 	}
 
 	return ret

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53604,6 +53604,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return (eventInterval.source === "APIUnreachableFromClient")
     }
 
+    function isStaticPodInstallMonitorActivity(eventInterval) {
+        return (eventInterval.source === "StaticPodInstallMonitor")
+    }
+
     function isEndpointConnectivity(eventInterval) {
         if (eventInterval.message.reason !== "DisruptionBegan" && eventInterval.message.reason !== "DisruptionSamplerOutageBegan") {
             return false
@@ -53732,6 +53736,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
     function isAPIUnreachableFromClientValue(item) {
         return [buildLocatorDisplayString(item.locator), "", "APIUnreachableFromClientMetrics"]
+    }
+
+    function isStaticPodInstallMonitorValue(item) {
+        return [buildLocatorDisplayString(item.locator), "", item.message.reason]
     }
 
     function disruptionValue(item) {
@@ -53948,6 +53956,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "api-unreachable", data: []})
         createTimelineData(isAPIUnreachableFromClientValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIUnreachableFromClientActivity, regex)
+
+        timelineGroups.push({group: "staticpod-install", data: []})
+        createTimelineData(isStaticPodInstallMonitorValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isStaticPodInstallMonitorActivity, regex)
 
         timelineGroups.push({ group: "etcd-leaders", data: [] })
         createTimelineData(etcdLeadershipLogsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdLeadershipAndNotEmpty, regex)


### PR DESCRIPTION
The monitor test works as follows:
- a) parse the kubelet log for SyncLoop lines (both PLEG and probe lines)
- b) generate events/interval for each of these lines from `a`
- c) add a monitor test that inspects the events from `b` and construct/compute new intervals:
     - etcd installer pod duration (derived from PLEG container start, and exit )
     - static pod (etcd for now) unready interval (derived from SyncLoop probe events)

This is an example, blue is installer pod duration, the red is etcd static pod unready window:
![image](https://github.com/user-attachments/assets/6dd68b13-bb74-4b44-9f13-d6e9d519dac2)

from: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29462/pull-ci-openshift-origin-master-e2e-gcp-ovn-upgrade/1882095583997464576 

The monitor test also flakes if:
- it finds two concurrent installer pods running on separate nodes
- it finds two concurrent unready window for the etcd static pod on separate nodes, which could potentially lead to etcd quorum loss