### PR TITLE
NO-JIRA: Skip fail for backend-sampler

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
@@ -33,6 +33,12 @@ func (l *lateRequestTracking) HandleAuditLogEvent(auditEvent *auditv1.Event, beg
 		if value_slice[0] == "loopback=true" {
 			return
 		}
+
+		//userAgent":"openshift-external-backend-sampler-new-openshift-api
+		if strings.HasPrefix(auditEvent.UserAgent, "openshift-external-backend-sampler") {
+			return
+		}
+
 		l.auditIDs = append(l.auditIDs, string(auditEvent.AuditID))
 	}
 }


### PR DESCRIPTION
Infrequently we see payload failures like [4.18.0-0.ci-2025-02-07-063709](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.18.0-0.ci/release/4.18.0-0.ci-2025-02-07-063709) - [aggregated-gcp-ovn-upgrade-4.18-micro-release](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-gcp-ovn-upgrade-4.18-micro-release-openshift-release-analysis-aggregator/1887753097934016512) - [1887753072755609600](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.18-e2e-gcp-ovn-upgrade/1887753072755609600)

```
{The following requests arrived when apiserver was gracefully shutting down:
b5ad407f-0eda-490f-bcc8-c1b052622cf9  more details in audit log}
```

Where 
```
grep -r b5ad407f-0eda-490f-bcc8-c1b052622cf9 .
./audit_logs/kube-apiserver/ci-op-frrzcqjg-1e160-8vns2-master-2-audit-2025-02-07T10-11-21.793.log:{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Metadata","auditID":"b5ad407f-0eda-490f-bcc8-c1b052622cf9","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default","verb":"get","user":{"username":"system:admin","groups":["system:masters","system:authenticated"]},"sourceIPs":["35.191.27.159"],"userAgent":"openshift-external-backend-sampler-new-kube-api","objectRef":{"resource":"namespaces","namespace":"default","name":"default","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2025-02-07T08:53:46.669837Z","stageTimestamp":"2025-02-07T08:53:46.675475Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":"","openshift.io/during-graceful":"loopback=false,,readyz=false"}}

```

Should we not fail payloads for this case or is this surfacing a problem with lb/proxy/kubeapi graceful shutdown?