### PR TITLE
OCPBUGS-55510: Update node selection in MCN scope test for two-node Openshift

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -478,6 +478,15 @@ func GetNodesByRole(oc *exutil.CLI, role string) ([]corev1.Node, error) {
 	return nodes.Items, nil
 }
 
+// `GetAllNodes` gets all nodes from a cluster
+func GetAllNodes(oc *exutil.CLI) ([]corev1.Node, error) {
+	nodes, err := oc.AsAdmin().KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Items, nil
+}
+
 // `isNodeReady` determines if a given node is ready
 func isNodeReady(node corev1.Node) bool {
 	// If the node is cordoned, it is not ready.


### PR DESCRIPTION
This closes [OCPBUGS-55510](https://issues.redhat.com/browse/OCPBUGS-55510).

**Work included:**
- Updates how nodes to test are selected in two-node Openshift environments for `Should properly block MCN updates from a MCD that is not the associated one`.

**How to verify:**
See the following payload rehearsals passing on the `Should properly block MCN updates from a MCD that is not the associated one` test.

- [x] Two-Node Fencing: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29744-nightly-4.19-e2e-metal-ovn-two-node-fencing/1917990008426336256
- [x] Two-Node Arbiter: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29744-nightly-4.19-e2e-metal-ovn-two-node-arbiter/1917978026507767808
- [x] SNO: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29744-nightly-4.19-e2e-aws-ovn-single-node-techpreview/1917978027585703936
- [x] Standard: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29744-ci-4.19-e2e-aws-ovn-techpreview/1917978027040444416