### PR TITLE
SDN-4930: Bump wait for UDN CR ready timeout

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -81,7 +81,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			userDefinedNetworkIPv6Subnet = "2014:100:200::0/60"
 			nadName                      = "gryffindor"
 
-			udnCrReadyTimeout = 5 * time.Second
+			udnCrReadyTimeout = 60 * time.Second
 		)
 
 		var (


### PR DESCRIPTION
Kube can take longer than 5 seconds to propagate events.

Seen as flake in CI run:

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.19-e2e-aws-ovn-techpreview/1884817108601147392

"when using openshift ovn-kubernetes UserDefinedNetwork CRD controller should create NetworkAttachmentDefinition according to spec"

I0130 05:39:30.032220       1 controller.go:415] Added Finalizer to UserDefinedNetwork [e2e-network-segmentation-e2e-8121/test-net]
I0130 05:39:30.196059       1 nad_controller.go:245] [clustermanager-nad-controller NAD controller]: finished syncing NAD e2e-network-segmentation-e2e-8121/test-net, took 118.678698ms
I0130 05:39:30.196212       1 secondary_network_cluster_manager.go:62] Creating new network controller for network e2e-network-segmentation-e2e-8121.test-net of topology layer2
I0130 05:39:30.196936       1 nad_controller.go:245] [clustermanager-nad-controller NAD controller]: finished syncing NAD e2e-network-segmentation-e2e-8121/test-net, took 542.403µs
I0130 05:39:35.497151       1 controller_helper.go:70] Created NetworkAttachmentDefinition [e2e-network-segmentation-e2e-8121/test-net]
I0130 05:39:35.505613       1 controller.go:453] Updated status UserDefinedNetwork [e2e-network-segmentation-e2e-8121/test-net]
