### PR TITLE
OCPBUGS-54412: Do not retry extension-sourced tests

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -505,7 +505,15 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 
 		// Make a copy of the all failing tests (subject to the max allowed flakes) so we can have
 		// a list of tests to retry.
+		failedExtensionTestCount := 0
 		for _, test := range failing {
+			// Do not retry extension tests -- we also want to remove retries from origin-sourced
+			// tests, but extensions is where we can start.
+			if test.binary != nil {
+				failedExtensionTestCount++
+				continue
+			}
+
 			retry := test.Retry()
 			retries = append(retries, retry)
 			if len(retries) > suite.MaximumAllowedFlakes {
@@ -513,7 +521,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 			}
 		}
 
-		logrus.Warningf("Retry count: %d", len(retries))
+		logrus.Warningf("%d tests failed, %d origin-sourced tests will be retried; %d extension tests will not", len(failing), len(retries), failedExtensionTestCount)
 
 		// Run the tests in the retries list.
 		q := newParallelTestQueue(testRunnerContext)

--- a/pkg/test/ginkgo/test_suite.go
+++ b/pkg/test/ginkgo/test_suite.go
@@ -121,10 +121,12 @@ func (t *testCase) Retry() *testCase {
 	copied := &testCase{
 		name:          t.name,
 		spec:          t.spec,
+		binary:        t.binary,
 		rawName:       t.rawName,
 		binaryName:    t.binaryName,
 		locations:     t.locations,
 		testExclusion: t.testExclusion,
+		testTimeout:   t.testTimeout,
 
 		previous: t,
 	}


### PR DESCRIPTION
I accidentally broke retries for extension tests, because the pointer to a test binary was omitted.  The retry errors with:

```
error: no test exists with that name: [sig-cli] Kubectl Port forwarding Shutdown client connection while the remote stream is writing data to the port-forward connection port-forward should keep working after detect broken connection [Suite:openshift/conformance/parallel] [Suite:k8s]
```

However, because our end goal is that we don't retry at all, and we've existed in this state for months, I'm leaving retries off for externally sourced tests.

origin-sourced tests will continue to retry with the hope we ratchet up test quality to also stop retrying them.