### PR TITLE
NO-ISSUE: Clean up MachineConfiguration fixture apply 

### DIFF
--- a/test/extended/machine_config/boot_image_update_agnostic.go
+++ b/test/extended/machine_config/boot_image_update_agnostic.go
@@ -18,8 +18,7 @@ import (
 
 func AllMachineSetTest(oc *exutil.CLI, fixture string) {
 	// This fixture applies a boot image update configuration that opts in all machinesets
-	err := oc.Run("apply").Args("-f", fixture).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
+	ApplyBootImageFixture(oc, fixture)
 
 	// Step through all machinesets and verify boot images are reconciled correctly.
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
@@ -35,11 +34,7 @@ func AllMachineSetTest(oc *exutil.CLI, fixture string) {
 func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
 
 	// This fixture applies a boot image update configuration that opts in any machineset with the label test=boot
-	err := oc.Run("apply").Args("-f", fixture).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	// Ensure status accounts for the fixture that was applied
-	WaitForMachineConfigurationStatusUpdate(oc)
+	ApplyBootImageFixture(oc, fixture)
 
 	// Pick a random machineset to test
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
@@ -66,11 +61,7 @@ func PartialMachineSetTest(oc *exutil.CLI, fixture string) {
 
 func NoneMachineSetTest(oc *exutil.CLI, fixture string) {
 	// This fixture applies a boot image update configuration that opts in no machinesets, i.e. feature is disabled.
-	err := oc.Run("apply").Args("-f", fixture).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	// Ensure status accounts for the fixture that was applied
-	WaitForMachineConfigurationStatusUpdate(oc)
+	ApplyBootImageFixture(oc, fixture)
 
 	// Step through all machinesets and verify boot images are reconciled correctly.
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
@@ -86,11 +77,7 @@ func NoneMachineSetTest(oc *exutil.CLI, fixture string) {
 func DegradeOnOwnerRefTest(oc *exutil.CLI, fixture string) {
 	e2eskipper.Skipf("This test is temporarily disabled until boot image skew enforcement is implemented")
 	// This fixture applies a boot image update configuration that opts in all machinesets
-	err := oc.Run("apply").Args("-f", fixture).Execute()
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	// Ensure status accounts for the fixture that was applied
-	WaitForMachineConfigurationStatusUpdate(oc)
+	ApplyBootImageFixture(oc, fixture)
 
 	// Pick a random machineset to test
 	machineClient, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())

--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -7,7 +7,6 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 
 	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -33,12 +32,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 	})
 
 	g.AfterEach(func() {
-		// Clear out boot image configuration between tests
-		err := oc.Run("apply").Args("-f", emptyMachineSetFixture).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Ensure status accounts for the fixture that was applied
-		WaitForMachineConfigurationStatusUpdate(oc)
+		ApplyBootImageFixture(oc, emptyMachineSetFixture)
 	})
 
 	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -7,7 +7,6 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 
 	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -34,8 +33,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 
 	g.AfterEach(func() {
 		// Clear out boot image configuration between tests
-		err := oc.Run("apply").Args("-f", emptyMachineSetFixture).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
+		ApplyBootImageFixture(oc, emptyMachineSetFixture)
 	})
 
 	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {

--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -307,3 +307,13 @@ func WaitForOneMasterNodeToBeReady(oc *exutil.CLI) error {
 	}, 5*time.Minute, 10*time.Second).Should(o.BeTrue())
 	return nil
 }
+
+// Applies a boot image fixture and waits for the MCO to reconcile the status
+func ApplyBootImageFixture(oc *exutil.CLI, fixture string) {
+	err := oc.Run("apply").Args("-f", fixture).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Ensure status accounts for the fixture that was applied
+	WaitForMachineConfigurationStatusUpdate(oc)
+
+}


### PR DESCRIPTION
Follow-up to https://github.com/openshift/origin/pull/29625 

This encapsulate the apply and wait into a single function, and also added it to a couple of spots that I missed in the original PR. 