### PR TITLE
CNTRLPLANE-371: Update etcd test data for k8s 1.33 release (missing data)

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -308,6 +308,11 @@ func testEtcd3StoragePath(t g.GinkgoTInterface, oc *exutil.CLI, etcdClient3Fn fu
 			ExpectedEtcdPath: "/registry/ipaddresses/192.168.2.3",
 			ExpectedGVK:      gvkP("networking.k8s.io", "v1beta1", "IPAddress"),
 		}
+		etcdStorageData[gvr("resource.k8s.io", "v1alpha3", "devicetaintrules")] = etcddata.StorageData{
+			Stub:             `{"metadata": {"name": "taint1name"}, "spec": {"taint": {"key": "example.com/taintkey", "value": "taintvalue", "effect": "NoSchedule"}}}`,
+			ExpectedEtcdPath: "/registry/devicetaintrules/taint1name",
+			ExpectedGVK:      gvkP("resource.k8s.io", "v1alpha3", "DeviceTaintRule"),
+		}
 
 		// Removed etcd data.
 		// TODO: When rebase has started, remove etcd storage data that has been removed


### PR DESCRIPTION
This missing data was caught by techpreview-serial jobs.