### PR TITLE
Fixing the Failure for make update for OCP-80983

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -40,6 +40,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/machine_config"
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
+	_ "github.com/openshift/origin/test/extended/node"
 	_ "github.com/openshift/origin/test/extended/node_tuning"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"

--- a/test/extended/node/OWNERS
+++ b/test/extended/node/OWNERS
@@ -1,0 +1,12 @@
+approvers:
+  - sairameshv
+  - haircommander
+  - rphillips
+  - harche
+  - mrunalp
+reviewers:
+  - sairameshv
+  - haircommander
+  - rphillips
+  - harche
+  - mrunalp

--- a/test/extended/node/cgroups.go
+++ b/test/extended/node/cgroups.go
@@ -1,0 +1,95 @@
+package node
+
+import (
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Feature:Remove support to configure Cgroup v1 from OCP version >= 4.19][apigroup:operator.openshift.io]", func() {
+
+	defer g.GinkgoRecover()
+	var (
+		oc = exutil.NewCLIWithoutNamespace("node").AsAdmin()
+	)
+	// Setup project to ensure a valid namespace exists
+	oc.SetupProject()
+
+	const cgroupV2 = "cgroup2fs"
+
+	g.It("Should result in an error when cgroupMode is changed from v2 to v1", func() {
+
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		if err != nil {
+			o.Expect(err).NotTo(o.HaveOccurred(), "error determining if running on MicroShift: %v", err)
+		}
+		if isMicroShift {
+			g.Skip("This test case is not supported in micoshift cluster ")
+		}
+
+		g.By("1) Check all the Nodes are in Ready state")
+		nodeStatusCheck(oc)
+
+		g.By("2) Check cgroup Version")
+		cgroupVersion := getCgroupVersion(oc)
+		e2e.Logf("Detected cgroup version: %s", cgroupVersion)
+		o.Expect(strings.Contains(cgroupVersion, cgroupV2)).Should(o.BeTrue())
+
+		g.By("3) Try Modifying node config to set cgroup mode to v1 [should give error]")
+		output, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("nodes.config.openshift.io", "cluster", "-p", "{\"spec\": {\"cgroupMode\": \"v1\"}}", "--type=merge").Output()
+		e2e.Logf("Cgroup version is %s", output)
+		o.Expect(err).Should(o.HaveOccurred())
+		o.Expect(strings.Contains(output, "Unsupported value: \"v1\"")).Should(o.BeTrue())
+
+	})
+
+})
+
+func nodeStatusCheck(oc *exutil.CLI) {
+
+	waitErr := wait.Poll(10*time.Second, 1*time.Minute, func() (bool, error) {
+		nodeName, nodeErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(nodeErr).NotTo(o.HaveOccurred())
+		e2e.Logf("\nNode Names are %v", nodeName)
+		nodes := strings.Fields(nodeName)
+
+		for _, node := range nodes {
+			nodeStatus, statusErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", node, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
+			o.Expect(statusErr).NotTo(o.HaveOccurred())
+			e2e.Logf("\nNode %s Status is %s\n", node, nodeStatus)
+
+			if nodeStatus == "True" {
+				e2e.Logf("\n NODES ARE READY\n ")
+
+			} else {
+				e2e.Logf("\n NODES ARE NOT READY\n ")
+				return false, nil
+			}
+		}
+		return true, nil
+
+	})
+	o.Expect(waitErr).NotTo(o.HaveOccurred(), "Nodes are NOT up and running")
+
+}
+
+func getCgroupVersion(oc *exutil.CLI) string {
+	workerNodes := getWorkersList(oc)
+	cgroupV, err := oc.AsAdmin().WithoutNamespace().Run("debug").Args("node/"+workerNodes[0], "--", "chroot", "/host", "stat", "-fc", "%T", "/sys/fs/cgroup").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("Cgroup version output: %s", cgroupV)
+	return cgroupV
+}
+
+func getWorkersList(oc *exutil.CLI) []string {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker", "-o=jsonpath={.items[*].metadata.name}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return strings.Fields(output)
+}

--- a/test/extended/node/cgroups.go
+++ b/test/extended/node/cgroups.go
@@ -19,8 +19,6 @@ var _ = g.Describe("[sig-node][Feature:Remove support to configure Cgroup v1 fro
 	var (
 		oc = exutil.NewCLIWithoutNamespace("node").AsAdmin()
 	)
-	// Setup project to ensure a valid namespace exists
-	oc.SetupProject()
 
 	const cgroupV2 = "cgroup2fs"
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1747,6 +1747,8 @@ var Annotations = map[string]string{
 
 	"[sig-node][Disruptive][Feature:KubeletGracefulShutdown] Kubelet with graceful shutdown configuration should respect pods termination grace period": " [Serial]",
 
+	"[sig-node][Feature:Remove support to configure Cgroup v1 from OCP version >= 4.19][apigroup:operator.openshift.io] Should result in an error when cgroupMode is changed from v2 to v1": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node][Late] should not have pod creation failures due to systemd timeouts": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with cyclictest": " [Serial]",


### PR DESCRIPTION
Test case OCP-80983 is getting failed in make update with below error: 

`goroutine 1 [running]:
  runtime/debug.Stack()
  	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
  github.com/openshift/origin/test/extended/util.FatalErr({0x6710e80, 0xc002325560})
  	/home/asahay/OCP-80983/origin/test/extended/util/client.go:1023 +0x25
  github.com/openshift/origin/test/extended/util.(*CLI).AdminConfig(0x0?)
  	/home/asahay/OCP-80983/origin/test/extended/util/client.go:824 +0x3b
  github.com/openshift/origin/test/extended/util.(*CLI).SetupProject(0xc0023eac80)
  	/home/asahay/OCP-80983/origin/test/extended/util/client.go:314 +0x1c
  github.com/openshift/origin/test/extended/node.init.func1()
  	/home/asahay/OCP-80983/origin/test/extended/node/cgroups.go:23 +0xe5
  github.com/onsi/ginkgo/v2/internal.NewNode.func2({0xc0023ea780?, 0x0?})
  	/home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/node.go:324 +0x13
  github.com/onsi/ginkgo/v2/internal.(*Suite).PushNode.func1(0xc0014c2908?)
  	/home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:209 +0x5b
  github.com/onsi/ginkgo/v2/internal.(*Suite).PushNode(_, {0x193, 0x2, {0x700cdee, 0x72}, 0xc000f9b120, {{0x8bf23cb, 0x3b}, 0x10, {0x0, ...}, ...}, ...})
  	/home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:211 +0x71e
  github.com/onsi/ginkgo/v2/internal.(*Suite).BuildTree(0xc000893508)
  	/home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:101 +0xb8
  k8s.io/kubernetes/openshift-hack/e2e/annotate.Run(0xa61c878?, 0x71be008)
  	/home/asahay/OCP-80983/origin/vendor/k8s.io/kubernetes/openshift-hack/e2e/annotate/annotate.go:31 +0xd5
  main.main()
  	/home/asahay/OCP-80983/origin/test/extended/util/annotate/annotate.go:14 +0x25`      

So, fixing it by removing oc.SetupProject() . 

cc @sairameshv 