### PR TITLE
OCPBUGS-54906: Change the test image to registry.k8s.io/e2e-test-images/agnhost

### DIFF
--- a/test/extended/router/external_certificate.go
+++ b/test/extended/router/external_certificate.go
@@ -37,7 +37,8 @@ const (
 	// secretReaderRoleBinding is the name of the RoleBinding associating the Role with the router service account.
 	secretReaderRoleBinding = "secret-reader-role-binding"
 	// helloOpenShiftResponse is the HTTP response from hello-openshift example pod.
-	helloOpenShiftResponse = "Hello OpenShift"
+	// https://github.com/kubernetes/kubernetes/blob/88dfcb225d41326113990e87b11137641c121a32/test/images/agnhost/netexec/netexec.go#L266-L269
+	helloOpenShiftResponse = "NOW:"
 	// defaultCertificateCN is the CommonName of router default certificate.
 	defaultCertificateCN = "ingress-operator"
 )
@@ -46,7 +47,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 	defer g.GinkgoRecover()
 	var (
 		oc            = exutil.NewCLIWithPodSecurityLevel("router-external-certificate", admissionapi.LevelBaseline)
-		helloPodPath  = exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
+		helloPodPath  = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "hello-openshift", "hello-pod.json")
 		helloPodName  = "hello-openshift"
 		helloPodSvc   = "hello-openshift"
 		defaultDomain string


### PR DESCRIPTION
The e2e tests are failing on AWS ARM64 platform.

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-aws-ovn-techpreview-multi-a-a/1909765152207540224

```
Failed to get endpoints for e2e-test-router-external-certificate-z6z2b/hello-openshift 
```

The failure is because `openshift/hello-openshift` is not a multi-arch image.

 
The [pod log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.19-ocp-e2e-aws-ovn-techpreview-multi-a-a/1909765152207540224/artifacts/ocp-e2e-aws-ovn-techpreview-multi-a-a/openshift-e2e-test/artifacts/junit/e2e-test-router-external-certificate-5cst4/hello-openshift/hello-openshift/logs.txt) said

```
exec container process `/hello-openshift`: Exec format error
```
 
We need to switch to a test image that supports Multi-arch. `registry.k8s.io/e2e-test-images/agnhost` is one such image widely used.

