### PR TITLE
OCPBUGS-53249: feat: support platform type external

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -28,6 +28,9 @@ import (
 	// Initialize nutanix as a provider
 	_ "github.com/openshift/origin/test/extended/util/nutanix"
 
+	// Initialize nutanix as a provider
+	_ "github.com/openshift/origin/test/extended/util/external"
+
 	// these are loading important global flags that we need to get and set
 	_ "k8s.io/kubernetes/test/e2e"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
@@ -135,7 +138,7 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		}
 		fallthrough
 
-	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud":
+	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud", "external":
 		if clusterState == nil {
 			clientConfig, err := e2e.LoadConfig(true)
 			if err != nil {

--- a/test/extended/util/external/provider.go
+++ b/test/extended/util/external/provider.go
@@ -1,0 +1,18 @@
+package external
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("external", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle external for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
This change register the platform type `external` as a valid `provider` (flag) when running the conformance tests.

This is required if we need more refinement when running conformance tests in that platform type (`External`), which was design inheriting from `None`. EP for more information: https://github.com/openshift/enhancements/blob/master/enhancements/cloud-integration/infrastructure-external-platform-type.md

For more information about the tests executed in this PR, see this comment: https://github.com/openshift/origin/pull/29623#issuecomment-2772616129

[1] OCPBUGS-53249 - The following PR implements granular skips for platform specific on tests coming from kubernetes suites: https://github.com/openshift/kubernetes/pull/2247