### PR TITLE
OCPBUGS-57517: Remove Python 3.8-ubi8 from Origin

### DIFF
--- a/test/extended/image_ecosystem/s2i_images.go
+++ b/test/extended/image_ecosystem/s2i_images.go
@@ -67,13 +67,6 @@ var s2iImages = map[string][]tc{
 			Arches:   []string{"amd64", "arm64", "ppc64le", "s390x"},
 		},
 		{
-			Version:  "38",
-			Cmd:      "python --version",
-			Expected: "Python 3.8",
-			Tag:      "3.8-ubi8",
-			Arches:   []string{"amd64", "arm64", "ppc64le", "s390x"},
-		},
-		{
 			Version:  "39",
 			Cmd:      "python --version",
 			Expected: "Python 3.9",

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1073,8 +1073,6 @@ var Annotations = map[string]string{
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should print the usage": "",
 
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.8-ubi8\" should print the usage": "",
-
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi8\" should print the usage": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled returning s2i usage when running the image \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi9\" should print the usage": "",
@@ -1118,8 +1116,6 @@ var Annotations = map[string]string{
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.11-ubi9\" should be SCL enabled": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.6-ubi8\" should be SCL enabled": "",
-
-	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.8-ubi8\" should be SCL enabled": "",
 
 	"[sig-devex][Feature:ImageEcosystem][Slow] openshift images should be SCL enabled using the SCL in s2i images \"image-registry.openshift-image-registry.svc:5000/openshift/python:3.9-ubi8\" should be SCL enabled": "",
 


### PR DESCRIPTION
Steps:
	modified:   test/extended/image_ecosystem/s2i_images.go
	modified:   test/extended/util/annotate/generated/zz_generated.annotations.go
	git add/commit/push
	make verify
	git status
	// as make verify made further changes to zz_generated.annotations.go
        git add test/extended/util/annotate/generated/zz_generated.annotations.go
        git commit/git push/git rebase -i/git push -f  
        // as make update-bindata indicated no changes, no changes were made to bindata.go
        make update-bindata 