### PR TITLE
TRT-1958: pass EXTENSION_ARTIFACT_DIR to binaries

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -29,6 +31,9 @@ type TestBinary struct {
 	imageTag string
 	// The binary path to extract from the image
 	binaryPath string
+
+	// Cache the info after gathering it
+	info *ExtensionInfo
 }
 
 var extensionBinaries = []TestBinary{
@@ -40,7 +45,10 @@ var extensionBinaries = []TestBinary{
 
 // Info returns information about this particular extension.
 func (b *TestBinary) Info(ctx context.Context) (*ExtensionInfo, error) {
-	var info ExtensionInfo
+	if b.info != nil {
+		return b.info, nil
+	}
+
 	start := time.Now()
 	binName := filepath.Base(b.binaryPath)
 
@@ -52,14 +60,14 @@ func (b *TestBinary) Info(ctx context.Context) (*ExtensionInfo, error) {
 	}
 	jsonBegins := bytes.IndexByte(infoJson, '{')
 	jsonEnds := bytes.LastIndexByte(infoJson, '}')
-	err = json.Unmarshal(infoJson[jsonBegins:jsonEnds+1], &info)
+	err = json.Unmarshal(infoJson[jsonBegins:jsonEnds+1], b.info)
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't unmarshal extension info: %s", string(infoJson))
 	}
-	info.Source.SourceBinary = binName
-	info.Source.SourceImage = b.imageTag
+	b.info.Source.SourceBinary = binName
+	b.info.Source.SourceImage = b.imageTag
 	logrus.Infof("Fetched info for %s in %v", binName, time.Since(start))
-	return &info, nil
+	return b.info, nil
 }
 
 // ListTests returns which tests this binary advertises.  Eventually, it should take an environment struct
@@ -103,6 +111,17 @@ func (b *TestBinary) RunTests(ctx context.Context, timeout time.Duration, env []
 	var results []*ExtensionTestResult
 	expectedTests := sets.New[string](names...)
 	binName := filepath.Base(b.binaryPath)
+
+	// Configure EXTENSION_ARTIFACTS_DIR -- extension is responsible for MkdirAll if they want
+	// to produce artifacts.
+	info, err := b.Info(ctx)
+	if err != nil {
+		// unlikely to happen in reality, we'll have always run info and cached it before running tests
+		logrus.Warningf("Failed to fetch info for %s: %v", binName, err)
+	}
+	// e.g. k8s-tests-ext's extension will be $ARTIFACT_DIR/openshift/payload/hyperkube
+	extensionArtifactsDir := path.Join(os.Getenv("ARTIFACT_DIR"), safeComponentPath(&info.Component))
+	env = append(env, fmt.Sprintf("EXTENSION_ARTIFACT_DIR=%s", extensionArtifactsDir))
 
 	// Build command
 	args := []string{"run-test"}
@@ -456,4 +475,15 @@ func runWithTimeout(ctx context.Context, c *exec.Cmd, timeout time.Duration) ([]
 		}()
 	}
 	return c.CombinedOutput()
+}
+
+// safeComponentPath sanitizes a component identifier to be safe for use as a file or directory name.
+func safeComponentPath(c *Component) string {
+	safeRegexp := regexp.MustCompile(`[<>:"/\\|?*\s]+`)
+
+	return path.Join(
+		safeRegexp.ReplaceAllString(c.Product, "_"),
+		safeRegexp.ReplaceAllString(c.Kind, "_"),
+		safeRegexp.ReplaceAllString(c.Name, "_"),
+	)
 }

--- a/pkg/test/extensions/types.go
+++ b/pkg/test/extensions/types.go
@@ -1,8 +1,9 @@
 package extensions
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // ExtensionInfo represents an extension to openshift-tests.
@@ -13,6 +14,9 @@ type ExtensionInfo struct {
 
 	// Suites that the extension wants to advertise/participate in.
 	Suites []Suite `json:"suites"`
+
+	// -- origin specific info --
+	ExtensionArtifactDir string `json:"extension_artifact_dir"`
 }
 
 // Source contains the details of the commit and source URL.


### PR DESCRIPTION
The enhancement calls for extensions that want to produce artifacts to write them to EXTENSION_ARTIFACT_DIR, this sets the path for each extension. Current design is to provide the dir but it's up to them to `mkdir -p` it -- I could be convinced to do that for them, but figure it's helpful when browsing CI artifacts to only see directories that have contents in them.