### PR TITLE
OCPBUGS-55110: Backport `MetricsCollectionProfiles` patches to 4.18

### DIFF
--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -58,7 +58,7 @@ type runner struct {
 var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
-	o.SetDefaultEventuallyTimeout(15 * time.Minute)
+	o.SetDefaultEventuallyTimeout(20 * time.Minute)
 	o.SetDefaultEventuallyPollingInterval(5 * time.Second)
 
 	r := &runner{}

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -85,11 +85,13 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				if errors.IsNotFound(err) {
 					g.By("initially, creating a configuration for the operator as it did not exist")
 					operatorConfiguration = nil
-					err = r.makeCollectionProfileConfigurationFor(tctx, collectionProfileDefault)
+					return r.makeCollectionProfileConfigurationFor(tctx, collectionProfileDefault)
 				}
+
+				return err
 			}
 
-			return err
+			return nil
 		}).Should(o.BeNil())
 		r.originalOperatorConfiguration = operatorConfiguration
 	})

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -52,7 +52,7 @@ type runner struct {
 // NOTE: The nested `Context` containers inside the following `Describe` container are used to group certain tests based on the environments they demand.
 // NOTE: When adding a test-case, ensure that the test-case is placed in the appropriate `Context` container.
 // NOTE: The containers themselves are guaranteed to run in the order in which they appear.
-var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set", g.Ordered, func() {
+var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
 	o.SetDefaultEventuallyTimeout(20 * time.Minute)

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -33,6 +33,9 @@ const (
 	operatorName              = "cluster-monitoring-operator"
 	operatorNamespaceName     = "openshift-monitoring"
 	operatorConfigurationName = "cluster-monitoring-config"
+
+	pollTimeout  = 15 * time.Minute
+	pollInterval = 5 * time.Second
 )
 
 var (
@@ -117,7 +120,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			}
 
 			return nil
-		}).Should(o.BeNil())
+		}, pollTimeout, pollInterval).Should(o.BeNil())
 	})
 
 	g.Context("initially, in a homogeneous default environment,", func() {

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			}
 
 			return nil
-		}).Should(o.BeNil())
+		}, pollTimeout, pollInterval).Should(o.BeNil())
 		r.originalOperatorConfiguration = operatorConfiguration
 	})
 
@@ -139,7 +139,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 
 		g.It("should expose default metrics", func() {
@@ -155,7 +155,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 	})
 
@@ -176,7 +176,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 					}
 
 					return nil
-				}).Should(o.BeNil())
+				}, pollTimeout, pollInterval).Should(o.BeNil())
 			}
 		})
 		g.It("should have at least one implementation for each collection profile", func() {
@@ -194,7 +194,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 					}
 
 					return nil
-				}).Should(o.BeNil())
+				}, pollTimeout, pollInterval).Should(o.BeNil())
 			}
 		})
 		g.It("should revert to default collection profile when an empty collection profile value is specified", func() {
@@ -211,7 +211,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 	})
 
@@ -231,7 +231,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 
 		g.It("should hide default metrics", func() {
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				kubeStateMetricsMonitor = monitors.Items[0]
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 
 			var kubeStateMetricsMainMetrics []string
 			kubeStateMetricsMonitorSpec := kubeStateMetricsMonitor.Spec
@@ -295,7 +295,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				wantCount := int(queryResponse.Data.Result[0].Value)
 
 				kubeStateMetricsMainMetricsString := strings.Join(kubeStateMetricsMainMetrics, "")
-				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */ ])
+				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */])
 				queryResponse, err = helper.RunQuery(tctx, r.pclient, kubeStateMetricsMainMetricsCountQuery)
 				if err != nil {
 					return err
@@ -310,7 +310,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}
 
 				return nil
-			}).Should(o.BeNil())
+			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 	})
 })

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -55,9 +55,6 @@ type runner struct {
 var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
-	o.SetDefaultEventuallyTimeout(20 * time.Minute)
-	o.SetDefaultEventuallyPollingInterval(5 * time.Second)
-
 	r := &runner{}
 	oc := exutil.NewCLI(projectName)
 	tctx := context.Background()

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -289,7 +289,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				wantCount := int(queryResponse.Data.Result[0].Value)
 
 				kubeStateMetricsMainMetricsString := strings.Join(kubeStateMetricsMainMetrics, "")
-				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */])
+				kubeStateMetricsMainMetricsCountQuery := fmt.Sprintf("count({__name__=~\"%s\"})", kubeStateMetricsMainMetricsString[:len(kubeStateMetricsMainMetricsString)-1 /* drop the last "|" or ")" */ ])
 				queryResponse, err = helper.RunQuery(tctx, r.pclient, kubeStateMetricsMainMetricsCountQuery)
 				if err != nil {
 					return err

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1305,15 +1305,15 @@ var Annotations = map[string]string{
 
 	"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to an HTTP(S) location if the runbook_url annotation is defined": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should expose information about the applied collection profile using meta-metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should expose information about the applied collection profile using meta-metrics": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should have at least one implementation for each collection profile": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should have at least one implementation for each collection profile": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a heterogeneous environment, should revert to default collection profile when an empty collection profile value is specified": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a heterogeneous environment, should revert to default collection profile when an empty collection profile value is specified": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set in a homogeneous minimal environment, should hide default metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set in a homogeneous minimal environment, should hide default metrics": " [Suite:openshift/conformance/serial]",
 
-	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The collection profiles feature-set initially, in a homogeneous default environment, should expose default metrics": " [Suite:openshift/conformance/parallel]",
+	"[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial] The collection profiles feature-set initially, in a homogeneous default environment, should expose default metrics": " [Suite:openshift/conformance/serial]",
 
 	"[sig-instrumentation][sig-builds][Feature:Builds] Prometheus when installed on the cluster should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -107,20 +107,21 @@ spec:
         boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]'
   - featureGate: MetricsCollectionProfiles
     tests:
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should expose
-        information about the applied collection profile using meta-metrics'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should have
-        at least one implementation for each collection profile'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a heterogeneous environment, should revert
-        to default collection profile when an empty collection profile value is specified'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set in a homogeneous minimal environment, should
-        hide default metrics'
-    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles] The
-        collection profiles feature-set initially, in a homogeneous default environment,
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        expose information about the applied collection profile using meta-metrics'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        have at least one implementation for each collection profile'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a heterogeneous environment, should
+        revert to default collection profile when an empty collection profile value
+        is specified'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set in a homogeneous minimal environment,
+        should hide default metrics'
+    - testName: '[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfiles][Serial]
+        The collection profiles feature-set initially, in a homogeneous default environment,
         should expose default metrics'
   - featureGate: NetworkDiagnosticsConfig
     tests:


### PR DESCRIPTION
Backport `MetricsCollectionProfiles` patches to 4.18 to make Sippy happy as it is on 4.19 for the same feature-gate. 