### PR TITLE
[release-4.18] OCPBUGS-48460, SDN-4930: UDN: wait for moar openshift

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -78,7 +78,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						}
 						ns, err := f.CreateNamespace(context.TODO(), f.BaseName, l)
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), ns.Name)
+						err = udnWaitForOpenShift(oc, ns.Name)
 						Expect(err).NotTo(HaveOccurred())
 
 						f.Namespace = ns

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -51,7 +51,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 			f.Namespace = namespace
 			Expect(err).NotTo(HaveOccurred())
-			err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), namespace.Name)
+			err = udnWaitForOpenShift(oc, namespace.Name)
 			Expect(err).NotTo(HaveOccurred())
 			nadClient, err = nadclient.NewForConfig(f.ClientConfig())
 			Expect(err).NotTo(HaveOccurred())
@@ -194,7 +194,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 							"e2e-framework": defaultNSName,
 						})
 						Expect(err).NotTo(HaveOccurred())
-						err = exutil.WaitForNamespaceSCCAnnotations(oc.AdminKubeClient().CoreV1(), defaultNetNamespace.Name)
+						err = udnWaitForOpenShift(oc, defaultNetNamespace.Name)
 						Expect(err).NotTo(HaveOccurred())
 						By("creating the network")
 						netConfig.namespace = defaultNetNamespace.Name


### PR DESCRIPTION
Platforms like SNO can be really slow. Waiting for SCC annotations wasn't enough. We also need to wait for service account as well to prevent flakes.

Signed-off-by: Tim Rozet <trozet@redhat.com>
(cherry picked from commit 20a602244abd5f0a5b6557dd6ea229d3784a267d)