### PR TITLE
OCPBUGS-59796: Revert #29836 "OCPBUGS-56045: OLMv1: Update test bundles [release-4.19]"

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -428,8 +428,8 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLM
 		checkFeatureCapability(oc)
 
 		const (
-			packageName = "cluster-logging"
-			version     = "6.2.2"
+			packageName = "elasticsearch-operator"
+			version     = "5.8.13"
 		)
 
 		cleanup, unique := applyResourceFile(oc, packageName, version, "", ceFile)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -53072,7 +53072,7 @@ spec:
   source:
     catalog:
       packageName: "openshift-pipelines-operator-rh"
-      version: "1.17.1"
+      version: "1.18.0"
       selector: {}
       upgradeConstraintPolicy: CatalogProvided
     sourceType: Catalog

--- a/test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
+++ b/test/extended/testdata/olmv1/install-pipeline-operator-base.yaml
@@ -28,7 +28,7 @@ spec:
   source:
     catalog:
       packageName: "openshift-pipelines-operator-rh"
-      version: "1.17.1"
+      version: "1.18.0"
       selector: {}
       upgradeConstraintPolicy: CatalogProvided
     sourceType: Catalog


### PR DESCRIPTION

Reverts #29836 ; tracked by OCPBUGS-59796

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR broke aws-minor and gcp-micro upgrade jobs on https://amd64.ocp.releases.ci.openshift.org/releasestream/4.19.0-0.ci/release/4.19.0-0.ci-2025-05-28-030643 in every run

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
Payload test aws-minor and gcp-micro
```

CC: @tmshort

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
