### PR TITLE
OCPBUGS-55902: pkg/monitortestlibrary/allowedalerts: Ignore KubeJobFailingSRE for now

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -35,12 +35,12 @@ func GetHistoricalData() *historicaldata.AlertBestMatcher {
 	return historicalData
 }
 
-// AllowedAlertNames is a  list of alerts we do not test against.
+// AllowedAlertNames is a list of alerts we do not test against.
 var AllowedAlertNames = []string{
 	"Watchdog",
 	"AlertmanagerReceiversNotConfigured",
 	"PrometheusRemoteWriteDesiredShards",
-	"KubeJobFailed", // this is a result of bug https://bugzilla.redhat.com/show_bug.cgi?id=2054426 .  We should catch these in the prometheus tests.
+	"KubeJobFailingSRE", // https://issues.redhat.com/browse/OCPBUGS-55635
 
 	// indicates a problem in the external Telemeter service, presently very common, does not impact our ability to e2e test:
 	"TelemeterClientFailures",


### PR DESCRIPTION
It's being worked up in [OCPBUGS-55635][1], and I don't want to fail [runs like this][2] in the meantime, because I expect the failure mode is a longstanding race that has been more frequent recently as a result of increased quay.io 502 rates.

I'm also dropping the `KubeJobFailed` allowance.  It had linked [bugzilla#2054426][3], which was moved to [OCPBUGS-9119][4] when we migrated from Bugzilla to Jira.  And then [OCPBUGS-9119][4] was closed without changes in 2023.  If we see more of this alert, we want to hear about it, so we can re-open.  And checking now, we aren't seeing it in anything more recent than 4.14:

```console
$ w3m -dump -cols 200 'https://search.dptools.openshift.org/?maxAge=48h&type=junit&search=KubeJobFailed+fired+for' | grep 'failures match'
periodic-ci-openshift-multiarch-master-nightly-4.14-ocp-e2e-aws-ovn-arm64-techpreview-serial (all) - 2 runs, 50% failed, 200% of failures match = 100% impact
periodic-ci-openshift-release-master-nightly-4.14-e2e-vsphere-ovn-techpreview (all) - 2 runs, 50% failed, 100% of failures match = 50% impact
periodic-ci-openshift-release-master-ci-4.14-e2e-aws-sdn-techpreview-serial (all) - 2 runs, 50% failed, 100% of failures match = 50% impact
```

and none of those jobs use the 4.19 origin suite I'm adjusting here.

[1]: https://issues.redhat.com/browse/OCPBUGS-55635
[2]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-rosa-sts-ovn/1916402286188302336
[3]: https://bugzilla.redhat.com/show_bug.cgi?id=2054426
[4]: https://issues.redhat.com/browse/OCPBUGS-9119