### PR TITLE
OKD-267: Support RFC339 based timestamp layout for reboot tests

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -284,7 +284,22 @@ func parseRebootInstances(rebootsOutput string) ([]bootTimelineEntry, error) {
 			continue
 		}
 		date := fields[0]
-		bootTime, err := time.Parse("2006-01-02T15:04:05-0700", date)
+
+		var bootTime time.Time
+		var err error
+
+		layouts := []string{
+			"2006-01-02T15:04:05-0700",
+			"2006-01-02T15:04:05-07:00", // for cs10, rhel10
+		}
+
+		for _, layout := range layouts {
+			bootTime, err = time.Parse(layout, date)
+			if err == nil {
+				break
+			}
+		}
+
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When testing https://github.com/openshift/release/pull/66397 - the pivot for the nodeimage to cs10 from cs9 seemed to work pretty well except one test which failed in the e2e with:

```
[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late] [Suite:openshift/conformance/parallel]
```

This test failed because the timestamp has changed to be more compliant with RFC339 (there was a PR in systemd about this a while back: https://github.com/systemd/systemd/pull/29134). This PR fixes that test to also support this layout.