### PR TITLE
 MCO-1615: Mco node degraded mcn condition

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -590,17 +590,28 @@ func CheckMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1
 	return conditionStatus == status
 }
 
-// `getMCNConditionStatus` returns the status of the desired condition type for MCN, or an empty string if the condition does not exist
-func getMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress) metav1.ConditionStatus {
+// `GetMCNCondition` returns the queried condition or nil if the condition does not exist
+func GetMCNCondition(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress) *metav1.Condition {
 	// Loop through conditions and return the status of the desired condition type
 	conditions := mcn.Status.Conditions
 	for _, condition := range conditions {
 		if condition.Type == string(conditionType) {
-			framework.Logf("MCN '%s' %s condition status is %s", mcn.Name, conditionType, condition.Status)
-			return condition.Status
+			return &condition
 		}
 	}
-	return ""
+	return nil
+}
+
+// `getMCNConditionStatus` returns the status of the desired condition type for MCN, or an empty string if the condition does not exist
+func getMCNConditionStatus(mcn *mcfgv1.MachineConfigNode, conditionType mcfgv1.StateProgress) metav1.ConditionStatus {
+	// Loop through conditions and return the status of the desired condition type
+	condition := GetMCNCondition(mcn, conditionType)
+	if condition == nil {
+		return ""
+	}
+
+	framework.Logf("MCN '%s' %s condition status is %s", mcn.Name, conditionType, condition.Status)
+	return condition.Status
 }
 
 // `ConfirmUpdatedMCNStatus` confirms that an MCN is in a fully updated state, which requires:

--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -436,6 +436,7 @@ func ValidateMCNConditionOnNodeDegrade(oc *exutil.CLI, fixture string, isSno boo
 		mcName = "91-master-testfile-invalid"
 	}
 
+	var degradedNodeMCN *mcfgv1.MachineConfigNode
 	// Cleanup MC and fix node degradation on failure or test completion
 	defer func() {
 		// Delete the applied MC
@@ -445,6 +446,13 @@ func ValidateMCNConditionOnNodeDegrade(oc *exutil.CLI, fixture string, isSno boo
 		// Recover the degraded MCP
 		recoverErr := RecoverFromDegraded(oc, poolName)
 		o.Expect(recoverErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Could not recover MCP '%v' from degraded state.", poolName))
+
+		// If the test reached checking the MCN ensure the NodeDegraded condition is properly restored
+		if degradedNodeMCN != nil {
+			conditionMet, err := WaitForMCNConditionStatus(clientSet, degradedNodeMCN.Name, mcfgv1.MachineConfigNodeNodeDegraded, metav1.ConditionFalse, 30*time.Second, 1*time.Second)
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for NodeDegraded=False: %v", err))
+			o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect NodeDegraded=False.")
+		}
 	}()
 
 	// Apply invalid MC
@@ -463,11 +471,16 @@ func ValidateMCNConditionOnNodeDegrade(oc *exutil.CLI, fixture string, isSno boo
 	o.Expect(degradedNodeErr).NotTo(o.HaveOccurred(), "Could not get degraded node.")
 
 	// Validate MCN of degraded node
-	degradedNodeMCN, degradedErr := clientSet.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), degradedNode.Name, metav1.GetOptions{})
+	degradedNodeMCN, degradedErr = clientSet.MachineconfigurationV1().MachineConfigNodes().Get(context.TODO(), degradedNode.Name, metav1.GetOptions{})
 	o.Expect(degradedErr).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting MCN of degraded node '%v'.", degradedNode.Name))
 	framework.Logf("Validating that `AppliedFilesAndOS` and `UpdateExecuted` conditions in '%v' MCN have a status of 'Unknown'.", degradedNodeMCN.Name)
 	o.Expect(CheckMCNConditionStatus(degradedNodeMCN, mcfgv1.MachineConfigNodeUpdateFilesAndOS, metav1.ConditionUnknown)).Should(o.BeTrue(), "Condition 'AppliedFilesAndOS' does not have the expected status of 'Unknown'.")
 	o.Expect(CheckMCNConditionStatus(degradedNodeMCN, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionUnknown)).Should(o.BeTrue(), "Condition 'UpdateExecuted' does not have the expected status of 'Unknown'.")
+	nodeDegradedCondition := GetMCNCondition(degradedNodeMCN, mcfgv1.MachineConfigNodeNodeDegraded)
+	o.Expect(nodeDegradedCondition).NotTo(o.BeNil())
+	o.Expect(nodeDegradedCondition.Status).Should(o.Equal(metav1.ConditionTrue), "Condition 'NodeDegraded' does not have the expected status of 'True'.")
+	o.Expect(nodeDegradedCondition.Message).Should(o.ContainSubstring(fmt.Sprintf("Node %s upgrade failure.", degradedNodeMCN.Name)), "Condition 'NodeDegraded' does not have the expected message.")
+	o.Expect(nodeDegradedCondition.Message).Should(o.ContainSubstring("/home/core: file exists"), "Condition 'NodeDegraded' does not have the expected message details.")
 }
 
 // `ValidateMCNProperties` checks that MCNs with correct properties are created on node creation


### PR DESCRIPTION
The MCN API has a condition to signal a failure durint the update of a MachineConfigNode. The condition was already in the API but the MCO was not handling it.
With the MCO now handling the condition our testing now needs to check it is properly set/unset when needed.