### PR TITLE
Allow multiple attempts in egress firewall test

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -151,7 +151,7 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	// Test curl to docs.redhat.com should pass
 	// because we have allow dns rule for docs.redhat.com
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "--retry", "10", "--retry-all-errors", "https://docs.redhat.com").Output()
 	expectNoError(err)
 
 	if checkWildcard {


### PR DESCRIPTION
this test is failing when using kata-containers, which might be related to longer startup times of kata-containers:

    curl: (28) Connection timed out after 1001 milliseconds

let's use the "--retry" feature of curl. This should not affect the successful tests as they should return immediately, while it might prolong the failing tests from 3s to 30s. With kata we need about 6-12s so 30s should be safe for us.