### PR TITLE
DNM: OCPBUGS-44633: fix tests replacing apply to create

### DIFF
--- a/test/extended/builds/subscription_content.go
+++ b/test/extended/builds/subscription_content.go
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][subscription-content] builds in
 			// Run oc commands as per the openshift documentation
 			stdOut, _, err := oc.AsAdmin().Run("get").Args("secret", "etc-pki-entitlement", "-n", "openshift-config-managed", "-o=go-template-file", "--template", secretTemplate).Outputs()
 			o.Expect(err).NotTo(o.HaveOccurred(), "getting secret openshift-config-managed/etc-pki-entitlement")
-			err = oc.Run("apply").Args("-f", "-").InputString(stdOut).Execute()
+			err = oc.Run("create").Args("-f", "-").InputString(stdOut).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred(), "creating secret etc-pki-entitlement")
 
 			g.By("setting up build outputs")


### PR DESCRIPTION
Validating OCPBUGS-44633 in 4.18 parallel with https://github.com/openshift/origin/pull/29603 (failing for unknown reasons on build)

---

Replace `apply` to `create` which is affecting those three tests included in the `openshift/conformance` suite:

```sh
"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 7 base images [Suite:openshift/conformance/parallel]"
"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 8 base images [Suite:openshift/conformance/parallel]"
"[sig-builds][Feature:Builds][subscription-content] builds installing subscription content [apigroup:build.openshift.io] should succeed for RHEL 9 base images [Suite:openshift/conformance/parallel]"
```

Those are permanent failure in the conformance suite, leading to false-positive issues on partner enablement tickets, and CI signals for platform type `External` jobs. See [Sippy](https://sippy.dptools.openshift.org/sippy-ng/tests/4.18?filters=%257B%2522items%2522%253A%255B%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522builds%2520installing%2520subscription%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=net_improvement) status.