### PR TITLE
NO-JIRA: OWNERS_ALIASES: Update OTA members / team lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,17 +2,21 @@
 
 aliases:
   cluster-version-operator-test-case-approvers:
-  - LalatenduMohanty
+  - DavidHurta
+  - hongkailiu
+  - PratikMahajan
   - wking
   - petr-muller
   cluster-version-operator-test-case-reviewers:
-  - LalatenduMohanty
+  - DavidHurta
+  - hongkailiu
+  - PratikMahajan
   - wking
   - petr-muller
   team-leads:
   - JAORMX # Infrastructure Security and Compliance
   - JoelSpeed # Cluster Infrastructure
-  - LalatenduMohanty # Over the Air Updates
+  - PratikMahajan # Over the Air Updates
   - Miciah # Network Edge
   - coreydaley # Build + Jenkins
   - ashishkamra # Performance and Latency Sensitive Application Platform


### PR DESCRIPTION
- @PratikMahajan replaced Lala as a team lead
- Both @DavidHurta and @hongkailiu are more than qualified to review and approve OTA-related tests