### PR TITLE
MCO-1652: Add new MCO disruptive suite

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -449,4 +449,17 @@ var staticSuites = []ginkgo.TestSuite{
 		},
 		TestTimeout: 60 * time.Minute,
 	},
+	{
+		Name: "openshift/machine-config-operator/disruptive",
+		Description: templates.LongDesc(`
+		This test suite runs tests to validate machine-config-operator functionality.
+		`),
+		Matches: func(name string) bool {
+			if isDisabled(name) {
+				return false
+			}
+			return strings.Contains(name, "[Suite:openshift/machine-config-operator/disruptive")
+		},
+		TestTimeout: 120 * time.Minute,
+	},
 }


### PR DESCRIPTION
Add an empty MCO suite, for testing purposes. Future tests will be moved over from serial and added via MCO OTE.

Alternative to https://github.com/openshift/origin/pull/29776