### PR TITLE
OSD-26270: re-enabled managed-upgrade-operator test by removing exclusion

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/exclusions.go
+++ b/pkg/monitortests/node/legacynodemonitortests/exclusions.go
@@ -43,9 +43,6 @@ func isThisContainerRestartExcluded(locator string, exclusion Exclusion) bool {
 			containerName: "container/ovn-acl-logging", // https://issues.redhat.com/browse/OCPBUGS-42344
 		},
 		{
-			containerName: "container/managed-upgrade-operator", // https://issues.redhat.com/browse/OSD-26270
-		},
-		{
 			// Managed services like ROSA. This is expected.
 			containerName: "container/osd-cluster-ready",
 		},


### PR DESCRIPTION
What type of PR is this?
Test Case Re-Enable

What this PR does / why we need it?
Previously, the managed-upgrade-operator test was excluded due to failures related to a known issue.
Now, after verification, the issue no longer exists. The test should be re-enabled to ensure the managed-upgrade-operator is properly monitored in CI.
By removing this exclusion, we allow failures to be properly detected and addressed in future OpenShift releases.

Key Changes:
- Removed the exclusion entry for `managed-upgrade-operator` in `exclusions.go`.  

Which Jira/GitHub issue(s) this PR fixes?
Part of [https://issues.redhat.com/browse/OSD-26270]

Special notes for your reviewer:
This PR removes the exclusion of `managed-upgrade-operator`, re-enabling the test in CI.  
Issue verification was done on OpenShift 4.18 and 4.19, and no pod restarts were observed.  
