### PR TITLE
OCPBUGS-77878:auditloganalyzer: update test name, remove duplicated test

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -390,7 +390,7 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 		}
 	}
 
-	testName = "API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients"
+	testName = "[sig-api-machinery][Feature:APIServer] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients"
 	switch {
 	case len(w.requestsDuringShutdownChecker.auditIDs) > 0:
 		ret = append(ret,

--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -2,29 +2,19 @@ package apiserver
 
 import (
 	"bufio"
-	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"os"
-	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	"k8s.io/klog/v2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	configv1 "github.com/openshift/api/config/v1"
-
 	"github.com/openshift/origin/pkg/test/ginkgo/result"
-	clihelpers "github.com/openshift/origin/test/extended/cli"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -180,119 +170,6 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 			}
 
 			t.Errorf("API LBs or the kubernetes service send requests to kube-apiserver before it is ready, probably due to broken LB configuration: %#v. This can lead to inconsistent responses like 403s in other components.", ev)
-		}
-	})
-
-	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients", func() {
-		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// set up
-		// apiserverName -> reader
-		logReaders := map[string]io.Reader{}
-		results := map[string]int{}
-
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			mgmtClusterOC := exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
-			pods, err := mgmtClusterOC.KubeClient().CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{LabelSelector: "hypershift.openshift.io/control-plane-component=kube-apiserver"})
-			o.Expect(err).To(o.BeNil())
-			for _, pod := range pods.Items {
-				fileName, err := mgmtClusterOC.Run("logs", "-n", pod.Namespace, pod.Name, "-c", "audit-logs").OutputToFile(pod.Name + "-audit.log")
-				o.Expect(err).NotTo(o.HaveOccurred())
-				reader, err := os.Open(fileName)
-				o.Expect(err).NotTo(o.HaveOccurred())
-				defer reader.Close()
-				logReaders[pod.Namespace+"-"+pod.Name] = reader
-			}
-		} else {
-			tempDir, err := ioutil.TempDir("", "test.oc-adm-must-gather.")
-			o.Expect(err).NotTo(o.HaveOccurred())
-			defer os.RemoveAll(tempDir)
-			args := []string{"--dest-dir", tempDir, "--", "/usr/bin/gather_audit_logs"}
-
-			// download the audit logs from the cluster
-			o.Expect(oc.Run("adm", "must-gather").Args(args...).Execute()).To(o.Succeed())
-
-			// act
-			expectedDirectoriesToExpectedCount := []string{path.Join(clihelpers.GetPluginOutputDir(tempDir), "audit_logs", "kube-apiserver")}
-			for _, auditDirectory := range expectedDirectoriesToExpectedCount {
-				err := filepath.Walk(auditDirectory, func(path string, info os.FileInfo, err error) error {
-					g.By(path)
-					o.Expect(err).NotTo(o.HaveOccurred())
-
-					if info.IsDir() {
-						return nil
-					}
-					fileName := filepath.Base(path)
-					if !clihelpers.IsAuditFile(fileName) {
-						return nil
-					}
-
-					file, err := os.Open(path)
-					o.Expect(err).NotTo(o.HaveOccurred())
-					defer file.Close()
-					fi, err := file.Stat()
-					o.Expect(err).NotTo(o.HaveOccurred())
-					if fi.Size() == 0 {
-						return nil
-					}
-
-					gzipReader, err := gzip.NewReader(file)
-					o.Expect(err).NotTo(o.HaveOccurred())
-
-					apiServerName := extractAPIServerNameFromAuditFile(fileName)
-					o.Expect(apiServerName).ToNot(o.BeEmpty())
-
-					logReaders[apiServerName] = gzipReader
-
-					return nil
-				})
-				o.Expect(err).NotTo(o.HaveOccurred())
-			}
-		}
-
-		for apiServerName, reader := range logReaders {
-			lateRequestCounter := 0
-			readFile := false
-
-			klog.Infof("Starting to scan logs for API server: %s", apiServerName)
-
-			scanner := bufio.NewScanner(reader)
-			for scanner.Scan() {
-				text := scanner.Text()
-				if !strings.HasSuffix(text, "}") {
-					continue // ignore truncated data
-				}
-				o.Expect(text).To(o.HavePrefix(`{"kind":"Event",`))
-
-				if strings.Contains(text, "openshift.io/during-graceful") && strings.Contains(text, "openshift-origin-external-backend-sampler") {
-					lateRequestCounter++
-					klog.Warningf("Detected late request event in %s: %s", apiServerName, text)
-				}
-				readFile = true
-			}
-			if !readFile {
-				klog.Errorf("No valid lines read for API server: %s", apiServerName)
-			}
-			klog.Infof("Finished scanning logs for API server: %s, lateRequestCounter=%d", apiServerName, lateRequestCounter)
-			o.Expect(readFile).To(o.BeTrue())
-
-			if lateRequestCounter > 0 {
-				previousLateRequestCounter, _ := results[apiServerName]
-				results[apiServerName] = previousLateRequestCounter + lateRequestCounter
-			}
-		}
-
-		var finalMessageBuilder strings.Builder
-		for apiServerName, lateRequestCounter := range results {
-			// tolerate a few late request
-			if lateRequestCounter > 10 {
-				finalMessageBuilder.WriteString(fmt.Sprintf("\n %v observed %v late requests", apiServerName, lateRequestCounter))
-			}
-		}
-		// for now, we will report it as flaky, change it to fail once it proves itself
-		if len(finalMessageBuilder.String()) > 0 {
-			result.Flakef("the following API Servers observed late requests: %v", finalMessageBuilder.String())
 		}
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -107,8 +107,6 @@ var Annotations = map[string]string{
 
 	"[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and don't send request early": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and stop sending requests": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-api-machinery][Feature:APIServer][Late] kube-apiserver terminates within graceful termination period": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Ensure that we create a JUnit for an existing test - so it should have expected prefix and suffix. Currently these tests are incorrectly [duplicated](https://sippy-auth.dptools.openshift.org/sippy-ng/tests/4.20?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522current_runs%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25227%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522never-stable%2522%257D%252C%257B%2522columnField%2522%253A%2522variants%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522aggregated%2522%257D%252C%257B%2522columnField%2522%253A%2522current_flake_percentage%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522%253D%2522%252C%2522value%2522%253A%2522100%2522%257D%252C%257B%2522id%2522%253A99%252C%2522columnField%2522%253A%2522name%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522API%2520LBs%2520follow%2520%252Freadyz%2520of%2520kube-apiserver%2520and%2520stop%2520sending%2520requests%2520before%2520server%2520shutdowns%2520for%2520external%2520clients%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sort=asc&sortField=net_improvement)