### PR TITLE
NO-JIRA: use quay.io/openshift/origin-cli:latest directly

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51638,11 +51638,6 @@ items:
       dockerfile: |
         FROM quay.io/openshift/origin-cli:latest
         WORKDIR /var/lib/origin
-        RUN source /etc/os-release \
-            && rhel_major=${VERSION_ID%.*} \
-            && yum config-manager \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -51663,9 +51658,6 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
-        from:
-          kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -18,11 +18,6 @@ items:
       dockerfile: |
         FROM quay.io/openshift/origin-cli:latest
         WORKDIR /var/lib/origin
-        RUN source /etc/os-release \
-            && rhel_major=${VERSION_ID%.*} \
-            && yum config-manager \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -43,9 +38,6 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
-        from:
-          kind: DockerImage
-          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
we have the following e2e test failing constantly:

```
Image signature workflow can push a signed image to openshift registry and verify it
```

this e2e is failing when attempting to build an image. the reported build failure is as follow:

```
error: build error: building at STEP "RUN source /etc/os-release && rhel_major=${VERSION_ID%!(BADPREC)%!}(MISSING) && yum config-manager --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/"     --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"":
while running runtime: exit status 6
```

this error seems to be related to the yum wrapper that has been added to the image.

this pr makes the e2e to use the image directly from the upstream repository (quay), that image does not contain the yum wrapper.