### PR TITLE
TRT-1575: Fail the test when an expected operator goes to degraded

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -138,8 +138,7 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "cluster-autoscaler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42875", nil
 			}
-			// flake this to collect more exceptions
-			return "https://issues.redhat.com/browse/TRT-1575", nil
+			return "", nil
 		}
 		return "We are not worried about other operator condition blips for stable-system tests yet.", nil
 	}
@@ -301,12 +300,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					return "https://issues.redhat.com/browse/OCPBUGS-38661", nil
 				}
 			default:
-				// flake this to collect more exceptions
-				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-					return "outside of upgrade window https://issues.redhat.com/browse/TRT-1575", nil
-				} else {
-					return "", nil
-				}
+				return "", nil
 			}
 		} else {
 			// SingleNode is expected to go Available=False and Degraded=True for most / all operators during upgrade
@@ -449,13 +443,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-38663", nil
 			}
 		}
-
-		// flake this to collect more exceptions
-		if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-			return "https://issues.redhat.com/browse/TRT-1575", nil
-		} else {
-			return "", nil
-		}
+		return "", nil
 	}
 
 	return testOperatorStateTransitions(events, []configv1.ClusterStatusConditionType{configv1.OperatorAvailable, configv1.OperatorDegraded}, except, clientConfig)


### PR DESCRIPTION
After we collect the known exceptions, we are removing the default flake behavior to catch any new regressions. 