### PR TITLE
OCPBUGS-55211: use regular user to create httproute

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -76,6 +76,7 @@ import (
 	userv1client "github.com/openshift/client-go/user/clientset/versioned"
 	"github.com/openshift/library-go/test/library/metrics"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	gatewayapiv1client "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 )
 
 // CLI provides function to call the OpenShift CLI and Kubernetes and OpenShift
@@ -674,6 +675,11 @@ func (c *CLI) BuildClient() buildv1client.Interface {
 	return buildv1client.NewForConfigOrDie(c.UserConfig())
 }
 
+// GatewayApiClient provides a GatewayAPI client for the current namespace user.
+func (c *CLI) GatewayApiClient() gatewayapiv1client.Interface {
+	return gatewayapiv1client.NewForConfigOrDie(c.UserConfig())
+}
+
 func (c *CLI) ImageClient() imagev1client.Interface {
 	return imagev1client.NewForConfigOrDie(c.UserConfig())
 }
@@ -715,6 +721,11 @@ func (c *CLI) AdminConfigClient() configv1client.Interface {
 		configv1client.NewForConfigOrDie(c.AdminConfig()),
 		c.configObjects,
 	)
+}
+
+// AdminGatewayApiClient provides a GatewayAPI client for the cluster admin user.
+func (c *CLI) AdminGatewayApiClient() gatewayapiv1client.Interface {
+	return gatewayapiv1client.NewForConfigOrDie(c.AdminConfig())
 }
 
 func (c *CLI) AdminImageClient() imagev1client.Interface {


### PR DESCRIPTION
enhancement for httproute test

1. use regular user to create httproute as well as pod/service
2. remove the step of cleaning up httproute
