### PR TITLE
OCPBUGS-51373: use non-fake boot image for patch

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -192,7 +192,7 @@ func generateGCPProviderSpecPatch(machineSet machinev1beta1.MachineSet) (string,
 
 	// Modify the boot image to a "fake" value
 	originalBootImage := providerSpec.Disks[0].Image
-	newBootImage := originalBootImage + "-fake-update"
+	newBootImage := "projects/centos-cloud/global/images/family/centos-stream-9"
 	newProviderSpec := providerSpec.DeepCopy()
 	for idx := range newProviderSpec.Disks {
 		newProviderSpec.Disks[idx].Image = newBootImage


### PR DESCRIPTION
[These tests ](https://github.com/openshift/origin/blob/1e0a8370f673513a40720f9c597a7028922d17db/test/extended/machine_config/boot_image_update_gcp.go#L44-L46)are failing as they use a fake disk image as part of a patch when checking GCP disk reconciliation.

This is due to recent changes with disk reconciliation on GCP: https://github.com/openshift/machine-api-provider-gcp/pull/108. We now check if the disk is UEFI compatible before trying to create the machine. 

This change updates the fake patch to use a real disk image. 