### PR TITLE
OCPBUGS-22413: Add myql-80 to fix known image check test for OKD

### DIFF
--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -102,6 +102,10 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 		// TODO: will not work for a disconnected test environment and should be emulated by launching
 		//   an authenticated registry in a pod on cluster
 		"registry.redhat.io/ubi8/nodejs-14:latest",
+
+		// used by builds tests.
+		// For OKD, samples imports mysql from quay.io. including this prevents the test from failing
+		"registry.redhat.io/rhel8/mysql-80:latest",
 	)
 	if len(fromRepository) > 0 {
 		allowedPrefixes.Insert(fromRepository)


### PR DESCRIPTION
This issue was peviously reported and even fixed through https://github.com/openshift/origin/pull/28357, but it was reverted by https://github.com/openshift/origin/pull/28367. Instead of changing the images, add this image to the allowed list so the test doesn't flake