### PR TITLE
OVNK: ignore stderr when running commands

### DIFF
--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1930,7 +1930,7 @@ func sdnHostsubnetFlushEgressCIDRs(oc *exutil.CLI, nodeName string) error {
 // runOcWithRetry runs the oc command with up to 5 retries if a timeout error occurred while running the command.
 func runOcWithRetry(oc *exutil.CLI, cmd string, args ...string) (string, error) {
 	var err error
-	var output string
+	var stdout string
 	maxRetries := 5
 
 	for numRetries := 0; numRetries < maxRetries; numRetries++ {
@@ -1938,7 +1938,9 @@ func runOcWithRetry(oc *exutil.CLI, cmd string, args ...string) (string, error) 
 			framework.Logf("Retrying oc command (retry count=%v/%v)", numRetries+1, maxRetries)
 		}
 
-		output, err = oc.Run(cmd).Args(args...).Output()
+		// stderrr can have spurious logs that can disrupt parsing done by
+		// callers, ignore it
+		stdout, _, err = oc.Run(cmd).Args(args...).Outputs()
 		// If an error was found, either return the error, or retry if a timeout error was found.
 		if err != nil {
 			if strings.Contains(strings.ToLower(err.Error()), "i/o timeout") {
@@ -1946,12 +1948,13 @@ func runOcWithRetry(oc *exutil.CLI, cmd string, args ...string) (string, error) 
 				framework.Logf("Warning: oc command encountered i/o timeout.\nerr=%v\n)", err)
 				continue
 			}
-			return output, err
+			return stdout, err
 		}
+
 		// Break out of loop if no error.
 		break
 	}
-	return output, err
+	return stdout, err
 }
 
 // listEgressIPs uses the dynamic admin client to return a pointer to


### PR DESCRIPTION
stderr may contain logs unrelated with the ran command that may disrupt parsing. Observed as [1] in [2].

1.
  I0523 06:49:35.567480 83973 client.go:952] Running 'oc --namespace=e2e-test-bgp-zlvr5 --kubeconfig=/tmp/secret/kubeconfig exec ovnkube-node-l2rv4 -n openshift-ovn-kubernetes -c ovnkube-controller -- /bin/bash -c ovs-vsctl get Port enp2s0 Interfaces'
  I0523 06:49:36.203600 83973 client.go:952] Running 'oc --namespace=e2e-test-bgp-zlvr5 --kubeconfig=/tmp/secret/kubeconfig exec ovnkube-node-l2rv4 -n openshift-ovn-kubernetes -c ovnkube-controller -- /bin/bash -c ovs-vsctl get Interface E0523 06:49:36.044467   85723 websocket.go:296] Unknown stream id 1 Type'

2.
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-ovn-kubernetes-release-4.20-periodics-e2e-metal-ipi-ovn-dualstack-bgp-local-gw-techpreview/1925763835906494464