### PR TITLE
TRT-2043: look for high latency audit requests

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
@@ -51,7 +51,7 @@ func CheckForLatency() *auditLatencyRecords {
 // HandleAuditLogEvent looks for latency annotations and increments counter for all latency buckets that are below
 // the latency value.  e.g a 4s latency will increment the 2,1 & 0 bucket count values.  0 is the min and will effectively be
 // all requests.  Data is collected to analyze over time for increases in latency completing requests
-func (v *auditLatencyRecords) HandleAuditLogEvent(auditEvent *auditv1.Event, beginning, end *metav1.MicroTime) {
+func (v *auditLatencyRecords) HandleAuditLogEvent(auditEvent *auditv1.Event, beginning, end *metav1.MicroTime, nodeName string) {
 
 	// we only want to count the response complete events
 	if beginning != nil && auditEvent.RequestReceivedTimestamp.Before(beginning) || end != nil && end.Before(&auditEvent.RequestReceivedTimestamp) || auditEvent.Stage != auditv1.StageResponseComplete {

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
@@ -76,7 +76,7 @@ func (v *auditLatencyRecords) HandleAuditLogEvent(auditEvent *auditv1.Event, beg
 	for _, latencyType := range latencyTypes {
 		// https://github.com/openshift/kubernetes/blob/2b03f04ce589a57cf80b2153c7e5056c53c374d3/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go#L156
 		// we only annotate requests over 500ms so default missing apiserver.latency.k8s.io/total to the minBucket if it isn't present
-		if totalLatency, ok := auditEvent.Annotations[latencyType]; ok || latencyType == "apiserver.latency.k8s.io/total" {
+		if latency, ok := auditEvent.Annotations[latencyType]; ok || latencyType == "apiserver.latency.k8s.io/total" {
 
 			var typeRecord map[string]*auditLatencySummaryRecord
 			var summaryRecord *auditLatencySummaryRecord
@@ -95,7 +95,7 @@ func (v *auditLatencyRecords) HandleAuditLogEvent(auditEvent *auditv1.Event, beg
 			}
 
 			// match regex
-			match := v.matcher.FindStringSubmatch(totalLatency)
+			match := v.matcher.FindStringSubmatch(latency)
 			if len(match) > 0 {
 				seconds, err := strconv.ParseFloat(match[1], 64)
 				if err == nil {

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go
@@ -1,0 +1,174 @@
+package auditloganalyzer
+
+import (
+	"fmt"
+	"github.com/openshift/origin/pkg/dataloader"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"sync"
+)
+
+var (
+	minBucket    = 0.0
+	buckets      = []float64{45.0, 30.0, 20.0, 10.0, 5.0, 2.0, 1.0}
+	latencyTypes = []string{"apiserver.latency.k8s.io/total", "apiserver.latency.k8s.io/etcd"}
+	knownVerbs   = []string{"get", "list", "watch", "post", "patch", "update", "create", "delete"}
+)
+
+type auditLatencyRecords struct {
+	lock    sync.Mutex
+	matcher *regexp.Regexp
+	summary auditLatencySummary
+}
+
+type auditLatencyBucket struct {
+	totalCounts map[string]int64
+}
+
+type auditLatencySummaryRecord struct {
+	buckets map[float64]*auditLatencyBucket
+}
+
+type auditLatencySummary struct {
+	resourceBuckets map[string]map[string]*auditLatencySummaryRecord
+}
+
+func CheckForLatency() *auditLatencyRecords {
+
+	decimalSeconds, err := regexp.Compile("([\\d\\.]+)s")
+	if err != nil {
+		panic(err)
+	}
+
+	summary := auditLatencySummary{resourceBuckets: make(map[string]map[string]*auditLatencySummaryRecord)}
+	return &auditLatencyRecords{matcher: decimalSeconds, summary: summary}
+}
+
+func (v *auditLatencyRecords) HandleAuditLogEvent(auditEvent *auditv1.Event, beginning, end *metav1.MicroTime) {
+	if beginning != nil && auditEvent.RequestReceivedTimestamp.Before(beginning) || end != nil && end.Before(&auditEvent.RequestReceivedTimestamp) {
+		return
+	}
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	resourceType := "unknown"
+	if auditEvent.ObjectRef != nil && len(auditEvent.ObjectRef.Resource) > 0 {
+		resourceType = auditEvent.ObjectRef.Resource
+	}
+
+	// rare but not always there...
+	verb := "missing"
+	if len(auditEvent.Verb) > 0 {
+		verb = auditEvent.Verb
+	}
+
+	// "apiserver.latency.k8s.io/total":"16.005122724s"
+	for _, latencyType := range latencyTypes {
+		// https://github.com/openshift/kubernetes/blob/2b03f04ce589a57cf80b2153c7e5056c53c374d3/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go#L156
+		// we only annotate requests over 500ms so default missing apiserver.latency.k8s.io/total to the minBucket if it isn't present
+		if totalLatency, ok := auditEvent.Annotations[latencyType]; ok || latencyType == "apiserver.latency.k8s.io/total" {
+
+			var typeRecord map[string]*auditLatencySummaryRecord
+			var summaryRecord *auditLatencySummaryRecord
+			var latencyBucket *auditLatencyBucket
+
+			if typeRecord, ok = v.summary.resourceBuckets[latencyType]; !ok {
+				newTypeRecord := make(map[string]*auditLatencySummaryRecord)
+				v.summary.resourceBuckets[latencyType] = newTypeRecord
+				typeRecord = newTypeRecord
+			}
+
+			if summaryRecord, ok = typeRecord[resourceType]; !ok {
+				newSummaryRecord := &auditLatencySummaryRecord{buckets: make(map[float64]*auditLatencyBucket)}
+				typeRecord[resourceType] = newSummaryRecord
+				summaryRecord = newSummaryRecord
+			}
+
+			// match regex
+			match := v.matcher.FindStringSubmatch(totalLatency)
+			if len(match) > 0 {
+				seconds, err := strconv.ParseFloat(match[1], 64)
+				if err == nil {
+					for _, b := range buckets {
+						if seconds > b {
+							if latencyBucket, ok = summaryRecord.buckets[b]; !ok {
+								newLatencyBucket := &auditLatencyBucket{make(map[string]int64)}
+								summaryRecord.buckets[b] = newLatencyBucket
+								latencyBucket = newLatencyBucket
+							}
+							break
+						}
+					}
+				}
+			}
+
+			if latencyBucket == nil {
+				if latencyBucket, ok = summaryRecord.buckets[minBucket]; !ok {
+					newLatencyBucket := &auditLatencyBucket{make(map[string]int64)}
+					summaryRecord.buckets[minBucket] = newLatencyBucket
+					latencyBucket = newLatencyBucket
+				}
+			}
+
+			latencyBucket.totalCounts[verb]++
+		}
+	}
+}
+
+func (v *auditLatencyRecords) WriteAuditLogSummary(artifactDir, name, timeSuffix string) error {
+	var dataFile dataloader.DataFile
+	var fileName string
+	var err error
+	var rows []map[string]string
+
+	rows = make([]map[string]string, 0)
+	reportBuckets := buckets
+	reportBuckets = append(reportBuckets, 0.0)
+	for latencyType, latencyRecords := range v.summary.resourceBuckets {
+		for resource, record := range latencyRecords {
+			for _, bucket := range reportBuckets {
+
+				if rv, ok := record.buckets[bucket]; ok {
+					foundVerbs := make(map[string]bool)
+					for verb, count := range rv.totalCounts {
+						data := map[string]string{"LatencyType": latencyType, "Resource": resource, "Verb": verb, "Bucket": fmt.Sprintf("%.0f", bucket), "Count": fmt.Sprintf("%d", count)}
+						rows = append(rows, data)
+						foundVerbs[verb] = true
+					}
+
+					for _, verb := range knownVerbs {
+						if !foundVerbs[verb] {
+							data := map[string]string{"LatencyType": latencyType, "Resource": resource, "Verb": verb, "Bucket": fmt.Sprintf("%.0f", bucket), "Count": fmt.Sprintf("%d", 0)}
+							rows = append(rows, data)
+						}
+					}
+
+				} else {
+					for _, verb := range knownVerbs {
+						data := map[string]string{"LatencyType": latencyType, "Resource": resource, "Verb": verb, "Bucket": fmt.Sprintf("%.0f", bucket), "Count": fmt.Sprintf("%d", 0)}
+						rows = append(rows, data)
+					}
+				}
+
+			}
+		}
+	}
+
+	dataFile = dataloader.DataFile{
+		TableName: "audit_latency_counts",
+		Schema:    map[string]dataloader.DataType{"LatencyType": dataloader.DataTypeString, "Resource": dataloader.DataTypeString, "Verb": dataloader.DataTypeString, "Bucket": dataloader.DataTypeFloat64, "Count": dataloader.DataTypeInteger},
+		Rows:      rows,
+	}
+	fileName = filepath.Join(artifactDir, fmt.Sprintf("%s-summary-counts%s-%s", name, timeSuffix, dataloader.AutoDataLoaderSuffix))
+	err = dataloader.WriteDataFile(fileName, dataFile)
+	if err != nil {
+		logrus.WithError(err).Warnf("unable to write data file: %s", fileName)
+	}
+
+	return nil
+}

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency_test.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency_test.go
@@ -1,0 +1,72 @@
+package auditloganalyzer
+
+import (
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"testing"
+	"time"
+)
+
+func Test_auditLogEventHandler(t *testing.T) {
+	handler := CheckForLatency()
+	mTime := metav1.NewMicroTime(time.Now())
+
+	//only one event over 15 seconds
+	handler.HandleAuditLogEvent(&auditv1.Event{
+		AuditID:                  "audit-id",
+		Stage:                    auditv1.StageResponseComplete,
+		Verb:                     "list",
+		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
+		RequestReceivedTimestamp: mTime,
+		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "15.999592078s", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "3.746852ms", "apiserver.latency.k8s.io/total": "16.005122724s"},
+	}, &mTime, nil)
+
+	// all sub second so default only
+	handler.HandleAuditLogEvent(&auditv1.Event{
+		AuditID:                  "audit-id",
+		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
+		Stage:                    auditv1.StageResponseComplete,
+		Verb:                     "list",
+		RequestReceivedTimestamp: mTime,
+		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "5.999592078ms", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "0.746852ms", "apiserver.latency.k8s.io/total": "6.005122724ms"},
+	}, &mTime, nil)
+
+	// total is over 2s but etcd is under
+	handler.HandleAuditLogEvent(&auditv1.Event{
+		AuditID:                  "audit-id",
+		Stage:                    auditv1.StageResponseComplete,
+		Verb:                     "list",
+		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
+		RequestReceivedTimestamp: mTime,
+		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "1.999592078s", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "0.746852ms", "apiserver.latency.k8s.io/total": "2.005122724s"},
+	}, &mTime, nil)
+
+	// no annotations so only default (0) total is incremented
+	handler.HandleAuditLogEvent(&auditv1.Event{
+		AuditID:                  "audit-id",
+		Stage:                    auditv1.StageResponseComplete,
+		Verb:                     "list",
+		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
+		RequestReceivedTimestamp: mTime,
+		Annotations:              map[string]string{},
+	}, &mTime, nil)
+
+	assert.NotNil(t, handler.summary.resourceBuckets)
+
+	assert.Equal(t, int64(1), handler.summary.resourceBuckets["apiserver.latency.k8s.io/total"]["testResource"].buckets[10.0].totalCounts["list"])
+	assert.Equal(t, int64(1), handler.summary.resourceBuckets["apiserver.latency.k8s.io/etcd"]["testResource"].buckets[10.0].totalCounts["list"])
+
+	assert.Equal(t, int64(1), handler.summary.resourceBuckets["apiserver.latency.k8s.io/total"]["testResource"].buckets[5.0].totalCounts["list"])
+	assert.Equal(t, int64(1), handler.summary.resourceBuckets["apiserver.latency.k8s.io/etcd"]["testResource"].buckets[5.0].totalCounts["list"])
+
+	assert.Equal(t, int64(2), handler.summary.resourceBuckets["apiserver.latency.k8s.io/total"]["testResource"].buckets[2.0].totalCounts["list"])
+	assert.Equal(t, int64(1), handler.summary.resourceBuckets["apiserver.latency.k8s.io/etcd"]["testResource"].buckets[2.0].totalCounts["list"])
+
+	assert.Equal(t, int64(2), handler.summary.resourceBuckets["apiserver.latency.k8s.io/total"]["testResource"].buckets[1.0].totalCounts["list"])
+	assert.Equal(t, int64(2), handler.summary.resourceBuckets["apiserver.latency.k8s.io/etcd"]["testResource"].buckets[1.0].totalCounts["list"])
+
+	// we only default the total latency when the annotation is missing as we don't know what additional resources it is using
+	assert.Equal(t, int64(4), handler.summary.resourceBuckets["apiserver.latency.k8s.io/total"]["testResource"].buckets[0.0].totalCounts["list"])
+	assert.Equal(t, int64(3), handler.summary.resourceBuckets["apiserver.latency.k8s.io/etcd"]["testResource"].buckets[0.0].totalCounts["list"])
+}

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency_test.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency_test.go
@@ -12,7 +12,7 @@ func Test_auditLogEventHandler(t *testing.T) {
 	handler := CheckForLatency()
 	mTime := metav1.NewMicroTime(time.Now())
 
-	//only one event over 15 seconds
+	// only one event over 15 seconds
 	handler.HandleAuditLogEvent(&auditv1.Event{
 		AuditID:                  "audit-id",
 		Stage:                    auditv1.StageResponseComplete,
@@ -20,7 +20,7 @@ func Test_auditLogEventHandler(t *testing.T) {
 		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
 		RequestReceivedTimestamp: mTime,
 		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "15.999592078s", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "3.746852ms", "apiserver.latency.k8s.io/total": "16.005122724s"},
-	}, &mTime, nil)
+	}, &mTime, nil, "testNode")
 
 	// all sub second so default only
 	handler.HandleAuditLogEvent(&auditv1.Event{
@@ -30,7 +30,7 @@ func Test_auditLogEventHandler(t *testing.T) {
 		Verb:                     "list",
 		RequestReceivedTimestamp: mTime,
 		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "5.999592078ms", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "0.746852ms", "apiserver.latency.k8s.io/total": "6.005122724ms"},
-	}, &mTime, nil)
+	}, &mTime, nil, "testNode")
 
 	// total is over 2s but etcd is under
 	handler.HandleAuditLogEvent(&auditv1.Event{
@@ -40,7 +40,7 @@ func Test_auditLogEventHandler(t *testing.T) {
 		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
 		RequestReceivedTimestamp: mTime,
 		Annotations:              map[string]string{"apiserver.latency.k8s.io/etcd": "1.999592078s", "apiserver.latency.k8s.io/response-write": "780ns", "apiserver.latency.k8s.io/serialize-response-object": "0.746852ms", "apiserver.latency.k8s.io/total": "2.005122724s"},
-	}, &mTime, nil)
+	}, &mTime, nil, "testNode")
 
 	// no annotations so only default (0) total is incremented
 	handler.HandleAuditLogEvent(&auditv1.Event{
@@ -50,7 +50,7 @@ func Test_auditLogEventHandler(t *testing.T) {
 		ObjectRef:                &auditv1.ObjectReference{Name: "testName", Resource: "testResource", Namespace: "testNamespace"},
 		RequestReceivedTimestamp: mTime,
 		Annotations:              map[string]string{},
-	}, &mTime, nil)
+	}, &mTime, nil, "testNode")
 
 	assert.NotNil(t, handler.summary.resourceBuckets)
 

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
@@ -41,7 +41,7 @@ func (v *auditViolations) HandleAuditLogEvent(auditEvent *auditv1.Event, beginni
 			violation: violation,
 			resource:  auditEvent.ObjectRef.Resource,
 			namespace: auditEvent.ObjectRef.Namespace,
-			name:      auditEvent.ObjectRef.Namespace,
+			name:      auditEvent.ObjectRef.Name,
 			username:  auditEvent.User.Username,
 		})
 	}

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -32,6 +32,7 @@ type auditLogAnalyzer struct {
 	requestsDuringShutdownChecker *lateRequestTracking
 	violationChecker              *auditViolations
 	watchCountTracking            *watchCountTracking
+	latencyChecker                *auditLatencyRecords
 
 	countsForInstall *CountsForRun
 }
@@ -44,6 +45,7 @@ func NewAuditLogAnalyzer() monitortestframework.MonitorTest {
 		requestsDuringShutdownChecker: CheckForRequestsDuringShutdown(),
 		violationChecker:              CheckForViolations(),
 		watchCountTracking:            NewWatchCountTracking(),
+		latencyChecker:                CheckForLatency(),
 	}
 }
 
@@ -88,6 +90,7 @@ func (w *auditLogAnalyzer) CollectData(ctx context.Context, storageDir string, b
 		w.requestsDuringShutdownChecker,
 		w.violationChecker,
 		w.watchCountTracking,
+		w.latencyChecker,
 	}
 	if w.requestCountTracking != nil {
 		auditLogHandlers = append(auditLogHandlers, w.requestCountTracking)
@@ -421,6 +424,14 @@ func (w *auditLogAnalyzer) WriteContentToStorage(ctx context.Context, storageDir
 		if err != nil {
 			// print any error and continue processing
 			fmt.Printf("unable to write audit log summary for %s - %v\n", "watch-requests", err)
+		}
+	}
+
+	if w.latencyChecker != nil {
+		err := w.latencyChecker.WriteAuditLogSummary(storageDir, "audit-latency", timeSuffix)
+		if err != nil {
+			// print any error and continue processing
+			fmt.Printf("unable to write audit log summary for %s - %v\n", "audit-latency", err)
 		}
 	}
 


### PR DESCRIPTION
[TRT-2043](https://issues.redhat.com/browse/TRT-2043) Provides initial implementation tracking etcd and total latency for audit records..  Creating 0,1, 2,5... second buckets to count requests that fall within each individual range (count only applies to one bucket, 5s does not also count as 1 or 2)