### PR TITLE
MCO-1741: Pass output to tests results in skipped OTE cases

### DIFF
--- a/pkg/test/ginkgo/test_runner.go
+++ b/pkg/test/ginkgo/test_runner.go
@@ -319,6 +319,7 @@ func (c *commandContext) RunTestInNewProcess(ctx context.Context, test *testCase
 			ret.testState = TestSucceeded
 		case extensions.ResultSkipped:
 			ret.testState = TestSkipped
+			ret.testOutputBytes = []byte(results[0].Output)
 		}
 		ret.start = extensions.Time(results[0].StartTime)
 		ret.end = extensions.Time(results[0].EndTime)


### PR DESCRIPTION
If and OTE based test outputs the skip reason as part of the output we need to pass it forward in the chain to let the junit package extract the reason.