### PR TITLE
MULTIARCH-5391: Add new featuregate test to check if desired.Architecture is set as intended

### DIFF
--- a/test/extended/clusterversion/OWNERS
+++ b/test/extended/clusterversion/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+  - cluster-version-operator-test-case-reviewers
+  - Prashanth684
+approvers:
+  - cluster-version-operator-test-case-approvers

--- a/test/extended/clusterversion/clusterversion.go
+++ b/test/extended/clusterversion/clusterversion.go
@@ -1,0 +1,43 @@
+package clusterversion
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// The desired architecture field was introduced as part of a feature that provides a toggle for an imagestream's importMode: https://github.com/openshift/api/pull/2024
+var _ = g.Describe("[sig-cluster-lifecycle][OCPFeatureGate:ImageStreamImportMode] ClusterVersion API", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("")
+
+	g.It("desired architecture should be valid when architecture is set in release payload metadata [apigroup:config.openshift.io]", func() {
+		TestClusterVersionDesiredArchitecture(g.GinkgoT(), oc)
+	})
+
+})
+
+func TestClusterVersionDesiredArchitecture(t g.GinkgoTInterface, oc *exutil.CLI) {
+	ctx := context.Background()
+
+	archMetadata, _, err := oc.AsAdmin().Run("adm", "release", "info", `-ojsonpath={.metadata.metadata.release\.openshift\.io\/architecture}`).Outputs()
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Check desired.Architecture in the CV
+	configClient, err := configclient.NewForConfig(oc.AdminConfig())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	clusterVersion, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if archMetadata == "multi" {
+		o.Expect(clusterVersion.Status.Desired.Architecture).To(o.Equal(configv1.ClusterVersionArchitectureMulti))
+	} else {
+		o.Expect(clusterVersion.Status.Desired.Architecture).To(o.BeEmpty())
+	}
+}

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cli"
 	_ "github.com/openshift/origin/test/extended/cloud_controller_manager"
 	_ "github.com/openshift/origin/test/extended/cluster"
+	_ "github.com/openshift/origin/test/extended/clusterversion"
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
 	_ "github.com/openshift/origin/test/extended/coreos"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -987,6 +987,8 @@ var Annotations = map[string]string{
 
 	"[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]": " [Suite:openshift/conformance/serial]",
 
+	"[sig-cluster-lifecycle][OCPFeatureGate:ImageStreamImportMode] ClusterVersion API desired architecture should be valid when architecture is set in release payload metadata [apigroup:config.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-coreos] [Conformance] CoreOS bootimages TestBootimagesPresent [apigroup:machineconfiguration.openshift.io]": " [Suite:openshift/conformance/parallel/minimal]",
 
 	"[sig-devex] check registry.redhat.io is available and samples operator can import sample imagestreams run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -115,6 +115,9 @@ spec:
         mock driver Static provisioning should honor pv retain reclaim policy'
   - featureGate: ImageStreamImportMode
     tests:
+    - testName: '[sig-cluster-lifecycle][OCPFeatureGate:ImageStreamImportMode] ClusterVersion
+        API desired architecture should be valid when architecture is set in release
+        payload metadata [apigroup:config.openshift.io]'
     - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial]
         ImageStream API import mode should be Legacy if the import mode specified
         in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]'


### PR DESCRIPTION
A new featuregated field was introduced a while ago under clusterversion status - `desired.Architecture` which denotes the architecture of the release image being reconciled to. As we plan to promote the feature gate to default - this adds a basic test to check if the `desired.Architecture` is set based on the `release.openshift.io/architecture: multi` being present as part of the release metadata.