### PR TITLE
NO-JIRA: Support known namespaces for terminationMessagePolicy tests

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/operator_mapping.go
+++ b/pkg/monitortestlibrary/platformidentification/operator_mapping.go
@@ -231,6 +231,7 @@ func init() {
 	utilruntime.Must(addNamespaceMapping("openshift-service-ca-operator", "service-ca"))
 	utilruntime.Must(addNamespaceMapping("openshift-user-workload-monitoring", "Unknown"))
 	utilruntime.Must(addNamespaceMapping("openshift-vsphere-infra", "Unknown"))
+	utilruntime.Must(addNamespaceMapping("openshift-infra", "Unknown"))
 
 	KnownNamespaces = sets.StringKeySet(namespaceToBugzillaComponent)
 }

--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -89,6 +89,13 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 		if strings.HasPrefix(pod.Namespace, "openshift-must-gather") {
 			continue
 		}
+		// namespace does not show up consistently so we get
+		// 1 pass or flake out of 10 runs and fail due to not
+		// enough passes
+		if strings.HasPrefix(pod.Namespace, "openshift-infra") {
+			continue
+		}
+
 		if _, ok := failuresByNamespace[pod.Namespace]; !ok {
 			failuresByNamespace[pod.Namespace] = []string{}
 		}


### PR DESCRIPTION
Aggregation failures for [gcp-ovn-rt-upgrade](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-gcp-ovn-rt-upgrade-4.19-minor-release-openshift-release-analysis-aggregator/1888480534607171584) due to the namespace `openshift-infra` showing up in only 1 out of 10 runs.

[Sippy](https://sippy.dptools.openshift.org/sippy-ng/tests/4.19?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%252C%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522all%2520containers%2520in%2520ns%252Fopenshift-infra%2520must%2520have%2520terminationMessagePolicy%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=net_improvement) shows only the one run currently

Skipping the namespace unless we want to manually add it to the list when missing.