### PR TITLE
NO-JIRA: router: Rename MarshalPrivateKeyToDERFormat to MarshalPrivateKeyToPEMString

### DIFF
--- a/test/extended/router/certgen/certgen.go
+++ b/test/extended/router/certgen/certgen.go
@@ -14,10 +14,10 @@ import (
 	"time"
 )
 
-// MarshalPrivateKeyToDERFormat converts the key to a string
-// representation (SEC 1, ASN.1 DER form) suitable for dropping into a
+// MarshalPrivateKeyToPEMString converts the key to a string
+// representation (PEM form) suitable for dropping into a
 // route's TLS key stanza.
-func MarshalPrivateKeyToDERFormat(key *ecdsa.PrivateKey) (string, error) {
+func MarshalPrivateKeyToPEMString(key *ecdsa.PrivateKey) (string, error) {
 	data, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal private key: %v", err)

--- a/test/extended/router/external_certificate.go
+++ b/test/extended/router/external_certificate.go
@@ -749,7 +749,7 @@ func generateTLSCertSecret(namespace, secretName string, secretType corev1.Secre
 		return nil, nil, err
 	}
 
-	derKey, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey)
+	pemKey, err := certgen.MarshalPrivateKeyToPEMString(tlsPrivateKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -766,7 +766,7 @@ func generateTLSCertSecret(namespace, secretName string, secretType corev1.Secre
 		},
 		StringData: map[string]string{
 			"tls.crt": pemCrt,
-			"tls.key": derKey,
+			"tls.key": pemKey,
 		},
 		Type: secretType,
 	}, rootDerBytes, nil

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -181,7 +181,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			_, tlsCrtData, tlsPrivateKey, err := certgen.GenerateKeyPair("Root CA", notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			derKey, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey)
+			pemKey, err := certgen.MarshalPrivateKeyToPEMString(tlsPrivateKey)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			pemCrt, err := certgen.MarshalCertToPEMString(tlsCrtData)
@@ -227,7 +227,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationEdge,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey,
+							Key:                           pemKey,
 							Certificate:                   pemCrt,
 						},
 						To: routev1.RouteTargetReference{
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationReencrypt,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey,
+							Key:                           pemKey,
 							Certificate:                   pemCrt,
 						},
 						To: routev1.RouteTargetReference{

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -242,10 +242,10 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			_, tlsCrt2Data, tlsPrivateKey2, err := certgen.GenerateKeyPair("Root CA", notBefore, notAfter)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			derKey1, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey1)
+			pemKey1, err := certgen.MarshalPrivateKeyToPEMString(tlsPrivateKey1)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
-			derKey2, err := certgen.MarshalPrivateKeyToDERFormat(tlsPrivateKey2)
+			pemKey2, err := certgen.MarshalPrivateKeyToPEMString(tlsPrivateKey2)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			pemCrt1, err := certgen.MarshalCertToPEMString(tlsCrt1Data)
@@ -329,7 +329,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationEdge,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey1,
+							Key:                           pemKey1,
 							Certificate:                   pemCrt1,
 						},
 						To: routev1.RouteTargetReference{
@@ -355,7 +355,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						TLS: &routev1.TLSConfig{
 							Termination:                   routev1.TLSTerminationReencrypt,
 							InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
-							Key:                           derKey2,
+							Key:                           pemKey2,
 							Certificate:                   pemCrt2,
 						},
 						To: routev1.RouteTargetReference{


### PR DESCRIPTION
The function `MarshalPrivateKeyToDERFormat` in `test/extended/router/certgen` package was incorrectly named, as it returns a PEM-encoded string, not DER.

This commit renames it to `MarshalPrivateKeyToPEMString` for accuracy and updates variable names accordingly to reflect the correct encoding.