### PR TITLE
SDN-4930: Get cluster IP family after setting up the network

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -89,9 +89,9 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						Expect(err).NotTo(HaveOccurred())
 						Expect(len(workerNodes)).To(BeNumerically(">=", 2))
 
-						isDualStack := getIPFamilyForCluster(f) == DualStack
-
 						provisionedNetConfig := createNetworkFn(netConfig)
+
+						isDualStack := getIPFamilyForCluster(f) == DualStack
 
 						for _, node := range workerNodes {
 							Eventually(func() bool {


### PR DESCRIPTION
`getIPFamilyForCluster` creates a pod to determine the cluster's IP family. 
When namespaces are labeled for the primary UDN, this must happen after the network is created or the pod will fail to start.

cc: @trozet 