### PR TITLE
SDN-4930: Bump UDN pod ready timeout

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -49,7 +49,7 @@ const RequiredUDNNamespaceLabel = "k8s.ovn.org/primary-user-defined-network"
 // these values when that bug is fixed but given the Kubernetes test default for a
 // pod to startup is 5mins: https://github.com/kubernetes/kubernetes/blob/60c4c2b2521fb454ce69dee737e3eb91a25e0535/test/e2e/framework/timeouts.go#L22-L23
 // we are not too far from the mark or against test policy
-const podReadyPollTimeout = 4 * time.Minute
+const podReadyPollTimeout = 10 * time.Minute
 const podReadyPollInterval = 6 * time.Second
 
 // NOTE: Upstream, we use either the default of gomega which is 1sec polltimeout with 10ms pollinterval OR


### PR DESCRIPTION
Metal platform is slow, and we can see it take over 4 minutes sometimes for the UDN pod to become ready.

Flake seen taking 4 minutes and 1 second:

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-metal-ipi-ovn-ipv6-techpreview/1884817018687852544

when using openshift ovn-kubernetes created using NetworkAttachmentDefinitions is isolated from the default network with L2 primary UDN

```
STEP: asserting the UDN pod udn-pod reaches the `Ready` state @ 01/30/25 06:35:55.176


I0130 06:39:56.485941    4237 cni.go:332] [e2e-network-segmentation-e2e-7214/udn-pod c2e64986fc2baa86e2fc2aeb3728175dfbe7d5832156f14fab1782e54faedb26 network default NAD default] ADD finished CNI request [e2e-network-segmentation-e2e-7214/udn-pod c2e64986fc2baa86e2fc2aeb3728175dfbe7d5832156f14fab1782e54faedb26 network default NAD default], result "{\"interfaces\":[{\"name\":\"c2e64986fc2baa8\",\"mac\":\"ee:23:54:30:1b:f8\"},{\"name\":\"eth0\",\"mac\":\"0a:58:80:79:e8:5f\",\"sandbox\":\"/var/run/netns/7f4c689c-9a7b-48e9-a9e2-df8bd3d3ea74\"},{\"name\":\"c2e64986fc2ba_3\",\"mac\":\"6a:cf:d6:9f:c9:5c\"},{\"name\":\"ovn-udn1\",\"mac\":\"0a:58:31:10:5a:7e\",\"sandbox\":\"/var/run/netns/7f4c689c-9a7b-48e9-a9e2-df8bd3d3ea74\"}],\"ips\":[{\"interface\":1,\"address\":\"fd01:0:0:4::2f6/64\"},{\"interface\":3,\"address\":\"2014:100:200::5/60\",\"gateway\":\"2014:100:200::1\"}],\"dns\":{}}", err <nil>
```



