### PR TITLE
OCPBUGS-56696: fix: remove un-needed test

### DIFF
--- a/test/extended/node_tuning/node_tuning.go
+++ b/test/extended/node_tuning/node_tuning.go
@@ -1,7 +1,6 @@
 package node_tuning
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -11,11 +10,7 @@ import (
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/openshift/origin/test/extended/util"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -116,57 +111,5 @@ var _ = g.Describe("[sig-node-tuning] NTO should", func() {
 
 		err = fmt.Errorf("case: %v\nexpected error got because of %v", g.CurrentSpecReport().FullText(), fmt.Sprintf("stalld service restarted : %v", errWait))
 		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
-	// OCPBUGS-18052
-	g.It("SNO installation does not finish due to wait for non-existing machine-config [Early]", func() {
-		isSNO, err := isSNOCluster(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if !isSNO {
-			g.Skip("only test on SNO cluster, skipping it ...")
-		}
-
-		var (
-			mcpConfigDaemonset *corev1.Pod
-		)
-
-		ctx := context.TODO()
-		nodeClient := oc.KubeClient().CoreV1().Nodes()
-		firstMasterNode, err := getFirstMasterNode(ctx, nodeClient)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		e2e.Logf("ensure that the status of mcp is on updated state")
-		config, err := e2e.LoadConfig()
-		e2e.ExpectNoError(err)
-		dynamicClient := dynamic.NewForConfigOrDie(config)
-		mcps := dynamicClient.Resource(schema.GroupVersionResource{
-			Group:    "machineconfiguration.openshift.io",
-			Version:  "v1",
-			Resource: "machineconfigpools",
-		})
-		pools, err := mcps.List(context.Background(), metav1.ListOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
-		for _, p := range pools.Items {
-			err = waitForUpdatedMCP(mcps, p.GetName())
-			o.Expect(err).NotTo(o.HaveOccurred())
-		}
-
-		e2e.Logf("ensure that the status of co machine-config is available state")
-		err = waitForClusterOperatorAvailable(oc, "machine-config")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		e2e.Logf("ensure that the status of co node-tuning is available state")
-		err = waitForClusterOperatorAvailable(oc, "node-tuning")
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		kf := oc.KubeFramework()
-		mcpConfigDaemonset, _ = exutil.GetMachineConfigDaemonByNode(kf.ClientSet, firstMasterNode)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		e2e.Logf("get pod logs for %v", mcpConfigDaemonset.Name)
-		podLogsStdout, err := getPodLogsLastLines(context.Background(), oc.KubeClient(), "openshift-machine-config-operator", mcpConfigDaemonset.Name, "machine-config-daemon", 20)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		e2e.Logf("check if the log of %v contains keyword [marking degraded due to|not found]", mcpConfigDaemonset.Name)
-		logAssertResult, err := podLogsMatch(mcpConfigDaemonset.Name, podLogsStdout, "Marking Degraded due to|not found")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(logAssertResult).To(o.BeFalse())
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1467,8 +1467,6 @@ var Annotations = map[string]string{
 
 	"[sig-node-tuning] NTO should OCP-66086 NTO Prevent from stalld continually restarting [Slow]": "",
 
-	"[sig-node-tuning] NTO should SNO installation does not finish due to wait for non-existing machine-config [Early]": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-node] Managed cluster record the number of nodes at the beginning of the tests [Early]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node] Managed cluster should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
This test does not accuratly capture the bug it references, the matcher would match on correct reasons to mark a mc as degraded thus giving false positives. Also the test is not needed because if the condition the test is checking for were ever to arise the install would simply fail before we ever come to this state. The bug the test references also has tests so we should be fine to remove this check since it's not providing any value.