### PR TITLE
WIP:test/extended/testdata/cmd/test/cmd/images: Collect all ImageStreams

### DIFF
--- a/test/extended/testdata/cmd/test/cmd/images.sh
+++ b/test/extended/testdata/cmd/test/cmd/images.sh
@@ -9,9 +9,9 @@ trap os::test::junit::reconcile_output EXIT
   os::cmd::expect_success 'oc login -u system:admin'
   cluster_admin_context="$( oc config current-context )"
   os::cmd::expect_success "oc config use-context '${original_context}'"
+	os::cmd::expect_success 'oc get -A -o json imagestreams'
   oc delete project test-cmd-images-2 merge-tags --context=${cluster_admin_context}
   oc delete all,templates --all --context=${cluster_admin_context}
-
   exit 0
 ) &> /dev/null
 


### PR DESCRIPTION
For debugging when they don't import successfully.