### PR TITLE
MCO-1594: updates for ManagedBootImageStatus

### DIFF
--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -13,6 +13,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 func AllMachineSetTest(oc *exutil.CLI, fixture string) {
@@ -76,6 +77,7 @@ func NoneMachineSetTest(oc *exutil.CLI, fixture string) {
 }
 
 func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
+	e2eskipper.Skipf("This test is temporarily disabled until boot image skew enforcement is implemented")
 	// This fixture applies a boot image update configuration that opts in all machinesets
 	err := oc.Run("apply").Args("-f", fixture).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -47,7 +47,11 @@ func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
 	// Label this machineset with the test=boot label
 	err = oc.Run("label").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-n", mapiNamespace, "test=boot").Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
-
+	defer func() {
+		// Unlabel the machineset at the end of test
+		err = oc.Run("label").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-n", mapiNamespace, "test-").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}()
 	// Step through all machinesets and verify that only the opted in machineset's boot images are reconciled.
 	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -55,9 +59,6 @@ func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
 		verifyMachineSetUpdate(oc, ms, machineSetUnderTest.Name == ms.Name)
 	}
 
-	// Unlabel the machineset
-	err = oc.Run("label").Args(mapiMachinesetQualifiedName, machineSetUnderTest.Name, "-n", mapiNamespace, "test-").Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
 func NoneMachineSetTest(oc *exutil.CLI, fixture string) {

--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -19,6 +19,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
 		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
 		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		emptyMachineSetFixture         = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
 
@@ -33,7 +34,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 
 	g.AfterEach(func() {
 		// Clear out boot image configuration between tests
-		err := oc.Run("apply").Args("-f", noneMachineSetFixture).Execute()
+		err := oc.Run("apply").Args("-f", emptyMachineSetFixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -19,6 +19,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
 		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
 		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		emptyMachineSetFixture         = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
 
@@ -33,7 +34,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 
 	g.AfterEach(func() {
 		// Clear out boot image configuration between tests
-		err := oc.Run("apply").Args("-f", noneMachineSetFixture).Execute()
+		err := oc.Run("apply").Args("-f", emptyMachineSetFixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -419,6 +419,7 @@
 // test/extended/testdata/long_names/Dockerfile
 // test/extended/testdata/long_names/fixture.json
 // test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml
+// test/extended/testdata/machine_config/machineconfigurations/managedbootimages-empty.yaml
 // test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml
 // test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml
 // test/extended/testdata/marketplace/csc/02-csc.yaml
@@ -49006,6 +49007,31 @@ func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAll
 	return a, nil
 }
 
+var _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+`)
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYaml, nil
+}
+
+func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/machineconfigurations/managedbootimages-empty.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml = []byte(`apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
@@ -49014,6 +49040,12 @@ metadata:
 spec:
   logLevel: Normal
   operatorLogLevel: Normal
+  managedBootImages:
+    machineManagers:
+      - resource: machinesets
+        apiGroup: machine.openshift.io
+        selection:
+          mode: None
 `)
 
 func testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYamlBytes() ([]byte, error) {
@@ -55698,6 +55730,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/long_names/Dockerfile":                                                           testExtendedTestdataLong_namesDockerfile,
 	"test/extended/testdata/long_names/fixture.json":                                                         testExtendedTestdataLong_namesFixtureJson,
 	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-all.yaml":                 testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml,
+	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-empty.yaml":               testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYaml,
 	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml":                testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml,
 	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml":             testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml,
 	"test/extended/testdata/marketplace/csc/02-csc.yaml":                                                     testExtendedTestdataMarketplaceCsc02CscYaml,
@@ -56443,6 +56476,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"machine_config": {nil, map[string]*bintree{
 					"machineconfigurations": {nil, map[string]*bintree{
 						"managedbootimages-all.yaml":     {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesAllYaml, map[string]*bintree{}},
+						"managedbootimages-empty.yaml":   {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesEmptyYaml, map[string]*bintree{}},
 						"managedbootimages-none.yaml":    {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml, map[string]*bintree{}},
 						"managedbootimages-partial.yaml": {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml, map[string]*bintree{}},
 					}},

--- a/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-empty.yaml
+++ b/test/extended/testdata/machine_config/machineconfigurations/managedbootimages-empty.yaml
@@ -6,9 +6,3 @@ metadata:
 spec:
   logLevel: Normal
   operatorLogLevel: Normal
-  managedBootImages:
-    machineManagers:
-      - resource: machinesets
-        apiGroup: machine.openshift.io
-        selection:
-          mode: None


### PR DESCRIPTION
This PR modifies boot image update tests:
- Use the explicit opt-out knob when opting out
- Skip the degrade test temporarily
- ensure cleanups are done in success or fail