### PR TITLE
ODC-7790: Remove ODODownloadsSyncDegraded

### DIFF
--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -132,7 +132,6 @@ var (
 			"OAuthServingCertValidationDegraded",
 			"OAuthServingCertValidationProgressing",
 			"OCDownloadsSyncDegraded",
-			"ODODownloadsSyncDegraded",
 			"OIDCClientConfigDegraded",
 			"OIDCClientConfigProgressing",
 			"PDBSyncDegraded",


### PR DESCRIPTION
This PR removes the ODODownloadsSyncDegraded as ODO is deprecated, and removing the ODOCLIDownloads from the console-operator.