### PR TITLE
OCPBUGS-52358: Fix egress firewall tests by updating the URL from docs.redhat.com to redhat.com

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 			_, err = noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 			expectNoError(err)
 		}
-		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
+		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://redhat.com").Output()
 		expectNoError(err)
 
 		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "http://www.google.com:80").Output()
@@ -148,10 +148,10 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 		_, err = oc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 		expectError(err)
 	}
-	// Test curl to docs.redhat.com should pass
-	// because we have allow dns rule for docs.redhat.com
+	// Test curl to redhat.com should pass
+	// because we have allow dns rule for redhat.com
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://redhat.com").Output()
 	expectNoError(err)
 
 	if checkWildcard {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43492,7 +43492,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Deny
     to:
       dnsName: www.google.com
@@ -43535,7 +43535,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       dnsName: "*.google.com"
@@ -43575,7 +43575,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Deny
     to:
       dnsName: www.google.com

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       dnsName: "*.google.com"

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32


### PR DESCRIPTION
This PR updates the egressfirewall tests to use redhat.com instead of docs.redhat.com as there are a lot of failure encountered for this URL. The issue with docs.redhat.com is that the TTL is very low (20s) because of which the ovnkube-node and the test pod are resolving to different IP addresses as shown in the following analysis:
- https://github.com/openshift/release/pull/62968#issuecomment-2740905648
- https://github.com/openshift/release/pull/62968#issuecomment-2740933499

The TTL of redhat.com is very large (2695s) which will ensure that the failure of the test is very less.