### PR TITLE
Udn hostnet isolation

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -1122,6 +1122,12 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				_, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: defaultNetNamespace,
+						// labels are required to run a hostNetwork pod
+						Labels: map[string]string{
+							psapi.AuditLevelLabel:   string(psapi.LevelPrivileged),
+							psapi.EnforceLevelLabel: string(psapi.LevelPrivileged),
+							psapi.WarnLevelLabel:    string(psapi.LevelPrivileged),
+						},
 					},
 				}, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1140,6 +1146,18 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						setRuntimeDefaultPSA(pod)
 					},
 				)
+				testNodeName := getPodNodeName(f.ClientSet, udnPod.Namespace, udnPod.Name)
+
+				By("creating default network hostNetwork client pod")
+				hostNetPod := frameworkpod.CreateExecPodOrFail(
+					context.Background(),
+					f.ClientSet,
+					defaultNetNamespace,
+					"host-net-client-pod",
+					func(pod *v1.Pod) {
+						pod.Spec.HostNetwork = true
+						pod.Spec.NodeName = testNodeName
+					})
 
 				udnIPv4, udnIPv6, err := podIPsForDefaultNetwork(
 					cs,
@@ -1156,6 +1174,11 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					By("checking the default network pod can't reach UDN pod on IP " + destIP)
 					Consistently(func() bool {
 						return connectToServer(podConfiguration{namespace: defaultClientPod.Namespace, name: defaultClientPod.Name}, destIP, port) != nil
+					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
+
+					By("checking the default hostNetwork pod can't reach UDN pod on IP " + destIP)
+					Consistently(func() bool {
+						return connectToServer(podConfiguration{namespace: hostNetPod.Namespace, name: hostNetPod.Name}, destIP, port) != nil
 					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
 				}
 
@@ -1175,6 +1198,11 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					Eventually(func() bool {
 						return connectToServer(podConfiguration{namespace: defaultClientPod.Namespace, name: defaultClientPod.Name}, destIP, port) == nil
 					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
+
+					By("checking the default hostNetwork pod can reach UDN pod on IP " + destIP)
+					Eventually(func() bool {
+						return connectToServer(podConfiguration{namespace: hostNetPod.Namespace, name: hostNetPod.Name}, destIP, port) == nil
+					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
 				}
 
 				By("Update UDN pod port with the wrong syntax")
@@ -1193,6 +1221,11 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					By("checking the default network pod can't reach UDN pod on IP " + destIP)
 					Eventually(func() bool {
 						return connectToServer(podConfiguration{namespace: defaultClientPod.Namespace, name: defaultClientPod.Name}, destIP, port) != nil
+					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
+
+					By("checking the default hostNetwork pod can't reach UDN pod on IP " + destIP)
+					Eventually(func() bool {
+						return connectToServer(podConfiguration{namespace: hostNetPod.Namespace, name: hostNetPod.Name}, destIP, port) != nil
 					}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
 				}
 				By("Verify syntax error is reported via event")

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -32,6 +32,7 @@ import (
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 	frameworkpod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
+	psapi "k8s.io/pod-security-admission/api"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/pointer"
 
@@ -187,6 +188,12 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						_, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: defaultNetNamespace,
+								// labels are required to run a hostNetwork pod
+								Labels: map[string]string{
+									psapi.AuditLevelLabel:   string(psapi.LevelPrivileged),
+									psapi.EnforceLevelLabel: string(psapi.LevelPrivileged),
+									psapi.WarnLevelLabel:    string(psapi.LevelPrivileged),
+								},
 							},
 						}, metav1.CreateOptions{})
 						Expect(err).NotTo(HaveOccurred())
@@ -245,6 +252,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							}
 						})
 
+						testNodeName := getPodNodeName(f.ClientSet, udnPod.Namespace, udnPod.Name)
+
 						const podGenerateName = "udn-test-pod-"
 						By("creating default network pod")
 						defaultPod := frameworkpod.CreateExecPodOrFail(
@@ -254,6 +263,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							podGenerateName,
 							func(pod *v1.Pod) {
 								pod.Spec.Containers[0].Args = []string{"netexec"}
+								pod.Spec.NodeName = testNodeName
 								setRuntimeDefaultPSA(pod)
 							},
 						)
@@ -265,6 +275,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							defaultNetNamespace,
 							podGenerateName,
 							func(pod *v1.Pod) {
+								pod.Spec.NodeName = testNodeName
 								setRuntimeDefaultPSA(pod)
 							},
 						)
@@ -318,8 +329,49 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						// The pod should be ready
 						Expect(podutils.IsPodReady(udnPod)).To(BeTrue())
 
-						// TODO
-						//By("checking non-kubelet default network host process can't reach the UDN pod")
+						By("restarting kubelet, pod should stay ready")
+						err = oc.AsAdmin().Run("debug").Args("node/"+testNodeName, "--", "chroot", "/host", "/bin/bash", "-c", "systemctl restart kubelet").Execute()
+						Expect(err).NotTo(HaveOccurred())
+
+						By("asserting healthcheck still works (kubelet can access the UDN pod)")
+						// The pod should stay ready
+						Consistently(func() bool {
+							return podutils.IsPodReady(udnPod)
+						}, 10*time.Second, 1*time.Second).Should(BeTrue())
+						Expect(udnPod.Status.ContainerStatuses[0].RestartCount).To(Equal(int32(0)))
+
+						By("checking default network hostNetwork pod can't reach the UDN pod")
+						hostNetPod := frameworkpod.CreateExecPodOrFail(
+							context.Background(),
+							f.ClientSet,
+							defaultNetNamespace,
+							"host-net-pod",
+							func(pod *v1.Pod) {
+								pod.Spec.HostNetwork = true
+								pod.Spec.NodeName = testNodeName
+							})
+
+						// positive check for reachable default network pod
+						for _, destIP := range []string{defaultIPv4, defaultIPv6} {
+							if destIP == "" {
+								continue
+							}
+							By("checking the default network hostNetwork can reach default pod on IP " + destIP)
+							Eventually(func() bool {
+								return connectToServer(podConfiguration{namespace: hostNetPod.Namespace, name: hostNetPod.Name}, destIP, defaultPort) == nil
+							}).Should(BeTrue())
+						}
+						// negative check for UDN pod
+						for _, destIP := range []string{udnIPv4, udnIPv6} {
+							if destIP == "" {
+								continue
+							}
+
+							By("checking the default network hostNetwork pod can't reach UDN pod on IP " + destIP)
+							Consistently(func() bool {
+								return connectToServer(podConfiguration{namespace: hostNetPod.Namespace, name: hostNetPod.Name}, destIP, port) != nil
+							}, serverConnectPollTimeout, serverConnectPollInterval).Should(BeTrue())
+						}
 
 						By("asserting UDN pod can't reach host via default network interface")
 						// Now try to reach the host from the UDN pod


### PR DESCRIPTION
Partial copy of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4799/commits/5b62be5dd6a61762b3d2b8a001c6ca039a4b4eba#diff-2be1e01ba9cf5c059a4f4f0cd2b974861043381664e7102e3783f48842891d43.
Non-kubelet host process checks are removed, as there is no way to directly access OCP nodes (without privileged host-network pods) anyway, and host-network checks exist separately.
Second commit is a copy of https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4799/commits/a822445f4b4af06173981887639376dc5d84c8fb

This will only work after https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4999 reached d/s together with host isolation enablement