### PR TITLE
SDN-4930: UDN tests wait for SCC annotation on namespace

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -78,6 +78,9 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
+						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						Expect(err).NotTo(HaveOccurred())
+
 						f.Namespace = ns
 						netConfig.namespace = f.Namespace.Name
 						// correctCIDRFamily makes use of the ginkgo framework so it needs to be in the testcase
@@ -275,6 +278,8 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][OCPFeatureGate:Netw
 				"e2e-framework":           f.BaseName,
 				RequiredUDNNamespaceLabel: "",
 			})
+			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = ns
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -115,6 +115,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
+						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 
 						netConfig.namespace = f.Namespace.Name
@@ -203,6 +205,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							l[RequiredUDNNamespaceLabel] = ""
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
+						Expect(err).NotTo(HaveOccurred())
+						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 						By("Creating second namespace for default network pods")
@@ -485,6 +489,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
+						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 						red := "red"
 						blue := "blue"
@@ -674,6 +680,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					"e2e-framework": f.BaseName,
 				})
 				Expect(err).NotTo(HaveOccurred())
+				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+				Expect(err).NotTo(HaveOccurred())
 				f.Namespace = namespace
 
 				By("create tests UserDefinedNetwork")
@@ -779,6 +787,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			}
 			ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 			Expect(err).NotTo(HaveOccurred())
+			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = ns
 
 			By("create primary network NetworkAttachmentDefinition")
@@ -832,6 +842,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					RequiredUDNNamespaceLabel: "",
 				})
 				f.Namespace = namespace
+				Expect(err).NotTo(HaveOccurred())
+				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
 				Expect(err).NotTo(HaveOccurred())
 				testTenantNamespaces = []string{
 					f.Namespace.Name + "blue",
@@ -1079,6 +1091,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				RequiredUDNNamespaceLabel: "",
 			})
 			Expect(err).NotTo(HaveOccurred())
+			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = namespace
 			testTenantNamespaces := []string{
 				f.Namespace.Name + "blue",
@@ -1158,6 +1172,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					RequiredUDNNamespaceLabel: "",
 				}
 				ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
+				Expect(err).NotTo(HaveOccurred())
+				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
 				Expect(err).NotTo(HaveOccurred())
 				f.Namespace = ns
 				By("create tests UserDefinedNetwork")

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -51,6 +51,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 			f.Namespace = namespace
 			Expect(err).NotTo(HaveOccurred())
+			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			Expect(err).NotTo(HaveOccurred())
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -191,6 +193,8 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						defaultNetNamespace, err := f.CreateNamespace(context.TODO(), defaultNSName, map[string]string{
 							"e2e-framework": defaultNSName,
 						})
+						Expect(err).NotTo(HaveOccurred())
+						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), defaultNetNamespace.Name)
 						Expect(err).NotTo(HaveOccurred())
 						By("creating the network")
 						netConfig.namespace = defaultNetNamespace.Name

--- a/test/extended/networking/network_segmentation_policy.go
+++ b/test/extended/networking/network_segmentation_policy.go
@@ -54,6 +54,8 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 			})
 			f.Namespace = namespace
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
Since we create our own namespaces for UDN, we need to wait for the cluster manager to annotate the namespace before we can try to create pods.