### PR TITLE
OCPBUGS-55994: Do not set the MTU when using NetworkAttachementDefinition

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -1919,7 +1919,6 @@ func generateNAD(config networkAttachmentConfig) *nadapi.NetworkAttachmentDefini
         "topology":%q,
         "subnets": %q,
         "excludeSubnets": %q,
-        "mtu": 1300,
         "netAttachDefName": %q,
         "vlanID": %d,
         "allowPersistentIPs": %t,


### PR DESCRIPTION
The static MTU can be incorrect in some clusters, instead rely on the fact that when the MTU is left unset OVN-Kubernetes will use a default equal to the clusterNetworkMTU:
https://github.com/ovn-kubernetes/ovn-kubernetes/blob/1df91ecad2dc2e283dd4106e2e5069aff9eb1eb5/go-controller/pkg/config/cni.go#L103

This approach is aligned with what is already being done for [C]UDNs. 