### PR TITLE
OCPBUGS-57206: Backport pr 29834 to release-4.19

### DIFF
--- a/test/extended/images/dryrun.go
+++ b/test/extended/images/dryrun.go
@@ -1,0 +1,44 @@
+package images
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+)
+
+var _ = g.Describe("[sig-imageregistry] Image --dry-run", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLIWithPodSecurityLevel("image-dry-run", admissionapi.LevelBaseline)
+	)
+
+	g.It("should not delete resources [apigroup:image.openshift.io]", func() {
+		g.By("preparing the image stream where the test image will be pushed")
+		err := oc.Run("tag").Args("--source=docker", image.ShellImage(), "test:latest").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = exutil.WaitForAnImageStreamTag(oc, oc.Namespace(), "test", "latest")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("triggering delete operation of istag with --dry-run=server")
+		err = oc.Run("delete").Args("istag/test:latest", "--dry-run=server").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("obtaining the test:latest image name")
+		_, err = oc.Run("get").Args("istag", "test:latest", "-o", "jsonpath={.image.metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("triggering delete operation of imagestream with --dry-run=server")
+		err = oc.Run("delete").Args("imagestream/test", "--dry-run=server").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("obtaining the test imagestream")
+		_, err = oc.Run("get").Args("imagestream", "test", "-o", "jsonpath={.image.metadata.name}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1169,6 +1169,8 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][apigroup:config.openshift.io] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-imageregistry] Image --dry-run should not delete resources [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Backport pr [29834](https://github.com/openshift/origin/pull/29834) to release-4.19 manually.