### PR TITLE
SDN-4930: Fix live migration tests

### DIFF
--- a/test/extended/networking/kubevirt/client.go
+++ b/test/extended/networking/kubevirt/client.go
@@ -87,7 +87,7 @@ func (c *Client) Login(vmName, hostname string) error {
 	return LoginToFedoraWithHostname(c.virtCtl, c.oc.Namespace(), vmName, "fedora", "fedora", hostname)
 }
 func (c *Client) GetJSONPath(resource, name, jsonPath string) (string, error) {
-	output, err := c.oc.Run("get").Args(resource, name, "-o", fmt.Sprintf(`jsonpath=%q`, jsonPath)).Output()
+	output, err := c.oc.AsAdmin().Run("get").Args(resource, name, "-n", c.oc.Namespace(), "-o", fmt.Sprintf(`jsonpath=%q`, jsonPath)).Output()
 	if err != nil {
 		return "", err
 	}

--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -34,7 +34,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 	// disable automatic namespace creation, we need to add the required UDN label
 	oc := exutil.NewCLIWithoutNamespace("network-segmentation-e2e")
 	f := oc.KubeFramework()
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	InOVNKubernetesContext(func() {
 		var (
@@ -238,7 +238,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 					udnManifest := generateUserDefinedNetworkManifest(&c)
 					By(fmt.Sprintf("Creating UserDefinedNetwork %s/%s", c.namespace, c.name))
 					Expect(applyManifest(c.namespace, udnManifest)).To(Succeed())
-					Eventually(userDefinedNetworkReadyFunc(oc.DynamicClient(), c.namespace, c.name), udnCrReadyTimeout, time.Second).Should(Succeed())
+					Eventually(userDefinedNetworkReadyFunc(oc.AdminDynamicClient(), c.namespace, c.name), udnCrReadyTimeout, time.Second).Should(Succeed())
 
 					nad, err := nadClient.NetworkAttachmentDefinitions(c.namespace).Get(
 						context.Background(), c.name, metav1.GetOptions{},


### PR DESCRIPTION
Now that we create the namespace for the tests NewCLIWithoutNamespace, implicitly another function is not called:

SetupProject->setupProject/setupNamespace->ChangeUser

ChangeUser will generate kubeconfig for the namespace user and set CLI.configPath. However we dont setup project, so we dont have a proper user account and the other scaffolding for a project. Therefore calling oc.DynamicClient or other OC commands that would use the user CLI.configPath wont work.

This would result in the "failed to open file" error because there was no user kubeconfig written to disk.

Just use admin for now.