### PR TITLE
NO-JIRA: OVNK BGP: set VRF-Lite timeout

### DIFF
--- a/test/extended/networking/route_advertisements.go
+++ b/test/extended/networking/route_advertisements.go
@@ -534,7 +534,9 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 
 				// All VRF-Lite checks for 'vrfLiteCUDNName' need to happen on a
 				// single test (or otherwise we should resort to a serial job)
-				g.It("Pods should be able to communicate on a secondary network", func() {
+				// This test has a long timeout due to its serial nature and also
+				// because of OCPBUGS-56488
+				g.It("Pods should be able to communicate on a secondary network [Timeout:30m]", func() {
 					g.By("testing with a layer 3 CUDN", func() { test("layer3") })
 					// TODO: Add test for layer 2 UDN once CORENET-5881 is done.
 					//g.By("testing with a layer 2 CUDN", func() { test("layer2") })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1779,7 +1779,7 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:RouteAdvertisements][apigroup:operator.openshift.io] when using openshift ovn-kubernetes [EgressIP] Advertising EgressIP [apigroup:user.openshift.io][apigroup:security.openshift.io] For the default network Pods should have the assigned EgressIPs and EgressIPs can be created, updated and deleted [apigroup:route.openshift.io] When the network is IPv6": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:RouteAdvertisements][apigroup:operator.openshift.io] when using openshift ovn-kubernetes [PodNetwork] Advertising a cluster user defined network [apigroup:user.openshift.io][apigroup:security.openshift.io] Over a VRF-Lite configuration Pods should be able to communicate on a secondary network": " [Suite:openshift/conformance/parallel]",
+	"[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:RouteAdvertisements][apigroup:operator.openshift.io] when using openshift ovn-kubernetes [PodNetwork] Advertising a cluster user defined network [apigroup:user.openshift.io][apigroup:security.openshift.io] Over a VRF-Lite configuration Pods should be able to communicate on a secondary network [Timeout:30m]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:RouteAdvertisements][apigroup:operator.openshift.io] when using openshift ovn-kubernetes [PodNetwork] Advertising a cluster user defined network [apigroup:user.openshift.io][apigroup:security.openshift.io] Over the default VRF When the network topology is Layer 2 External host should be able to query route advertised pods by the pod IP": " [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -603,7 +603,7 @@ spec:
         when using openshift ovn-kubernetes [PodNetwork] Advertising a cluster user
         defined network [apigroup:user.openshift.io][apigroup:security.openshift.io]
         Over a VRF-Lite configuration Pods should be able to communicate on a secondary
-        network'
+        network [Timeout:30m]'
     - testName: '[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:RouteAdvertisements][apigroup:operator.openshift.io]
         when using openshift ovn-kubernetes [PodNetwork] Advertising a cluster user
         defined network [apigroup:user.openshift.io][apigroup:security.openshift.io]


### PR DESCRIPTION
The VRF-Lite test is composed of many serial checks which makes it long. But it is also taking longer due to OCPBUGS-56488.