### PR TITLE
OCPBUGS-57397: properties should wrap around property

### DIFF
--- a/pkg/test/ginkgo/junitapi/types.go
+++ b/pkg/test/ginkgo/junitapi/types.go
@@ -36,7 +36,7 @@ type JUnitTestSuite struct {
 	Duration float64 `xml:"time,attr"`
 
 	// Properties holds other properties of the test suite as a mapping of name to value
-	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
 
 	// TestCases are the test cases contained in the test suite
 	TestCases []*JUnitTestCase `xml:"testcase"`

--- a/tools/junitreport/pkg/api/types.go
+++ b/tools/junitreport/pkg/api/types.go
@@ -36,7 +36,7 @@ type TestSuite struct {
 	Duration float64 `xml:"time,attr"`
 
 	// Properties holds other properties of the test suite as a mapping of name to value
-	Properties []*TestSuiteProperty `xml:"properties,omitempty"`
+	Properties []*TestSuiteProperty `xml:"properties>property,omitempty"`
 
 	// TestCases are the test cases contained in the test suite
 	TestCases []*TestCase `xml:"testcase"`


### PR DESCRIPTION
`openshift-tests` is generating invalid unit xml like 
```
<testsuite name="openshift-tests" tests="14" skipped="0" failures="1" time="240">
<property name="TestVersion" value="4.19.0-202506020913.p0.g33fe530.assembly.stream.el9-33fe530"/>
```