### PR TITLE
UPSTREAM: <carry>: disable etcd readiness checks by default

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/apimachinery/health_handlers.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/apimachinery/health_handlers.go
@@ -82,7 +82,6 @@ var (
 	requiredReadyzChecks = sets.NewString(
 		"[+]ping ok",
 		"[+]log ok",
-		"[+]etcd ok",
 		"[+]informer-sync ok",
 		"[+]poststarthook/start-apiserver-admission-initializer ok",
 		"[+]poststarthook/generic-apiserver-start-informers ok",


### PR DESCRIPTION
https://github.com/openshift/kubernetes/pull/2174 for more context.