### PR TITLE
MCO-1739: Move MCO disruptive testsuite to OTE

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -412,16 +412,6 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout: 60 * time.Minute,
 	},
 	{
-		Name: "openshift/machine-config-operator/disruptive",
-		Description: templates.LongDesc(`
-		This test suite runs tests to validate machine-config-operator functionality.
-		`),
-		Qualifiers: []string{
-			`name.contains("[Suite:openshift/machine-config-operator/disruptive")`,
-		},
-		TestTimeout: 120 * time.Minute,
-	},
-	{
 		Name: "openshift/two-node",
 		Description: templates.LongDesc(`
 		This test suite runs tests to validate two-node.


### PR DESCRIPTION
With the MCO now using OTE the disruptive test suite is declared there.