### PR TITLE
OCPBUGS-56796: Skip failing test

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -425,6 +425,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLM
 	})
 
 	g.It("should block cluster upgrades if an incompatible operator is installed", func(ctx g.SpecContext) {
+		g.Skip("Temporarily skipping this test due to https://issues.redhat.com/browse/OCPBUGS-56796")
 		checkFeatureCapability(oc)
 
 		const (


### PR DESCRIPTION
Skip failing test linked to https://issues.redhat.com/browse/OCPBUGS-56796 to unblock release.