### PR TITLE
TRT-2092: Fix default cert issuer name in RouteExternalCertificate test case

### DIFF
--- a/test/extended/router/certgen/certgen.go
+++ b/test/extended/router/certgen/certgen.go
@@ -47,7 +47,7 @@ func MarshalCertToPEMString(derBytes []byte) (string, error) {
 // GenerateKeyPair creates root CA, certificate and key with optional
 // hosts. Certificate is valid from notBefore and expires after
 // notAfter.
-func GenerateKeyPair(notBefore, notAfter time.Time, hosts ...string) ([]byte, []byte, *ecdsa.PrivateKey, error) {
+func GenerateKeyPair(rootCertCN string, notBefore, notAfter time.Time, hosts ...string) ([]byte, []byte, *ecdsa.PrivateKey, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
@@ -63,7 +63,7 @@ func GenerateKeyPair(notBefore, notAfter time.Time, hosts ...string) ([]byte, []
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
 			Organization: []string{"Red Hat"},
-			CommonName:   "Root CA",
+			CommonName:   rootCertCN,
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -178,7 +178,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			notAfter := time.Now().Add(24 * time.Hour)
 
 			// Generate crt/key for routes that need them.
-			_, tlsCrtData, tlsPrivateKey, err := certgen.GenerateKeyPair(notBefore, notAfter)
+			_, tlsCrtData, tlsPrivateKey, err := certgen.GenerateKeyPair("Root CA", notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			derKey, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey)

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -236,10 +236,10 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			notAfter := time.Now().Add(24 * time.Hour)
 
 			// Generate crts/keys for routes that need them.
-			_, tlsCrt1Data, tlsPrivateKey1, err := certgen.GenerateKeyPair(notBefore, notAfter)
+			_, tlsCrt1Data, tlsPrivateKey1, err := certgen.GenerateKeyPair("Root CA", notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			_, tlsCrt2Data, tlsPrivateKey2, err := certgen.GenerateKeyPair(notBefore, notAfter)
+			_, tlsCrt2Data, tlsPrivateKey2, err := certgen.GenerateKeyPair("Root CA", notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			derKey1, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey1)


### PR DESCRIPTION
The current logic for verifying the default certificate relies on checking the issuer CommonName against predefined values for different cluster profiles (Self-Managed, HyperShift, Managed Service). However, for managed service clusters (like ROSA), the default certificate issuer CN is dynamic (e.g. R10, R11, etc.), making it difficult to know the exact value beforehand.

This PR modifies the verification logic to handle the dynamic issuer CN. Instead of checking for a specific CN, the updated logic checks if the certificate is not issued by the external certificate issuer. This ensures that the route will not use the external certificate once removed.

Follow up: https://github.com/openshift/origin/pull/29731
