### PR TITLE
CNTRLPLANE-1: Bump to latest downstream version of ginkgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -308,7 +308,7 @@ require (
 )
 
 replace (
-	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20240806135314-3946b2b7b2a8
+	github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
 	k8s.io/api => github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20250131233843-55625722a4b8
 	k8s.io/apiextensions-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20250131233843-55625722a4b8
 	k8s.io/apimachinery => github.com/openshift/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20250131233843-55625722a4b8

--- a/go.sum
+++ b/go.sum
@@ -649,8 +649,8 @@ github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20250
 github.com/openshift/kubernetes/staging/src/k8s.io/sample-apiserver v0.0.0-20250131233843-55625722a4b8/go.mod h1:owAehkeYLq2tHccss/uBNAaqS7UtrFlgkK40soLfHLc=
 github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70 h1:VLj8CU9q009xlMuR4wNcqDX4lVa2Ji3u/iYnBLHtQUc=
 github.com/openshift/library-go v0.0.0-20250129210218-fe56c2cf5d70/go.mod h1:TQx0VEhZ/92qRXIMDu2Wg4bUPmw5HRNE6wpSZ+IsP0Y=
-github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20240806135314-3946b2b7b2a8 h1:HJvLw9nNfoqCs16h505eP8E1kVmq6KNdzGm5csPlYsQ=
-github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20240806135314-3946b2b7b2a8/go.mod h1:rlwLi9PilAFJ8jCg9UE1QP6VBpd6/xj3SRC0d6TU0To=
+github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12 h1:AKx/w1qpS8We43bsRgf8Nll3CGlDHpr/WAXvuedTNZI=
+github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
+++ b/vendor/github.com/onsi/ginkgo/v2/CHANGELOG.md
@@ -1,3 +1,50 @@
+## 2.21.0
+
+
+  ### Features
+  - add support for GINKGO_TIME_FORMAT [a69eb39]
+  - add GINKGO_NO_COLOR to disable colors via environment variables [bcab9c8]
+
+  ### Fixes
+  - increase threshold in timeline matcher [e548367]
+  - Fix the document by replacing `SpecsThatWillBeRun` with `SpecsThatWillRun`
+  [c2c4d3c]
+
+  ### Maintenance
+  - bump various dependencies [7e65a00]
+
+## 2.20.2
+
+Require Go 1.22+
+
+### Maintenance
+- bump go to v1.22 [a671816]
+
+## 2.20.1
+
+### Fixes
+- make BeSpecEvent duration matcher more forgiving [d6f9640]
+
+## 2.20.0
+
+### Features
+- Add buildvcs flag [be5ab95]
+
+### Maintenance
+- Add update-deps to makefile [d303d14]
+- bump all dependencies [7a50221]
+
+## 2.19.1
+
+### Fixes
+- update supported platforms for race conditions [63c8c30]
+- [build] Allow custom name for binaries. [ff41e27]
+
+### Maintenance
+- bump gomega [76f4e0c]
+- Bump rexml from 3.2.6 to 3.2.8 in /docs (#1417) [b69c00d]
+- Bump golang.org/x/sys from 0.20.0 to 0.21.0 (#1425) [f097741]
+
 ## 2.19.0
 
 ### Features

--- a/vendor/github.com/onsi/ginkgo/v2/Makefile
+++ b/vendor/github.com/onsi/ginkgo/v2/Makefile
@@ -4,8 +4,13 @@ all:  vet test
 
 .PHONY: test
 test:
-	go run github.com/onsi/ginkgo/v2/ginkgo -r -p
+	go run github.com/onsi/ginkgo/v2/ginkgo -r -p -randomize-all -keep-going
 
 .PHONY: vet
 vet:
 	go vet ./...
+
+.PHONY: update-deps
+update-deps:
+	go get -u ./...
+	go mod tidy

--- a/vendor/github.com/onsi/ginkgo/v2/OWNERS
+++ b/vendor/github.com/onsi/ginkgo/v2/OWNERS
@@ -1,3 +1,4 @@
+reviewers:
 approvers:
-  - bparees
-  - soltysh
+  - bertinatto
+  - stbenjam

--- a/vendor/github.com/onsi/ginkgo/v2/core_dsl_patch.go
+++ b/vendor/github.com/onsi/ginkgo/v2/core_dsl_patch.go
@@ -1,6 +1,8 @@
 package ginkgo
 
 import (
+	"io"
+
 	"github.com/onsi/ginkgo/v2/internal"
 	"github.com/onsi/ginkgo/v2/internal/global"
 	"github.com/onsi/ginkgo/v2/types"
@@ -16,6 +18,10 @@ func GetSuite() *internal.Suite {
 
 func GetFailer() *internal.Failer {
 	return global.Failer
+}
+
+func NewWriter(w io.Writer) *internal.Writer {
+	return internal.NewWriter(w)
 }
 
 func GetWriter() *internal.Writer {

--- a/vendor/github.com/onsi/ginkgo/v2/formatter/formatter.go
+++ b/vendor/github.com/onsi/ginkgo/v2/formatter/formatter.go
@@ -82,6 +82,10 @@ func New(colorMode ColorMode) Formatter {
 		return fmt.Sprintf("\x1b[38;5;%dm", colorCode)
 	}
 
+	if _, noColor := os.LookupEnv("GINKGO_NO_COLOR"); noColor {
+		colorMode = ColorModeNone
+	}
+
 	f := Formatter{
 		ColorMode: colorMode,
 		colors: map[string]string{

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/build/build_command.go
@@ -2,6 +2,8 @@ package build
 
 import (
 	"fmt"
+	"os"
+	"path"
 
 	"github.com/onsi/ginkgo/v2/ginkgo/command"
 	"github.com/onsi/ginkgo/v2/ginkgo/internal"
@@ -53,7 +55,18 @@ func buildSpecs(args []string, cliConfig types.CLIConfig, goFlagsConfig types.Go
 		if suite.State.Is(internal.TestSuiteStateFailedToCompile) {
 			fmt.Println(suite.CompilationError.Error())
 		} else {
-			fmt.Printf("Compiled %s.test\n", suite.PackageName)
+			if len(goFlagsConfig.O) == 0 {
+				goFlagsConfig.O = path.Join(suite.Path, suite.PackageName+".test")
+			} else {
+				stat, err := os.Stat(goFlagsConfig.O)
+				if err != nil {
+					panic(err)
+				}
+				if stat.IsDir() {
+					goFlagsConfig.O += "/" + suite.PackageName + ".test"
+				}
+			}
+			fmt.Printf("Compiled %s\n", goFlagsConfig.O)
 		}
 	}
 

--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/internal/compile.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/internal/compile.go
@@ -25,6 +25,18 @@ func CompileSuite(suite TestSuite, goFlagsConfig types.GoFlagsConfig) TestSuite 
 		return suite
 	}
 
+	if len(goFlagsConfig.O) > 0 {
+		userDefinedPath, err := filepath.Abs(goFlagsConfig.O)
+		if err != nil {
+			suite.State = TestSuiteStateFailedToCompile
+			suite.CompilationError = fmt.Errorf("Failed to compute compilation target path %s:\n%s", goFlagsConfig.O, err.Error())
+			return suite
+		}
+		path = userDefinedPath
+	}
+
+	goFlagsConfig.O = path
+
 	ginkgoInvocationPath, _ := os.Getwd()
 	ginkgoInvocationPath, _ = filepath.Abs(ginkgoInvocationPath)
 	packagePath := suite.AbsPath()
@@ -34,7 +46,7 @@ func CompileSuite(suite TestSuite, goFlagsConfig types.GoFlagsConfig) TestSuite 
 		suite.CompilationError = fmt.Errorf("Failed to get relative path from package to the current working directory:\n%s", err.Error())
 		return suite
 	}
-	args, err := types.GenerateGoTestCompileArgs(goFlagsConfig, path, "./", pathToInvocationPath)
+	args, err := types.GenerateGoTestCompileArgs(goFlagsConfig, "./", pathToInvocationPath)
 	if err != nil {
 		suite.State = TestSuiteStateFailedToCompile
 		suite.CompilationError = fmt.Errorf("Failed to generate go test compile flags:\n%s", err.Error())

--- a/vendor/github.com/onsi/ginkgo/v2/internal/spec_patch.go
+++ b/vendor/github.com/onsi/ginkgo/v2/internal/spec_patch.go
@@ -11,3 +11,12 @@ func (s Spec) CodeLocations() []types.CodeLocation {
 func (s Spec) AppendText(text string) {
 	s.Nodes[len(s.Nodes)-1].Text += text
 }
+
+func (s Spec) Labels() []string {
+	var labels []string
+	for _, n := range s.Nodes {
+		labels = append(labels, n.Labels...)
+	}
+
+	return labels
+}

--- a/vendor/github.com/onsi/ginkgo/v2/types/types.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/types.go
@@ -3,13 +3,21 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
 )
 
 const GINKGO_FOCUS_EXIT_CODE = 197
-const GINKGO_TIME_FORMAT = "01/02/06 15:04:05.999"
+
+var GINKGO_TIME_FORMAT = "01/02/06 15:04:05.999"
+
+func init() {
+	if os.Getenv("GINKGO_TIME_FORMAT") != "" {
+		GINKGO_TIME_FORMAT = os.Getenv("GINKGO_TIME_FORMAT")
+	}
+}
 
 // Report captures information about a Ginkgo test run
 type Report struct {

--- a/vendor/github.com/onsi/ginkgo/v2/types/types_patch.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/types_patch.go
@@ -4,4 +4,5 @@ type TestSpec interface {
 	CodeLocations() []CodeLocation
 	Text() string
 	AppendText(text string)
+	Labels() []string
 }

--- a/vendor/github.com/onsi/ginkgo/v2/types/version.go
+++ b/vendor/github.com/onsi/ginkgo/v2/types/version.go
@@ -1,3 +1,3 @@
 package types
 
-const VERSION = "2.19.0"
+const VERSION = "2.21.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -701,8 +701,8 @@ github.com/munnerz/goautoneg
 # github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f
 ## explicit
 github.com/mxk/go-flowrate/flowrate
-# github.com/onsi/ginkgo/v2 v2.20.2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20240806135314-3946b2b7b2a8
-## explicit; go 1.20
+# github.com/onsi/ginkgo/v2 v2.20.2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
+## explicit; go 1.22.0
 github.com/onsi/ginkgo/v2
 github.com/onsi/ginkgo/v2/config
 github.com/onsi/ginkgo/v2/formatter
@@ -3783,7 +3783,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 sigs.k8s.io/yaml/goyaml.v2
 sigs.k8s.io/yaml/goyaml.v3
-# github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20240806135314-3946b2b7b2a8
+# github.com/onsi/ginkgo/v2 => github.com/openshift/onsi-ginkgo/v2 v2.6.1-0.20241205171354-8006f302fd12
 # k8s.io/api => github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20250131233843-55625722a4b8
 # k8s.io/apiextensions-apiserver => github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20250131233843-55625722a4b8
 # k8s.io/apimachinery => github.com/openshift/kubernetes/staging/src/k8s.io/apimachinery v0.0.0-20250131233843-55625722a4b8


### PR DESCRIPTION
We missed this when bumped the o/k dependency to 1.32.

/hold

Until we get a good nightly with the o/k bump.  