### PR TITLE
TRT-2086: Support sharding tests across multiple invocations of openshift-tests

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -356,12 +356,16 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	early, notEarly := splitTests(tests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Early]")
 	})
+	logrus.Infof("Found %d early tests", len(early))
 
 	late, primaryTests := splitTests(notEarly, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Late]")
 	})
+	logrus.Infof("Found %d late tests", len(late))
 
-	// Sharding always runs early and late tests in every invocation. TODO: does that make sense?
+	// Sharding always runs early and late tests in every invocation. I think this
+	// makes sense, because these tests may collect invariant data we want to know about
+	// every run.
 	primaryTests, err = sharder.Shard(primaryTests, o.ShardCount, o.ShardID)
 	if err != nil {
 		return err
@@ -378,6 +382,11 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	mustGatherTests, openshiftTests := splitTests(openshiftTests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[sig-cli] oc adm must-gather")
 	})
+
+	logrus.Infof("Found %d openshift tests", len(openshiftTests))
+	logrus.Infof("Found %d kube tests", len(kubeTests))
+	logrus.Infof("Found %d storage tests", len(storageTests))
+	logrus.Infof("Found %d must-gather tests", len(mustGatherTests))
 
 	// If user specifies a count, duplicate the kube and openshift tests that many times.
 	expectedTestCount := len(early) + len(late)

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -19,6 +19,15 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"golang.org/x/mod/semver"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
 	"github.com/openshift/origin/pkg/clioptions/clusterdiscovery"
 	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
 	"github.com/openshift/origin/pkg/defaultmonitortests"
@@ -28,14 +37,6 @@ import (
 	"github.com/openshift/origin/pkg/riskanalysis"
 	"github.com/openshift/origin/pkg/test/extensions"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/pflag"
-	"golang.org/x/mod/semver"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
-	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -55,6 +56,16 @@ type GinkgoRunSuiteOptions struct {
 	FailFast    bool
 	Timeout     time.Duration
 	JUnitDir    string
+
+	// ShardCount is the total number of partitions the test suite is divided into.
+	// Each executor runs one of these partitions.
+	ShardCount int
+
+	// ShardStrategy is which strategy we'll use for dividing tests.
+	ShardStrategy string
+
+	// ShardID is the 1-based index of the shard this instance is responsible for running.
+	ShardID int
 
 	// SyntheticEventTests allows the caller to translate events or outside
 	// context into a failure.
@@ -78,7 +89,8 @@ type GinkgoRunSuiteOptions struct {
 
 func NewGinkgoRunSuiteOptions(streams genericclioptions.IOStreams) *GinkgoRunSuiteOptions {
 	return &GinkgoRunSuiteOptions{
-		IOStreams: streams,
+		IOStreams:     streams,
+		ShardStrategy: "hash",
 	}
 }
 
@@ -98,6 +110,10 @@ func (o *GinkgoRunSuiteOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&o.ExactMonitorTests, "monitor", o.ExactMonitorTests,
 		fmt.Sprintf("list of exactly which monitors to enable. All others will be disabled.  Current monitors are: [%s]", strings.Join(monitorNames, ", ")))
 	flags.StringSliceVar(&o.DisableMonitorTests, "disable-monitor", o.DisableMonitorTests, "list of monitors to disable.  Defaults for others will be honored.")
+
+	flags.IntVar(&o.ShardID, "shard-id", o.ShardID, "When tests are sharded across instances, which instance we are")
+	flags.IntVar(&o.ShardCount, "shard-count", o.ShardCount, "Number of shards used to run tests across multiple instances")
+	flags.StringVar(&o.ShardStrategy, "shard-strategy", o.ShardStrategy, "Which strategy to use for sharding (hash)")
 }
 
 func (o *GinkgoRunSuiteOptions) Validate() error {
@@ -134,6 +150,12 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	tests, err := testsForSuite()
 	if err != nil {
 		return fmt.Errorf("failed reading origin test suites: %w", err)
+	}
+
+	var sharder Sharder
+	switch o.ShardStrategy {
+	default:
+		sharder = &HashSharder{}
 	}
 
 	logrus.WithField("suite", suite.Name).Infof("Found %d internal tests in openshift-tests binary", len(tests))
@@ -338,6 +360,12 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 	late, primaryTests := splitTests(notEarly, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Late]")
 	})
+
+	// Sharding always runs early and late tests in every invocation. TODO: does that make sense?
+	primaryTests, err = sharder.Shard(primaryTests, o.ShardCount, o.ShardID)
+	if err != nil {
+		return err
+	}
 
 	kubeTests, openshiftTests := splitTests(primaryTests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[Suite:k8s]")

--- a/pkg/test/ginkgo/sharder.go
+++ b/pkg/test/ginkgo/sharder.go
@@ -1,0 +1,45 @@
+package ginkgo
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Sharder interface {
+	// Shard selects tests for the given executor and total shards.
+	// The returned slice must be deterministic and non-overlapping across shards.
+	Shard(allTests []*testCase, shardCount, shardID int) ([]*testCase, error)
+
+	// Name returns the name of the strategy (e.g. "hash", "time-balanced").
+	Name() string
+}
+
+type HashSharder struct{}
+
+func (h *HashSharder) Shard(allTests []*testCase, shardCount, shardID int) ([]*testCase, error) {
+	var selected []*testCase
+
+	if shardID > shardCount {
+		return nil, fmt.Errorf("shard %d is greater than %d", shardID, shardCount)
+	}
+
+	if shardID == 0 || shardCount == 0 {
+		logrus.Warningf("Sharding disabled, returning all tests")
+		return allTests, nil
+	}
+
+	for _, test := range allTests {
+		sum := sha256.Sum256([]byte(test.name))
+		val := binary.BigEndian.Uint32(sum[:4])
+		shard := (int(val) % shardCount) + 1
+		if shard == shardID {
+			selected = append(selected, test)
+		}
+	}
+	return selected, nil
+}
+
+func (h *HashSharder) Name() string { return "hash" }

--- a/pkg/test/ginkgo/sharder.go
+++ b/pkg/test/ginkgo/sharder.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -22,6 +23,14 @@ type HashSharder struct{}
 func (h *HashSharder) Shard(allTests []*testCase, shardCount, shardID int) ([]*testCase, error) {
 	var selected []*testCase
 
+	start := time.Now()
+
+	log := logrus.WithField("sharder", h.Name()).
+		WithField("shardCount", shardCount).
+		WithField("shardID", shardID)
+
+	log.Infof("Determining sharding of %d tests", len(allTests))
+
 	if shardID > shardCount {
 		return nil, fmt.Errorf("shard %d is greater than %d", shardID, shardCount)
 	}
@@ -39,6 +48,9 @@ func (h *HashSharder) Shard(allTests []*testCase, shardCount, shardID int) ([]*t
 			selected = append(selected, test)
 		}
 	}
+
+	log.Infof("Completed sharding in %+v, this instance will run %d tests", time.Since(start), len(selected))
+
 	return selected, nil
 }
 

--- a/pkg/test/ginkgo/sharder_test.go
+++ b/pkg/test/ginkgo/sharder_test.go
@@ -1,0 +1,144 @@
+package ginkgo
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+func TestHashSharder_DeterministicSharding(t *testing.T) {
+	sharder := &HashSharder{}
+	shardCount := 10
+	shardID := 3
+
+	// Generate 1000 unique test cases
+	var allTests []*testCase
+	for i := 0; i < 1000; i++ {
+		allTests = append(allTests, &testCase{name: fmt.Sprintf("test-%d", i)})
+	}
+
+	// Shard multiple times and ensure determinism
+	shardedOnce, err := sharder.Shard(allTests, shardCount, shardID)
+	if err != nil {
+		t.Fatalf("shard failed: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		shardedAgain, err := sharder.Shard(allTests, shardCount, shardID)
+		if err != nil {
+			t.Fatalf("shard repeat %d failed: %v", i, err)
+		}
+
+		if len(shardedOnce) != len(shardedAgain) {
+			t.Errorf("iteration %d: expected %d tests, got %d", i, len(shardedOnce), len(shardedAgain))
+		}
+
+		for j := range shardedOnce {
+			if shardedOnce[j].name != shardedAgain[j].name {
+				t.Errorf("iteration %d, test %d: expected %s, got %s", i, j, shardedOnce[j].name, shardedAgain[j].name)
+			}
+		}
+	}
+}
+
+func TestHashSharder_BalancedSharding(t *testing.T) {
+	sharder := &HashSharder{}
+	totalShards := 10
+	numTests := 12345
+	allowedDeviation := 0.10 // 10%
+
+	var allTests []*testCase
+	for i := 0; i < numTests; i++ {
+		allTests = append(allTests, &testCase{name: fmt.Sprintf("test-%d", i)})
+	}
+
+	shardCounts := make([]int, totalShards)
+
+	for shardID := 1; shardID <= totalShards; shardID++ {
+		sharded, err := sharder.Shard(allTests, totalShards, shardID)
+		if err != nil {
+			t.Fatalf("sharding failed for shardID %d: %v", shardID, err)
+		}
+		shardCounts[shardID-1] = len(sharded)
+	}
+
+	expected := float64(numTests) / float64(totalShards)
+	for i, count := range shardCounts {
+		diff := math.Abs(float64(count) - expected)
+		if diff/expected > allowedDeviation {
+			t.Errorf("Shard %d has %d tests (expected ~%.0f, deviation %.2f%%)", i+1, count, expected, (diff/expected)*100)
+		} else {
+			t.Logf("Shard %d has %d tests", i+1, count)
+		}
+	}
+}
+
+func TestHashSharder_DisabledSharding(t *testing.T) {
+	sharder := &HashSharder{}
+	tests := []*testCase{{name: "test-a"}, {name: "test-b"}}
+
+	sharded, err := sharder.Shard(tests, 0, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sharded) != len(tests) {
+		t.Errorf("expected all tests returned when sharding is disabled")
+	}
+}
+
+func TestHashSharder_InvalidShardID(t *testing.T) {
+	sharder := &HashSharder{}
+	tests := []*testCase{{name: "test-a"}}
+
+	_, err := sharder.Shard(tests, 10, 11)
+	if err == nil {
+		t.Errorf("expected error for invalid shard id")
+	}
+}
+
+func TestHashSharder_EmptyInput(t *testing.T) {
+	sharder := &HashSharder{}
+	var empty []*testCase
+
+	sharded, err := sharder.Shard(empty, 5, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(sharded) != 0 {
+		t.Errorf("expected 0 tests, got %d", len(sharded))
+	}
+}
+
+func TestHashSharder_MoreShardsThanTests(t *testing.T) {
+	sharder := &HashSharder{}
+	totalShards := 20
+	numTests := 10
+
+	var allTests []*testCase
+	for i := 0; i < numTests; i++ {
+		allTests = append(allTests, &testCase{name: fmt.Sprintf("test-%d", i)})
+	}
+
+	seenTests := make(map[string]bool)
+	totalAssigned := 0
+
+	for executor := 1; executor <= totalShards; executor++ {
+		sharded, err := sharder.Shard(allTests, totalShards, executor)
+		if err != nil {
+			t.Fatalf("sharding failed: %v", err)
+		}
+
+		for _, test := range sharded {
+			if seenTests[test.name] {
+				t.Errorf("test %s assigned to multiple shards", test.name)
+			}
+			seenTests[test.name] = true
+		}
+
+		totalAssigned += len(sharded)
+	}
+
+	if totalAssigned != numTests {
+		t.Errorf("total assigned tests = %d; expected %d", totalAssigned, numTests)
+	}
+}


### PR DESCRIPTION
Design doc https://docs.google.com/document/d/14uXl_JF-n7WvJj7xQOmn7wRm71LM7Fbuw-2QnP_-bTs/edit?tab=t.0

Parallelizes test execution by distributing tests across multiple CI jobs. 

Results:
- 2h25m https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29696/pull-ci-openshift-origin-main-e2e-aws-ovn-serial-shard-1/1914824055555362816
- 2h30m https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29696/pull-ci-openshift-origin-main-e2e-aws-ovn-serial-shard-2/1914852911179894784