### PR TITLE
MCO-1631: Remove "[sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema"

### DIFF
--- a/test/extended/operators/check_crd_status.go
+++ b/test/extended/operators/check_crd_status.go
@@ -98,6 +98,7 @@ func checkStatusInSchema(crdItemList []apiextensionsv1.CustomResourceDefinition)
 		"imagecontentpolicies.config.openshift.io",
 		"imagecontentsourcepolicies.operator.openshift.io",
 		"machineconfigs.machineconfiguration.openshift.io",
+		"pinnedimagesets.machineconfiguration.openshift.io",
 		"netnamespaces.network.openshift.io",
 		"rangeallocations.security.internal.openshift.io",
 		"rolebindingrestrictions.authorization.openshift.io",

--- a/test/extended/operators/check_crd_status_test.go
+++ b/test/extended/operators/check_crd_status_test.go
@@ -27,23 +27,6 @@ func Test_checkSubresourceStatus(t *testing.T) {
 	})
 }
 
-func Test_checkStatusInSchema(t *testing.T) {
-
-	crdClient := setupLocalAPIClientset()
-	t.Run("Test_checkStatusInSchema test", func(t *testing.T) {
-		crdList, err := getCRDItemList(*crdClient)
-		if err != nil {
-			t.Errorf("Fail: %s", err)
-		}
-		failures := checkStatusInSchema(crdList)
-		if len(failures) > 0 {
-			t.Error("There should be no failures")
-			for _, i := range failures {
-				fmt.Println(i)
-			}
-		}
-	})
-}
 func setupLocalAPIClientset() *apiextensionsclientset.Clientset {
 	// Get the kubeconfig by creating an Openshift cluster with cluster-bot, downloading it,
 	// and using the filename for KUBECONFIG.

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -245,8 +245,6 @@ var Annotations = map[string]string{
 
 	"[sig-arch][Early] APIs for openshift.io must have stable versions": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-arch][Early] CRDs for openshift.io should have subresource.status": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-arch][Early] Managed cluster should [apigroup:config.openshift.io] start all core operators": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
"[sig-arch][Early] CRDs for openshift.io should have a status in the CRD schema" is no longer relevant.

We only want to be checking for:
If a CRD has a "status" field in the schema but no subresource.status defined. (which causes several problems). Its covered by an existing test "[sig-arch][Early] CRDs for openshift.io should have subresource.status". Hence leaving no need for the prior test to exist.


This work blocks https://github.com/openshift/api/pull/2257, which is necessary to ship PIS as a feature for 4.19