### PR TITLE
NO-JIRA: faultyloadbalancer test: pass instead of skip

### DIFF
--- a/pkg/monitortests/kubeapiserver/faultyloadbalancer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/faultyloadbalancer/monitortest.go
@@ -117,13 +117,11 @@ func (jut *junitTest) OnOverlap(shutdown, unreachable monitorapi.Interval) {
 }
 
 func (jut *junitTest) Skip() []*junitapi.JUnitTestCase {
-	skipped := &junitapi.JUnitTestCase{
-		Name: jut.name,
-		SkipMessage: &junitapi.SkipMessage{
-			Message: "No kube-apiserver shutdown interval found",
-		},
+	passed := &junitapi.JUnitTestCase{
+		Name:      jut.name,
+		SystemOut: "No kube-apiserver shutdown interval found",
 	}
-	return []*junitapi.JUnitTestCase{skipped}
+	return []*junitapi.JUnitTestCase{passed}
 }
 
 func (jut *junitTest) Result() []*junitapi.JUnitTestCase {


### PR DESCRIPTION
When aggregation runs several tests it expects either pass or fail. If insufficient number of passes found the aggregation test would fail.

This commit would ensure test either passes or fails without skips, in order not to confuse aggregation