### PR TITLE
OCPBUGS-50701: Add test case for checking EgressFirewall DNS names in caps

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -154,6 +154,12 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://redhat.com").Output()
 	expectNoError(err)
 
+	// Test curl to amazon.com should pass
+	// because we have allow dns rule for amazon.com
+	g.By("sending traffic that matches allow dns rule")
+	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m3", "https://amazon.com").Output()
+	expectNoError(err)
+
 	if checkWildcard {
 		// Test curl to `www.google.com` and `translate.google.com` should pass
 		// because we have allow dns rule for `*.google.com`.

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43528,6 +43528,9 @@ spec:
   - type: Allow
     to:
       dnsName: redhat.com
+  - type: Allow
+    to:
+      dnsName: AMAZON.COM
   - type: Deny
     to:
       dnsName: www.google.com
@@ -43573,6 +43576,9 @@ spec:
       dnsName: redhat.com
   - type: Allow
     to:
+      dnsName: AMAZON.COM
+  - type: Allow
+    to:
       dnsName: "*.google.com"
   - type: Allow
     to:
@@ -43611,6 +43617,9 @@ spec:
   - type: Allow
     to:
       dnsName: redhat.com
+  - type: Allow
+    to:
+      dnsName: amazon.com
   - type: Allow
     to:
       cidrSelector: 8.8.8.8/32

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -7,6 +7,9 @@ spec:
   - type: Allow
     to:
       dnsName: redhat.com
+  - type: Allow
+    to:
+      dnsName: AMAZON.COM
   - type: Deny
     to:
       dnsName: www.google.com

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
@@ -9,6 +9,9 @@ spec:
       dnsName: redhat.com
   - type: Allow
     to:
+      dnsName: AMAZON.COM
+  - type: Allow
+    to:
       dnsName: "*.google.com"
   - type: Allow
     to:

--- a/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
+++ b/test/extended/testdata/egress-firewall/sdn-egressnetworkpolicy-test.yaml
@@ -9,6 +9,9 @@ spec:
       dnsName: redhat.com
   - type: Allow
     to:
+      dnsName: amazon.com
+  - type: Allow
+    to:
       cidrSelector: 8.8.8.8/32
   - type: Deny
     to:


### PR DESCRIPTION
This PR adds test case for checking EgressFirewall DNS names in caps.

This is a follow-up of https://github.com/openshift/origin/pull/29540.

The issue faced here is similar to https://issues.redhat.com/browse/OCPBUGS-52358 which is fixed by https://github.com/openshift/origin/pull/29618.

In this PR `amazon.com` is used which has a large TTL value (~700s).