### PR TITLE
OCPBUGS-53285: Add/remove team members to the OWNERS file for Builds

### DIFF
--- a/test/extended/builds/OWNERS
+++ b/test/extended/builds/OWNERS
@@ -1,6 +1,9 @@
 reviewers:
-  - coreydaley
-  - gabemontero
+  - sayan-biswas
+  - divyansh42
+  - prabhapa
+  - moebasim
 approvers:
-  - gabemontero
-  - coreydaley
+  - sayan-biswas
+  - prabhapa
+  - moebasim


### PR DESCRIPTION
New owners added to build component and old ones removed