### PR TITLE
OCPBUGS-58354: disruptioninclusterapiserver: bump timeout to 10 mins

### DIFF
--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -96,7 +96,7 @@ func (i *InvariantInClusterDisruption) createDeploymentAndWaitToRollout(ctx cont
 		return fmt.Errorf("error creating deployment %s: %v", deploymentObj.Namespace, err)
 	}
 
-	timeLimitedCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	timeLimitedCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
 	if _, watchErr := watchtools.UntilWithSync(timeLimitedCtx,


### PR DESCRIPTION
The test should give more time for deployment to roll out. On some openstack tests it takes 7 minutes now

