### PR TITLE
OCPBUGS-55317: Skip GatewayAPIController tests on clusters without OLM capabilities

### DIFF
--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -25,6 +25,13 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
+var (
+	requiredCapabilities = []configv1.ClusterVersionCapability{
+		configv1.ClusterVersionCapabilityMarketplace,
+		configv1.ClusterVersionCapabilityOperatorLifecycleManager,
+	}
+)
+
 var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", g.Ordered, g.Serial, func() {
 	defer g.GinkgoRecover()
 	var (
@@ -58,6 +65,11 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		// skip non clould platforms since gateway needs LB service
 		skipGatewayIfNonCloudPlatform(oc)
+
+		// GatewayAPIController relies on OSSM OLM operator.
+		// Skipping on clusters which don't have capabilities required
+		// to install an OLM operator.
+		exutil.SkipIfMissingCapabilities(oc, requiredCapabilities...)
 
 		// create the default gatewayClass
 		gatewayClass := buildGatewayClass(gatewayClassName, gatewayClassControllerName)


### PR DESCRIPTION
This ensures GatewayAPIController tests are only run on clusters where OLM and related capabilities are enabled.