### PR TITLE
chore(test/extended/prometheus): bump the series limit of total series sent via telemetry from each cluster

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -423,7 +423,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		case isManagedServiceCluster:
 			averageSeriesLimit = 850
 		default:
-			averageSeriesLimit = 760
+			averageSeriesLimit = 780
 		}
 
 		tests := map[string]bool{


### PR DESCRIPTION


In 4.20 techpreview, more series are to be sent to telemetry, compared to a 4.19 techpreview:

ALERTS{}	12					      |	ALERTS{}	9
apiserver_list_watch_request_success_total:rate:sum{}	2	apiserver_list_watch_request_success_total:rate:sum{}	2
cco_credentials_mode{}	1					cco_credentials_mode{}	1
cluster:alertmanager_integrations:max{}	1			cluster:alertmanager_integrations:max{}	1
cluster:apiserver_current_inflight_requests:sum:max_over_time	cluster:apiserver_current_inflight_requests:sum:max_over_time
cluster:capacity_cpu_cores:sum{}	2			cluster:capacity_cpu_cores:sum{}	2
cluster:capacity_memory_bytes:sum{}	2			cluster:capacity_memory_bytes:sum{}	2
cluster:console_auth_login_failures_total:sum{}	1	      <
cluster:console_auth_login_requests_total:sum{}	1	      <
cluster:console_auth_login_successes_total:sum{}	3     <
cluster:console_auth_logout_requests_total:sum{}	1     <
cluster:console_customization_perspectives_info:max{}	1     <
cluster:console_plugins_info:max{}	2		      <
cluster:controlplane_topology:info{}	1			cluster:controlplane_topology:info{}	1
cluster:cpu_usage_cores:sum{}	1				cluster:cpu_usage_cores:sum{}	1
cluster:infrastructure_topology:info{}	1			cluster:infrastructure_topology:info{}	1
cluster:ingress_controller_aws_nlb_active:sum{}	1		cluster:ingress_controller_aws_nlb_active:sum{}	1
cluster:kube_persistentvolume_plugin_type_counts:sum{}	1	cluster:kube_persistentvolume_plugin_type_counts:sum{}	1
cluster:kube_persistentvolumeclaim_resource_requests_storage_	cluster:kube_persistentvolumeclaim_resource_requests_storage_
cluster:kubelet_volume_stats_used_bytes:provisioner:sum{}	cluster:kubelet_volume_stats_used_bytes:provisioner:sum{}
cluster:memory_usage_bytes:sum{}	1			cluster:memory_usage_bytes:sum{}	1
cluster:network_attachment_definition_enabled_instance_up:max	cluster:network_attachment_definition_enabled_instance_up:max
cluster:network_attachment_definition_instances:max{}	17	cluster:network_attachment_definition_instances:max{}	17
cluster:node_instance_type_count:sum{}	2			cluster:node_instance_type_count:sum{}	2
cluster:openshift_route_info:tls_termination:sum{}	3	cluster:openshift_route_info:tls_termination:sum{}	3
cluster:ovnkube_controller_admin_network_policies_db_objects:	cluster:ovnkube_controller_admin_network_policies_db_objects:
cluster:ovnkube_controller_admin_network_policies_rules:max{}	cluster:ovnkube_controller_admin_network_policies_rules:max{}
cluster:ovnkube_controller_baseline_admin_network_policies_db	cluster:ovnkube_controller_baseline_admin_network_policies_db
cluster:ovnkube_controller_baseline_admin_network_policies_ru	cluster:ovnkube_controller_baseline_admin_network_policies_ru
cluster:ovnkube_controller_egress_routing_via_host:max{}	cluster:ovnkube_controller_egress_routing_via_host:max{}
cluster:route_metrics_controller_routes_per_shard:avg{}	1	cluster:route_metrics_controller_routes_per_shard:avg{}	1
cluster:route_metrics_controller_routes_per_shard:max{}	1	cluster:route_metrics_controller_routes_per_shard:max{}	1
cluster:route_metrics_controller_routes_per_shard:median{}	cluster:route_metrics_controller_routes_per_shard:median{}
cluster:route_metrics_controller_routes_per_shard:min{}	1	cluster:route_metrics_controller_routes_per_shard:min{}	1
cluster:telemetry_selected_series:count{}	1		cluster:telemetry_selected_series:count{}	1
cluster:usage:containers:sum{}	1				cluster:usage:containers:sum{}	1
cluster:usage:ingress_frontend_bytes_in:rate5m:sum{}	1	cluster:usage:ingress_frontend_bytes_in:rate5m:sum{}	1
cluster:usage:ingress_frontend_bytes_out:rate5m:sum{}	1	cluster:usage:ingress_frontend_bytes_out:rate5m:sum{}	1
cluster:usage:ingress_frontend_connections:sum{}	1	cluster:usage:ingress_frontend_connections:sum{}	1
cluster:usage:kube_node_ready:avg5m{}	1			cluster:usage:kube_node_ready:avg5m{}	1
cluster:usage:kube_schedulable_node_ready_reachable:avg5m{}	cluster:usage:kube_schedulable_node_ready_reachable:avg5m{}
cluster:usage:openshift:ingress_request_error:fraction5m{}	cluster:usage:openshift:ingress_request_error:fraction5m{}
cluster:usage:openshift:ingress_request_total:irate5m{}	1	cluster:usage:openshift:ingress_request_total:irate5m{}	1
cluster:usage:openshift:kube_running_pod_ready:avg{}	1	cluster:usage:openshift:kube_running_pod_ready:avg{}	1
cluster:usage:resources:sum{}	335			      |	cluster:usage:resources:sum{}	331
cluster:usage:workload:capacity_physical_cpu_core_seconds{}	cluster:usage:workload:capacity_physical_cpu_core_seconds{}
cluster:usage:workload:capacity_physical_cpu_cores:max:5m{}	cluster:usage:workload:capacity_physical_cpu_cores:max:5m{}
cluster:usage:workload:capacity_physical_cpu_cores:min:5m{}	cluster:usage:workload:capacity_physical_cpu_cores:min:5m{}
cluster:usage:workload:ingress_request_error:fraction5m{}	cluster:usage:workload:ingress_request_error:fraction5m{}
cluster:usage:workload:ingress_request_total:irate5m{}	1	cluster:usage:workload:ingress_request_total:irate5m{}	1
cluster:usage:workload:kube_running_pod_ready:avg{}	1	cluster:usage:workload:kube_running_pod_ready:avg{}	1
cluster:virt_platform_nodes:sum{}	2			cluster:virt_platform_nodes:sum{}	2
cluster:volume_manager_selinux_volumes_admitted_total{}	1	cluster:volume_manager_selinux_volumes_admitted_total{}	1
cluster_feature_set{}	1					cluster_feature_set{}	1
cluster_infrastructure_provider{}	1			cluster_infrastructure_provider{}	1
cluster_installer{}	1					cluster_installer{}	1
cluster_legacy_scheduler_policy{}	1			cluster_legacy_scheduler_policy{}	1
cluster_master_schedulable{}	1				cluster_master_schedulable{}	1
cluster_operator_conditions{}	165			      |	cluster_operator_conditions{}	164
cluster_operator_up{}	36					cluster_operator_up{}	36
cluster_version_capability{}	17				cluster_version_capability{}	17
cluster_version_payload{}	2				cluster_version_payload{}	2
cluster_version{}	4					cluster_version{}	4
code:apiserver_request_total:rate:sum{}	16		      |	code:apiserver_request_total:rate:sum{}	17
console_url{}	1						console_url{}	1
count:up1{}	78					      |	count:up0{}	1
							      >	count:up1{}	77
csv_succeeded{}	2						csv_succeeded{}	2
imageregistry:imagestreamtags_count:sum{}	4		imageregistry:imagestreamtags_count:sum{}	4 imageregistry:operations_count:sum{}	4			imageregistry:operations_count:sum{}	4 insightsclient_request_send_total{}	1			insightsclient_request_send_total{}	1 instance:etcd_disk_backend_commit_duration_seconds:histogram_	instance:etcd_disk_backend_commit_duration_seconds:histogram_ instance:etcd_disk_wal_fsync_duration_seconds:histogram_quant	instance:etcd_disk_wal_fsync_duration_seconds:histogram_quant instance:etcd_mvcc_db_total_size_in_bytes:sum{}	3		instance:etcd_mvcc_db_total_size_in_bytes:sum{}	3 instance:etcd_mvcc_db_total_size_in_use_in_bytes:sum{}	3	instance:etcd_mvcc_db_total_size_in_use_in_bytes:sum{}	3 instance:etcd_network_peer_round_trip_time_seconds:histogram_	instance:etcd_network_peer_round_trip_time_seconds:histogram_ instance:etcd_object_counts:sum{}	9			instance:etcd_object_counts:sum{}	9 monitoring:container_memory_working_set_bytes:sum{}	1	monitoring:container_memory_working_set_bytes:sum{}	1 monitoring:haproxy_server_http_responses_total:sum{}	2	monitoring:haproxy_server_http_responses_total:sum{}	2 namespace_job:scrape_samples_post_metric_relabeling:topk3{}	namespace_job:scrape_samples_post_metric_relabeling:topk3{} namespace_job:scrape_series_added:topk3_sum1h{}	3		namespace_job:scrape_series_added:topk3_sum1h{}	3 node_role_os_version_machine:cpu_capacity_cores:sum{}	2	node_role_os_version_machine:cpu_capacity_cores:sum{}	2 node_role_os_version_machine:cpu_capacity_sockets:sum{}	2	node_role_os_version_machine:cpu_capacity_sockets:sum{}	2 olm_resolution_duration_seconds{}	3			olm_resolution_duration_seconds{}	3 openshift:cpu_usage_cores:sum{}	1				openshift:cpu_usage_cores:sum{}	1 openshift:memory_usage_bytes:sum{}	1			openshift:memory_usage_bytes:sum{}	1 openshift:openshift_network_operator_ipsec_state:info{}	1	openshift:openshift_network_operator_ipsec_state:info{}	1 openshift:prometheus_tsdb_head_samples_appended_total:sum{}	openshift:prometheus_tsdb_head_samples_appended_total:sum{} openshift:prometheus_tsdb_head_series:sum{}	1		openshift:prometheus_tsdb_head_series:sum{}	1 os_image_url_override:sum{}	1				os_image_url_override:sum{}	1 profile:cluster_monitoring_operator_collection_profile:max{}	profile:cluster_monitoring_operator_collection_profile:max{} subscription_sync_total{}	1				subscription_sync_total{}	1 workload:cpu_usage_cores:sum{}	1				workload:cpu_usage_cores:sum{}	1 workload:memory_usage_bytes:sum{}	1			workload:memory_usage_bytes:sum{}	1