### PR TITLE
OCPBUGS-56933: fix deployment rollout wait to wait for desired replicas

### DIFF
--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -106,7 +106,7 @@ func (i *InvariantInClusterDisruption) createDeploymentAndWaitToRollout(ctx cont
 		nil,
 		func(event watch.Event) (bool, error) {
 			deployment := event.Object.(*appsv1.Deployment)
-			return deployment.Status.AvailableReplicas == deployment.Status.Replicas, nil
+			return deployment.Status.AvailableReplicas == *deployment.Spec.Replicas, nil
 		},
 	); watchErr != nil {
 		return fmt.Errorf("deployment %s didn't roll out: %v", deploymentObj.Name, watchErr)


### PR DESCRIPTION
I suspect this causes this instance of [alerts firing](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?Architecture=amd64&Architecture=amd64&FeatureSet=default&FeatureSet=default&Installer=ipi&Installer=ipi&Network=ovn&Network=ovn&NetworkAccess=default&Platform=vsphere&Platform=vsphere&Scheduler=default&SecurityMode=default&Suite=unknown&Suite=unknown&Topology=ha&Topology=ha&Upgrade=minor&Upgrade=minor&baseEndTime=2025-02-25%2023%3A59%3A59&baseRelease=4.18&baseStartTime=2025-01-26%2000%3A00%3A00&capability=Other&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Monitoring&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=amd64%20default%20ipi%20ovn%20vsphere%20unknown%20ha%20minor&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-05-30%2023%3A59%3A59&sampleRelease=4.19&sampleStartTime=2025-05-23%2000%3A00%3A00&testBasisRelease=4.16&testId=openshift-tests-upgrade%3Ac1f54790201ec8f4241eca902f854b79&testName=%5Bsig-instrumentation%5D%20Prometheus%20%5Bapigroup%3Aimage.openshift.io%5D%20when%20installed%20on%20the%20cluster%20shouldn%27t%20report%20any%20alerts%20in%20firing%20state%20apart%20from%20Watchdog%20and%20AlertmanagerReceiversNotConfigured%20%5BEarly%5D%5Bapigroup%3Aconfig.openshift.io%5D%20%5BSkipped%3ADisconnected%5D%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D).

see instance here: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-upgrade-from-stable-4.18-e2e-vsphere-upgrade/1927491432545783808 among others.

/assign @dgoodwin @neisw @vrutkovs 

