### PR TITLE
OPRUN-3965: Enable OTE for Operator Controller (OLMv1)

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -177,6 +177,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/machine-api-tests-ext.gz",
 	},
 	{
+		imageTag:   "olm-operator-controller",
+		binaryPath: "/usr/bin/olmv1-tests-ext.gz",
+	},
+	{
 		imageTag:   "machine-config-operator",
 		binaryPath: "/usr/bin/machine-config-tests-ext.gz",
 	},


### PR DESCRIPTION
This PR has the purpose of registering the bin: https://github.com/openshift/operator-framework-operator-controller/tree/main/openshift/tests-extension so that we can move forward after the tests from olmv1, which are in: https://github.com/openshift/origin/tree/main/test/extended/olm

The bin is added here: https://github.com/openshift/operator-framework-operator-controller/blob/main/openshift/operator-controller.Dockerfile#L5-L12
