### PR TITLE
[WIP] TLS 1.3 / Modern profile tests

### DIFF
--- a/test/extended/apiserver/tls.go
+++ b/test/extended/apiserver/tls.go
@@ -1,13 +1,89 @@
 package apiserver
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
+	"strings"
+	"time"
 
 	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
 	"github.com/openshift/library-go/pkg/crypto"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
+
+const tlsTestDuration = 10 * time.Minute
+const tlsWaitForCleanupDuration = 10 * time.Minute
+
+var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Serial]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("apiserver")
+
+	g.It("TestTLSModernProfile", func() {
+		ctx, ctxCancelFn := context.WithTimeout(context.Background(), tlsTestDuration)
+		defer ctxCancelFn()
+
+		t := g.GinkgoT()
+
+		configClient := oc.AdminConfigClient()
+		
+		operatorClient := oc.AdminOperatorClient()
+
+		defer func() {
+			g.By("Cleanup - removing TLS profile")
+
+			cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), tlsWaitForCleanupDuration)
+			defer cancelCleanup()
+	
+			kasStatus, err := operatorClient.OperatorV1().KubeAPIServers().Get(cleanupCtx, "cluster", metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+	
+			currentRevision := kasStatus.Status.LatestAvailableRevision
+	
+			removeModernProfilePatch := `[{"op":"remove","path":"/spec/tlsSecurityProfile"}]`
+	
+			_, err = configClient.ConfigV1().APIServers().Patch(cleanupCtx, "cluster", types.JSONPatchType, []byte(removeModernProfilePatch), metav1.PatchOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+	
+			_, err = waitForKASIncrementedRevision(cleanupCtx, operatorClient, "cluster", currentRevision)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		}()
+
+		g.By("Applying a JSON Patch to use the modern TLS profile")
+
+		kasStatus, err := operatorClient.OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		currentRevision := kasStatus.Status.LatestAvailableRevision
+
+		addModernProfilePatch := `[{"op":"add","path":"/spec/tlsSecurityProfile","value":{"type":"Modern","modern":{}}}]`
+
+		_, err = configClient.ConfigV1().APIServers().Patch(ctx, "cluster", types.JSONPatchType, []byte(addModernProfilePatch), metav1.PatchOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Dialing the API with a minimum TLS version of 1.3")
+
+		_, err = waitForKASIncrementedRevision(ctx, operatorClient, "cluster", currentRevision)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		config := &tls.Config{MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, InsecureSkipVerify: true}
+
+		host := strings.TrimPrefix(oc.AdminConfig().Host, "https://")
+
+		conn, err := tls.Dial("tcp4", host, config)
+		if err != nil {
+			t.Fatalf("Expected success with TLS 1.3, got %v", err)
+		}
+
+		conn.Close()
+	})
+})
 
 var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	defer g.GinkgoRecover()
@@ -15,8 +91,6 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 	oc := exutil.NewCLI("apiserver")
 
 	g.It("TestTLSDefaults", func() {
-		g.Skip("skipping because it was broken in master")
-
 		t := g.GinkgoT()
 		// Verify we fail with TLS versions less than the default, and work with TLS versions >= the default
 		for _, tlsVersionName := range crypto.ValidTLSVersions() {
@@ -24,8 +98,10 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 			expectSuccess := tlsVersion >= crypto.DefaultTLSVersion()
 			config := &tls.Config{MinVersion: tlsVersion, MaxVersion: tlsVersion, InsecureSkipVerify: true}
 
+			host := strings.TrimPrefix(oc.AdminConfig().Host, "https://")
+
 			{
-				conn, err := tls.Dial("tcp4", oc.AdminConfig().Host, config)
+				conn, err := tls.Dial("tcp4", host, config)
 				if err == nil {
 					conn.Close()
 				}
@@ -62,3 +138,20 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 
 	})
 })
+
+func waitForKASIncrementedRevision(ctx context.Context, operatorClient operatorv1client.Interface, name string, currentRevision int32) (int32, error) {
+	for {
+		kasStatus, _ := operatorClient.OperatorV1().KubeAPIServers().Get(context.Background(), name, metav1.GetOptions{})
+		// Intentionally don't return if this errors, as the API server is most likely still coming online, which is what we're waiting for.
+		
+		if ctx.Err() != nil {
+			return 0, fmt.Errorf("timed out waiting for KubeAPIServer to increment revision")
+		}
+		
+		if kasStatus.Status.LatestAvailableRevision > currentRevision {
+			return kasStatus.Status.LatestAvailableRevision, nil
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/test/extended/etcd/tls.go
+++ b/test/extended/etcd/tls.go
@@ -1,0 +1,59 @@
+package etcd
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const tlsTestDuration = 10 * time.Minute
+const tlsWaitForCleanupDuration = 10 * time.Minute
+
+var _ = g.Describe("[sig-etcd][Serial] etcd", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("etcd-tls").AsAdmin()
+
+	g.It("Test TLS 1.3 Configuration", func() {
+		ctx, ctxCancelFn := context.WithTimeout(context.Background(), tlsTestDuration)
+		defer ctxCancelFn()
+
+		operatorClient := oc.AdminOperatorClient()
+
+		originalEtcd, err := operatorClient.OperatorV1().Etcds().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		defer func() {
+			g.By("Cleanup - removing TLS configuration")
+
+			cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), tlsWaitForCleanupDuration)
+			defer cancelCleanup()
+
+			_, err := operatorClient.OperatorV1().Etcds().Update(cleanupCtx, originalEtcd, metav1.UpdateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			err = waitForEtcdToStabilizeOnTheSameRevision(g.GinkgoT(), oc)
+			err = errors.Wrap(err, "timed out waiting for etcd pods to stabilize after cleaning up TLS 1.3")
+			o.Expect(err).ToNot(o.HaveOccurred())
+		}()
+
+		g.By("Applying a JSON Patch to use TLS 1.3")
+
+		addTLS13Patch := `[{"op":"replace","path":"/spec/observedConfig/servingInfo","value":{"cipherSuites":["TLS_AES_128_GCM_SHA256","TLS_AES_256_GCM_SHA384","TLS_CHACHA20_POLY1305_SHA256"],"minTLSVersion":"VersionTLS13"}}]`
+
+		_, err = operatorClient.OperatorV1().Etcds().Patch(ctx, "cluster", types.JSONPatchType, []byte(addTLS13Patch), metav1.PatchOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Expecting etcd to stabilize without errors")
+
+		err = waitForEtcdToStabilizeOnTheSameRevision(g.GinkgoT(), oc)
+		err = errors.Wrap(err, "timed out waiting for etcd pods to stabilize using TLS 1.3")
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+})


### PR DESCRIPTION
This PR:

* Removes a skip on an existing TLS test - it appears to have been a setup issue
* Adds a TLS modern profile test to APIServer (see https://github.com/openshift/kubernetes/pull/2135) (tested)
* Adds (WIP) TLS 1.3 test to etcd. (untested, trouble getting a dev cluster at the moment)