### PR TITLE
NO-JIRA: We should always run tests where we have no opinion on their gate

### DIFF
--- a/pkg/clioptions/suiteselection/feature_filter.go
+++ b/pkg/clioptions/suiteselection/feature_filter.go
@@ -70,7 +70,11 @@ func (f *featureGateFilter) includeTest(name string) bool {
 		return false
 	}
 
-	return f.enabled.HasAll(featureGates...)
+	// It is important that we always return true if we don't know the status of the gate.
+	// This generally means we have no opinion on whether the feature is on or off.
+	// We expect the default case to be on, as this is what would happen after a feature is promoted,
+	// and the gate is removed.
+	return true
 }
 
 func includeNonFeatureGateTest(name string) bool {


### PR DESCRIPTION
When a test is added, that contains `[OCPFeatureGate:`, we expect that the gate already exists in openshift/api and we therefore have an opinion about the gate as to whether it is enabled or disabled.

In all cases, we render every known gate as either enabled or disabled, so every gate has an opinion.

However, when we remove gates, we no longer have an opinion, and the current code disables the tests.

Generally, removing the gate means the feature was promoted to default in a previous release, and therefore the tests should continue to run.

In some cases, the gate may be removed without ever graduating. This is rare, and in these cases we would start running their tests with the feature removed, which would fail, and we would find out pretty quickly.

This seems like the lesser of two evils, the alternative is we just stop running tests and are oblivious to this