### PR TITLE
OCPBUGS-55441: Fix MCN tests for two-node clusters & add more logs to scope tests

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -101,6 +101,31 @@ func IsSingleNode(oc *exutil.CLI) bool {
 	return infra.Status.ControlPlaneTopology == osconfigv1.SingleReplicaTopologyMode
 }
 
+// `skipOnTwoNodeTopology` skips the test if the cluster is using two-node topology, including
+// both standard and arbiter cases.
+func skipOnTwoNodeTopology(oc *exutil.CLI) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.ControlPlaneTopology == osconfigv1.DualReplicaTopologyMode || infra.Status.ControlPlaneTopology == osconfigv1.HighlyAvailableArbiterMode {
+		e2eskipper.Skipf("This test does not apply to two-node topologies")
+	}
+}
+
+// `IsTwoNode` returns true if the cluster is using two-node topology and false otherwise
+func IsTwoNode(oc *exutil.CLI) bool {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error determining cluster infrastructure.")
+	return infra.Status.ControlPlaneTopology == osconfigv1.DualReplicaTopologyMode
+}
+
+// `IsTwoNodeArbiter` returns true if the cluster is using two-node arbiter topology and false otherwise
+func IsTwoNodeArbiter(oc *exutil.CLI) bool {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Error determining cluster infrastructure.")
+	return infra.Status.ControlPlaneTopology == osconfigv1.HighlyAvailableArbiterMode &&
+		infra.Status.InfrastructureTopology == osconfigv1.HighlyAvailableTopologyMode
+}
+
 // skipOnMetal skips the test if the cluster is using Metal PLatform
 func skipOnMetal(oc *exutil.CLI) {
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})


### PR DESCRIPTION
This closes OCPBUGS-55441.

**Work included:**
- Updates `Should have MCN properties matching associated node properties for nodes in default MCPs` in standard two-node Openshift to test for only master MCP association.
- Updates `Should have MCN properties matching associated node properties for nodes in default MCPs` in two-node arbiter Openshift to test for master & arbiter MCP association.
- Skips `Should have MCN properties matching associated node properties for nodes in custom MCPs` test on two-node openshift.
- Adds more logs to scope impersonation tests to help with future debugging, if necessary.

**To test:**
See payload rehearsals with successful MCN tests:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29732-nightly-4.19-e2e-metal-ovn-two-node-fencing/1917310610672979968
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29732-nightly-4.19-e2e-metal-ovn-two-node-arbiter/1917315640822075392