### PR TITLE
[WIP] OCPBUGS-49441: Skip negotiated protocol check for router gRPC interoperability tests

### DIFF
--- a/test/extended/router/grpc-interop/clientconn.go
+++ b/test/extended/router/grpc-interop/clientconn.go
@@ -9,6 +9,8 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	grpcinteropcredentials "github.com/openshift/origin/test/extended/router/grpc-interop/credentials"
 )
 
 type DialParams struct {
@@ -39,7 +41,7 @@ func Dial(cfg DialParams) (*grpc.ClientConn, error) {
 			}
 			tlsConfig.RootCAs = rootCAs
 		}
-		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+		opts = append(opts, grpc.WithTransportCredentials(grpcinteropcredentials.NewTLS(tlsConfig, credentials.NewTLS(tlsConfig))))
 	} else {
 		opts = append(opts, grpc.WithInsecure())
 	}

--- a/test/extended/router/grpc-interop/credentials/internal/credentials/README.md
+++ b/test/extended/router/grpc-interop/credentials/internal/credentials/README.md
@@ -1,0 +1,1 @@
+## Copied from `vendor/google.golang.org/grpc/internal/credentials/`

--- a/test/extended/router/grpc-interop/credentials/internal/credentials/credentials.go
+++ b/test/extended/router/grpc-interop/credentials/internal/credentials/credentials.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package credentials
+
+import (
+	"context"
+)
+
+// requestInfoKey is a struct to be used as the key to store RequestInfo in a
+// context.
+type requestInfoKey struct{}
+
+// NewRequestInfoContext creates a context with ri.
+func NewRequestInfoContext(ctx context.Context, ri any) context.Context {
+	return context.WithValue(ctx, requestInfoKey{}, ri)
+}
+
+// RequestInfoFromContext extracts the RequestInfo from ctx.
+func RequestInfoFromContext(ctx context.Context) any {
+	return ctx.Value(requestInfoKey{})
+}
+
+// clientHandshakeInfoKey is a struct used as the key to store
+// ClientHandshakeInfo in a context.
+type clientHandshakeInfoKey struct{}
+
+// ClientHandshakeInfoFromContext extracts the ClientHandshakeInfo from ctx.
+func ClientHandshakeInfoFromContext(ctx context.Context) any {
+	return ctx.Value(clientHandshakeInfoKey{})
+}
+
+// NewClientHandshakeInfoContext creates a context with chi.
+func NewClientHandshakeInfoContext(ctx context.Context, chi any) context.Context {
+	return context.WithValue(ctx, clientHandshakeInfoKey{}, chi)
+}

--- a/test/extended/router/grpc-interop/credentials/internal/credentials/spiffe.go
+++ b/test/extended/router/grpc-interop/credentials/internal/credentials/spiffe.go
@@ -1,0 +1,75 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package credentials defines APIs for parsing SPIFFE ID.
+//
+// All APIs in this package are experimental.
+package credentials
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/url"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+var logger = grpclog.Component("credentials")
+
+// SPIFFEIDFromState parses the SPIFFE ID from State. If the SPIFFE ID format
+// is invalid, return nil with warning.
+func SPIFFEIDFromState(state tls.ConnectionState) *url.URL {
+	if len(state.PeerCertificates) == 0 || len(state.PeerCertificates[0].URIs) == 0 {
+		return nil
+	}
+	return SPIFFEIDFromCert(state.PeerCertificates[0])
+}
+
+// SPIFFEIDFromCert parses the SPIFFE ID from x509.Certificate. If the SPIFFE
+// ID format is invalid, return nil with warning.
+func SPIFFEIDFromCert(cert *x509.Certificate) *url.URL {
+	if cert == nil || cert.URIs == nil {
+		return nil
+	}
+	var spiffeID *url.URL
+	for _, uri := range cert.URIs {
+		if uri == nil || uri.Scheme != "spiffe" || uri.Opaque != "" || (uri.User != nil && uri.User.Username() != "") {
+			continue
+		}
+		// From this point, we assume the uri is intended for a SPIFFE ID.
+		if len(uri.String()) > 2048 {
+			logger.Warning("invalid SPIFFE ID: total ID length larger than 2048 bytes")
+			return nil
+		}
+		if len(uri.Host) == 0 || len(uri.Path) == 0 {
+			logger.Warning("invalid SPIFFE ID: domain or workload ID is empty")
+			return nil
+		}
+		if len(uri.Host) > 255 {
+			logger.Warning("invalid SPIFFE ID: domain length larger than 255 characters")
+			return nil
+		}
+		// A valid SPIFFE certificate can only have exactly one URI SAN field.
+		if len(cert.URIs) > 1 {
+			logger.Warning("invalid SPIFFE ID: multiple URI SANs")
+			return nil
+		}
+		spiffeID = uri
+	}
+	return spiffeID
+}

--- a/test/extended/router/grpc-interop/credentials/internal/credentials/syscallconn.go
+++ b/test/extended/router/grpc-interop/credentials/internal/credentials/syscallconn.go
@@ -1,0 +1,58 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package credentials
+
+import (
+	"net"
+	"syscall"
+)
+
+type sysConn = syscall.Conn
+
+// syscallConn keeps reference of rawConn to support syscall.Conn for channelz.
+// SyscallConn() (the method in interface syscall.Conn) is explicitly
+// implemented on this type,
+//
+// Interface syscall.Conn is implemented by most net.Conn implementations (e.g.
+// TCPConn, UnixConn), but is not part of net.Conn interface. So wrapper conns
+// that embed net.Conn don't implement syscall.Conn. (Side note: tls.Conn
+// doesn't embed net.Conn, so even if syscall.Conn is part of net.Conn, it won't
+// help here).
+type syscallConn struct {
+	net.Conn
+	// sysConn is a type alias of syscall.Conn. It's necessary because the name
+	// `Conn` collides with `net.Conn`.
+	sysConn
+}
+
+// WrapSyscallConn tries to wrap rawConn and newConn into a net.Conn that
+// implements syscall.Conn. rawConn will be used to support syscall, and newConn
+// will be used for read/write.
+//
+// This function returns newConn if rawConn doesn't implement syscall.Conn.
+func WrapSyscallConn(rawConn, newConn net.Conn) net.Conn {
+	sysConn, ok := rawConn.(syscall.Conn)
+	if !ok {
+		return newConn
+	}
+	return &syscallConn{
+		Conn:    newConn,
+		sysConn: sysConn,
+	}
+}

--- a/test/extended/router/grpc-interop/credentials/internal/credentials/util.go
+++ b/test/extended/router/grpc-interop/credentials/internal/credentials/util.go
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package credentials
+
+import (
+	"crypto/tls"
+)
+
+const alpnProtoStrH2 = "h2"
+
+// AppendH2ToNextProtos appends h2 to next protos.
+func AppendH2ToNextProtos(ps []string) []string {
+	for _, p := range ps {
+		if p == alpnProtoStrH2 {
+			return ps
+		}
+	}
+	ret := make([]string, 0, len(ps)+1)
+	ret = append(ret, ps...)
+	return append(ret, alpnProtoStrH2)
+}
+
+// CloneTLSConfig returns a shallow clone of the exported
+// fields of cfg, ignoring the unexported sync.Once, which
+// contains a mutex and must not be copied.
+//
+// If cfg is nil, a new zero tls.Config is returned.
+//
+// TODO: inline this function if possible.
+func CloneTLSConfig(cfg *tls.Config) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{}
+	}
+
+	return cfg.Clone()
+}

--- a/test/extended/router/grpc-interop/credentials/tls.go
+++ b/test/extended/router/grpc-interop/credentials/tls.go
@@ -1,0 +1,88 @@
+package credentials
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"google.golang.org/grpc/credentials"
+
+	credinternal "github.com/openshift/origin/test/extended/router/grpc-interop/credentials/internal/credentials"
+)
+
+// NewTLS constructs a TransportCredentials object based on the provided TLS configuration.
+// The returned TransportCredentials do not verify the negotiated protocol during the client handshake.
+// These credentials are intended for use with gRPC-go clients to bypass the enforced ALPN enablement
+// introduced in gRPC-go version 1.67.0 (https://github.com/grpc/grpc-go/pull/7535).
+func NewTLS(c *tls.Config, delegatedCreds credentials.TransportCredentials) credentials.TransportCredentials {
+	return &tlsCredsNoALPNCheck{
+		TransportCredentials: delegatedCreds,
+		config:               c,
+	}
+}
+
+type tlsCredsNoALPNCheck struct {
+	credentials.TransportCredentials
+	config *tls.Config
+}
+
+// ClientHandshake is a direct copy of gRPC's TLS credentials client handshake method
+// (google.golang.org/grpc/credentials/tls.go#tlsCreds), with the omission of protocol negotiation checks.
+func (c *tlsCredsNoALPNCheck) ClientHandshake(ctx context.Context, authority string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	// use local cfg to avoid clobbering ServerName if using multiple endpoints
+	cfg := credinternal.CloneTLSConfig(c.config)
+	if cfg.ServerName == "" {
+		serverName, _, err := net.SplitHostPort(authority)
+		if err != nil {
+			// If the authority had no host port or if the authority cannot be parsed, use it as-is.
+			serverName = authority
+		}
+		cfg.ServerName = serverName
+	}
+	conn := tls.Client(rawConn, cfg)
+	errChannel := make(chan error, 1)
+	go func() {
+		errChannel <- conn.Handshake()
+		close(errChannel)
+	}()
+	select {
+	case err := <-errChannel:
+		if err != nil {
+			conn.Close()
+			return nil, nil, err
+		}
+	case <-ctx.Done():
+		conn.Close()
+		return nil, nil, ctx.Err()
+	}
+
+	// NOTE: The negotiated protocol check is removed!
+
+	tlsInfo := credentials.TLSInfo{
+		State: conn.ConnectionState(),
+		CommonAuthInfo: credentials.CommonAuthInfo{
+			SecurityLevel: credentials.PrivacyAndIntegrity,
+		},
+	}
+	id := credinternal.SPIFFEIDFromState(conn.ConnectionState())
+	if id != nil {
+		tlsInfo.SPIFFEID = id
+	}
+	return credinternal.WrapSyscallConn(rawConn, conn), tlsInfo, nil
+}
+
+func (c *tlsCredsNoALPNCheck) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return c.TransportCredentials.ServerHandshake(rawConn)
+}
+
+func (c *tlsCredsNoALPNCheck) Info() credentials.ProtocolInfo {
+	return c.TransportCredentials.Info()
+}
+
+func (c *tlsCredsNoALPNCheck) Clone() credentials.TransportCredentials {
+	return c.TransportCredentials.Clone()
+}
+
+func (c *tlsCredsNoALPNCheck) OverrideServerName(serverNameOverride string) error {
+	return c.TransportCredentials.OverrideServerName(serverNameOverride)
+}


### PR DESCRIPTION
Implement custom TLS credentials that bypass the negotiated protocol check. These credentials are used in the router's gRPC client instead of the default ones to prepare for the gRPC module bump, which enforces ALPN enablement starting from version 1.67.0.

This approach avoids setting the `GRPC_ENFORCE_ALPN_ENABLED` variable, ensuring that other tests using the gRPC module are not impacted. Note that `GRPC_ENFORCE_ALPN_ENABLED` is only read at the initialization of the grpc module.