### PR TITLE
MCO-1634: Improve MCN test stability

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -515,6 +515,7 @@ func WaitForMCPToBeReady(oc *exutil.CLI, machineConfigClient *machineconfigclien
 		}
 		// Check if the pool is in an updated state with the correct number of ready machines
 		if IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) && mcp.Status.UpdatedMachineCount == readyMachineCount {
+			framework.Logf("MCP '%v' is 'Updated' with %v ready machines.", poolName, mcp.Status.UpdatedMachineCount)
 			return true
 		}
 		framework.Logf("MCP '%v' has %v ready machines. Waiting for the desired ready machine count of %v.", poolName, mcp.Status.UpdatedMachineCount, readyMachineCount)

--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -41,6 +41,9 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	)
 
 	g.It("[Serial]Should have MCN properties matching associated node properties [apigroup:machineconfiguration.openshift.io]", func() {
+		// Skip test when there are errors connecting to the cluster
+		SkipOnConnectionError(oc)
+
 		if IsSingleNode(oc) { //handle SNO clusters
 			ValidateMCNPropertiesSNO(oc, infraMCPFixture)
 		} else { //handle standard, non-SNO, clusters
@@ -49,6 +52,9 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	})
 
 	g.It("[Serial]Should properly transition through MCN conditions on node update [apigroup:machineconfiguration.openshift.io]", func() {
+		// Skip test when there are errors connecting to the cluster
+		SkipOnConnectionError(oc)
+
 		if IsSingleNode(oc) {
 			ValidateMCNConditionTransitionsSNO(oc, masterMCFixture)
 		} else {
@@ -57,6 +63,9 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	})
 
 	g.It("[Serial][Slow]Should properly report MCN conditions on node degrade [apigroup:machineconfiguration.openshift.io]", func() {
+		// Skip test when there are errors connecting to the cluster
+		SkipOnConnectionError(oc)
+
 		if IsSingleNode(oc) { //handle SNO clusters
 			ValidateMCNConditionOnNodeDegrade(oc, invalidMasterMCFixture, true)
 		} else { //handle standard, non-SNO, clusters


### PR DESCRIPTION
This skips the MCN tests that run on SNO on connection errors. This should decrease the failures we see in SNO that are due to issues connecting to the cluster.