### PR TITLE
OCPBUGS-59157: Ensure CSI tests are defined before OTE initialization

### DIFF
--- a/pkg/clioptions/clusterdiscovery/csi.go
+++ b/pkg/clioptions/clusterdiscovery/csi.go
@@ -6,11 +6,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/origin/test/extended/storage/csi"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/storage/external"
 	"sigs.k8s.io/yaml"
+
+	"github.com/openshift/origin/test/extended/storage/csi"
 )
 
 const (
@@ -18,8 +19,8 @@ const (
 	OCPManifestEnvVar = "TEST_OCP_CSI_DRIVER_FILES"
 )
 
-// Initialize openshift/csi suite, i.e. define CSI tests from TEST_CSI_DRIVER_FILES.
-func initCSITests() error {
+// InitCSITests initializes the openshift/csi suite, i.e. define CSI tests from TEST_CSI_DRIVER_FILES.
+func InitCSITests() error {
 	ocpDrivers := sets.New[string]()
 	upstreamDrivers := sets.New[string]()
 

--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -58,7 +58,7 @@ func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfig
 	// allow the CSI tests to access test data, but only briefly
 	// TODO: ideally CSI would not use any of these test methods
 	var err error
-	exutil.WithCleanup(func() { err = initCSITests() })
+	exutil.WithCleanup(func() { err = InitCSITests() })
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
External storage tests aren't being found after moving to OTE, this makes InitCSITests a public function and calls it so those ginkgo tests are defined before we initialize OTE.