### PR TITLE
support component-extension for openshift-tests

### DIFF
--- a/pkg/test/extensions/provider.go
+++ b/pkg/test/extensions/provider.go
@@ -93,9 +93,14 @@ func (provider *ExternalBinaryProvider) Cleanup() {
 // Note: When developing openshift-tests on a non-Linux non-AMD64 computer (i.e. on Apple Silicon), external
 // binaries won't work.  You would need to run it in a Linux environment (VM or container), and even then
 // override the payload selection with an aarch64 payload unless x86 emulation is enabled.
-func (provider *ExternalBinaryProvider) ExtractBinaryFromReleaseImage(tag, binary string) (*TestBinary, error) {
+func (provider *ExternalBinaryProvider) ExtractBinaryFromReleaseImage(tag, binary string, compExts map[string]string) (*TestBinary, error) {
 	if provider.binPath == "" {
 		return nil, fmt.Errorf("extraction path is not set, cleanup was already run")
+	}
+
+	var ext string
+	if val, ok := compExts[tag]; ok {
+		ext = val
 	}
 
 	// Allow overriding image path to an already existing local path, mostly useful
@@ -109,6 +114,7 @@ func (provider *ExternalBinaryProvider) ExtractBinaryFromReleaseImage(tag, binar
 		return &TestBinary{
 			imageTag:   tag,
 			binaryPath: override,
+			extension:  ext,
 		}, nil
 	}
 
@@ -134,6 +140,7 @@ func (provider *ExternalBinaryProvider) ExtractBinaryFromReleaseImage(tag, binar
 		return &TestBinary{
 			imageTag:   tag,
 			binaryPath: binPath,
+			extension:  ext,
 		}, nil
 	}
 
@@ -184,6 +191,7 @@ func (provider *ExternalBinaryProvider) ExtractBinaryFromReleaseImage(tag, binar
 
 	return &TestBinary{
 		binaryPath: extractedBinary,
+		extension:  ext,
 	}, nil
 }
 

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -79,6 +79,8 @@ type GinkgoRunSuiteOptions struct {
 
 	IncludeSuccessOutput bool
 
+	ComponentExtensions map[string]string
+
 	CommandEnv []string
 
 	DryRun        bool
@@ -118,6 +120,7 @@ func (o *GinkgoRunSuiteOptions) BindFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&o.ShardID, "shard-id", o.ShardID, "When tests are sharded across instances, which instance we are")
 	flags.IntVar(&o.ShardCount, "shard-count", o.ShardCount, "Number of shards used to run tests across multiple instances")
 	flags.StringVar(&o.ShardStrategy, "shard-strategy", o.ShardStrategy, "Which strategy to use for sharding (hash)")
+	flags.Var(extensions.NewStringToMap(&o.ComponentExtensions), "component-extension", "Set extension which is used for the component as <component tag>=<component extension id> pairs (e.g. --component-extension=tag1:id1,tag2=id2 or --component-extension=tag1:id1 --component-extension=tag2=id2)")
 }
 
 func (o *GinkgoRunSuiteOptions) Validate() error {
@@ -170,7 +173,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 		// Extract all test binaries
 		extractionContext, extractionContextCancel := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer extractionContextCancel()
-		cleanUpFn, externalBinaries, err := extensions.ExtractAllTestBinaries(extractionContext, 10)
+		cleanUpFn, externalBinaries, err := extensions.ExtractAllTestBinaries(extractionContext, 10, o.ComponentExtensions)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
support component-extension for openshift-tests so that it can get and run extenal cases except for default extension

as we known, for one component, there is external binary for it. it has one registry and then we register extension in registry.
when we register the first extension, it is also named "default" besides its ID, like"production:type:xxx".
from second extension, it is not named "default" as well and only has its ID.

currently when openshift-tests execute the external cases, it only support to get cases and execute them from "default" extension of the external binary.  if we want openshift-tests to execute the cases only from non default extension of the external binary, we need one parameter to tell openshift-tests which extension it need to get cases so that it set "--component=xxx" when openshift-tests call info/images/list/run-test interface of the external binary.

the usage of parameter:
`--component-extension=tag1:id1,tag2=id2` or `--component-extension=tag1:id1 --component-extension=tag2=id2`
the tag is image stream tag of the component(for example, [machine-api-operator](https://github.com/openshift/origin/blob/main/pkg/test/extensions/binary.go#L59)), and the id is the extension id when creating extension (for example, [openshift:payload:machine-api-operator](https://github.com/openshift/machine-api-operator/blob/main/cmd/machine-api-tests-ext/main.go#L35)).

note: for current openshift CI job, no need to any change for the steps which use openshift-tests because it suppose to get cases from default extension and we do not set parameter component-extension.


by the way, why we possible register the second extension?
when we try to migrate the QE cases from openshift-tests-private repo to component repo, the case which is in default extension will be selected and executed by openshift-tests in openshift CI job. it requires the cases stable and less duration.
but we have some cases which can not meet this and we can not drop them, so maybe we create the second extension and put such cases into the second extension once the openshift-tests-private repo is deprecated. and then we could create  module owned prow job to use openshift-tests with parameter component-extension to execute these external cases.
(if the openshift-tests-private repo is not deprecated, maybe we do not migrate such case to component repo, and do not need to create second extension and do not need this parameter)

why we do not execute such case with external binary directly in module owned prow job and have to use the openshift-tests?
the run-test/run-suite of the external binary execute the case in one process, and it can only run cases in serial although the case should be ran in parallel. but openshift-tests execute the case in different process, so it could run the case in parallel.

/cc @stbenjam 
Hi, you are the expert of OTE. could you please help review it? thanks
if you want more members to review it, please add the members. thanks

(Frankly, I am not sure if it is good and correct solution.)



