### PR TITLE
Fix broken intervals charts

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>EVENT_INTERVAL_TITLE_GOES_HERE</title>
-    <script src="https://unpkg.com/timelines-chart"></script>
+    <script src="https://cdn.jsdelivr.net/npm/timelines-chart"></script>
     <script src="https://d3js.org/d3-array.v1.min.js"></script>
     <script src="https://d3js.org/d3-collection.v1.min.js"></script>
     <script src="https://d3js.org/d3-color.v1.min.js"></script>

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>EVENT_INTERVAL_TITLE_GOES_HERE</title>
-    <script src="https://unpkg.com/timelines-chart"></script>
+    <script src="https://cdn.jsdelivr.net/npm/timelines-chart"></script>
     <script src="https://d3js.org/d3-array.v1.min.js"></script>
     <script src="https://d3js.org/d3-collection.v1.min.js"></script>
     <script src="https://d3js.org/d3-color.v1.min.js"></script>


### PR DESCRIPTION
The timelines-chart seems to have changed at this unpkg location, if you
load that in a browser and search for the TimelinesChart object we use,
it's no longer there, though it does load some js.

The github repo for the actual project
https://github.com/vasturiano/timelines-chart
recommends this new url and I've confirmed this works by downloading an
html intervals file and editing it.
