### PR TITLE
OPRUN-3783: OLMv1: Add support for preflight permissions checks (fixed)

### DIFF
--- a/test/extended/olm/olmv1-preflight.go
+++ b/test/extended/olm/olmv1-preflight.go
@@ -1,0 +1,136 @@
+package operators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLI("openshift-operator-controller")
+
+	g.BeforeEach(func() {
+		exutil.PreTestDump()
+	})
+
+	g.AfterEach(func() {
+		if g.CurrentSpecReport().Failed() {
+			exutil.DumpPodLogsStartingWith("", oc)
+		}
+	})
+
+	g.It("should report error when {services} are not specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 1)
+	})
+
+	g.It("should report error when {create} verb is not specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 2)
+	})
+
+	g.It("should report error when {ClusterRoleBindings} are not specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 3)
+	})
+
+	g.It("should report error when {ConfigMap:resourceNames} are not all specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 4)
+	})
+
+	g.It("should report error when {clusterextension/finalizer} is not specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 5)
+	})
+
+	g.It("should report error when {escalate, bind} is not specified", func(ctx g.SpecContext) {
+		runNegativePreflightTest(ctx, oc, 6)
+	})
+})
+
+func runNegativePreflightTest(ctx g.SpecContext, oc *exutil.CLI, iteration int) {
+	checkFeatureCapability(oc)
+
+	baseDir := exutil.FixturePath("testdata", "olmv1")
+	crFile := filepath.Join(baseDir, fmt.Sprintf("install-pipeline-operator-%d.yaml", iteration))
+	ceFile := filepath.Join(baseDir, "install-pipeline-operator-base.yaml")
+
+	g.By(fmt.Sprintf("applying %s", crFile))
+	cleanupCr, unique := applyPreflightFile(oc, "", crFile)
+	g.DeferCleanup(cleanupCr)
+
+	g.By(fmt.Sprintf("applying %s", ceFile))
+	cleanupCe, _ := applyPreflightFile(oc, unique, ceFile)
+	g.DeferCleanup(cleanupCe)
+
+	ceName := "install-test-ce-" + unique
+
+	g.By("waiting for the ClusterExtention to report failure")
+	var lastReason string
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			b, err, s := waitForPreflightFailure(oc, ceName)
+			if lastReason != s {
+				g.GinkgoLogr.Info(fmt.Sprintf("waitForPreflightFailure: %q", s))
+				lastReason = s
+			}
+			return b, err
+		})
+	o.Expect(lastReason).To(o.BeEmpty())
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func applyPreflightFile(oc *exutil.CLI, unique, file string) (func(), string) {
+	// packageName and version are specified in the files and do not change
+	return applyResourceFile(oc, "", "", unique, file)
+}
+
+func waitForPreflightFailure(oc *exutil.CLI, ceName string) (bool, error, string) {
+	var conditions []metav1.Condition
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextensions.olm.operatorframework.io", ceName, "-o=jsonpath={.status.conditions}").Output()
+	if err != nil {
+		return false, err, ""
+	}
+	// no data yet, so try again
+	if output == "" {
+		return false, nil, "no output"
+	}
+	if err := json.Unmarshal([]byte(output), &conditions); err != nil {
+		return false, fmt.Errorf("error in json.Unmarshal(%v): %v", output, err), ""
+	}
+	c := meta.FindStatusCondition(conditions, typeProgressing)
+	if c == nil {
+		return false, nil, fmt.Sprintf("condition not present: %q", typeProgressing)
+	}
+	if c.Status != metav1.ConditionTrue {
+		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
+	}
+
+	messagePrefix := "pre-authorization failed:"
+	if !strings.HasPrefix(c.Message, messagePrefix) {
+		return false, nil, fmt.Sprintf("expected message to contain %q: %+v", messagePrefix, c)
+	}
+
+	messageContains := "service account requires the following permissions to manage cluster extension:"
+	if !strings.Contains(c.Message, messageContains) {
+		return false, nil, fmt.Sprintf("expected message to contain %q: %+v", messageContains, c)
+	}
+
+	c = meta.FindStatusCondition(conditions, typeInstalled)
+	if c == nil {
+		return false, nil, fmt.Sprintf("condition not present: %q", typeInstalled)
+	}
+	if c.Status != metav1.ConditionFalse {
+		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionFalse, c)
+	}
+	return true, nil, ""
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -456,6 +456,14 @@
 // test/extended/testdata/olm/subscription.yaml
 // test/extended/testdata/olmv1/install-catalog.yaml
 // test/extended/testdata/olmv1/install-operator.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-0.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-1.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-2.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-3.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-4.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-5.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-6.yaml
+// test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
 // test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
@@ -50548,30 +50556,30 @@ func testExtendedTestdataOlmv1InstallCatalogYaml() (*asset, error) {
 var _testExtendedTestdataOlmv1InstallOperatorYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: install-test-sa-{PACKAGENAME}
+  name: install-test-sa-{UNIQUE}
   namespace: {NAMESPACE}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: install-test-crb-{PACKAGENAME}
+  name: install-test-crb-{UNIQUE}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  name: install-test-sa-{PACKAGENAME}
+  name: install-test-sa-{UNIQUE}
   namespace: {NAMESPACE}
 ---
 apiVersion: olm.operatorframework.io/v1
 kind: ClusterExtension
 metadata:
-  name: install-test-ce-{PACKAGENAME}
+  name: install-test-ce-{UNIQUE}
 spec:
   namespace: {NAMESPACE}
   serviceAccount:
-    name: install-test-sa-{PACKAGENAME}
+    name: install-test-sa-{UNIQUE}
   source:
     catalog:
       packageName: {PACKAGENAME}
@@ -50592,6 +50600,2495 @@ func testExtendedTestdataOlmv1InstallOperatorYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-operator.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator0Yaml = []byte(`# This is the baseline RBAC needed to install the operator.
+# Other versions of install-pipeline-operator-X.yaml have had something removed
+# So, diff against this version to know exactly what has been removed (even though
+# there is a comment at the top of the file).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator0YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator0Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator0Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator0YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-0.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator1Yaml = []byte(`# Remove (namespace-scoped) services from resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator1YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator1Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator1Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator1YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-1.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator2Yaml = []byte(`# Remove create verb from '' API group
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator2YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator2Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator2Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator2YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-2.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator3Yaml = []byte(`# Remove CRB from list of resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator3YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator3Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator3Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator3YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-3.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator4Yaml = []byte(`# Be explicit about configmap resource names
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - configmaps
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+  resourceNames:
+    - config-logging
+    - tekton-config-defaults
+    - tekton-config-observability
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator4YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator4Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator4Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator4YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-4.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator5Yaml = []byte(`# Remove clusterextensions/finalizers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator5YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator5Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator5Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator5YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-5.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperator6Yaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperator6YamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperator6Yaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperator6Yaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperator6YamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-6.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: install-test-sa-{UNIQUE}
+  namespace: {NAMESPACE}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: install-test-crb-{UNIQUE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: install-test-cr-{UNIQUE}
+subjects:
+- kind: ServiceAccount
+  name: install-test-sa-{UNIQUE}
+  namespace: {NAMESPACE}
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: install-test-ce-{UNIQUE}
+spec:
+  namespace: {NAMESPACE}
+  serviceAccount:
+    name: install-test-sa-{UNIQUE}
+  source:
+    catalog:
+      packageName: "openshift-pipelines-operator-rh"
+      version: "1.18.0"
+      selector: {}
+      upgradeConstraintPolicy: CatalogProvided
+    sourceType: Catalog
+`)
+
+func testExtendedTestdataOlmv1InstallPipelineOperatorBaseYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml, nil
+}
+
+func testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1InstallPipelineOperatorBaseYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/install-pipeline-operator-base.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -56201,6 +58698,14 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/olm/subscription.yaml":                                                           testExtendedTestdataOlmSubscriptionYaml,
 	"test/extended/testdata/olmv1/install-catalog.yaml":                                                      testExtendedTestdataOlmv1InstallCatalogYaml,
 	"test/extended/testdata/olmv1/install-operator.yaml":                                                     testExtendedTestdataOlmv1InstallOperatorYaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-0.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator0Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-1.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator1Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-2.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator2Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-3.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator3Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-4.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator4Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-5.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator5Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-6.yaml":                                          testExtendedTestdataOlmv1InstallPipelineOperator6Yaml,
+	"test/extended/testdata/olmv1/install-pipeline-operator-base.yaml":                                       testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml,
 	"test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml":                               testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml":                          testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml":                   testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml,
@@ -56986,8 +59491,16 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"subscription.yaml":  {testExtendedTestdataOlmSubscriptionYaml, map[string]*bintree{}},
 				}},
 				"olmv1": {nil, map[string]*bintree{
-					"install-catalog.yaml":  {testExtendedTestdataOlmv1InstallCatalogYaml, map[string]*bintree{}},
-					"install-operator.yaml": {testExtendedTestdataOlmv1InstallOperatorYaml, map[string]*bintree{}},
+					"install-catalog.yaml":                {testExtendedTestdataOlmv1InstallCatalogYaml, map[string]*bintree{}},
+					"install-operator.yaml":               {testExtendedTestdataOlmv1InstallOperatorYaml, map[string]*bintree{}},
+					"install-pipeline-operator-0.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator0Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-1.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator1Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-2.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator2Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-3.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator3Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-4.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator4Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-5.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator5Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-6.yaml":    {testExtendedTestdataOlmv1InstallPipelineOperator6Yaml, map[string]*bintree{}},
+					"install-pipeline-operator-base.yaml": {testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml, map[string]*bintree{}},
 				}},
 				"poddisruptionbudgets": {nil, map[string]*bintree{
 					"always-allow-policy-pdb.yaml":             {testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml, map[string]*bintree{}},

--- a/test/extended/testdata/olmv1/install-pipeline-operator-0.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-0.yaml
@@ -1,0 +1,334 @@
+# This is the baseline RBAC needed to install the operator.
+# Other versions of install-pipeline-operator-X.yaml have had something removed
+# So, diff against this version to know exactly what has been removed (even though
+# there is a comment at the top of the file).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-1.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-1.yaml
@@ -1,0 +1,329 @@
+# Remove (namespace-scoped) services from resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-2.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-2.yaml
@@ -1,0 +1,330 @@
+# Remove create verb from '' API group
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-3.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-3.yaml
@@ -1,0 +1,329 @@
+# Remove CRB from list of resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-4.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-4.yaml
@@ -1,0 +1,347 @@
+# Be explicit about configmap resource names
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - configmaps
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+  resourceNames:
+    - config-logging
+    - tekton-config-defaults
+    - tekton-config-observability
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-5.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-5.yaml
@@ -1,0 +1,322 @@
+# Remove clusterextensions/finalizers
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+    - bind
+    - escalate
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-6.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-6.yaml
@@ -1,0 +1,328 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: install-test-cr-{UNIQUE}
+rules:
+- apiGroups:
+  - olm.operatorframework.io
+  resources:
+  - clusterextensions/finalizers
+  verbs:
+  - update
+  # Scoped to the name of the ClusterExtension
+  resourceNames:
+  - install-test-ce-{UNIQUE}
+- apiGroups:
+    - ''
+  resources:
+    - nodes
+  verbs:
+    - list
+- apiGroups:
+    - ''
+  resources:
+    - pods
+    - pods/finalizers
+    - services
+    - services/finalizers
+    - endpoints
+    - endpoints/finalizers
+    - persistentvolumeclaims
+    - persistentvolumeclaims/finalizers
+    - events
+    - events/finalizers
+    - configmaps
+    - configmaps/finalizers
+    - secrets
+    - secrets/finalizers
+    - pods/log
+    - limitranges
+    - limitranges/finalizers
+    - namespaces
+    - namespaces/finalizers
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - extensions
+    - apps
+  resources:
+    - ingresses
+    - ingresses/finalizers
+    - ingresses/status
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - apps
+  resources:
+    - deployments
+    - deployments/finalizers
+    - daemonsets
+    - daemonsets/finalizers
+    - replicasets
+    - replicasets/finalizers
+    - statefulsets
+    - statefulsets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterroles
+    - clusterroles/finalizers
+    - roles
+    - roles/finalizers
+    - clusterrolebindings
+    - clusterrolebindings/finalizers
+    - rolebindings
+    - rolebindings/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - ''
+  resources:
+    - serviceaccounts
+    - serviceaccounts/finalizers
+  verbs:
+    - impersonate
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+    - customresourcedefinitions/finalizers
+    - customresourcedefinitions/status
+  verbs:
+    - get
+    - create
+    - update
+    - delete
+    - list
+    - patch
+    - watch
+- apiGroups:
+    - admissionregistration.k8s.io
+  resources:
+    - mutatingwebhookconfigurations
+    - mutatingwebhookconfigurations/finalizers
+    - validatingwebhookconfigurations
+    - validatingwebhookconfigurations/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - build.knative.dev
+  resources:
+    - builds
+    - builds/finalizers
+    - buildtemplates
+    - buildtemplates/finalizers
+    - clusterbuildtemplates
+    - clusterbuildtemplates/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - extensions
+  resources:
+    - deployments
+    - deployments/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - tekton.dev
+    - resolution.tekton.dev
+    - triggers.tekton.dev
+    - operator.tekton.dev
+    - pipelinesascode.tekton.dev
+    - dashboard.tekton.dev
+  resources:
+    - '*'
+  verbs:
+    - add
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+    - securitycontextconstraints/finalizers
+  verbs:
+    - use
+    - get
+    - list
+    - create
+    - update
+    - delete
+- apiGroups:
+    - events.k8s.io
+  resources:
+    - events
+  verbs:
+    - create
+- apiGroups:
+    - route.openshift.io
+  resources:
+    - routes
+    - routes/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+    - leases/finalizers
+  verbs:
+    - get
+    - list
+    - create
+    - update
+    - delete
+    - patch
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleyamlsamples
+    - consoleyamlsamples/finalizers
+    - consoleclidownloads
+    - consoleclidownloads/finalizers
+    - consolequickstarts
+    - consolequickstarts/finalizers
+    - consolelinks
+    - consolelinks/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - autoscaling
+  resources:
+    - horizontalpodautoscalers
+    - horizontalpodautoscalers/finalizers
+  verbs:
+    - delete
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - policy
+  resources:
+    - poddisruptionbudgets
+    - poddisruptionbudgets/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
+    - servicemonitors
+    - servicemonitors/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - batch
+  resources:
+    - jobs
+    - jobs/finalizers
+    - cronjobs
+    - cronjobs/finalizers
+  verbs:
+    - delete
+    - deletecollection
+    - create
+    - patch
+    - get
+    - list
+    - update
+    - watch
+- apiGroups:
+    - console.openshift.io
+  resources:
+    - consoleplugins
+    - consoleplugins/finalizers
+  verbs:
+    - get
+    - list
+    - watch
+    - create
+    - delete
+    - update
+    - patch

--- a/test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
@@ -11,7 +11,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-admin
+  name: install-test-cr-{UNIQUE}
 subjects:
 - kind: ServiceAccount
   name: install-test-sa-{UNIQUE}
@@ -27,8 +27,8 @@ spec:
     name: install-test-sa-{UNIQUE}
   source:
     catalog:
-      packageName: {PACKAGENAME}
-      version: {VERSION}
+      packageName: "openshift-pipelines-operator-rh"
+      version: "1.18.0"
       selector: {}
       upgradeConstraintPolicy: CatalogProvided
     sourceType: Catalog

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1865,6 +1865,18 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {ClusterRoleBindings} are not specified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {ConfigMap:resourceNames} are not all specified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {clusterextension/finalizer} is not specified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {create} verb is not specified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {escalate, bind} is not specified": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {services} are not specified": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -469,6 +469,26 @@ spec:
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]
         OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/metas
         endpoint'
+  - featureGate: NewOLMPreflightPermissionChecks
+    tests:
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {ClusterRoleBindings}
+        are not specified'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {ConfigMap:resourceNames}
+        are not all specified'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {clusterextension/finalizer}
+        is not specified'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {create} verb is
+        not specified'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {escalate, bind}
+        is not specified'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
+        OLMv1 operator preflight checks should report error when {services} are not
+        specified'
   - featureGate: OrderedNamespaceDeletion
     tests:
     - testName: '[sig-api-machinery] OrderedNamespaceDeletion namespace deletion should


### PR DESCRIPTION
Adds several data files, of which -0 is the basic one that allows for installation, and -1 through -6 have minor removals to cause a failure. They are each combined with -base to attempt to install an operator.

This reapplies cf207152efc99fb5474650649bddd43cea89c71b with fixes due to upstream-to-downstream merge.