### PR TITLE
Revert "NO-JIRA: use quay.io/openshift/origin-cli:latest directly"

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51639,6 +51639,11 @@ items:
       dockerfile: |
         FROM quay.io/openshift/origin-cli:latest
         WORKDIR /var/lib/origin
+        RUN source /etc/os-release \
+            && rhel_major=${VERSION_ID%.*} \
+            && yum config-manager \
+            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
+            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -51659,6 +51664,9 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
+        from:
+          kind: DockerImage
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -18,6 +18,11 @@ items:
       dockerfile: |
         FROM quay.io/openshift/origin-cli:latest
         WORKDIR /var/lib/origin
+        RUN source /etc/os-release \
+            && rhel_major=${VERSION_ID%.*} \
+            && yum config-manager \
+            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
+            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
         RUN yum install -y skopeo && \
             yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
@@ -38,6 +43,9 @@ items:
         env:
           - name: "BUILD_LOGLEVEL"
             value: "2"
+        from:
+          kind: DockerImage
+          name: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
     output:
       to:
         kind: ImageStreamTag


### PR DESCRIPTION
The DNF wrapper should no longer fail when it is not connected to the VPN after https://github.com/openshift-eng/ocp-build-data/pull/6019