### PR TITLE
feat: update tests to account for arbiter node

### DIFF
--- a/test/extended/arbiter_topology/arbiter_topology.go
+++ b/test/extended/arbiter_topology/arbiter_topology.go
@@ -13,9 +13,11 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 	appv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	kapierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -24,9 +26,9 @@ const (
 )
 
 var (
-	defaultExpectedPodCount      = 17
-	expectedPodCountsPerPlatform = map[v1.PlatformType]int{
-		v1.BareMetalPlatformType: 17,
+	defaultExpectedMaxPodCount      = 30
+	expectedMaxPodCountsPerPlatform = map[v1.PlatformType]int{
+		v1.BareMetalPlatformType: 30,
 		// Add more platforms as needed
 	}
 )
@@ -82,8 +84,8 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] required pods on th
 		g.By("inferring platform type")
 
 		// Default to baremetal count of 17 expected Pods, if platform type does not exist in map
-		if expectedCount, exists := expectedPodCountsPerPlatform[infraStatus.PlatformStatus.Type]; exists {
-			defaultExpectedPodCount = expectedCount
+		if expectedCount, exists := expectedMaxPodCountsPerPlatform[infraStatus.PlatformStatus.Type]; exists {
+			defaultExpectedMaxPodCount = expectedCount
 		}
 		g.By("Retrieving the Arbiter node name")
 		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
@@ -104,7 +106,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] required pods on th
 				}
 			}
 		}
-		o.Expect(podCount).To(o.Equal(defaultExpectedPodCount), "Expected the correct number of running pods on the Arbiter node")
+		o.Expect(podCount).To(o.BeNumerically("<=", defaultExpectedMaxPodCount), "Expected the max number of running pods on the Arbiter node")
 	})
 })
 
@@ -159,8 +161,9 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io] Deployments on Highly
 	})
 
 	g.It("should be created on master nodes when no node selected", func() {
+		ctx := context.Background()
 		g.By("Retrieving Master nodes")
-		masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
 			LabelSelector: labelNodeRoleMaster,
 		})
 		o.Expect(err).To(o.BeNil(), "Expected to retrieve Master nodes without error")
@@ -184,7 +187,14 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io] Deployments on Highly
 		o.Expect(err).To(o.BeNil(), "Expected Normal pods to be running on Master nodes")
 		o.Expect(len(normalPods)).To(o.Equal(1), "Expected exactly one Normal pod to be running on a Master node")
 
-		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), normalPods[0], metav1.GetOptions{})
+		var pod *corev1.Pod
+		err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 300*time.Second, true, func(ctx context.Context) (done bool, err error) {
+			pod, err = oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(ctx, normalPods[0], metav1.GetOptions{})
+			if kapierror.IsTimeout(err) {
+				return false, err
+			}
+			return true, nil
+		})
 		o.Expect(err).To(o.BeNil(), "Expected to retrieve Normal pod without error")
 
 		_, exists := masterNodeMap[pod.Spec.NodeName]
@@ -223,8 +233,17 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io] Evaluate DaemonSet pl
 		o.Expect(len(daemonSetPods)).To(o.Equal(1), "Expected exactly one DaemonSet pod to be running")
 
 		g.By("Validating that DaemonSet pods are NOT scheduled on the Arbiter node")
+
+		ctx := context.TODO()
 		for _, podName := range daemonSetPods {
-			pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), podName, metav1.GetOptions{})
+			var pod *corev1.Pod
+			err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 300*time.Second, true, func(ctx context.Context) (done bool, err error) {
+				pod, err = oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), podName, metav1.GetOptions{})
+				if kapierror.IsTimeout(err) {
+					return false, err
+				}
+				return true, nil
+			})
 			o.Expect(err).To(o.BeNil(), "Expected to retrieve DaemonSet pod without error")
 
 			o.Expect(pod.Spec.NodeName).NotTo(o.Equal(arbiterNodeName),

--- a/test/extended/etcd/invariants.go
+++ b/test/extended/etcd/invariants.go
@@ -25,26 +25,36 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]", func() {
 		exutil.SkipIfExternalControlplaneTopology(oc, "clusters with external controlplane topology don't have master nodes")
 		masterNodeLabelSelectorString := "node-role.kubernetes.io/master"
-		masterNodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: masterNodeLabelSelectorString})
+		controlPlaneNodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: masterNodeLabelSelectorString})
 		o.Expect(err).ToNot(o.HaveOccurred())
 
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		if *controlPlaneTopology == configv1.HighlyAvailableArbiterMode {
+			arbiterNodeLabelSelectorString := "node-role.kubernetes.io/arbiter"
+			arbiterNodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: arbiterNodeLabelSelectorString})
+			o.Expect(err).ToNot(o.HaveOccurred())
+			controlPlaneNodeList.Items = append(controlPlaneNodeList.Items, arbiterNodeList.Items...)
+		}
+
 		ipFamily := getCurrentNetworkTopology(oc)
-		currentMasterNodesIPListSet := sets.NewString()
-		for _, masterNode := range masterNodeList.Items {
-			for _, masterNodeAddress := range masterNode.Status.Addresses {
-				if masterNodeAddress.Type == corev1.NodeInternalIP {
+		currentControlPlaneNodesIPListSet := sets.NewString()
+		for _, controlPlaneNode := range controlPlaneNodeList.Items {
+			for _, nodeAddress := range controlPlaneNode.Status.Addresses {
+				if nodeAddress.Type == corev1.NodeInternalIP {
 					switch ipFamily {
 					case "tcp4":
-						isIPv4, err := isIPv4(masterNodeAddress.Address)
+						isIPv4, err := isIPv4(nodeAddress.Address)
 						o.Expect(err).ToNot(o.HaveOccurred())
 						if isIPv4 {
-							currentMasterNodesIPListSet.Insert(masterNodeAddress.Address)
+							currentControlPlaneNodesIPListSet.Insert(nodeAddress.Address)
 						}
 					case "tcp6":
-						isIPv4, err := isIPv4(masterNodeAddress.Address)
+						isIPv4, err := isIPv4(nodeAddress.Address)
 						o.Expect(err).ToNot(o.HaveOccurred())
 						if !isIPv4 {
-							currentMasterNodesIPListSet.Insert(masterNodeAddress.Address)
+							currentControlPlaneNodesIPListSet.Insert(nodeAddress.Address)
 						}
 					default:
 						g.GinkgoT().Fatalf("unexpected ip family: %q", ipFamily)
@@ -60,16 +70,16 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 			currentVotingMemberIPListSet.Insert(votingMemberIP)
 		}
 
-		if currentVotingMemberIPListSet.Len() != currentMasterNodesIPListSet.Len() {
+		if currentVotingMemberIPListSet.Len() != currentControlPlaneNodesIPListSet.Len() {
 			g.GinkgoT().Fatalf(
 				"incorrect number of voting members found in openshift-etcd/etcd-endpoints, expected it to match the number of master nodes = %d, members from the cm = %v, master nodes = %v",
-				currentMasterNodesIPListSet.Len(),
+				currentControlPlaneNodesIPListSet.Len(),
 				currentVotingMemberIPListSet.List(),
-				currentMasterNodesIPListSet.List())
+				currentControlPlaneNodesIPListSet.List())
 		}
 
-		if !currentVotingMemberIPListSet.Equal(currentMasterNodesIPListSet) {
-			g.GinkgoT().Fatalf("IPs of voting members from openshift-etcd/etcd-endpoints =%v don't match master nodes IPs = %v ", currentVotingMemberIPListSet.List(), currentMasterNodesIPListSet.List())
+		if !currentVotingMemberIPListSet.Equal(currentControlPlaneNodesIPListSet) {
+			g.GinkgoT().Fatalf("IPs of voting members from openshift-etcd/etcd-endpoints =%v don't match master nodes IPs = %v ", currentVotingMemberIPListSet.List(), currentControlPlaneNodesIPListSet.List())
 		}
 	})
 })


### PR DESCRIPTION
added poller for oc checks for resources
added upper bound pod count for arbiter for the time being, exact number match is not useful during tests updatd etcd member count to reflect arbiter as part of the control plane count