### PR TITLE
TRT-1853: Pass applicable environment flags to the external binary

### DIFF
--- a/pkg/clioptions/clusterdiscovery/cluster.go
+++ b/pkg/clioptions/clusterdiscovery/cluster.go
@@ -90,6 +90,7 @@ type ClusterState struct {
 	NetworkSpec          *operatorv1.NetworkSpec
 	ControlPlaneTopology *configv1.TopologyMode
 	OptionalCapabilities []configv1.ClusterVersionCapability
+	Version              *configv1.ClusterVersion
 }
 
 // DiscoverClusterState creates a ClusterState based on a live cluster
@@ -152,6 +153,7 @@ func DiscoverClusterState(clientConfig *rest.Config) (*ClusterState, error) {
 	if err != nil {
 		return nil, err
 	}
+	state.Version = clusterVersion
 	state.OptionalCapabilities = clusterVersion.Status.Capabilities.EnabledCapabilities
 
 	return state, nil

--- a/pkg/test/extensions/types.go
+++ b/pkg/test/extensions/types.go
@@ -174,14 +174,16 @@ func (dbt *DBTime) UnmarshalJSON(b []byte) error {
 type EnvironmentFlagName string
 
 const (
-	platform     EnvironmentFlagName = "platform"
-	network      EnvironmentFlagName = "network"
-	networkStack EnvironmentFlagName = "network-stack"
-	upgrade      EnvironmentFlagName = "upgrade"
-	topology     EnvironmentFlagName = "topology"
-	architecture EnvironmentFlagName = "architecture"
-	fact         EnvironmentFlagName = "fact"
-	version      EnvironmentFlagName = "version"
+	platform             EnvironmentFlagName = "platform"
+	network              EnvironmentFlagName = "network"
+	networkStack         EnvironmentFlagName = "network-stack"
+	upgrade              EnvironmentFlagName = "upgrade"
+	topology             EnvironmentFlagName = "topology"
+	architecture         EnvironmentFlagName = "architecture"
+	externalConnectivity EnvironmentFlagName = "external-connectivity"
+	optionalCapability   EnvironmentFlagName = "optional-capability"
+	fact                 EnvironmentFlagName = "fact"
+	version              EnvironmentFlagName = "version"
 )
 
 type EnvironmentFlagsBuilder struct {
@@ -220,6 +222,16 @@ func (e *EnvironmentFlagsBuilder) AddArchitecture(value string) *EnvironmentFlag
 	return e
 }
 
+func (e *EnvironmentFlagsBuilder) AddExternalConnectivity(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(externalConnectivity, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddOptionalCapability(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(optionalCapability, value))
+	return e
+}
+
 func (e *EnvironmentFlagsBuilder) AddFact(value string) *EnvironmentFlagsBuilder {
 	e.flags = append(e.flags, newEnvironmentFlag(fact, value))
 	return e
@@ -247,7 +259,8 @@ func newEnvironmentFlag(name EnvironmentFlagName, value string) EnvironmentFlag 
 }
 
 func (ef EnvironmentFlag) ArgString() string {
-	return fmt.Sprintf("%s=%s", ef.Name, ef.Value)
+	return fmt.Sprintf("--%s=%s", ef.Name, ef.Value)
+	//return fmt.Sprintf("%s=%s", ef.Name, ef.Value)
 }
 
 type EnvironmentFlags []EnvironmentFlag
@@ -267,12 +280,14 @@ func (ef EnvironmentFlags) String() string {
 
 // EnvironmentFlagVersions holds the "Since" version metadata for each flag.
 var EnvironmentFlagVersions = map[EnvironmentFlagName]string{
-	platform:     "v1.0",
-	network:      "v1.0",
-	networkStack: "v1.0",
-	upgrade:      "v1.0",
-	topology:     "v1.0",
-	architecture: "v1.0",
-	fact:         "v1.0", //TODO(sgoeddel): this will be set in a later version
-	version:      "v1.0",
+	platform:             "v1.0",
+	network:              "v1.0",
+	networkStack:         "v1.0",
+	upgrade:              "v1.0",
+	topology:             "v1.0",
+	architecture:         "v1.0",
+	externalConnectivity: "v1.0",
+	optionalCapability:   "v1.0",
+	fact:                 "v1.0", //TODO(sgoeddel): this will be set in a later version
+	version:              "v1.0",
 }

--- a/pkg/test/extensions/types.go
+++ b/pkg/test/extensions/types.go
@@ -1,9 +1,13 @@
 package extensions
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 // ExtensionInfo represents an extension to openshift-tests.
@@ -164,4 +168,111 @@ func (dbt *DBTime) UnmarshalJSON(b []byte) error {
 	}
 	*dbt = (DBTime)(parsedTime)
 	return nil
+}
+
+// EnvironmentFlagName enumerates each possible EnvironmentFlag's name to be passed to the external binary
+type EnvironmentFlagName string
+
+const (
+	platform     EnvironmentFlagName = "platform"
+	network      EnvironmentFlagName = "network"
+	networkStack EnvironmentFlagName = "network-stack"
+	upgrade      EnvironmentFlagName = "upgrade"
+	topology     EnvironmentFlagName = "topology"
+	architecture EnvironmentFlagName = "architecture"
+	fact         EnvironmentFlagName = "fact"
+	version      EnvironmentFlagName = "version"
+)
+
+type EnvironmentFlagsBuilder struct {
+	flags EnvironmentFlags
+}
+
+func (e *EnvironmentFlagsBuilder) AddPlatform(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(platform, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddNetwork(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(network, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddNetworkStack(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(networkStack, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddUpgrade(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(upgrade, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddTopology(value *configv1.TopologyMode) *EnvironmentFlagsBuilder {
+	if value != nil {
+		e.flags = append(e.flags, newEnvironmentFlag(topology, string(*value)))
+	}
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddArchitecture(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(architecture, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddFact(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(fact, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) AddVersion(value string) *EnvironmentFlagsBuilder {
+	e.flags = append(e.flags, newEnvironmentFlag(version, value))
+	return e
+}
+
+func (e *EnvironmentFlagsBuilder) Build() EnvironmentFlags {
+	return e.flags
+}
+
+// EnvironmentFlag contains the info required to build an argument to pass to the external binary for the given Name
+type EnvironmentFlag struct {
+	Name         EnvironmentFlagName
+	Value        string
+	SinceVersion string
+}
+
+// newEnvironmentFlag creates an EnvironmentFlag including the determination of the SinceVersion
+func newEnvironmentFlag(name EnvironmentFlagName, value string) EnvironmentFlag {
+	return EnvironmentFlag{Name: name, Value: value, SinceVersion: EnvironmentFlagVersions[name]}
+}
+
+func (ef EnvironmentFlag) ArgString() string {
+	return fmt.Sprintf("%s=%s", ef.Name, ef.Value)
+}
+
+type EnvironmentFlags []EnvironmentFlag
+
+// ArgStrings properly formats all EnvironmentFlags as a list of argument strings to pass to the external binary
+func (ef EnvironmentFlags) ArgStrings() []string {
+	var argStrings []string
+	for _, flag := range ef {
+		argStrings = append(argStrings, flag.ArgString())
+	}
+	return argStrings
+}
+
+func (ef EnvironmentFlags) String() string {
+	return strings.Join(ef.ArgStrings(), ", ")
+}
+
+// EnvironmentFlagVersions holds the "Since" version metadata for each flag.
+var EnvironmentFlagVersions = map[EnvironmentFlagName]string{
+	platform:     "v1.0",
+	network:      "v1.0",
+	networkStack: "v1.0",
+	upgrade:      "v1.0",
+	topology:     "v1.0",
+	architecture: "v1.0",
+	fact:         "v1.0", //TODO(sgoeddel): this will be set in a later version
+	version:      "v1.0",
 }

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -704,7 +704,11 @@ func determineEnvironmentFlags(upgrade bool, dryRun bool) (extensions.Environmen
 	if err != nil {
 		logrus.WithError(err).Warn("error Discovering Cluster State, flags requiring it will not be present")
 	}
-	config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), dryRun, true, clusterState)
+	provider := os.Getenv("TEST_PROVIDER")
+	if clusterState == nil { // If we know we cannot discover the clusterState, the provider must be set to "none" in order for the config to be loaded without error
+		provider = "none"
+	}
+	config, err := clusterdiscovery.DecodeProvider(provider, dryRun, true, clusterState)
 	if err != nil {
 		logrus.WithError(err).Error("error determining information about the cluster")
 		return nil, err

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -716,6 +716,12 @@ func determineEnvironmentFlags(upgrade bool, dryRun bool) (extensions.Environmen
 		upgradeType = determineUpgradeType(clusterState.Version.Status)
 	}
 
+	arch := "Unknown"
+	if len(clusterState.Masters.Items) > 0 {
+		//TODO(sgoeddel): eventually, we may need to check every node and pass "multi" as the value if any of them differ from the masters
+		arch = clusterState.Masters.Items[0].Status.NodeInfo.Architecture
+	}
+
 	envFlagBuilder := &extensions.EnvironmentFlagsBuilder{}
 	envFlagBuilder.
 		AddPlatform(config.ProviderName).
@@ -723,7 +729,7 @@ func determineEnvironmentFlags(upgrade bool, dryRun bool) (extensions.Environmen
 		AddNetworkStack(config.IPFamily).
 		AddTopology(clusterState.ControlPlaneTopology).
 		AddUpgrade(upgradeType).
-		AddArchitecture(clusterState.Masters.Items[0].Status.NodeInfo.Architecture). //TODO(sgoeddel): eventually, we may need to check every node and pass "multi" as the value if any of them differ from the masters
+		AddArchitecture(arch).
 		AddExternalConnectivity(determineExternalConnectivity(config)).
 		AddVersion(clusterState.Version.Status.Desired.Version)
 	for _, optionalCapability := range clusterState.OptionalCapabilities {


### PR DESCRIPTION
The values for these flags are determined by inspecting the cluster.

There will also be an additional PR to translate the current test skips in `openshift/kubernetes` to utilize these flags instead.

For: https://issues.redhat.com/browse/TRT-1853