### PR TITLE
OCPBUGS-57421: Add sustaining engineers to owners on image ecosystem

### DIFF
--- a/test/extended/image_ecosystem/OWNERS
+++ b/test/extended/image_ecosystem/OWNERS
@@ -1,10 +1,8 @@
 reviewers:
-  - coreydaley
   - aroyoredhat
   - shannon
   - rhdmalone
 approvers:
-  - coreydaley
   - dperaza4dustbit
   - aroyoredhat
   - shannon

--- a/test/extended/image_ecosystem/OWNERS
+++ b/test/extended/image_ecosystem/OWNERS
@@ -1,5 +1,11 @@
 reviewers:
   - coreydaley
+  - aroyoredhat
+  - shannon
+  - rhdmalone
 approvers:
   - coreydaley
   - dperaza4dustbit
+  - aroyoredhat
+  - shannon
+  - rhdmalone


### PR DESCRIPTION
 As the sustaining engineering team is owner of the samples operator component, we need to constantly update this group of files to fix the image ecosystem tests.