### PR TITLE
Add MCO's OTE tests to origin

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -59,6 +59,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "machine-api-operator",
 		binaryPath: "/machine-api-tests-ext.gz",
 	},
+	{
+		imageTag:   "machine-config-operator",
+		binaryPath: "/bin/machine-config-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
This change adds the MCO's OTE binary to the list of extended tests to be pulled.