### PR TITLE
Fixing the Failure for make update for OCP-80983 on 4.20

### DIFF
--- a/test/extended/node/cgroups.go
+++ b/test/extended/node/cgroups.go
@@ -19,8 +19,6 @@ var _ = g.Describe("[sig-node][Feature:Remove support to configure Cgroup v1 fro
 	var (
 		oc = exutil.NewCLIWithoutNamespace("node").AsAdmin()
 	)
-	// Setup project to ensure a valid namespace exists
-	oc.SetupProject()
 
 	const cgroupV2 = "cgroup2fs"
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1857,6 +1857,8 @@ var Annotations = map[string]string{
 
 	"[sig-node][Feature:Builds][apigroup:build.openshift.io] zstd:chunked Image should successfully run date command": " [Skipped:Disconnected] [Suite:openshift/conformance/parallel]",
 
+	"[sig-node][Feature:Remove support to configure Cgroup v1 from OCP version >= 4.19][apigroup:operator.openshift.io] Should result in an error when cgroupMode is changed from v2 to v1": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-node][Late] should not have pod creation failures due to systemd timeouts": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-node][Suite:openshift/nodes/realtime/latency][Disruptive] Real time kernel should meet latency requirements when tested with cyclictest": " [Serial]",


### PR DESCRIPTION
Fix `make update` for this PR
https://github.com/openshift/origin/pull/29883. Test case OCP-80983 is getting failed in make update with below error:

`goroutine 1 [running]: runtime/debug.Stack() /usr/local/go/src/runtime/debug/stack.go:26 +0x5e github.com/openshift/origin/test/extended/util.FatalErr({0x6710e80, 0xc002325560}) /home/asahay/OCP-80983/origin/test/extended/util/client.go:1023 +0x25 github.com/openshift/origin/test/extended/util.(*CLI).AdminConfig(0x0?) /home/asahay/OCP-80983/origin/test/extended/util/client.go:824 +0x3b github.com/openshift/origin/test/extended/util.(*CLI).SetupProject(0xc0023eac80) /home/asahay/OCP-80983/origin/test/extended/util/client.go:314 +0x1c github.com/openshift/origin/test/extended/node.init.func1() /home/asahay/OCP-80983/origin/test/extended/node/cgroups.go:23 +0xe5 github.com/onsi/ginkgo/v2/internal.NewNode.func2({0xc0023ea780?, 0x0?}) /home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/node.go:324 +0x13 github.com/onsi/ginkgo/v2/internal.(*Suite).PushNode.func1(0xc0014c2908?) /home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:209 +0x5b github.com/onsi/ginkgo/v2/internal.(*Suite).PushNode(_, {0x193, 0x2, {0x700cdee, 0x72}, 0xc000f9b120, {{0x8bf23cb, 0x3b}, 0x10, {0x0, ...}, ...}, ...}) /home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:211 +0x71e github.com/onsi/ginkgo/v2/internal.(*Suite).BuildTree(0xc000893508) /home/asahay/OCP-80983/origin/vendor/github.com/onsi/ginkgo/v2/internal/suite.go:101 +0xb8 k8s.io/kubernetes/openshift-hack/e2e/annotate.Run(0xa61c878?, 0x71be008) /home/asahay/OCP-80983/origin/vendor/k8s.io/kubernetes/openshift-hack/e2e/annotate/annotate.go:31 +0xd5 main.main() /home/asahay/OCP-80983/origin/test/extended/util/annotate/annotate.go:14 +0x25`

So, fixing it by removing oc.SetupProject() .

cc @sairameshv