### PR TITLE
OCPBUGS-55830: Only update boot disks during GCP boot image updates tests

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -261,7 +261,9 @@ func generateGCPProviderSpecPatch(machineSet machinev1beta1.MachineSet) (string,
 	newBootImage := "projects/centos-cloud/global/images/family/centos-stream-9"
 	newProviderSpec := providerSpec.DeepCopy()
 	for idx := range newProviderSpec.Disks {
-		newProviderSpec.Disks[idx].Image = newBootImage
+		if newProviderSpec.Disks[idx].Boot {
+			newProviderSpec.Disks[idx].Image = newBootImage
+		}
 	}
 	newProviderSpecPatch, err := marshalProviderSpec(newProviderSpec)
 	o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
Updates test to account for https://github.com/openshift/machine-config-operator/pull/5084 