### PR TITLE
Revert "trt-2163: return error"

### DIFF
--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -15,7 +15,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
-	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -329,14 +328,8 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	cmd.Stdout = out
 	cmd.Stderr = errOut
 	if err := cmd.Run(); err != nil {
-		// specifically ipv6 disconnected isn't expected to work
-		jobType, err := platformidentification.GetJobType(context.TODO(), adminRESTConfig)
-		if err == nil && jobType.Platform == "metal" {
-			i.notSupportedReason = fmt.Sprintf("unable to determine openshift-tests image for metal platform: %v: %v", err, errOut.String())
-			return nil
-		}
-
-		return fmt.Errorf("unable to determine openshift-tests image: %v: %v", err, errOut.String())
+		i.notSupportedReason = fmt.Sprintf("unable to determine openshift-tests image: %v: %v", err, errOut.String())
+		return nil
 	}
 	i.openshiftTestsImagePullSpec = strings.TrimSpace(out.String())
 	log.Infof("openshift-tests image pull spec is %v", i.openshiftTestsImagePullSpec)


### PR DESCRIPTION
Reverts openshift/origin#29946

Suspect this is causing issues with rosa [jobs](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.20.0-0.nightly/release/4.20.0-0.nightly-2025-07-05-175352)

```
: [Jira:"kube-apiserver"] monitor test apiserver-incluster-availability setup expand_less 	1s
{  failed during setup
unable to determine openshift-tests image: <nil>: error: unable to read image registry.ci.openshift.org/ocp/release@sha256:134f97ce0eae159c298d005ebfce05897b8350efa362141549db049e6af90088: unauthorized: authentication required
}
```