### PR TITLE
OCPBUGS-54700: aws/edge: prevent test using unschedulable nodes

### DIFF
--- a/test/extended/networking/tap.go
+++ b/test/extended/networking/tap.go
@@ -35,7 +35,15 @@ var _ = g.Describe("[sig-network][Feature:tap]", func() {
 		if len(workerNodes.Items) == 0 {
 			e2e.Failf("cluster should have nodes")
 		}
-		worker = &workerNodes.Items[0]
+		// Preventing to select worker nodes in variants which applies NoSchedule taints
+		// to some worker nodes, preventing this test to fail to schedule.
+		for idx, wk := range workerNodes.Items {
+			if len(wk.Spec.Taints) == 0 {
+				worker = &workerNodes.Items[idx]
+				break
+			}
+		}
+		o.Expect(worker).NotTo(o.BeNil())
 
 		// Load tun module.
 		_, err = exutil.ExecCommandOnMachineConfigDaemon(f.ClientSet, oc, worker, []string{


### PR DESCRIPTION
This change prevents the test `"[sig-network][Feature:tap] should create a pod with a tap interface"`  to fail when selecting a worker node that have taints applied to it. This is impacting some variants such as aws/edge (or similar setup) nodes when the first node in the worker list is the edge node, which have `NoSchedule` taints.

This is a permanent failure in CI in edge zones. This is an an example of failed job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.15-e2e-aws-ovn-shared-vpc-edge-zones/1908671470251282432

~~~
                    lastTransitionTime: "2025-04-06T02:03:23Z"
                    message: '0/8 nodes are available: 2 node(s) had untolerated taint {node-role.kubernetes.io/edge:
                      }, 3 node(s) didn''t match Pod''s node affinity/selector, 3 node(s) had untolerated
                      taint {node-role.kubernetes.io/master: }. preemption: 0/8 nodes are available:
                      8 Preemption is not helpful for scheduling..'
~~~