### PR TITLE
SDN-4930: Increases timeouts for live migration

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -57,8 +57,10 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 			const (
 				nadName           = "blue"
 				bindingName       = "passt"
-				udnCrReadyTimeout = 5 * time.Second
-				vmName            = "myvm"
+				udnCrReadyTimeout = 60 * time.Second
+				// TODO(trozet): lower this timeout once https://issues.redhat.com/browse/OCPBUGS-49727 is fixed
+				udnNetworkReadyTimeout = 5 * time.Minute
+				vmName                 = "myvm"
 			)
 			var (
 				cidrIPv4 = "203.203.0.0/16"
@@ -100,7 +102,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 							Eventually(func() bool {
 								isNetProvisioned, err := isNetworkProvisioned(oc, node.Name, provisionedNetConfig.networkName)
 								return err == nil && isNetProvisioned
-							}).WithPolling(time.Second).WithTimeout(udnCrReadyTimeout).Should(
+							}).WithPolling(time.Second).WithTimeout(udnNetworkReadyTimeout).Should(
 								BeTrueBecause("the network must be ready before creating workloads"),
 							)
 						}


### PR DESCRIPTION
Checking if the CR was created can take longer than 5 seconds if the cluster is loaded. Bring it inline with other tests to 60 seconds.

Network ready timeout can be much longer than 5 seconds. Create a timeout just for that, and for now make it 5 minutes due to the known bug where network start up takes too long:
https://issues.redhat.com/browse/OCPBUGS-49727