### PR TITLE
OCPBUGS-54771: Component Readiness: [Networking / ovn-kubernetes] [EgressFirewall] test regressed

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -72,7 +72,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 			_, err = noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 			expectNoError(err)
 		}
-		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.openshift.com").Output()
+		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
 		expectNoError(err)
 
 		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "http://www.google.com:80").Output()
@@ -122,10 +122,10 @@ func sendEgressFwTraffic(f *e2e.Framework, oc *exutil.CLI, pod string, nodeSelec
 		_, err = oc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 		expectError(err)
 	}
-	// Test curl to docs.openshift.com should pass
-	// because we have allow dns rule for docs.openshift.com
+	// Test curl to docs.redhat.com should pass
+	// because we have allow dns rule for docs.redhat.com
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.openshift.com").Output()
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
 	expectNoError(err)
 
 	// Test curl to www.google.com:80 should fail

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -72,7 +72,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 			_, err = noegFwoc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 			expectNoError(err)
 		}
-		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
+		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://redhat.com").Output()
 		expectNoError(err)
 
 		_, err = noegFwoc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "http://www.google.com:80").Output()
@@ -122,10 +122,10 @@ func sendEgressFwTraffic(f *e2e.Framework, oc *exutil.CLI, pod string, nodeSelec
 		_, err = oc.Run("exec").Args(pod, "--", "ping", "-c", "1", "1.1.1.1").Output()
 		expectError(err)
 	}
-	// Test curl to docs.redhat.com should pass
-	// because we have allow dns rule for docs.redhat.com
+	// Test curl to redhat.com should pass
+	// because we have allow dns rule for redhat.com
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://docs.redhat.com").Output()
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://redhat.com").Output()
 	expectNoError(err)
 
 	// Test curl to www.google.com:80 should fail

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -39600,7 +39600,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.openshift.com
+      dnsName: docs.redhat.com
   - type: Deny
     to:
       dnsName: www.google.com
@@ -39643,7 +39643,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.openshift.com
+      dnsName: docs.redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -39600,7 +39600,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Deny
     to:
       dnsName: www.google.com
@@ -39643,7 +39643,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Deny
     to:
       dnsName: www.google.com

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.openshift.com
+      dnsName: docs.redhat.com
   - type: Deny
     to:
       dnsName: www.google.com

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.redhat.com
+      dnsName: redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -6,7 +6,7 @@ spec:
   egress:
   - type: Allow
     to:
-      dnsName: docs.openshift.com
+      dnsName: docs.redhat.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32


### PR DESCRIPTION
Fix egress firewall tests by updating the URL from docs.redhat.com to redhat.com