### PR TITLE
 OCPBUGS-49647: Fixing build s2i ruby test data inline with latest ruby version(>=3.0)

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -18595,7 +18595,7 @@ var _testExtendedTestdataBuildsS2iEnvironmentBuildAppGemfile = []byte(`source "h
 
 gem "rack"
 gem "rackup"
-`)
+gem "webrick"`)
 
 func testExtendedTestdataBuildsS2iEnvironmentBuildAppGemfileBytes() ([]byte, error) {
 	return _testExtendedTestdataBuildsS2iEnvironmentBuildAppGemfile, nil

--- a/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
+++ b/test/extended/testdata/builds/s2i-environment-build-app/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "rack"
 gem "rackup"
+gem "webrick"


### PR DESCRIPTION
The test data for s2i image creation with source type as binary has issues post base image upgrade to ruby 3.0 (test/extended/testdata/builds/test-env-build.json) This is because webrick server is removed from default ruby libraries from 3.0 version,hence a webserver should be installed externally.The test data is missing this causing permanant failure post ruby 3.0 upgrade.

This fix is updating the test data with required dependencies to create a stable app to fulfill the testcase criteria.

signed-off by : moebasim(mbasim@redhat.com)
