### PR TITLE
NO-ISSUE: Wait for MachineConfiguration status to be upto date

### DIFF
--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -38,6 +38,9 @@ func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
 	err := oc.Run("apply").Args("-f", fixture).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
+	// Ensure status accounts for the fixture that was applied
+	WaitForMachineConfigurationStatusUpdate(oc)
+
 	// Pick a random machineset to test
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -66,6 +69,9 @@ func NoneMachineSetTest(oc *exutil.CLI, fixture string) {
 	err := oc.Run("apply").Args("-f", fixture).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
 
+	// Ensure status accounts for the fixture that was applied
+	WaitForMachineConfigurationStatusUpdate(oc)
+
 	// Step through all machinesets and verify boot images are reconciled correctly.
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
 	o.Expect(err).NotTo(o.HaveOccurred())
@@ -82,6 +88,9 @@ func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
 	// This fixture applies a boot image update configuration that opts in all machinesets
 	err := oc.Run("apply").Args("-f", fixture).Execute()
 	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Ensure status accounts for the fixture that was applied
+	WaitForMachineConfigurationStatusUpdate(oc)
 
 	// Pick a random machineset to test
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())

--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -36,6 +36,9 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		// Clear out boot image configuration between tests
 		err := oc.Run("apply").Args("-f", emptyMachineSetFixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Ensure status accounts for the fixture that was applied
+		WaitForMachineConfigurationStatusUpdate(oc)
 	})
 
 	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {


### PR DESCRIPTION
Before running through the remainder for test, we need to ensure that the fixture applied has been propagated through the status. This adds a short wait check to accounts for this.