### PR TITLE
OCPBUGS-49600: Display etcd bootstrap event on timeline

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -101,6 +101,11 @@
 
     }
 
+    function isEtcdBootstrap(eventInterval) {
+        return eventInterval.source === 'PodLog' && eventInterval.message.reason === "EtcdBootstrap";
+
+    }
+
     function isPodLog(eventInterval) {
         if (eventInterval.source === 'PodLog') {
             return true
@@ -500,6 +505,7 @@
 
         timelineGroups.push({ group: "etcd-leaders", data: [] })
         createTimelineData(etcdLeadershipLogsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdLeadershipAndNotEmpty, regex)
+        createTimelineData("Bootstrap", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdBootstrap, regex)
 
         timelineGroups.push({group: "cloud-metrics", data: []})
         createTimelineData(cloudMetricsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isCloudMetrics, regex)

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -262,6 +262,8 @@ const (
 
 	ReasonHighGeneration    IntervalReason = "HighGeneration"
 	ReasonInvalidGeneration IntervalReason = "GenerationViolation"
+
+	ReasonEtcdBootstrap IntervalReason = "EtcdBootstrap"
 )
 
 type AnnotationKey string

--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openshift/origin/pkg/monitortests/testframework/watchnamespaces"
 	"strings"
 	"time"
+
+	"github.com/openshift/origin/pkg/monitortests/testframework/watchnamespaces"
 
 	"github.com/openshift/origin/pkg/monitor"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -203,6 +204,17 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 				Locator(logLine.Locator).
 				Message(monitorapi.NewMessage().
 					Reason(monitorapi.ReasonBadOperatorApply).
+					HumanMessage(logLine.Line),
+				).
+				Build(logLine.Instant, logLine.Instant),
+		)
+	case strings.Contains(logLine.Line, "Removing bootstrap member") || strings.Contains(logLine.Line, "Successfully removed bootstrap member") || strings.Contains(logLine.Line, "Cluster etcd operator bootstrapped successfully"): // ceo removed bootstrap member
+		g.recorder.AddIntervals(
+			monitorapi.NewInterval(monitorapi.SourcePodLog, monitorapi.Info).
+				Locator(logLine.Locator).
+				Display().
+				Message(monitorapi.NewMessage().
+					Reason(monitorapi.ReasonEtcdBootstrap).
 					HumanMessage(logLine.Line),
 				).
 				Build(logLine.Instant, logLine.Instant),

--- a/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
+++ b/pkg/monitortests/testframework/operatorloganalyzer/operator_log_scraper.go
@@ -173,7 +173,7 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 					Reason(monitorapi.LeaseAcquiringStarted).
 					HumanMessage(logLine.Line),
 				).
-				Build(logLine.Instant, logLine.Instant),
+				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	case strings.Contains(logLine.Line, "successfully acquired lease") &&
 		!strings.Contains(logLine.Line, "Degraded"): // need to exclude lines that re-embed the kube-controller-manager log
@@ -184,7 +184,7 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 					Reason(monitorapi.LeaseAcquired).
 					HumanMessage(logLine.Line),
 				).
-				Build(logLine.Instant, logLine.Instant),
+				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	case strings.Contains(logLine.Line, "unable to ApplyStatus for operator") &&
 		strings.Contains(logLine.Line, "is invalid"): // apply failures
@@ -195,7 +195,7 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 					Reason(monitorapi.ReasonBadOperatorApply).
 					HumanMessage(logLine.Line),
 				).
-				Build(logLine.Instant, logLine.Instant),
+				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	case strings.Contains(logLine.Line, "unable to Apply for operator") &&
 		strings.Contains(logLine.Line, "is invalid"): // apply failures
@@ -206,7 +206,7 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 					Reason(monitorapi.ReasonBadOperatorApply).
 					HumanMessage(logLine.Line),
 				).
-				Build(logLine.Instant, logLine.Instant),
+				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	case strings.Contains(logLine.Line, "Removing bootstrap member") || strings.Contains(logLine.Line, "Successfully removed bootstrap member") || strings.Contains(logLine.Line, "Cluster etcd operator bootstrapped successfully"): // ceo removed bootstrap member
 		g.recorder.AddIntervals(
@@ -217,7 +217,7 @@ func (g operatorLogHandler) HandleLogLine(logLine podaccess.LogLineContent) {
 					Reason(monitorapi.ReasonEtcdBootstrap).
 					HumanMessage(logLine.Line),
 				).
-				Build(logLine.Instant, logLine.Instant),
+				Build(logLine.Instant, logLine.Instant.Add(time.Second)),
 		)
 	}
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53556,6 +53556,11 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
     }
 
+    function isEtcdBootstrap(eventInterval) {
+        return eventInterval.source === 'PodLog' && eventInterval.message.reason === "EtcdBootstrap";
+
+    }
+
     function isPodLog(eventInterval) {
         if (eventInterval.source === 'PodLog') {
             return true
@@ -53955,6 +53960,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({ group: "etcd-leaders", data: [] })
         createTimelineData(etcdLeadershipLogsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdLeadershipAndNotEmpty, regex)
+        createTimelineData("Bootstrap", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isEtcdBootstrap, regex)
 
         timelineGroups.push({group: "cloud-metrics", data: []})
         createTimelineData(cloudMetricsValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isCloudMetrics, regex)


### PR DESCRIPTION
Update `operator_log_scraper.go` to record start/finish of etcd bootstrap member removal. This also updates other events tracked there to have a duration of 1 sec otherwise these are not being displayed on spyglass interval chart