### PR TITLE
OPRUN-3863: Add olmv1 webhook support origin tests

### DIFF
--- a/test/extended/olm/olmv1-webhook-support.go
+++ b/test/extended/olm/olmv1-webhook-support.go
@@ -1,0 +1,316 @@
+package operators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	conditionTypeServing   = "Serving"
+	conditionTypeInstalled = "Installed"
+
+	openshiftServiceCANamespace            = "openshift-service-ca"
+	openshiftServiceCASigningKeySecretName = "signing-key"
+)
+
+var (
+	webhookTestBaseDir              = exutil.FixturePath("testdata", "olmv1", "webhook-support")
+	webhookOperatorInstallNamespace = "webhook-operator"
+)
+
+var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks", g.Ordered, g.Serial, func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("openshift-operator-controller-webhooks")
+
+	g.BeforeAll(func(ctx g.SpecContext) {
+		g.By("checking olmv1 capability is enabled")
+		checkFeatureCapability(oc)
+
+		g.By("creating the webhook-operator catalog")
+		manifest, err := os.ReadFile(filepath.Join(webhookTestBaseDir, "webhook-operator-catalog.yaml"))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		cleanup, err := applyRenderedManifests(oc, string(manifest))
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(cleanup)
+
+		g.By("waiting for the webhook-operator catalog to be serving")
+		var lastReason string
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				isDone, err, status := checkCatalogServing(oc, "webhook-operator-catalog")
+				if lastReason != status {
+					g.GinkgoLogr.Info(fmt.Sprintf("waitForWebhookOperatorCatalogServing: %q", status))
+					lastReason = status
+				}
+				return isDone, err
+			})
+		o.Expect(lastReason).To(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("installing the webhook operator")
+		extManifests, err := getWebhookClusterExtensionInstallManifests(webhookOperatorInstallNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		cleanup, err = applyRenderedManifests(oc, extManifests)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(cleanup)
+
+		g.By("waiting for the webhook operator to be installed")
+		lastReason = ""
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true,
+			func(ctx context.Context) (bool, error) {
+				isDone, err, status := checkOperatorInstalled(oc, "webhook-operator")
+				if lastReason != status {
+					g.GinkgoLogr.Info(fmt.Sprintf("waitForWebhookOperatorInstalled: %q", status))
+					lastReason = status
+				}
+				return isDone, err
+			})
+		o.Expect(lastReason).To(o.BeEmpty())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("waiting for the webhook operator deployment to be Available")
+		err = oc.AsAdmin().WithoutNamespace().Run("wait").Args("--for=condition=Available", "-n", webhookOperatorInstallNamespace, "deployments/webhook-operator-webhook").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+
+	g.AfterEach(func() {
+		if g.CurrentSpecReport().Failed() {
+			exutil.DumpPodLogsStartingWith("", oc)
+		}
+	})
+
+	g.It("should have a working validating webhook", func(ctx g.SpecContext) {
+		g.By("creating a webhook test resource that will be rejected by the validating webhook")
+		resource := getWebhookOperatorResource("validating-webhook-test", webhookOperatorInstallNamespace, false)
+
+		// even if the resource gets created, it will be cleaned up when test gets torn down and the
+		// webhook-operator namespace gets deleted
+		o.Eventually(func(cg o.Gomega) {
+			_, err := applyRenderedManifests(oc, resource)
+			cg.Expect(err).To(o.HaveOccurred())
+			cg.Expect(err.Error()).To(o.ContainSubstring("Invalid value: false: Spec.Valid must be true"))
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(o.Succeed())
+	})
+
+	g.It("should have a working mutating webhook", func(ctx g.SpecContext) {
+		g.By("creating a valid webhook test resource")
+		var (
+			mutatingWebhookResourceName = "mutating-webhook-test"
+			resource                    = getWebhookOperatorResource(mutatingWebhookResourceName, webhookOperatorInstallNamespace, true)
+		)
+
+		o.Eventually(func(cg o.Gomega) {
+			cleanup, err := applyRenderedManifests(oc, resource)
+			cg.Expect(err).NotTo(o.HaveOccurred())
+			// clean up fn will only be scheduled if there are no errors
+			g.DeferCleanup(cleanup)
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(o.Succeed())
+
+		cfg, err := clientcmd.BuildConfigFromFlags("", exutil.KubeConfigPath())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		c, err := dynamic.NewForConfig(cfg)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		v1WebhookTestClient := c.Resource(schema.GroupVersionResource{
+			Group:    "webhook.operators.coreos.io",
+			Version:  "v1",
+			Resource: "webhooktests",
+		}).Namespace(webhookOperatorInstallNamespace)
+
+		g.By("getting the created resource in v1 schema")
+		obj, err := v1WebhookTestClient.Get(ctx, mutatingWebhookResourceName, metav1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(obj).ToNot(o.BeNil())
+
+		g.By("validating the resource spec")
+		spec := obj.Object["spec"].(map[string]interface{})
+		o.Expect(spec).To(o.Equal(map[string]interface{}{
+			"valid":  true,
+			"mutate": true,
+		}))
+	})
+
+	g.It("should have a working conversion webhook", func(ctx g.SpecContext) {
+		var (
+			conversionWebhookResourceName = "conversion-webhook-test"
+			resource                      = getWebhookOperatorResource(conversionWebhookResourceName, webhookOperatorInstallNamespace, true)
+		)
+
+		o.Eventually(func(cg o.Gomega) {
+			cleanup, err := applyRenderedManifests(oc, resource)
+			cg.Expect(err).NotTo(o.HaveOccurred())
+			// clean up fn will only be scheduled if there are no errors
+			g.DeferCleanup(cleanup)
+		}).WithTimeout(10 * time.Second).WithPolling(250 * time.Millisecond).Should(o.Succeed())
+
+		cfg, err := clientcmd.BuildConfigFromFlags("", exutil.KubeConfigPath())
+		o.Expect(err).ToNot(o.HaveOccurred())
+		c, err := dynamic.NewForConfig(cfg)
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		v2WebhookTestClient := c.Resource(schema.GroupVersionResource{
+			Group:    "webhook.operators.coreos.io",
+			Version:  "v2",
+			Resource: "webhooktests",
+		}).Namespace(webhookOperatorInstallNamespace)
+
+		g.By("getting the created resource in v2 schema")
+		obj, err := v2WebhookTestClient.Get(ctx, conversionWebhookResourceName, metav1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		o.Expect(obj).ToNot(o.BeNil())
+
+		g.By("validating the resource spec")
+		spec := obj.Object["spec"].(map[string]interface{})
+		o.Expect(spec).To(o.Equal(map[string]interface{}{
+			"conversion": map[string]interface{}{
+				"valid":  true,
+				"mutate": true,
+			},
+		}))
+	})
+
+	g.It("should be tolerant to openshift-service-ca certificate rotation", func(ctx g.SpecContext) {
+		resource := getWebhookOperatorResource("some-resource", webhookOperatorInstallNamespace, true)
+
+		// delete tls secret
+		g.By("deleting the openshift-service-ca signing-key secret")
+		err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("secret", openshiftServiceCASigningKeySecretName, "--namespace", openshiftServiceCANamespace).Execute()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// even with the secret deleted the webhook should still be responsive
+		g.By("checking webhook is responsive through cert rotation")
+		o.Eventually(func(g o.Gomega) {
+			cleanup, err := applyRenderedManifests(oc, resource)
+			g.Expect(err).ToNot(o.HaveOccurred())
+			cleanup()
+		}).WithTimeout(30 * time.Second).WithPolling(500 * time.Millisecond).Should(o.Succeed())
+	})
+
+	g.It("should be tolerant to tls secret deletion", func(ctx g.SpecContext) {
+		resource := getWebhookOperatorResource("some-resource", webhookOperatorInstallNamespace, true)
+		certificateSecretName := "webhook-operator-webhook-service-cert"
+
+		g.By("ensuring secret exists")
+		o.Eventually(func(g o.Gomega) {
+			err := oc.AsAdmin().WithoutNamespace().Run("get").Args("secret", certificateSecretName, "-n", webhookOperatorInstallNamespace).Execute()
+			o.Expect(err).ToNot(o.HaveOccurred())
+		}).Should(o.Succeed())
+
+		// delete tls secret
+		g.By("checking webhook is responsive through secret recreation")
+		err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("secret", certificateSecretName, "-n", webhookOperatorInstallNamespace).Execute()
+		o.Expect(err).ToNot(o.HaveOccurred())
+
+		// even with the secret deleted the webhook should still be responsive
+		o.Eventually(func(g o.Gomega) {
+			cleanup, err := applyRenderedManifests(oc, resource)
+			g.Expect(err).ToNot(o.HaveOccurred())
+			cleanup()
+		}).WithTimeout(10 * time.Second).WithPolling(100 * time.Millisecond).Should(o.Succeed())
+	})
+})
+
+func checkCatalogServing(oc *exutil.CLI, catalogName string) (bool, error, string) {
+	cmdArgs := []string{
+		"clustercatalogs.olm.operatorframework.io",
+		catalogName,
+		"-o=jsonpath={.status.conditions}",
+	}
+
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(cmdArgs...).Output()
+	if err != nil {
+		return false, err, ""
+	}
+	// no data yet, so try again
+	if output == "" {
+		return false, nil, "no output"
+	}
+
+	var conditions []metav1.Condition
+	if err := json.Unmarshal([]byte(output), &conditions); err != nil {
+		return false, fmt.Errorf("error in json.Unmarshal(%v): %v", output, err), ""
+	}
+	c := meta.FindStatusCondition(conditions, conditionTypeServing)
+	if c == nil {
+		return false, nil, fmt.Sprintf("condition not present: %q", conditionTypeServing)
+	}
+	if c.Status != metav1.ConditionTrue {
+		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
+	}
+	return true, nil, ""
+}
+
+func checkOperatorInstalled(oc *exutil.CLI, extName string) (bool, error, string) {
+	cmdArgs := []string{
+		"clusterextensions.olm.operatorframework.io",
+		extName,
+		"-o=jsonpath={.status.conditions}",
+	}
+
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(cmdArgs...).Output()
+	if err != nil {
+		return false, err, ""
+	}
+	// no data yet, so try again
+	if output == "" {
+		return false, nil, "no output"
+	}
+
+	var conditions []metav1.Condition
+	if err := json.Unmarshal([]byte(output), &conditions); err != nil {
+		return false, fmt.Errorf("error in json.Unmarshal(%v): %v", output, err), ""
+	}
+	c := meta.FindStatusCondition(conditions, conditionTypeInstalled)
+	if c == nil {
+		return false, nil, fmt.Sprintf("condition not present: %q", conditionTypeInstalled)
+	}
+	if c.Status != metav1.ConditionTrue {
+		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
+	}
+	return true, nil, ""
+}
+
+func applyRenderedManifests(oc *exutil.CLI, manifests string) (func(), error) {
+	g.By(fmt.Sprintf("applying manifests %q", manifests))
+	err := oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", "-").InputString(manifests).Execute()
+	return func() {
+		err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("-f", "-").InputString(manifests).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}, err
+}
+
+func getWebhookClusterExtensionInstallManifests(installNamespace string) (string, error) {
+	bytes, err := os.ReadFile(filepath.Join(webhookTestBaseDir, "webhook-operator.yaml"))
+	if err != nil {
+		return "", err
+	}
+	return strings.ReplaceAll(string(bytes), "{NAMESPACE}", installNamespace), nil
+}
+
+func getWebhookOperatorResource(name string, namespace string, valid bool) string {
+	return fmt.Sprintf(`apiVersion: webhook.operators.coreos.io/v1
+kind: WebhookTest
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  valid: %t
+`, name, namespace, valid)
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -477,6 +477,9 @@
 // test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
 // test/extended/testdata/olmv1/install-quay-operator-ownns.yaml
 // test/extended/testdata/olmv1/install-quay-operator-singlens.yaml
+// test/extended/testdata/olmv1/operator.yaml
+// test/extended/testdata/olmv1/webhook-support/webhook-operator-catalog.yaml
+// test/extended/testdata/olmv1/webhook-support/webhook-operator.yaml
 // test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
@@ -53732,6 +53735,142 @@ func testExtendedTestdataOlmv1InstallQuayOperatorSinglensYaml() (*asset, error) 
 	return a, nil
 }
 
+var _testExtendedTestdataOlmv1OperatorYaml = []byte(`apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: install-test-sa-quay-operator
+  namespace: testit
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: install-test-crb-quay-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: install-test-sa-quay-operator
+  namespace: testit
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: install-test-ce-quay-operator
+spec:
+  namespace: testit
+  serviceAccount:
+    name: install-test-sa-quay-operator
+  source:
+    catalog:
+      packageName: quay-operator
+      version: 3.13.0
+      selector: {}
+      upgradeConstraintPolicy: CatalogProvided
+    sourceType: Catalog
+`)
+
+func testExtendedTestdataOlmv1OperatorYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1OperatorYaml, nil
+}
+
+func testExtendedTestdataOlmv1OperatorYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1OperatorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/operator.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYaml = []byte(`apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: webhook-operator-catalog
+spec:
+  source:
+    type: Image
+    image:
+      ref: quay.io/operator-framework/webhook-operator-index:0.0.3
+`)
+
+func testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYaml, nil
+}
+
+func testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/webhook-support/webhook-operator-catalog.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYaml = []byte(`---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: webhook-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook-operator-installer
+  namespace: webhook-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: webhook-operator-installer
+    namespace: webhook-operator
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: webhook-operator
+spec:
+  namespace: webhook-operator
+  serviceAccount:
+    name: webhook-operator-installer
+  source:
+    catalog:
+      packageName: webhook-operator
+      version: 0.0.1
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: webhook-operator-catalog
+      upgradeConstraintPolicy: CatalogProvided
+    sourceType: Catalog
+`)
+
+func testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYaml, nil
+}
+
+func testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/olmv1/webhook-support/webhook-operator.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml = []byte(`---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -59409,6 +59548,9 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/olmv1/install-pipeline-operator-base.yaml":                                       testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml,
 	"test/extended/testdata/olmv1/install-quay-operator-ownns.yaml":                                          testExtendedTestdataOlmv1InstallQuayOperatorOwnnsYaml,
 	"test/extended/testdata/olmv1/install-quay-operator-singlens.yaml":                                       testExtendedTestdataOlmv1InstallQuayOperatorSinglensYaml,
+	"test/extended/testdata/olmv1/operator.yaml":                                                             testExtendedTestdataOlmv1OperatorYaml,
+	"test/extended/testdata/olmv1/webhook-support/webhook-operator-catalog.yaml":                             testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYaml,
+	"test/extended/testdata/olmv1/webhook-support/webhook-operator.yaml":                                     testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYaml,
 	"test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml":                               testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml":                          testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml":                   testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml,
@@ -60223,6 +60365,11 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"install-pipeline-operator-base.yaml":             {testExtendedTestdataOlmv1InstallPipelineOperatorBaseYaml, map[string]*bintree{}},
 					"install-quay-operator-ownns.yaml":                {testExtendedTestdataOlmv1InstallQuayOperatorOwnnsYaml, map[string]*bintree{}},
 					"install-quay-operator-singlens.yaml":             {testExtendedTestdataOlmv1InstallQuayOperatorSinglensYaml, map[string]*bintree{}},
+					"operator.yaml":                                   {testExtendedTestdataOlmv1OperatorYaml, map[string]*bintree{}},
+					"webhook-support": {nil, map[string]*bintree{
+						"webhook-operator-catalog.yaml": {testExtendedTestdataOlmv1WebhookSupportWebhookOperatorCatalogYaml, map[string]*bintree{}},
+						"webhook-operator.yaml":         {testExtendedTestdataOlmv1WebhookSupportWebhookOperatorYaml, map[string]*bintree{}},
+					}},
 				}},
 				"poddisruptionbudgets": {nil, map[string]*bintree{
 					"always-allow-policy-pdb.yaml":             {testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml, map[string]*bintree{}},

--- a/test/extended/testdata/olmv1/operator.yaml
+++ b/test/extended/testdata/olmv1/operator.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: install-test-sa-quay-operator
+  namespace: testit
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: install-test-crb-quay-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: install-test-sa-quay-operator
+  namespace: testit
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: install-test-ce-quay-operator
+spec:
+  namespace: testit
+  serviceAccount:
+    name: install-test-sa-quay-operator
+  source:
+    catalog:
+      packageName: quay-operator
+      version: 3.13.0
+      selector: {}
+      upgradeConstraintPolicy: CatalogProvided
+    sourceType: Catalog

--- a/test/extended/testdata/olmv1/webhook-support/webhook-operator-catalog.yaml
+++ b/test/extended/testdata/olmv1/webhook-support/webhook-operator-catalog.yaml
@@ -1,0 +1,9 @@
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterCatalog
+metadata:
+  name: webhook-operator-catalog
+spec:
+  source:
+    type: Image
+    image:
+      ref: quay.io/operator-framework/webhook-operator-index:0.0.3

--- a/test/extended/testdata/olmv1/webhook-support/webhook-operator.yaml
+++ b/test/extended/testdata/olmv1/webhook-support/webhook-operator.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: webhook-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: webhook-operator-installer
+  namespace: webhook-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: webhook-operator-installer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: webhook-operator-installer
+    namespace: webhook-operator
+---
+apiVersion: olm.operatorframework.io/v1
+kind: ClusterExtension
+metadata:
+  name: webhook-operator
+spec:
+  namespace: webhook-operator
+  serviceAccount:
+    name: webhook-operator-installer
+  source:
+    catalog:
+      packageName: webhook-operator
+      version: 0.0.1
+      selector:
+        matchLabels:
+          olm.operatorframework.io/metadata.name: webhook-operator-catalog
+      upgradeConstraintPolicy: CatalogProvided
+    sourceType: Catalog

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1939,6 +1939,16 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {services} are not specified": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate rotation": " [Suite:openshift/conformance/serial]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should be tolerant to tls secret deletion": " [Suite:openshift/conformance/serial]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working conversion webhook": " [Suite:openshift/conformance/serial]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working mutating webhook": " [Suite:openshift/conformance/serial]",
+
+	"[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial] OLMv1 operator with webhooks should have a working validating webhook": " [Suite:openshift/conformance/serial]",
+
 	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -951,6 +951,19 @@ spec:
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected]
         OLMv1 operator preflight checks should report error when {services} are not
         specified'
+  - featureGate: NewOLMWebhookProviderOpenshiftServiceCA
+    tests:
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial]
+        OLMv1 operator with webhooks should be tolerant to openshift-service-ca certificate
+        rotation'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial]
+        OLMv1 operator with webhooks should be tolerant to tls secret deletion'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial]
+        OLMv1 operator with webhooks should have a working conversion webhook'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial]
+        OLMv1 operator with webhooks should have a working mutating webhook'
+    - testName: '[sig-olmv1][OCPFeatureGate:NewOLMWebhookProviderOpenshiftServiceCA][Skipped:Disconnected][Serial]
+        OLMv1 operator with webhooks should have a working validating webhook'
   - featureGate: OrderedNamespaceDeletion
     tests:
     - testName: '[sig-api-machinery] OrderedNamespaceDeletion namespace deletion should


### PR DESCRIPTION
Adds origin tests for the webhook support feature. Test need to be run serially to enable BeforeSuite functionality which installs the webhook operator for the tests:
- check validating webhook
- check mutating webhook
- check conversion webhook
- check service availability during cert secret deletion by continuously creating and deleting a resource after the deletion of the cert secret
- check deployment availability during cert rotation, which is forced to happen when the openshift-service-ca signing key gets deleted.


(I'm not sure I'd add the last two if it weren't for the need to have 5 tests)