### PR TITLE
MCO-1722: Handle check for Disconnnected Clusters for PIS Testing using curl

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -128,8 +128,8 @@ func IsTwoNodeArbiter(oc *exutil.CLI) bool {
 
 // `IsDisconnected` returns true if the cluster is a Disconnected cluster and false otherwise
 func IsDisconnected(oc *exutil.CLI, nodeName string) bool {
-	networkStatus, _ := exutil.DebugNodeRetryWithOptionsAndChroot(oc, nodeName, "openshift-machine-config-operator", "systemctl", "is-active", "NetworkManager-wait-online.service")
-	if networkStatus == "active" {
+	networkStatus, _ := exutil.DebugNodeRetryWithOptionsAndChroot(oc, nodeName, "openshift-machine-config-operator", "sh", "-c", "curl -s --connect-timeout 5 http://fedoraproject.org/static/hotspot.txt &>/dev/null && echo \"Connected\" || echo \"Disconnected\"")
+	if networkStatus == "Connected" {
 		return false
 	}
 	return true


### PR DESCRIPTION
helpers: Handle Disconnnected Clusters using curl
pinnedimages: In metal disconnected case, check for existence of images prior to MCN status