### PR TITLE
(olmv1 tests) Increase timeout threshold for `verifyAPIEndpoints`

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -672,7 +672,7 @@ spec:
 
 	// Wait for job completion
 	var lastErr error
-	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
 		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 			"job", jobName, "-n", "default", "-o=jsonpath={.status}").Output()
 		if err != nil {


### PR DESCRIPTION
30 seconds timeout is causing the tests to fail in the first run, but pass in the second run. Increasing the timeout to 2 minutes.