### PR TITLE
auto negative tests of gatewayapicontroller

### DIFF
--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,15 +16,18 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatoringressv1 "github.com/openshift/api/operatoringress/v1"
+	operatoringressclientset "github.com/openshift/client-go/operatoringress/clientset/versioned"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	clientset "k8s.io/client-go/kubernetes"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/utils/pointer"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -245,6 +250,172 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Validating the http connectivity to the backend application")
 		assertHttpRouteConnection(defaultRoutename)
+	})
+
+	g.It("Ensure OSSM subscription and istio could be deleted and then get recreated", func() {
+		const (
+			operatorNamespace      = "openshift-operators"
+			ingressNamespace       = "openshift-ingress"
+			ossmSubscriptionName   = "servicemeshoperator3"
+			csvName                = "servicemeshoperator3.v3.0.0"
+			ossmOperatorDeployment = "servicemesh-operator3"
+			istiodDeployment       = "istiod-openshift-gateway"
+			istioName              = "openshift-gateway"
+		)
+
+		// deleted the OSSM subscription and then checked if it was restored
+		g.By(fmt.Sprintf("Try to delete the subscription %s", ossmSubscriptionName))
+		_, err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", operatorNamespace, "subscription/"+ossmSubscriptionName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("Wait untill the the OSSM subscription %s is automatically created successfully", ossmSubscriptionName))
+		var unhealthy string
+		o.Eventually(func() string {
+			var err error
+			unhealthy, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", operatorNamespace, "subscription", ossmSubscriptionName, `-o=jsonpath={.status.conditions[?(@.type=="CatalogSourcesUnhealthy")].status}`).Output()
+			if err != nil {
+				e2e.Logf("Failed to check %s, error: %v, retrying...", ossmSubscriptionName, err)
+			}
+			e2e.Logf("Wait CatalogSourcesUnhealthy status to be False, and got %s", unhealthy)
+			return unhealthy
+		}, 5*time.Minute, time.Second).Should(o.Equal("False"))
+
+		g.By(fmt.Sprintf("Wait untill the the OSSM csv %s is automatically created successfully", csvName))
+		var phase string
+		o.Eventually(func() string {
+			var err error
+			phase, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", operatorNamespace, "csv", csvName, `-o=jsonpath={.status.phase}`).Output()
+			if err != nil {
+				e2e.Logf("Failed to check %s, error: %v, retrying...", csvName, err)
+			}
+			e2e.Logf(fmt.Sprintf("Wait for phase to be Succeeded, and got %s", phase))
+			return phase
+		}, 5*time.Minute, time.Second).Should(o.Equal("Succeeded"))
+
+		// deleted the istiod deployment and then checked if it was restored
+		deleteDeploymentAndWaitAvailableAgain(oc, istiodDeployment, ingressNamespace)
+
+		// deleted the istio and check if it was restored
+		g.By(fmt.Sprintf("Try to delete the istio %s", istioName))
+		output, err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("-n", ingressNamespace, "istio/"+istioName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring("deleted"))
+
+		g.By(fmt.Sprintf("Wait untill the the istiod %s is automatically created successfully", istioName))
+		o.Eventually(func() string {
+			readyReplicas, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ingressNamespace, "istio/"+istioName, `-o=jsonpath={.status.revisions.ready}`).Output()
+			if err != nil {
+				e2e.Logf("Failed to check istio %s, error: %v, retrying...", istioName, err)
+			}
+			e2e.Logf("Wait for the ready replicas to be 1, and got %s", readyReplicas)
+			return readyReplicas
+		}, 5*time.Minute, time.Second).Should(o.Equal("1"))
+	})
+
+	g.It("Ensure gateway loadbalancer service and dnsrecords could be deleted and then get recreated", func() {
+		const (
+			operatorNamespace = "openshift-operators"
+			ingressNamespace  = "openshift-ingress"
+			gatewayName       = "gateway"
+		)
+
+		g.By("Ensure default GatewayClass is accepted")
+		errCheck := checkGatewayClass(oc, gatewayClassName)
+		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q was not installed and accepted", gatewayClassName)
+
+		g.By("Getting the default domain")
+		defaultIngressDomain, err := getDefaultIngressClusterDomainName(oc, time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to find default domain name")
+		defaultDomain := strings.Replace(defaultIngressDomain, "apps.", "gw-default.", 1)
+
+		g.By("Create the default Gateway")
+		gw := names.SimpleNameGenerator.GenerateName("gateway-")
+		gateways = append(gateways, gw)
+		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, defaultDomain)
+		o.Expect(gwerr).NotTo(o.HaveOccurred(), "failed to create Gateway")
+
+		g.By("Verify the gateway's LoadBalancer service and DNSRecords")
+		assertGatewayLoadbalancerReady(oc, gw, gw+"-openshift-default")
+
+		// check the dns record is created and status of the published dnsrecord of all zones are True
+		assertDNSRecordStatus(oc, gw)
+
+		// deleted the gateway loadbalancer service and then checked if it was restored
+		gatewayLbService := gw + "-openshift-default"
+		g.By(fmt.Sprintf("Try to delete the gateway lb service %s", gatewayLbService))
+		coreClient := clientset.NewForConfigOrDie(oc.AdminConfig())
+		lbService, err := coreClient.CoreV1().Services(ingressNamespace).Get(context.Background(), gatewayLbService, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		createdTime1 := lbService.ObjectMeta.CreationTimestamp
+		err = oc.AdminKubeClient().CoreV1().Services(ingressNamespace).Delete(context.Background(), gatewayLbService, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("Wait until the gateway lb service %s is automatically recreated successfully", gatewayLbService))
+		o.Eventually(func() bool {
+			lbService, err := coreClient.CoreV1().Services(ingressNamespace).Get(context.Background(), gatewayLbService, metav1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					return false
+				}
+				e2e.Logf("Error getting the gateway lb service %s: %v, retrying...", gatewayLbService, err)
+				return false
+			}
+
+			createdTime2 := lbService.ObjectMeta.CreationTimestamp
+			if createdTime2 == createdTime1 {
+				return false
+			}
+
+			lb := lbService.Status.LoadBalancer
+			searchInfo := regexp.MustCompile("(IP:([0-9\\.a-fA-F:]+))|(Hostname:([0-9\\.\\-a-zA-Z]+))").FindStringSubmatch(lb.String())
+			if len(searchInfo) > 0 {
+				if gwlb := searchInfo[2]; len(gwlb) > 0 {
+					e2e.Logf("New load balancer ip %s is available", gwlb)
+					return true
+				}
+				if gwlb := searchInfo[4]; len(gwlb) > 0 {
+					e2e.Logf("New load balancer hostname %s is available", gwlb)
+					return true
+				}
+			}
+			e2e.Logf("Failed to get the new IP or hostname of the gateway lb service %s, retrying...", gatewayLbService)
+			return false
+		}, 5*time.Minute, 3*time.Second).Should(o.Equal(true))
+
+		// deleted the gateway dnsrecords then checked if it was restored
+		g.By(fmt.Sprintf("Get some info of the gateway dnsrecords in %s namespace, then try to delete it", ingressNamespace))
+		ingressclient := operatoringressclientset.NewForConfigOrDie(oc.AdminConfig())
+		dnsrecordList, err := ingressclient.IngressV1().DNSRecords(ingressNamespace).List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		dnsrecordName := dnsrecordList.Items[0].ObjectMeta.Name
+		targets := dnsrecordList.Items[0].Spec.Targets
+		targetsList1 := getSortedString(targets)
+		e2e.Logf("gwapi dnsrecords targetsList1 is %v", targetsList1)
+
+		err = ingressclient.IngressV1().DNSRecords(ingressNamespace).Delete(context.Background(), dnsrecordName, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By(fmt.Sprintf("Wait unitl the gateway dnsrecords in %s namespace is automatically created successfully", ingressNamespace))
+		o.Eventually(func() bool {
+			dnsrecordList, err := ingressclient.IngressV1().DNSRecords(ingressNamespace).List(context.Background(), metav1.ListOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			targetsList2 := getSortedString(dnsrecordList.Items[0].Spec.Targets)
+
+			if targetsList2 != targetsList1 {
+				e2e.Logf("The gateway dnsrecords has not a targetsIP or a different one %s with %s, retrying...", getSortedString(targetsList2), targetsList1)
+				return false
+			}
+			e2e.Logf("gwapi dnsrecords targetsList2 is %v", targetsList2)
+
+			for _, zone := range dnsrecordList.Items[0].Status.Zones {
+				for _, condition := range zone.Conditions {
+					if condition.Status != "True" || condition.Reason != "ProviderSuccess" {
+						return false
+					}
+				}
+			}
+			return true
+		}, 3*time.Minute, 3*time.Second).Should(o.Equal(true))
 	})
 })
 
@@ -672,4 +843,86 @@ func isOKD(oc *exutil.CLI) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+// used to delete a deployment and wait for it is automatically recreated again
+func deleteDeploymentAndWaitAvailableAgain(oc *exutil.CLI, deploymentName, ns string) {
+	g.By(fmt.Sprintf("Try to delete the deployment %s in %s namespace", deploymentName, ns))
+	client := clientset.NewForConfigOrDie(oc.AdminConfig())
+	err := client.AppsV1().Deployments(ns).Delete(context.Background(), deploymentName, metav1.DeleteOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By(fmt.Sprintf("Wait until the deployment %s in %s namespace is recreated and returns back healthy", deploymentName, ns))
+	err = wait.Poll(3*time.Second, 300*time.Second, func() (bool, error) {
+		deployment, err := client.AppsV1().Deployments(ns).Get(context.Background(), deploymentName, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			e2e.Logf("Error getting %s deployment: %v, retrying", deploymentName, err)
+			return false, nil
+		}
+
+		readyReplicas := deployment.Status.ReadyReplicas
+		e2e.Logf("The ready replicas is %v", readyReplicas)
+		if readyReplicas != 1 {
+			e2e.Logf(`The deployment %s in %s namespace is not ready(AvailableReplicas: %v), retrying`, deploymentName, ns, deployment.Status.AvailableReplicas)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func ensureLbServiceRetrieveLbAddress(oc *exutil.CLI, ingressNamespace, gatewayLbService string) (string, error) {
+	var gwlb string
+	coreClient := clientset.NewForConfigOrDie(oc.AdminConfig())
+	logCount := 0
+	err := wait.Poll(3*time.Second, 300*time.Second, func() (bool, error) {
+		lbService, err := coreClient.CoreV1().Services(ingressNamespace).Get(context.Background(), gatewayLbService, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			e2e.Logf("Error getting the gateway lb service %s: %v, retrying...", gatewayLbService, err)
+			return false, nil
+		}
+
+		lb := lbService.Status.LoadBalancer
+		if logCount%10 == 0 {
+			e2e.Logf("The lbService.Status.LoadBalancer is:\n%s", lb.String())
+		}
+		logCount++
+
+		searchInfo := regexp.MustCompile("(IP:([0-9\\.a-fA-F:]+))|(Hostname:([0-9\\.\\-a-zA-Z]+))").FindStringSubmatch(lb.String())
+		if len(searchInfo) > 0 {
+			if gwlb = searchInfo[2]; len(gwlb) > 0 {
+				e2e.Logf("New load balancer ip %s is available", gwlb)
+				return true, nil
+			}
+			if gwlb = searchInfo[4]; len(gwlb) > 0 {
+				e2e.Logf("New load balancer hostname %s is available", gwlb)
+				return true, nil
+			}
+		} else {
+			e2e.Logf("Failed to get a new load balancer ip or hostname, retrying")
+		}
+		return false, nil
+	})
+	return gwlb, err
+}
+
+// used to sort string type of slice or string which can be split to the slice by the space character
+func getSortedString(obj interface{}) string {
+	objList := []string{}
+	str, ok := obj.(string)
+	if ok {
+		objList = strings.Split(str, " ")
+	}
+	strList, ok := obj.([]string)
+	if ok {
+		objList = strList
+	}
+	sort.Strings(objList)
+	return strings.Join(objList, " ")
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1457,9 +1457,13 @@ var Annotations = map[string]string{
 
 	"[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure OSSM and OLM related resources are created after creating GatewayClass": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure OSSM subscription and istio could be deleted and then get recreated": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure custom gatewayclass can be accepted": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure default gatewayclass is accepted": " [Suite:openshift/conformance/parallel]",
+
+	"[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure gateway loadbalancer service and dnsrecords could be deleted and then get recreated": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network] Internal connectivity for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]": " [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -88,9 +88,14 @@ spec:
     - testName: '[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
         Ensure OSSM and OLM related resources are created after creating GatewayClass'
     - testName: '[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
+        Ensure OSSM subscription and istio could be deleted and then get recreated'
+    - testName: '[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
         Ensure custom gatewayclass can be accepted'
     - testName: '[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
         Ensure default gatewayclass is accepted'
+    - testName: '[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]
+        Ensure gateway loadbalancer service and dnsrecords could be deleted and then
+        get recreated'
   - featureGate: HardwareSpeed
     tests:
     - testName: '[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to


### PR DESCRIPTION
@lihongan @melvinjoseph86 @rhamini3 please help review the draft PR of negative tests for OSSM related resources, thanks.

For now, this PR covered 5 tests:
```
    deleted the OSSM subscription and then checked if it was restored
    deleted the istiod deployment and then checked if it was restored
    deleted the istio and check if it was restored
    deleted the gateway loadbalancer service and then checked if it was restored
    deleted the gateway dnsrecords then checked if it was restored
```

% ./openshift-tests run-test "[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure OSSM subscription and istio could be deleted and then get recreated"

```
    STEP: Try to delete the subscription servicemeshoperator3 @ 05/26/25 11:48:56.016
  I0526 11:48:56.016505 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg delete -n openshift-operators subscription/servicemeshoperator3'
    STEP: Wait untill the the OSSM subscription servicemeshoperator3 is automatically created successfully @ 05/26/25 11:48:57.322
  I0526 11:48:57.323232 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg get -n openshift-operators subscription servicemeshoperator3 -o=jsonpath={.status.conditions[?(@.type=="CatalogSourcesUnhealthy")].status}'
  I0526 11:48:58.397634 78905 gatewayapicontroller.go:279] Wait CatalogSourcesUnhealthy status to be False, and got False
    STEP: Wait untill the the OSSM csv servicemeshoperator3.v3.0.0 is automatically created successfully @ 05/26/25 11:48:58.397
  I0526 11:48:58.398144 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg get -n openshift-operators csv servicemeshoperator3.v3.0.0 -o=jsonpath={.status.phase}'
  I0526 11:49:00.159501 78905 gatewayapicontroller.go:291] Wait for phase to be Succeeded, and got Succeeded
    STEP: Try to delete the deployment istiod-openshift-gateway in openshift-ingress namespace @ 05/26/25 11:49:00.159
    STEP: Wait until the deployment istiod-openshift-gateway in openshift-ingress namespace is recreated and returns back healthy @ 05/26/25 11:49:00.981
  I0526 11:49:04.237984 78905 gatewayapicontroller.go:867] The ready replicas is 1
    STEP: Try to delete the istio openshift-gateway @ 05/26/25 11:49:04.238
  I0526 11:49:04.238208 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg delete -n openshift-ingress istio/openshift-gateway'
    STEP: Wait untill the the istiod openshift-gateway is automatically created successfully @ 05/26/25 11:49:05.365
  I0526 11:49:05.365865 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg get -n openshift-ingress istio/openshift-gateway -o=jsonpath={.status.revisions.ready}'
  I0526 11:49:06.228979 78905 gatewayapicontroller.go:310] Wait for the ready replicas to be 1, and got 0
  I0526 11:49:07.229721 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg get -n openshift-ingress istio/openshift-gateway -o=jsonpath={.status.revisions.ready}'
  I0526 11:49:08.049573 78905 gatewayapicontroller.go:310] Wait for the ready replicas to be 1, and got 0
  I0526 11:49:09.050943 78905 client.go:957] Running 'oc --kubeconfig=/Users/shudi/kubecfg get -n openshift-ingress istio/openshift-gateway -o=jsonpath={.status.revisions.ready}'
  I0526 11:49:09.927040 78905 gatewayapicontroller.go:310] Wait for the ready replicas to be 1, and got 1
  I0526 11:49:10.213822 78905 client.go:641] Deleted {user.openshift.io/v1, Resource=users  e2e-test-gatewayapi-controller-9jvh6-user}, err: <nil>
  I0526 11:49:10.490323 78905 client.go:641] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-gatewayapi-controller-9jvh6}, err: <nil>
  I0526 11:49:10.745805 78905 client.go:641] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~rIBImvNEqURUSzr4niwlLz-cIjQSgRjn2cvWNpzH6-U}, err: <nil>
    STEP: Cleaning up the GatewayAPI Objects @ 05/26/25 11:49:10.745
    STEP: Destroying namespace "e2e-test-gatewayapi-controller-9jvh6" for this suite. @ 05/26/25 11:49:10.746
  • [26.933 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 26.934 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

% ./openshift-tests run-test "[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure gateway loadbalancer service and dnsrecords could be deleted and then get recreated"

```
    STEP: Ensure default GatewayClass is accepted @ 05/26/25 11:51:40.527
    STEP: Getting the default domain @ 05/26/25 11:51:42.771
    STEP: Create the default Gateway @ 05/26/25 11:51:43.015
  I0526 11:51:45.517686 79090 gatewayapicontroller.go:520] Found gateway "gateway-7dmkw" but the controller is still not programmed, retrying...
  I0526 11:51:47.506474 79090 gatewayapicontroller.go:514] The gateway controller for gateway "gateway-7dmkw" is programmed
  I0526 11:51:47.506608 79090 gatewayapicontroller.go:525] Gateway "gateway-7dmkw" successfully programmed!
    STEP: Verify the gateway's LoadBalancer service and DNSRecords @ 05/26/25 11:51:47.506
  I0526 11:51:48.760734 79090 gatewayapicontroller.go:565] Got load balancer address for service "gateway-7dmkw-openshift-default": ae1f69502aeec425490cd15ae8383bb1-24564593.us-east-2.elb.amazonaws.com
    STEP: Try to delete the gateway lb service gateway-7dmkw-openshift-default @ 05/26/25 11:51:51.346
    STEP: Wait until the gateway lb service gateway-7dmkw-openshift-default is automatically recreated successfully @ 05/26/25 11:51:51.84
  I0526 11:51:55.323699 79090 gatewayapicontroller.go:381] Failed to get the new IP or hostname of the gateway lb service gateway-7dmkw-openshift-default, retrying...
  I0526 11:51:58.573686 79090 gatewayapicontroller.go:377] New load balancer hostname aac24dab29f334ccdbcbfe95ecb45309-1652474690.us-east-2.elb.amazonaws.com is available
    STEP: Get some info of the gateway dnsrecords in openshift-ingress namespace, then try to delete it @ 05/26/25 11:51:58.573
  I0526 11:51:58.818319 79090 gatewayapicontroller.go:393] gwapi dnsrecords targetsList1 is aac24dab29f334ccdbcbfe95ecb45309-1652474690.us-east-2.elb.amazonaws.com
    STEP: Wait unitl the gateway dnsrecords in openshift-ingress namespace is automatically created successfully @ 05/26/25 11:51:59.136
  I0526 11:51:59.378677 79090 gatewayapicontroller.go:408] gwapi dnsrecords targetsList2 is aac24dab29f334ccdbcbfe95ecb45309-1652474690.us-east-2.elb.amazonaws.com
  I0526 11:51:59.636481 79090 client.go:641] Deleted {user.openshift.io/v1, Resource=users  e2e-test-gatewayapi-controller-zxzvn-user}, err: <nil>
  I0526 11:51:59.883729 79090 client.go:641] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-gatewayapi-controller-zxzvn}, err: <nil>
  I0526 11:52:00.160289 79090 client.go:641] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~DiKcRyl4OLZltkFR1TkyWfgjEk5IaiqH4UjC4-JKYsA}, err: <nil>
    STEP: Cleaning up the GatewayAPI Objects @ 05/26/25 11:52:00.16
    STEP: Destroying namespace "e2e-test-gatewayapi-controller-zxzvn" for this suite. @ 05/26/25 11:52:00.409
  • [29.082 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 29.082 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```
