### PR TITLE
TRT-2006: Revert "NO-JIRA: Add test case for checking EgressFirewall DNS names in caps"

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -154,12 +154,6 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.openshift.com").Output()
 	expectNoError(err)
 
-	// Test curl to docs.redhat.com should pass
-	// because we have allow dns rule for docs.redhat.com
-	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
-	expectNoError(err)
-
 	if checkWildcard {
 		// Test curl to `www.google.com` and `translate.google.com` should pass
 		// because we have allow dns rule for `*.google.com`.

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43491,9 +43491,6 @@ spec:
   - type: Allow
     to:
       dnsName: docs.openshift.com
-  - type: Allow
-    to:
-      dnsName: DOCS.REDHAT.COM
   - type: Deny
     to:
       dnsName: www.google.com
@@ -43539,9 +43536,6 @@ spec:
       dnsName: docs.openshift.com
   - type: Allow
     to:
-      dnsName: DOCS.REDHAT.COM
-  - type: Allow
-    to:
       dnsName: "*.google.com"
   - type: Allow
     to:
@@ -43580,9 +43574,6 @@ spec:
   - type: Allow
     to:
       dnsName: docs.openshift.com
-  - type: Allow
-    to:
-      dnsName: docs.redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -7,9 +7,6 @@ spec:
   - type: Allow
     to:
       dnsName: docs.openshift.com
-  - type: Allow
-    to:
-      dnsName: DOCS.REDHAT.COM
   - type: Deny
     to:
       dnsName: www.google.com

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
@@ -9,9 +9,6 @@ spec:
       dnsName: docs.openshift.com
   - type: Allow
     to:
-      dnsName: DOCS.REDHAT.COM
-  - type: Allow
-    to:
       dnsName: "*.google.com"
   - type: Allow
     to:

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -9,9 +9,6 @@ spec:
       dnsName: docs.openshift.com
   - type: Allow
     to:
-      dnsName: docs.redhat.com
-  - type: Allow
-    to:
       cidrSelector: 8.8.8.8/32
   - type: Deny
     to:


### PR DESCRIPTION
Reverts openshift/origin#29414

Just checking if this is causing issues on Azure.