### PR TITLE
[release-4.15] OCPBUGS-55477: support provider type external

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -27,6 +27,9 @@ import (
 	// Initialize nutanix as a provider
 	_ "github.com/openshift/origin/test/extended/util/nutanix"
 
+	// Initialize external as a provider
+	_ "github.com/openshift/origin/test/extended/util/external"
+
 	// these are loading important global flags that we need to get and set
 	_ "k8s.io/kubernetes/test/e2e"
 	_ "k8s.io/kubernetes/test/e2e/lifecycle"
@@ -117,7 +120,7 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		}
 		fallthrough
 
-	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud":
+	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud", "external":
 		if clusterState == nil {
 			clientConfig, err := e2e.LoadConfig(true)
 			if err != nil {

--- a/test/extended/util/external/provider.go
+++ b/test/extended/util/external/provider.go
@@ -1,0 +1,18 @@
+package external
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func init() {
+	framework.RegisterProvider("external", newProvider)
+}
+
+func newProvider() (framework.ProviderInterface, error) {
+	return &Provider{}, nil
+}
+
+// Provider is a structure to handle external for e2e testing
+type Provider struct {
+	framework.NullProvider
+}


### PR DESCRIPTION
Support platform type `External` as a valid provider in the test framework. The external platform initially act as None, and not require additional configuration at this moment. This change will add the minimum support to allow CI readiness for this platform.

The initial support has been added to 4.19, in order to skip permanent failures added in upstream kube on 4.18.

As the --provider flag is added in the CI step level, and that step does not support release check, it will be complex to implement a logic in CI instead of just global support of --provider across all versions the platform type external jobs are tested: 4.15+.

References:
- 4.19: https://github.com/openshift/origin/pull/29623
- 4.18: https://github.com/openshift/origin/pull/29666
- 4.17: https://github.com/openshift/origin/pull/29737
- 4.16: https://github.com/openshift/origin/pull/29738
- 4.15:  https://github.com/openshift/origin/pull/29739