### PR TITLE
OCPBUGS-55342: Skip Hypershift for MachineConfigNodes and PinnedImages tests

### DIFF
--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -43,6 +43,13 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
 
+	g.BeforeEach(func(ctx context.Context) {
+		//skip these tests on hypershift platforms
+		if ok, _ := exutil.IsHypershift(ctx, oc.AdminConfigClient()); ok {
+			g.Skip("PinnedImages is not supported on hypershift. Skipping tests.")
+		}
+	})
+
 	g.It("Should have MCN properties matching associated node properties for nodes in default MCPs [apigroup:machineconfiguration.openshift.io]", func() {
 		if IsSingleNode(oc) { //handle SNO clusters
 			ValidateMCNPropertiesSNO(oc)

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -45,6 +45,14 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:Machin
 
 		busyboxImage = "quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f"
 	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		//skip these tests on hypershift platforms
+		if ok, _ := exutil.IsHypershift(ctx, oc.AdminConfigClient()); ok {
+			g.Skip("MachineConfigNodes is not supported on hypershift. Skipping tests.")
+		}
+	})
+
 	// Ensure each test pins a separate image, since we are not deleting them after each
 
 	g.It("All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]", func() {


### PR DESCRIPTION
Closes: OCPBUGS-55342

Per [this Slack message](https://redhat-internal.slack.com/archives/CE4L0F143/p1745431032849839?thread_ts=1744910197.447789&cid=CE4L0F143) from @yuqi-zhang, MachineConfigNodes and PinnedImageSets are not supported features on Hypershift. Therefore, the tests for these features should be skipped on the Hypershift platform.

**Work included:**
- Skip tests related to the `PinnedImages` and `MachineConfigNodes` feature gates on Hypershift.