### PR TITLE
OCPBUGS-57032: upgrade.go: wait some time after node upgrade

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -188,6 +188,9 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 						clusterUpgrade(f, client, dynamicClient, config, upgCtx.Versions[i]),
 						fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
 				}
+				// Sleep to give some time to the workloads on the last upgraded
+				// node to restart.
+				time.Sleep(30 * time.Second)
 			},
 		)
 	})


### PR DESCRIPTION
For the "Cluster should remain functional during upgrade" test, TRT noticed flakes from the step that verifies that deamonsets are running on all expected nodes after an upgrade.  This flake was caused by the verification of the deamonset happening too quickly after the upgrade. As soon as the last upgraded node becomes ready the check happens, but it doesn't always leave enough time for the deamonset to restart, thus causing the test to fail.