### PR TITLE
OCPQE-29454: labelcompare

### DIFF
--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -116,6 +116,26 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 		}
 	})
 
+	g.It("the Machine provider spec zone should match the label on the paired node", func() {
+		exutil.SkipIfNotPlatform(oc, v1.AWSPlatformType)
+		g.By("Listing all Machines ...")
+		machineClient := dc.Resource(schema.GroupVersionResource{Group: "machine.openshift.io", Resource: "machines", Version: "v1beta1"})
+		obj, err := machineClient.List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred())
+		machines := objx.Map(obj.UnstructuredContent())
+		items := objects(machines.Get("items"))
+		for _, machine := range items {
+			machineProviderSpecZone := machine.Get("spec.providerSpec.value.placement.availabilityZone").String()
+			if machineProviderSpecZone == "" {
+				continue
+			}
+			nodeName := nodeNameFromNodeRef(machine)
+			labelOnTheNode, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", nodeName, "-o=jsonpath={.metadata.labels.topology\\.kubernetes\\.io\\/zone}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get node label")
+			o.Expect(labelOnTheNode).To(o.Equal(machineProviderSpecZone))
+		}
+	})
+
 	g.It("[sig-scheduling][Early] control plane machine set operator should not cause an early rollout", func() {
 		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -981,6 +981,8 @@ var Annotations = map[string]string{
 
 	"[sig-cluster-lifecycle][Feature:Machines] Managed cluster should have machine resources [apigroup:machine.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-cluster-lifecycle][Feature:Machines] Managed cluster should the Machine provider spec zone should match the label on the paired node": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should recover from deleted worker machines [apigroup:machine.openshift.io]": " [Serial]",
 
 	"[sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should have same number of Machines and Nodes [apigroup:machine.openshift.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
passed in local @JoelSpeed @sunzhaohua2 @miyadav @shellyyang1989 PTAL, thanks!
```
  Will run 1 of 1 specs
  ------------------------------
  [sig-cluster-lifecycle][Feature:Machines] Managed cluster should the Machine provider spec zone should match the label on the paired node
  github.com/openshift/origin/test/extended/machines/machines.go:119
    STEP: Creating a kubernetes client @ 05/22/25 17:29:53.816
  I0522 17:29:53.819079    6382 discovery.go:214] Invalidating discovery information
    STEP: Listing all Machines ... @ 05/22/25 17:29:54.114
  I0522 17:29:54.686744 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-20-69.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  I0522 17:29:56.306668 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-39-58.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  I0522 17:29:57.594502 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-80-165.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  I0522 17:29:58.891679 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-6-87.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  I0522 17:30:00.156501 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-43-182.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  I0522 17:30:01.361538 6382 client.go:952] Running 'oc --kubeconfig=/Users/liuhuali/huali-test/kubeconfig2 get node ip-10-0-85-255.us-east-2.compute.internal -o=jsonpath={.metadata.labels.topology\.kubernetes\.io\/zone}'
  • [8.774 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 8.775 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```