### PR TITLE
OCPBUGS-56381: feat: update test to account for two node fencing

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2321,6 +2321,15 @@ func IsMicroShiftCluster(kubeClient k8sclient.Interface) (bool, error) {
 	return true, nil
 }
 
+func IsTwoNodeFencing(ctx context.Context, configClient clientconfigv1.Interface) bool {
+	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	return infrastructure.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode
+}
+
 func groupName(groupVersionName string) string {
 	return strings.Split(groupVersionName, "/")[0]
 }


### PR DESCRIPTION
updated baremetal test to account for the difference in two node fencing baremetal deployment
