### PR TITLE
OCPBUGS-55384: OCPBUGS-55968: Fix PIS tests on SNO & Enable applicable MCN & PIS tests on SNO

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -430,19 +430,19 @@ func ValidateMCNForNodeInPool(oc *exutil.CLI, clientSet *machineconfigclient.Cli
 	return nil
 }
 
-// `GetRandomNode` gets a random node from a given MCP and checks whether the node is ready. If no
+// `GetRandomNode` gets a random node from with a given role and checks whether the node is ready. If no
 // nodes are ready, it will wait for up to 5 minutes for a node to become available.
-func GetRandomNode(oc *exutil.CLI, pool string) corev1.Node {
-	if node := getRandomNode(oc, pool); isNodeReady(node) {
+func GetRandomNode(oc *exutil.CLI, role string) corev1.Node {
+	if node := getRandomNode(oc, role); isNodeReady(node) {
 		return node
 	}
 
 	// If no nodes are ready, wait for up to 5 minutes for one to be ready
 	waitPeriod := time.Minute * 5
-	framework.Logf("No ready nodes found for pool '%s', waiting up to %s for a ready node to become available", pool, waitPeriod)
+	framework.Logf("No ready nodes found with role '%s', waiting up to %s for a ready node to become available", role, waitPeriod)
 	var targetNode corev1.Node
 	o.Eventually(func() bool {
-		if node := getRandomNode(oc, pool); isNodeReady(node) {
+		if node := getRandomNode(oc, role); isNodeReady(node) {
 			targetNode = node
 			return true
 		}
@@ -453,9 +453,9 @@ func GetRandomNode(oc *exutil.CLI, pool string) corev1.Node {
 	return targetNode
 }
 
-// `getRandomNode` gets a random node from a given pool
-func getRandomNode(oc *exutil.CLI, pool string) corev1.Node {
-	nodes, err := GetNodesByRole(oc, pool)
+// `getRandomNode` gets a random node with a given role
+func getRandomNode(oc *exutil.CLI, role string) corev1.Node {
+	nodes, err := GetNodesByRole(oc, role)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(nodes).ShouldNot(o.BeEmpty())
 

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -439,6 +439,8 @@
 // test/extended/testdata/machine_config/pinnedimage/customInvalidPis.yaml
 // test/extended/testdata/machine_config/pinnedimage/customMCPpis.yaml
 // test/extended/testdata/machine_config/pinnedimage/invalidPis.yaml
+// test/extended/testdata/machine_config/pinnedimage/masterInvalidPis.yaml
+// test/extended/testdata/machine_config/pinnedimage/masterPis.yaml
 // test/extended/testdata/machine_config/pinnedimage/pis.yaml
 // test/extended/testdata/marketplace/csc/02-csc.yaml
 // test/extended/testdata/marketplace/opsrc/02-opsrc.yaml
@@ -49636,6 +49638,58 @@ func testExtendedTestdataMachine_configPinnedimageInvalidpisYaml() (*asset, erro
 	return a, nil
 }
 
+var _testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: PinnedImageSet
+metadata:
+  name: test-pinned
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+spec:
+  pinnedImages:
+   - name: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86d26e7ebcccd6f07a75db5b1e56283b25c2ee1c6a755d6ffc5a4d59beb9cdef
+`)
+
+func testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYaml, nil
+}
+
+func testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/pinnedimage/masterInvalidPis.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataMachine_configPinnedimageMasterpisYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
+kind: PinnedImageSet
+metadata:
+  name: test-pinned
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+spec:
+  pinnedImages:
+   - name: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+`)
+
+func testExtendedTestdataMachine_configPinnedimageMasterpisYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configPinnedimageMasterpisYaml, nil
+}
+
+func testExtendedTestdataMachine_configPinnedimageMasterpisYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configPinnedimageMasterpisYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/pinnedimage/masterPis.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataMachine_configPinnedimagePisYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
 kind: PinnedImageSet
 metadata:
@@ -58803,6 +58857,8 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/machine_config/pinnedimage/customInvalidPis.yaml":                                testExtendedTestdataMachine_configPinnedimageCustominvalidpisYaml,
 	"test/extended/testdata/machine_config/pinnedimage/customMCPpis.yaml":                                    testExtendedTestdataMachine_configPinnedimageCustommcppisYaml,
 	"test/extended/testdata/machine_config/pinnedimage/invalidPis.yaml":                                      testExtendedTestdataMachine_configPinnedimageInvalidpisYaml,
+	"test/extended/testdata/machine_config/pinnedimage/masterInvalidPis.yaml":                                testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYaml,
+	"test/extended/testdata/machine_config/pinnedimage/masterPis.yaml":                                       testExtendedTestdataMachine_configPinnedimageMasterpisYaml,
 	"test/extended/testdata/machine_config/pinnedimage/pis.yaml":                                             testExtendedTestdataMachine_configPinnedimagePisYaml,
 	"test/extended/testdata/marketplace/csc/02-csc.yaml":                                                     testExtendedTestdataMarketplaceCsc02CscYaml,
 	"test/extended/testdata/marketplace/opsrc/02-opsrc.yaml":                                                 testExtendedTestdataMarketplaceOpsrc02OpsrcYaml,
@@ -59585,6 +59641,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"customInvalidPis.yaml": {testExtendedTestdataMachine_configPinnedimageCustominvalidpisYaml, map[string]*bintree{}},
 						"customMCPpis.yaml":     {testExtendedTestdataMachine_configPinnedimageCustommcppisYaml, map[string]*bintree{}},
 						"invalidPis.yaml":       {testExtendedTestdataMachine_configPinnedimageInvalidpisYaml, map[string]*bintree{}},
+						"masterInvalidPis.yaml": {testExtendedTestdataMachine_configPinnedimageMasterinvalidpisYaml, map[string]*bintree{}},
+						"masterPis.yaml":        {testExtendedTestdataMachine_configPinnedimageMasterpisYaml, map[string]*bintree{}},
 						"pis.yaml":              {testExtendedTestdataMachine_configPinnedimagePisYaml, map[string]*bintree{}},
 					}},
 				}},

--- a/test/extended/testdata/machine_config/pinnedimage/masterInvalidPis.yaml
+++ b/test/extended/testdata/machine_config/pinnedimage/masterInvalidPis.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: PinnedImageSet
+metadata:
+  name: test-pinned
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+spec:
+  pinnedImages:
+   - name: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:86d26e7ebcccd6f07a75db5b1e56283b25c2ee1c6a755d6ffc5a4d59beb9cdef

--- a/test/extended/testdata/machine_config/pinnedimage/masterPis.yaml
+++ b/test/extended/testdata/machine_config/pinnedimage/masterPis.yaml
@@ -1,0 +1,9 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: PinnedImageSet
+metadata:
+  name: test-pinned
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+spec:
+  pinnedImages:
+   - name: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f


### PR DESCRIPTION
Closes: OCPBUGS-55384
Closes: OCPBUGS-55968

**Work included:**
- Reenable the following tests on SNO
   - [MCN] `Should properly block MCN updates by impersonation of the MCD SA`
   - [MCN] `Should properly update the MCN from the associated MCD`
   - [PIS] `All Nodes in a standard Pool should have the PinnedImages PIS`
- Update the PIS tests running on SNO to use a PIS file targeting the master pool
- General updates to logs & function descriptions

**How to verify:**
SNO tech preview jobs should succeed for all PIS & MCN tests enabled for single-node topologies.
- Parallel suite: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29785-nightly-4.20-e2e-aws-ovn-single-node-techpreview/1922321162600189952
- Serial suite: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-29785-nightly-4.20-e2e-aws-ovn-single-node-techpreview-serial/1922321163137060864

**Local testing:**
The following tests are applicable to the single-node topology and should pass when run against a 4.20 SNO cluster with techpreview enabled.

_PinnedImageSets_
```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:MachineConfigNodes][Serial] All Nodes in a standard Pool should have the PinnedImages PIS [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/serial]"
```

```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:MachineConfigNodes][Serial] Invalid PIS leads to degraded MCN in a standard Pool [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/serial]"
```

_MachineConfigNode_
```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:MachineConfigNodes] [Serial]Should properly transition through MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/serial]"
```

```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:MachineConfigNodes] Should have MCN properties matching associated node properties for nodes in default MCPs [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/parallel]"
```

```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:MachineConfigNodes] Should properly block MCN updates by impersonation of the MCD SA [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/parallel]"
```

```
./openshift-tests run-test "[sig-mco][OCPFeatureGate:MachineConfigNodes] Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io] [Suite:openshift/conformance/parallel]"
```