### PR TITLE
OCPEDGE-1675: feat: update some tests to account for the arbiter node

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-target-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-target-deployment.yaml
@@ -48,6 +48,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-host-network-poller-deployment.yaml
@@ -63,6 +63,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-pod-network-poller-deployment.yaml
@@ -61,6 +61,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/host-network-to-service-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/host-network-to-service-poller-deployment.yaml
@@ -64,6 +64,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-target-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-target-deployment.yaml
@@ -55,6 +55,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-host-network-poller-deployment.yaml
@@ -62,6 +62,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-pod-network-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-pod-network-poller-deployment.yaml
@@ -60,6 +60,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-service-poller-deployment.yaml
+++ b/pkg/monitortests/network/disruptionpodnetwork/pod-network-to-service-poller-deployment.yaml
@@ -63,6 +63,10 @@ spec:
         - key: "node-role.kubernetes.io/edge"
           operator: "Exists"
           effect: "NoSchedule"
+        # Ensure pod can be scheduled on arbiter nodes
+        - key: "node-role.kubernetes.io/arbiter"
+          operator: "Exists"
+          effect: "NoSchedule"
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/test/extended/arbiter_topology/arbiter_topology.go
+++ b/test/extended/arbiter_topology/arbiter_topology.go
@@ -3,6 +3,7 @@ package arbiter_topology
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -97,7 +98,11 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] required pods on th
 				FieldSelector: "spec.nodeName=" + node.Name + ",status.phase=Running",
 			})
 			o.Expect(err).To(o.BeNil(), "Expected to retrieve pods without error")
-			podCount = len(pods.Items) + podCount
+			for _, pod := range pods.Items {
+				if !strings.HasPrefix(pod.Namespace, "openshift-e2e-") {
+					podCount += 1
+				}
+			}
 		}
 		o.Expect(podCount).To(o.Equal(defaultExpectedPodCount), "Expected the correct number of running pods on the Arbiter node")
 	})

--- a/test/extended/cpu_partitioning/utils.go
+++ b/test/extended/cpu_partitioning/utils.go
@@ -32,6 +32,7 @@ const (
 	namespaceMachineConfigOperator = "openshift-machine-config-operator"
 	nodeWorkerLabel                = "node-role.kubernetes.io/worker"
 	nodeMasterLabel                = "node-role.kubernetes.io/master"
+	nodeArbiterLabel               = "node-role.kubernetes.io/arbiter"
 
 	milliCPUToCPU = 1000
 	// 100000 microseconds is equivalent to 100ms


### PR DESCRIPTION
Resolves failures in CRI-O workload partitioning tests
Resolves failures in Pod-Poller tests