### PR TITLE
TRT-2164: Restore retry functionality

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -509,15 +509,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 
 		// Make a copy of the all failing tests (subject to the max allowed flakes) so we can have
 		// a list of tests to retry.
-		failedExtensionTestCount := 0
 		for _, test := range failing {
-			// Do not retry extension tests -- we also want to remove retries from origin-sourced
-			// tests, but extensions is where we can start.
-			if test.binary != nil {
-				failedExtensionTestCount++
-				continue
-			}
-
 			retry := test.Retry()
 			retries = append(retries, retry)
 			if len(retries) > suite.MaximumAllowedFlakes {
@@ -525,7 +517,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, junitSuiteName string, mon
 			}
 		}
 
-		logrus.Warningf("%d tests failed, %d origin-sourced tests will be retried; %d extension tests will not", len(failing), len(retries), failedExtensionTestCount)
+		logrus.Warningf("Retry count: %d", len(retries))
 
 		// Run the tests in the retries list.
 		q := newParallelTestQueue(testRunnerContext)


### PR DESCRIPTION
The default behavior of our test suites are we retry once on failure.

When migrating to OTE, I had broken retries for extension-sourced tests including kubernetes. This appeared to have largely gone unnoticed so we made it intentional in https://github.com/openshift/origin/pull/29867.

However, once we started looking at Component Readiness, the now-failing flakes compared to the previously flaked tests is resulting in dozens of regressions.

This restores the old behavior of retrying any test.

We looked at a few alternatives, including removing the concept of "flakes" entirely from Component Readiness, and instead consider them discrete results. That means a flake where one pass and one fails occurs we count it as two results.

Benefits of this approach is we have long wanted to do some heavy testing of new tests within a single job run, and we'd be able to view these results in the desired way, but when we attempted to turn this in, we ended up with 1,000+ regressions; we suspect flakes are not stable because they tend to fail for outside reasons (e.g. api server unavailability).