### PR TITLE
Revert "TRT-2049: check for any watch requests"

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
@@ -141,21 +141,11 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 	ret := []*junitapi.JUnitTestCase{}
 
 	testName := "[sig-arch][Late] operators should not create watch channels very often"
-	testMinRequestsName := "[sig-arch][Late] operators should have watch channel requests"
 	oc := exutil.NewCLIWithoutNamespace("operator-watch")
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		ret = append(ret, &junitapi.JUnitTestCase{
 			Name: testName,
-			FailureOutput: &junitapi.FailureOutput{
-				Message: err.Error(),
-				Output:  err.Error(),
-			},
-		},
-		)
-
-		ret = append(ret, &junitapi.JUnitTestCase{
-			Name: testMinRequestsName,
 			FailureOutput: &junitapi.FailureOutput{
 				Message: err.Error(),
 				Output:  err.Error(),
@@ -391,9 +381,6 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 			return []*junitapi.JUnitTestCase{{
 				Name:        testName,
 				SkipMessage: &junitapi.SkipMessage{Message: fmt.Sprintf("unsupported single node platform type: %v", infra.Spec.PlatformSpec.Type)},
-			}, {
-				Name:        testMinRequestsName,
-				SkipMessage: &junitapi.SkipMessage{Message: fmt.Sprintf("unsupported single node platform type: %v", infra.Spec.PlatformSpec.Type)},
 			}}, nil
 
 		}
@@ -403,32 +390,12 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 			return []*junitapi.JUnitTestCase{{
 				Name:        testName,
 				SkipMessage: &junitapi.SkipMessage{Message: fmt.Sprintf("unsupported platform type: %v", infra.Spec.PlatformSpec.Type)},
-			}, {
-				Name:        testMinRequestsName,
-				SkipMessage: &junitapi.SkipMessage{Message: fmt.Sprintf("unsupported platform type: %v", infra.Spec.PlatformSpec.Type)},
 			}}, nil
 		}
 		upperBound = upperBounds[infra.Spec.PlatformSpec.Type]
 	}
 
 	watchRequestCounts := s.SummarizeWatchCountRequests()
-
-	if len(watchRequestCounts) > 0 {
-		ret = append(ret,
-			&junitapi.JUnitTestCase{
-				Name: testMinRequestsName,
-			},
-		)
-	} else {
-		ret = append(ret,
-			&junitapi.JUnitTestCase{
-				Name: testMinRequestsName,
-				FailureOutput: &junitapi.FailureOutput{
-					Message: "Expected at least one watch request count to be present",
-				},
-			},
-		)
-	}
 
 	operatorBoundExceeded := []string{}
 	for _, item := range watchRequestCounts {


### PR DESCRIPTION
Reverts openshift/origin#29674

Failing hypershift

validate fix with `/payload-job periodic-ci-openshift-hypershift-release-4.19-periodics-e2e-aws-ovn-conformance`