### PR TITLE
Draft Commit for gatewayAPIController featuregate

### DIFF
--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -1,0 +1,171 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	sailv1 "github.com/istio-ecosystem/sail-operator/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiclientset "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+)
+
+var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLIWithPodSecurityLevel("gatewayapi-controller", admissionapi.LevelBaseline)
+	)
+	const (
+		// The expected OSSM subscription name.
+		expectedSubscriptionName = "servicemeshoperator3"
+		// The expected OSSM operator namespace.
+		expectedSubscriptionNamespace = "openshift-operators"
+		// The gatewayclass name used to create ossm and other gateway api resources.
+		gatewayClassName = "openshift-default"
+		// gatewayClassControllerName is the name that must be used to create a supported gatewayClass.
+		gatewayClassControllerName = "openshift.io/gateway-controller/v1"
+	)
+	g.BeforeEach(func() {
+		// create the default gatewayClass and confirm that it is accepted
+		gwapiClient := gatewayapiclientset.NewForConfigOrDie(oc.AdminConfig())
+
+		gatewayClass := buildGatewayClass(gatewayClassName, gatewayClassControllerName)
+		gwc, err := gwapiClient.GatewayV1().GatewayClasses().Create(context.TODO(), gatewayClass, metav1.CreateOptions{})
+		if err != nil {
+			e2e.Logf("Gateway Class %s already exists, or has failed to be created, checking its status", gwc.Name)
+		}
+
+		errCheck := checkGatewayClass(oc, gatewayClassName)
+		o.Expect(errCheck).NotTo(o.HaveOccurred())
+		e2e.Logf("GatewayClass %s successfully installed and accepted!", gwc.Name)
+
+	})
+
+	g.Describe("Verify Gateway API controller resources are created", func() {
+		g.It("and ensure OSSM related resources are created", func() {
+			coreClient := clientset.NewForConfigOrDie(oc.AdminConfig())
+			//check the subscription
+			g.By("Check OSSM subscription and CSV")
+			csvName, err := oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "subscription", expectedSubscriptionName, "-o=jsonpath={.status.installedCSV}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("The subscription is installed and the CSV is: %v", csvName)
+			csvStatus, err := oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "clusterserviceversion", csvName, "-o=jsonpath={.status.phase}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(csvStatus).To(o.Equal("Succeeded"))
+
+			g.By("check OSSM Pod and istiod pod is present with OSSM Operator installation")
+			podList, err := coreClient.CoreV1().Pods("openshift-operators").List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(podList).To(o.ContainSubstring(`servicemesh-operator3`))
+
+			podList, err = coreClient.CoreV1().Pods("openshift-ingress").List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(podList).To(o.ContainSubstring(`istiod-openshift-gateway`))
+
+			g.By("Confirm that ISTIO CR is created and in healthy state")
+			resource := types.NamespacedName{Namespace: "openshift-ingress", Name: "openshift-gateway"}
+
+			errIstio := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 30*time.Second, false, func(context context.Context) (bool, error) {
+				istioStatus, errIstio := oc.AsAdmin().Run("get").Args("-n", resource.Namespace, "istio", resource.Name, "-o=jsonpath={.status.state}").Output()
+				if errIstio != nil {
+					e2e.Logf("failed to get Istio CR %s, retrying...", "openshift-gateway")
+					return false, nil
+				}
+				if istioStatus == string(sailv1.IstioReasonHealthy) {
+					e2e.Logf("Found Istio %s/%s, and it reports ready", resource.Namespace, resource.Name)
+					return true, nil
+				}
+				e2e.Logf("Found Istio %s/%s, but it isn't ready.  Retrying...", resource.Namespace, resource.Name)
+				return false, nil
+			})
+			if errIstio != nil {
+				e2e.Failf("Expected ISTIO CR %s not found", "openshift-gateway")
+			}
+
+		})
+		g.It("and ensure custom gatewayclass can be accepted", func() {
+			gwapiClient := gatewayapiclientset.NewForConfigOrDie(oc.AdminConfig())
+			coreClient := clientset.NewForConfigOrDie(oc.AdminConfig())
+
+			g.By("Create Custom GatewayClass")
+			gatewayClass := buildGatewayClass("custom-gateway", gatewayClassControllerName)
+			gwc, err := gwapiClient.GatewayV1().GatewayClasses().Create(context.TODO(), gatewayClass, metav1.CreateOptions{})
+			if err != nil {
+				e2e.Logf("Gateway Class %s already exists, or has failed to be created, checking its status", "custom-gateway")
+			}
+			errCheck := checkGatewayClass(oc, "custom-gateway")
+			o.Expect(errCheck).NotTo(o.HaveOccurred())
+			e2e.Logf("GatewayClass %s successfully installed and accepted!", gwc.Name)
+
+			g.By("Deleting Custom GatewayClass and confirming that it is no longer there")
+			err = gwapiClient.GatewayV1().GatewayClasses().Delete(context.Background(), "custom-gateway", metav1.DeleteOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			_, err = gwapiClient.GatewayV1().GatewayClasses().Get(context.Background(), "custom-gateway", metav1.GetOptions{})
+			o.Expect(err).To(o.HaveOccurred())
+			e2e.Logf("The custom gatewayClass %s has been sucessfully deleted", "custom-gateway")
+
+			g.By("check if default gatewayClass is accepted and ISTIO CR and pod are still available")
+			defaultCheck := checkGatewayClass(oc, gatewayClassName)
+			o.Expect(defaultCheck).NotTo(o.HaveOccurred())
+
+			podList, err := coreClient.CoreV1().Pods("openshift-ingress").List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(podList).To(o.ContainSubstring(`istiod-openshift-gateway`))
+
+			istioCR, err := oc.AsAdmin().Run("get").Args("-n", "openshift-ingress", "istio", "openshift-gateway").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(istioCR).To(o.ContainSubstring(`openshift-gateway`))
+
+		})
+
+	})
+})
+
+func checkGatewayClass(oc *exutil.CLI, name string) error {
+	gwapiClient := gatewayapiclientset.NewForConfigOrDie(oc.AdminConfig())
+
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
+		gwc, err := gwapiClient.GatewayV1().GatewayClasses().Get(context, name, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("failed to get gatewayclass %s, retrying...", name)
+			return false, nil
+		}
+		for _, condition := range gwc.Status.Conditions {
+			if condition.Type == string(gatewayapiv1.GatewayClassConditionStatusAccepted) {
+				if condition.Status == metav1.ConditionTrue {
+					return true, nil
+				}
+			}
+		}
+		e2e.Logf("Found gatewayclass %s but it is not accepted, retrying...", name)
+		return false, nil
+	})
+
+	if waitErr != nil {
+		return fmt.Errorf("Gatewayclass %s is not accepted", name)
+	}
+	e2e.Logf("Gateway Class %s is created and accpeted", name)
+	return nil
+}
+
+// buildGatewayClass initializes the GatewayClass and returns its address.
+func buildGatewayClass(name, controllerName string) *gatewayapiv1.GatewayClass {
+	return &gatewayapiv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: gatewayapiv1.GatewayClassSpec{
+			ControllerName: gatewayapiv1.GatewayController(controllerName),
+		},
+	}
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1587,6 +1587,10 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:DNSNameResolver][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall with wildcard dns rules is created": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API controller resources are created and ensure OSSM related resources are created": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API controller resources are created and ensure custom gatewayclass can be accepted": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API CRDs and ensure CRD of experimental group can not be created": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API CRDs and ensure CRD of experimental group is not installed": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -79,6 +79,14 @@ spec:
         Verify Gateway API CRDs and ensure existing CRDs can not be updated'
     - testName: '[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io]
         Verify Gateway API CRDs and ensure required CRDs should already be installed'
+  - featureGate: GatewayAPIController
+    tests:
+    - testName: '[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
+        Verify Gateway API controller resources are created and ensure OSSM related
+        resources are created'
+    - testName: '[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
+        Verify Gateway API controller resources are created and ensure custom gatewayclass
+        can be accepted'
   - featureGate: HardwareSpeed
     tests:
     - testName: '[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to


### PR DESCRIPTION
Draft PR for Network Ingress and DNS team for the 2/5 e2e tests to graduate featureGate to GA

Internal QE team review requested
@melvinjoseph86 @ShudiLi @lihongan 

Test Results:
```
% ./openshift-tests run-test "[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API controller resources are created and ensure OSSM related resources are created [Suite:openshift/conformance/parallel]"
openshift-tests v4.1.0-9173-g6aecfce
INFO[0000] Decoding provider                             clusterState="<nil>" discover=false dryRun=false func=DecodeProvider 
  I0401 17:03:24.321209 46951 client.go:423] Project "e2e-test-gatewayapi-controller-hsgbr" has been fully provisioned.
  I0401 17:03:24.384356 46951 gatewayapicontroller.go:46] Gateway Class  already exists, or has failed to be created, checking its status
  I0401 17:03:26.456565 46951 gatewayapicontroller.go:159] Gateway Class openshift-default is created and accpeted
  I0401 17:03:26.456670 46951 gatewayapicontroller.go:51] GatewayClass  successfully installed and accepted!
    STEP: Check OSSM subscription and CSV @ 04/01/25 17:03:26.458
  I0401 17:03:26.459280 46951 client.go:941] Running 'oc --namespace=e2e-test-gatewayapi-controller-hsgbr --kubeconfig=../../Downloads/kubeconfig (14) get -n openshift-operators subscription servicemeshoperator3 -o=jsonpath={.status.installedCSV}'
  I0401 17:03:28.278993 46951 gatewayapicontroller.go:62] The subscription is installed and the CSV is: servicemeshoperator3.v3.0.0
  I0401 17:03:28.279101 46951 client.go:941] Running 'oc --namespace=e2e-test-gatewayapi-controller-hsgbr --kubeconfig=../../Downloads/kubeconfig (14) get -n openshift-operators clusterserviceversion servicemeshoperator3.v3.0.0 -o=jsonpath={.status.phase}'
    STEP: check OSSM Pod and istiod pod is present with OSSM Operator installation @ 04/01/25 17:03:28.954
    STEP: Confirm that ISTIO CR is created and in healthy state @ 04/01/25 17:03:29.17
  I0401 17:03:30.171898 46951 client.go:941] Running 'oc --namespace=e2e-test-gatewayapi-controller-hsgbr --kubeconfig=../../Downloads/kubeconfig (14) get -n openshift-ingress istio openshift-gateway -o=jsonpath={.status.state}'
  I0401 17:03:30.519227 46951 gatewayapicontroller.go:86] Found Istio openshift-ingress/openshift-gateway, and it reports ready
  I0401 17:03:30.583599 46951 client.go:639] Deleted {user.openshift.io/v1, Resource=users  e2e-test-gatewayapi-controller-hsgbr-user}, err: <nil>
  I0401 17:03:30.645264 46951 client.go:639] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-gatewayapi-controller-hsgbr}, err: <nil>
  I0401 17:03:30.706605 46951 client.go:639] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~LguMEtAcU5MuJ0D8J32SlbqMz1Y91RC-YNVnnHy-12U}, err: <nil>
    STEP: Destroying namespace "e2e-test-gatewayapi-controller-hsgbr" for this suite. @ 04/01/25 17:03:30.707
  • [8.773 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 8.773 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
iamin@iamin-mac origin % ./openshift-tests run-test "[sig-network][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API controller resources are created and ensure custom gatewayclass can be accepted [Suite:openshift/conformance/parallel]"
openshift-tests v4.1.0-9173-g6aecfce

  I0401 17:04:22.632107 47379 client.go:423] Project "e2e-test-gatewayapi-controller-lgqgr" has been fully provisioned.
  I0401 17:04:22.684344 47379 gatewayapicontroller.go:46] Gateway Class  already exists, or has failed to be created, checking its status
  I0401 17:04:24.734002 47379 gatewayapicontroller.go:159] Gateway Class openshift-default is created and accpeted
  I0401 17:04:24.734130 47379 gatewayapicontroller.go:51] GatewayClass  successfully installed and accepted!
    STEP: Create Custom GatewayClass @ 04/01/25 17:04:24.738
  I0401 17:04:26.832647 47379 gatewayapicontroller.go:159] Gateway Class custom-gateway is created and accpeted
  I0401 17:04:26.832776 47379 gatewayapicontroller.go:109] GatewayClass custom-gateway successfully installed and accepted!
    STEP: Deleting Custom GatewayClass and confirming that it is no longer there @ 04/01/25 17:04:26.832
  I0401 17:04:26.918686 47379 gatewayapicontroller.go:117] The custom gatewayClass custom-gateway has been sucessfully deleted
    STEP: check if default gatewayClass is accepted and ISTIO CR and pod are still available @ 04/01/25 17:04:26.918
  I0401 17:04:28.972460 47379 gatewayapicontroller.go:159] Gateway Class openshift-default is created and accpeted
  I0401 17:04:29.075922 47379 client.go:941] Running 'oc --namespace=e2e-test-gatewayapi-controller-lgqgr --kubeconfig=../../Downloads/kubeconfig (14) get -n openshift-ingress istio openshift-gateway'
  I0401 17:04:29.623067 47379 client.go:639] Deleted {user.openshift.io/v1, Resource=users  e2e-test-gatewayapi-controller-lgqgr-user}, err: <nil>
  I0401 17:04:29.665672 47379 client.go:639] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-gatewayapi-controller-lgqgr}, err: <nil>
  I0401 17:04:29.716593 47379 client.go:639] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~NV6iR3nFZXP889Dhevf5opNKL_3z7PHbG0qxnRwNshs}, err: <nil>
    STEP: Destroying namespace "e2e-test-gatewayapi-controller-lgqgr" for this suite. @ 04/01/25 17:04:29.717
  • [9.293 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 9.293 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped`