### PR TITLE
Bump limits for AWS cluster CAPI operator

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
@@ -170,7 +170,7 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 			"cloud-credential-operator":              176.0,
 			"cluster-autoscaler-operator":            132.0,
 			"cluster-baremetal-operator":             125.0,
-			"cluster-capi-operator":                  200.0,
+			"cluster-capi-operator":                  250.0,
 			"cluster-image-registry-operator":        189.0,
 			"cluster-monitoring-operator":            186.0,
 			"cluster-node-tuning-operator":           115.0,


### PR DESCRIPTION
Addressing the issue seen in the [e2e-aws-serial-techpreview job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_api/2279/pull-ci-openshift-api-master-e2e-aws-serial-techpreview/1914559524530819072)
```
 [sig-arch][Late] operators should not create watch channels very often expand_less	0s
{Operator "cluster-capi-operator" produces more watch requests than expected: watchrequestcount=434, upperbound=400, ratio=1.09  }
```