### PR TITLE
WRKLDS-1653: update pathological ScalingReplicaSet event exception

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -434,7 +434,7 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 			monitorapi.LocatorDeploymentKey: regexp.MustCompile(`(controller-manager|route-controller-manager)`),
 		},
 		messageReasonRegex: regexp.MustCompile(`^ScalingReplicaSet$`),
-		messageHumanRegex:  regexp.MustCompile(`\(combined from similar events\): Scaled (down|up) replica set.*controller-manager-[a-z0-9-]+ to [0-9]+`),
+		messageHumanRegex:  regexp.MustCompile(`\(combined from similar events\): Scaled (down|up) replica set.*controller-manager-[a-z0-9-]+ from [0-9]+ to [0-9]+`),
 	})
 
 	// Match pod sandbox errors as "interesting" so they get charted, but we do not ever allow them to repeat


### PR DESCRIPTION
caused by the kube bump and needed to fix failing jobs in https://github.com/openshift/openshift-controller-manager/pull/366