### PR TITLE
SDN-4930: UDN: wait for moar openshift

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -78,7 +78,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						err = udnWaitForOpenShift(oc, ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 
 						f.Namespace = ns
@@ -281,7 +281,7 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][OCPFeatureGate:Netw
 				"e2e-framework":           f.BaseName,
 				RequiredUDNNamespaceLabel: "",
 			})
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+			err = udnWaitForOpenShift(oc, ns.Name)
 			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = ns
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -20,6 +20,7 @@ import (
 	nadapi "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	nadclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
 
+	kubeauthorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +116,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						err = udnWaitForOpenShift(oc, ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 
@@ -206,7 +207,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						err = udnWaitForOpenShift(oc, ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 						By("Creating second namespace for default network pods")
@@ -489,7 +490,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						err = udnWaitForOpenShift(oc, ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 						f.Namespace = ns
 						red := "red"
@@ -680,7 +681,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					"e2e-framework": f.BaseName,
 				})
 				Expect(err).NotTo(HaveOccurred())
-				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+				err = udnWaitForOpenShift(oc, namespace.Name)
 				Expect(err).NotTo(HaveOccurred())
 				f.Namespace = namespace
 
@@ -787,7 +788,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			}
 			ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 			Expect(err).NotTo(HaveOccurred())
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+			err = udnWaitForOpenShift(oc, ns.Name)
 			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = ns
 
@@ -843,7 +844,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				})
 				f.Namespace = namespace
 				Expect(err).NotTo(HaveOccurred())
-				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+				err = udnWaitForOpenShift(oc, namespace.Name)
 				Expect(err).NotTo(HaveOccurred())
 				testTenantNamespaces = []string{
 					f.Namespace.Name + "blue",
@@ -1091,7 +1092,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				RequiredUDNNamespaceLabel: "",
 			})
 			Expect(err).NotTo(HaveOccurred())
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			err = udnWaitForOpenShift(oc, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 			f.Namespace = namespace
 			testTenantNamespaces := []string{
@@ -1173,7 +1174,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				}
 				ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 				Expect(err).NotTo(HaveOccurred())
-				err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+				err = udnWaitForOpenShift(oc, ns.Name)
 				Expect(err).NotTo(HaveOccurred())
 				f.Namespace = ns
 				By("create tests UserDefinedNetwork")
@@ -2244,4 +2245,33 @@ func Network(ipn *net.IPNet) *net.IPNet {
 		IP:   maskedIP,
 		Mask: ipn.Mask,
 	}
+}
+
+func udnWaitForOpenShift(oc *exutil.CLI, namespace string) error {
+	serviceAccountName := "default"
+	framework.Logf("Waiting for ServiceAccount %q to be provisioned...", serviceAccountName)
+	err := exutil.WaitForServiceAccount(oc.AdminKubeClient().CoreV1().ServiceAccounts(namespace), serviceAccountName)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting on permissions in namespace %q ...", namespace)
+	err = exutil.WaitForSelfSAR(1*time.Second, 60*time.Second, oc.AdminKubeClient(), kubeauthorizationv1.SelfSubjectAccessReviewSpec{
+		ResourceAttributes: &kubeauthorizationv1.ResourceAttributes{
+			Namespace: namespace,
+			Verb:      "create",
+			Group:     "",
+			Resource:  "pods",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting on SCC annotations in namespace %q ...", namespace)
+	err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -51,7 +51,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 			f.Namespace = namespace
 			Expect(err).NotTo(HaveOccurred())
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			err = udnWaitForOpenShift(oc, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
@@ -194,7 +194,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							"e2e-framework": defaultNSName,
 						})
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), defaultNetNamespace.Name)
+						err = udnWaitForOpenShift(oc, defaultNetNamespace.Name)
 						Expect(err).NotTo(HaveOccurred())
 						By("creating the network")
 						netConfig.namespace = defaultNetNamespace.Name

--- a/test/extended/networking/network_segmentation_policy.go
+++ b/test/extended/networking/network_segmentation_policy.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 			})
 			f.Namespace = namespace
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			err = udnWaitForOpenShift(oc, namespace.Name)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
Platforms like SNO can be really slow. Waiting for SCC annotations wasn't enough. We also need to wait for service account as well to prevent flakes.