### PR TITLE
Using explicit project.project.openshift.io APIGroup in delete call

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -426,7 +426,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	g.It("new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
 		// Test deleting and recreating a project
 		o.Expect(oc.Run("adm", "new-project").Args("recreated-project", "--admin=createuser1").Execute()).To(o.Succeed())
-		o.Expect(oc.Run("delete").Args("project", "recreated-project").Execute()).To(o.Succeed())
+		o.Expect(oc.Run("delete").Args("project.project.openshift.io", "recreated-project").Execute()).To(o.Succeed())
 		err := wait.Poll(cliInterval, deleteCliTimeout, func() (bool, error) {
 			out, err := ocns.Run("get").Args("project/recreated-project").Output()
 			return err != nil && strings.Contains(out, "not found"), nil
@@ -435,7 +435,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 
 		o.Expect(oc.Run("adm", "new-project").Args("recreated-project", "--admin=createuser2").Execute()).To(o.Succeed())
 		defer func() {
-			oc.Run("delete").Args("project", "recreated-project").Execute()
+			oc.Run("delete").Args("project.project.openshift.io", "recreated-project").Execute()
 		}()
 
 		out, err := oc.Run("get").Args("rolebinding", "admin", "-n", "recreated-project", "-o", "jsonpath={.subjects[*].name}").Output()


### PR DESCRIPTION
Case `[sig-cli] oc adm new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io] [Suite:openshift/conformance/parallel] ` ran into below failure of CI job https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63786/rehearse-63786-periodic-ci-openshift-release-master-nightly-4.18-e2e-metal-ovn-sno-cert-rotation-shutdown-60d/1915312418464993280:
```
{  fail [github.com/openshift/origin/test/extended/cli/admin.go:429]: Expected success, but got an error:
    <*fmt.wrapError | 0xc005108940>: 
    Error running /usr/local/bin/oc --kubeconfig=/home/assisted/build/kubeconfig/kubeconfig_test-infra-cluster-3aa674c4 delete project recreated-project:
    StdOut>
    Error from server (NotFound): projects.config.openshift.io "recreated-project" not found
    StdErr>
    Error from server (NotFound): projects.config.openshift.io "recreated-project" not found
    exit status 1
    
    {
        msg: "Error running /usr/local/bin/oc --kubeconfig=/home/assisted/build/kubeconfig/kubeconfig_test-infra-cluster-3aa674c4 delete project recreated-project:\nStdOut>\nError from server (NotFound): projects.config.openshift.io \"recreated-project\" not found\nStdErr>\nError from server (NotFound): projects.config.openshift.io \"recreated-project\" not found\nexit status 1\n",
        err: <*exec.ExitError | 0xc005108920>{
            ProcessState: {
                pid: 115048,
                status: 256,
                rusage: {
                    Utime: {Sec: 0, Usec: 156354},
                    Stime: {Sec: 0, Usec: 37206},
                    Maxrss: 214832,
                    Ixrss: 0,
                    Idrss: 0,
                    Isrss: 0,
                    Minflt: 3610,
                    Majflt: 3,
                    Nswap: 0,
                    Inblock: 0,
                    Oublock: 0,
                    Msgsnd: 0,
                    Msgrcv: 0,
                    Nsignals: 0,
                    Nvcsw: 634,
                    Nivcsw: 20,
                },
            },
            Stderr: nil,
        },
    }
Ginkgo exit error 1: exit with code 1}
```
Observed the normal results,
```
I0428 03:35:17.282015 72485 client.go:941] Running 'oc --kubeconfig=/tmp/kubeconfig-446840673 adm new-project recreated-project --admin=createuser1'
Created project recreated-project
I0428 03:35:17.980358 72485 client.go:941] Running 'oc --kubeconfig=/tmp/kubeconfig-446840673 delete project recreated-project'
project.project.openshift.io "recreated-project" deleted
```

Error from server (NotFound): projects.config.openshift.io "recreated-project" not found
Here we noticed the api group config.openshift.io
But projects are in project.openshift.io,  the resource "projects" is being resolved to projects.config.openshift.io instead of project.openshift.io when delete with 'not found' error.

Using explicit project.project.openshift.io APIGroup in delete call will avoid the above error.