### PR TITLE
SDN-4930: Fix live migration test detecting dualstack

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -89,7 +89,10 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(workerNodes)).To(BeNumerically(">=", 2))
 
-						isDualStack := getIPFamilyForCluster(f) == DualStack
+						isDualStack := false
+						if strings.Contains(netConfig.cidr, ",") {
+							isDualStack = true
+						}
 
 						provisionedNetConfig := createNetworkFn(netConfig)
 

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -1364,7 +1364,8 @@ func generateIPAMLifecycle(params *networkAttachmentConfigParams) string {
 	if !params.allowPersistentIPs {
 		return ""
 	}
-	return "ipamLifecycle: Persistent"
+	return `ipam:
+      lifecycle: Persistent`
 }
 
 func createManifest(namespace, manifest string) (func(), error) {


### PR DESCRIPTION
Live migration test was launching a pod to determine if cluster is dualstack. This would happen before UDN is created, so it would fail on a namespace that was enabled for UDN (network did not exist yet).

The check is really not needed, since a few lines above we already determine if the cluster is dualstack or not via a service CIDR check. Leverage that.