### PR TITLE
OPRUN-3692: Olmv1-catalogd tests for API endpoints

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -13,6 +13,7 @@ import (
 	o "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -97,6 +98,210 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLM
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(meta.IsStatusConditionPresentAndEqual(conditions, "Serving", metav1.ConditionTrue)).To(o.BeTrue())
 		}
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/all endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-community-operators"
+		endpoint := "all"
+
+		g.By(fmt.Sprintf("Testing api/v1/all endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s", baseURL, endpoint)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/all endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-certified-operators"
+		endpoint := "all"
+
+		g.By(fmt.Sprintf("Testing api/v1/all endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s", baseURL, endpoint)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/all endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-redhat-marketplace"
+		endpoint := "all"
+
+		g.By(fmt.Sprintf("Testing api/v1/all endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s", baseURL, endpoint)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/all endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-redhat-operators"
+		endpoint := "all"
+
+		g.By(fmt.Sprintf("Testing api/v1/all endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s", baseURL, endpoint)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/metas endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-community-operators"
+		endpoint := "metas"
+		query := "schema=olm.package"
+
+		g.By(fmt.Sprintf("Testing api/v1/metas endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s?%s", baseURL, endpoint, query)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/metas endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-certified-operators"
+		endpoint := "metas"
+		query := "schema=olm.package"
+
+		g.By(fmt.Sprintf("Testing api/v1/metas endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s?%s", baseURL, endpoint, query)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/metas endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-redhat-marketplace"
+		endpoint := "metas"
+		query := "schema=olm.package"
+
+		g.By(fmt.Sprintf("Testing api/v1/metas endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s?%s", baseURL, endpoint, query)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
+	})
+})
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("default")
+
+	g.It("should serve FBC via the /v1/api/metas endpoint", func(ctx g.SpecContext) {
+		checkFeatureCapability(oc)
+
+		catalog := "openshift-redhat-operators"
+		endpoint := "metas"
+		query := "schema=olm.package"
+
+		g.By(fmt.Sprintf("Testing api/v1/metas endpoint for catalog %q", catalog))
+		baseURL, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"clustercatalogs.olm.operatorframework.io",
+			catalog,
+			"-o=jsonpath={.status.urls.base}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(baseURL).NotTo(o.BeEmpty(), fmt.Sprintf("Base URL not found for catalog %s", catalog))
+
+		serviceURL := fmt.Sprintf("%s/api/v1/%s?%s", baseURL, endpoint, query)
+		g.GinkgoLogr.Info(fmt.Sprintf("Using service URL: %s", serviceURL))
+
+		verifyAPIEndpoint(ctx, oc, serviceURL)
 	})
 })
 
@@ -415,5 +620,97 @@ func checkFeatureCapability(oc *exutil.CLI) {
 	o.Expect(err).NotTo(o.HaveOccurred())
 	if !cap {
 		g.Skip("Test only runs with OperatorLifecycleManagerV1 capability")
+	}
+}
+
+// verifyAPIEndpoint runs a job to validate the given service endpoint of a ClusterCatalog
+func verifyAPIEndpoint(ctx g.SpecContext, oc *exutil.CLI, serviceURL string) {
+	jobName := fmt.Sprintf("test-catalog-endpoint-%s", rand.String(5))
+
+	jobYAML := fmt.Sprintf(`
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  template:
+    spec:
+      containers:
+      - name: api-tester
+        image: registry.redhat.io/rhel8/httpd-24:latest
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "50Mi"
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -ex
+          curl -v -k "%s" 
+          if [ $? -ne 0 ]; then
+            echo "Failed to access endpoint"
+            exit 1
+          fi
+          echo "Successfully verified API endpoint"
+          exit 0
+      restartPolicy: Never
+  backoffLimit: 2
+`, jobName, "default", serviceURL)
+
+	tempFile, err := os.CreateTemp("", "api-test-job-*.yaml")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	err = os.WriteFile(tempFile.Name(), []byte(jobYAML), 0644)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", tempFile.Name()).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Wait for job completion
+	var lastErr error
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"job", jobName, "-n", "default", "-o=jsonpath={.status}").Output()
+		if err != nil {
+			lastErr = err
+			g.GinkgoLogr.Info(fmt.Sprintf("error getting job status: %v (will retry)", err))
+			return false, nil
+		}
+
+		if output == "" {
+			return false, nil // Job status not available yet
+		}
+
+		// Parse job status
+		var status struct {
+			Succeeded int `json:"succeeded"`
+			Failed    int `json:"failed"`
+		}
+
+		if err := json.Unmarshal([]byte(output), &status); err != nil {
+			g.GinkgoLogr.Info(fmt.Sprintf("Error parsing job status: %v", err))
+			return false, nil
+		}
+
+		if status.Succeeded > 0 {
+			return true, nil
+		}
+
+		if status.Failed > 0 {
+			return false, fmt.Errorf("job failed")
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		if lastErr != nil {
+			g.GinkgoLogr.Error(nil, fmt.Sprintf("Last error encountered while polling: %v", lastErr))
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "Job failed or timed out")
 	}
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1779,11 +1779,27 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io] required pods on the Arbiter node Should verify that the correct number of pods are running on the Arbiter node": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install should fail to install if it has an invalid reference": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/all endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators Catalog should serve FBC via the /v1/api/all endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace Catalog should serve FBC via the /v1/api/all endpoint": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/all endpoint": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -398,6 +398,14 @@ spec:
         should be installed'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New
         Catalog Install should fail to install if it has an invalid reference'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-certified-operators
+        Catalog should serve FBC via the /v1/api/all endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-community-operators
+        Catalog should serve FBC via the /v1/api/all endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-marketplace
+        Catalog should serve FBC via the /v1/api/all endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators
+        Catalog should serve FBC via the /v1/api/all endpoint'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
         installation should block cluster upgrades if an incompatible operator is
         installed'
@@ -405,6 +413,20 @@ spec:
         installation should fail to install a non-existing cluster extension'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
         installation should install a cluster extension'
+  - featureGate: NewOLMCatalogdAPIV1Metas
+    tests:
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]
+        OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/metas
+        endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]
+        OLMv1 openshift-community-operators Catalog should serve FBC via the /v1/api/metas
+        endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]
+        OLMv1 openshift-redhat-marketplace Catalog should serve FBC via the /v1/api/metas
+        endpoint'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]
+        OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/metas
+        endpoint'
   - featureGate: OrderedNamespaceDeletion
     tests:
     - testName: '[sig-api-machinery] OrderedNamespaceDeletion namespace deletion should


### PR DESCRIPTION
Introduces tests for the new `api/v1/metas` endpoint when NewOLMCatalogdAPIV1Metas feature gate in enabled.