### PR TITLE
OTA-1580: Add basic test for `oc adm upgrade status` CLI

### DIFF
--- a/test/extended/cli/adm_upgrade/OWNERS
+++ b/test/extended/cli/adm_upgrade/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- cluster-version-operator-test-case-approvers
+reviewers:
+- cluster-version-operator-test-case-reviewers

--- a/test/extended/cli/adm_upgrade/status.go
+++ b/test/extended/cli/adm_upgrade/status.go
@@ -1,0 +1,24 @@
+package adm_upgrade
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status", func() {
+	defer g.GinkgoRecover()
+
+	f := framework.NewDefaultFramework("oc-adm-upgrade-status")
+	f.SkipNamespaceCreation = true
+
+	oc := exutil.NewCLIWithoutNamespace("oc-adm-upgrade-status").AsAdmin()
+
+	g.It("reports correctly when the cluster is not updating", func() {
+		cmd := oc.Run("adm", "upgrade", "status").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
+		out, err := cmd.Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(out).To(o.Equal("The cluster is not updating."))
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/builds"
 	_ "github.com/openshift/origin/test/extended/ci"
 	_ "github.com/openshift/origin/test/extended/cli"
+	_ "github.com/openshift/origin/test/extended/cli/adm_upgrade"
 	_ "github.com/openshift/origin/test/extended/cloud_controller_manager"
 	_ "github.com/openshift/origin/test/extended/cluster"
 	_ "github.com/openshift/origin/test/extended/clusterversion"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -991,6 +991,8 @@ var Annotations = map[string]string{
 
 	"[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] test-cmd: test/cmd/volumes.sh [apigroup:image.openshift.io]": "",
 
+	"[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status reports correctly when the cluster is not updating": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] copy by strategy should copy files with the rsync strategy": "",
 
 	"[sig-cli][Slow] can use rsync to upload files to pods [apigroup:template.openshift.io] copy by strategy should copy files with the rsync-daemon strategy": "",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -1575,6 +1575,10 @@ spec:
         container''s primary UID belongs to some groups in the image when scheduled
         node supports SupplementalGroupsPolicy it should NOT add SupplementalGroups
         to them [LinuxOnly]'
+  - featureGate: UpgradeStatus
+    tests:
+    - testName: '[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status reports
+        correctly when the cluster is not updating'
   - featureGate: UserNamespacesSupport
     tests:
     - testName: '[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType]


### PR DESCRIPTION
- Add a new subdirectory to hold OTA-owned `oc adm upgrade` subcommand tests
- Add a way to pass env vars to `oc` CLI to enable gated subcommand testing
- When not updating, the command emits a simple message stating just that

This has some overlap with https://github.com/openshift/origin/pull/29831 (code placement, ownership, client support for enabling environment variables)
