### PR TITLE
NO-JIRA: Support skipping [OCP]FeatureGate tests

### DIFF
--- a/pkg/clioptions/suiteselection/feature_filter.go
+++ b/pkg/clioptions/suiteselection/feature_filter.go
@@ -78,5 +78,5 @@ func includeNonFeatureGateTest(name string) bool {
 }
 
 var (
-	featureGateRegex = regexp.MustCompile(`\[OCPFeatureGate:([^]]*)\]`)
+	featureGateRegex = regexp.MustCompile(`\[(?:OCP)?FeatureGate:([^]]*)\]`)
 )


### PR DESCRIPTION
Extends skipped tests labeled `FeatureGate`. Previously worked only for label `OCPFeatureGate`.