### PR TITLE
NO ISSUE: Temporarily skip PinnedImageSet tests on SNO & metal

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -101,6 +101,15 @@ func IsSingleNode(oc *exutil.CLI) bool {
 	return infra.Status.ControlPlaneTopology == osconfigv1.SingleReplicaTopologyMode
 }
 
+// skipOnMetal skips the test if the cluster is using Metal PLatform
+func skipOnMetal(oc *exutil.CLI) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.Platform == osconfigv1.BareMetalPlatformType {
+		e2eskipper.Skipf("This test does not apply to metal")
+	}
+}
+
 // getRandomMachineSet picks a random machineset present on the cluster
 func getRandomMachineSet(machineClient *machineclient.Clientset) machinev1beta1.MachineSet {
 	machineSets, err := machineClient.MachineV1beta1().MachineSets("openshift-machine-api").List(context.TODO(), metav1.ListOptions{})

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -50,6 +50,10 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:Machin
 		if ok, _ := exutil.IsHypershift(ctx, oc.AdminConfigClient()); ok {
 			g.Skip("PinnedImages is not supported on hypershift. Skipping tests.")
 		}
+
+		// TODO (ijanssen/rsaini): re-enable PIS tests on metal after fixing OCPBUGS-55394
+		// (temporarily) skip these tests on metal platforms
+		skipOnMetal(oc)
 	})
 
 	// Ensure each test pins a separate image, since we are not deleting them after each
@@ -105,6 +109,10 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:Machin
 	})
 
 	g.It("All Nodes in a standard Pool should have the PinnedImages PIS [apigroup:machineconfiguration.openshift.io]", func() {
+		// TODO (ijanssen/rsaini): re-enable this test on SNO after fixing OCPBUGS-55384
+		// (temporarily) skip these tests on SNO
+		skipOnSingleNodeTopology(oc)
+
 		kubeClient, err := kubernetes.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), "Get KubeClient")
 


### PR DESCRIPTION
Contributors: @RishabhSaini & @isabella-janssen 

This temporarily skips all PIS tests on metal and the `All Nodes in a standard Pool should have the PinnedImages PIS` on SNO while the team addresses OCPBUGS-55394 & OCPBUGS-55384.