### PR TITLE
Exclude imagestream import mode toggle tests for SNO

### DIFF
--- a/test/extended/images/tagimportmode.go
+++ b/test/extended/images/tagimportmode.go
@@ -107,6 +107,9 @@ func TestImageConfigImageStreamImportModeLegacy(t g.GinkgoTInterface, oc *exutil
 	if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
 		g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
 	}
+	if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
+		g.Skip("skipping this test for SNO as it involves an openshift-apiserver disruption")
+	}
 
 	clusterAdminConfigClient := oc.AdminConfigClient().ConfigV1()
 	imageConfig, err := clusterAdminConfigClient.Images().Get(ctx, "cluster", metav1.GetOptions{})
@@ -150,6 +153,9 @@ func TestImageConfigImageStreamImportModePreserveOriginal(t g.GinkgoTInterface, 
 	ctx := context.Background()
 	if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
 		g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
+	}
+	if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
+		g.Skip("skipping this test for SNO as it involves an openshift-apiserver disruption")
 	}
 
 	clusterAdminConfigClient := oc.AdminConfigClient().ConfigV1()


### PR DESCRIPTION
These tests involve changing the openshift-apiserver's observed config which causes the apiserver to restart. This is causing disruptions for SNO and the SNO techpreview tests are failing. Exclude these tests for SNO.

failing job example: https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-aws-ovn-single-node-techpreview-serial