### PR TITLE
TRT-2165: Include select pending alert intervals in spyglass

### DIFF
--- a/pkg/monitortests/testframework/timelineserializer/rendering.go
+++ b/pkg/monitortests/testframework/timelineserializer/rendering.go
@@ -193,12 +193,27 @@ func isLessInterestingAlert(eventInterval monitorapi.Interval) bool {
 	if eventInterval.Source != monitorapi.SourceAlert {
 		return false
 	}
+	alertName := eventInterval.Locator.Keys[monitorapi.LocatorAlertKey]
+
+	// Normally we don't want to display pending alerts, but allow some to show so we can see high CPU
+	// as it's detected.
 	if eventInterval.Message.Annotations[monitorapi.AnnotationAlertState] == "pending" {
-		// Skip pending alerts:
-		return true
+		switch alertName {
+		// Alerts we DO want to see pending intervals for in the minimal spyglass file
+		case "ExtremelyHighIndividualControlPlaneCPU":
+		case "HighOverallControlPlaneCPU":
+		case "HighOverallControlPlaneMemory":
+		case "SystemMemoryExceedsReservation":
+		case "etcdHighCommitDurations":
+		case "etcdGRPCRequestsSlow":
+		case "etcdHighFsyncDurations":
+		case "etcdDatabaseHighFragmentationRatio":
+		default:
+			// Skip pending alerts other than the specific ones listed above:
+			return true
+		}
 	}
 
-	alertName := eventInterval.Locator.Keys[monitorapi.LocatorAlertKey]
 	if len(alertName) == 0 {
 		return true
 	}


### PR DESCRIPTION
We use a limited file for the most interesting intervals to lower strain
on browsers and memory.

Typically we do not show pending alerts there. However some alerts
related to etcd and CPU are high value to see as soon as they go
pending, because it helps us correlate when tests were failing.

Include a small set of pending alerts in the spyglass files we show by
default.
