### PR TITLE
TRT-1854: set network for MicroShift to OVNKubernetes

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -110,7 +110,7 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		config := &ClusterConfiguration{
 			ProviderName: "skeleton",
 		}
-		// Add NoOptionalCapabilities for MicroShift
+		// Add special configurations for MicroShift
 		coreClient, err := e2e.LoadClientset(true)
 		if err != nil {
 			log.WithError(err).Error("error in LoadClientset")
@@ -123,6 +123,8 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		}
 		if isMicroShift {
 			config.HasNoOptionalCapabilities = true
+			// Currently, for the sake of testing, MicroShift can always be assumed to be using OVNKubernetes
+			config.NetworkPlugin = "OVNKubernetes"
 		}
 
 		return config, nil


### PR DESCRIPTION
MicroShift has no `--network` flag set when running OTE tests which is causing it to miss a skip that it should have.

There is some [special configuration](https://github.com/openshift/release/blob/master/ci-operator/step-registry/openshift/microshift/e2e/origin-conformance/openshift-microshift-e2e-origin-conformance-commands.sh#L46-L71) that sets it to `OVNKubernetes` for tests. I confirmed that this is a safe assumption to make in [this thread](https://redhat-internal.slack.com/archives/C03DP9PABNC/p1748958779190589). If, in the future, they start testing it with other network plugins we will have to be smarter about differentiating them.