### PR TITLE
SDCICD-1437: exclude additional managed job

### DIFF
--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -30,6 +30,9 @@ var excludedPriorityClassPods = map[string][]string{
 		"configure-alertmanager-operator",
 		"osd-cluster-ready",
 	},
+	"openshift-operator-lifecycle-manager": {
+		"sre-replace-packageserver-csv",
+	},
 }
 
 var _ = Describe("[sig-arch] Managed cluster should", func() {


### PR DESCRIPTION
sre-replace-packageserver-csv is a simple job in the managed-cluster-config repository that deletes the CSV named packageserver. Exclude it along with the other managed jobs

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-rosa-sts-ovn/1886261426582982656