### PR TITLE
CORS-3989: set proxy for http transport in router and imageregistry cases

### DIFF
--- a/test/extended/images/redirect.go
+++ b/test/extended/images/redirect.go
@@ -96,6 +96,8 @@ var _ = g.Describe("[sig-imageregistry] Image registry [apigroup:route.openshift
 		// create a custom http client so we can reliably detect the redirects
 		httpClient := http.Client{
 			Transport: &http.Transport{
+				// Use the HTTP proxy configured in the environment variables.
+				Proxy: http.ProxyFromEnvironment,
 				TLSClientConfig: &tls.Config{
 					InsecureSkipVerify: true, // this token will be gone shortly and if someone can intercept the router in a CI cluster, they can intercept a lot.
 				},

--- a/test/extended/router/external_certificate.go
+++ b/test/extended/router/external_certificate.go
@@ -518,6 +518,8 @@ func httpsGetCall(oc *exutil.CLI, hostname string, rootDerBytes []byte) (string,
 	}
 	client := &http.Client{
 		Transport: &http.Transport{
+			// Use the HTTP proxy configured in the environment variables.
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				RootCAs: certPool,
 			},
@@ -626,6 +628,8 @@ func httpsGetCallWithExecPod(oc *exutil.CLI, url string, rootCertPEM []byte) (st
 func verifyRouteServesDefaultCert(oc *exutil.CLI, hostname string) (string, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
+			// Use the HTTP proxy configured in the environment variables.
+			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: true,
 			},


### PR DESCRIPTION
Some image registry and router e2e test cases failed in [job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/64371/rehearse-64371-pull-ci-openshift-installer-main-e2e-azure-private/1917463259321995264), which were running in private cluster.
Private cluster needs to be accessed through a proxy, so set proxy for http transport in those cases.

