### PR TITLE
OCPBUGS-48749: Add/remove team members to the OWNERS file for Builds

### DIFF
--- a/test/extended/builds/OWNERS
+++ b/test/extended/builds/OWNERS
@@ -1,5 +1,9 @@
 reviewers:
   - sayan-biswas
   - divyansh42
+  - prabhapa
+  - moebasim
 approvers:
   - sayan-biswas
+  - prabhapa
+  - moebasim

--- a/test/extended/testdata/builds/OWNERS
+++ b/test/extended/testdata/builds/OWNERS
@@ -1,5 +1,7 @@
 reviewers:
-  - coreydaley
+  - prabhapa
+  - moebasim
   - divyansh42
 approvers:
-  - coreydaley
+  - prabhapa
+  - moebasim


### PR DESCRIPTION
new build components owners are added and old ones removed