### PR TITLE
OCPBUGS-59203: OCPBUGS-57524: Improve MCN test stability

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -1002,7 +1002,7 @@ func GetNodeInMachine(oc *exutil.CLI, machineName string) (corev1.Node, error) {
 	return *node, nil
 }
 
-// `GetNewReadyNodeInMachine` waits up to 2 minutes for the newly provisioned node in a desired machine node to be ready
+// `GetNewReadyNodeInMachine` waits up to 4 minutes for the newly provisioned node in a desired machine node to be ready
 func GetNewReadyNodeInMachine(oc *exutil.CLI, machineName string) (corev1.Node, error) {
 	desiredNode := corev1.Node{}
 	err := fmt.Errorf("no ready node in Machine: %s", machineName)
@@ -1021,7 +1021,7 @@ func GetNewReadyNodeInMachine(oc *exutil.CLI, machineName string) (corev1.Node, 
 		}
 
 		return false
-	}, 2*time.Minute, 3*time.Second).Should(o.BeTrue())
+	}, 4*time.Minute, 5*time.Second).Should(o.BeTrue(), fmt.Sprintf("Node in machine %v never became ready.", machineName))
 	return desiredNode, err
 }
 

--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -91,7 +91,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		ValidateMCNScopeImpersonationPathTest(oc)
 	})
 
-	g.It("[Suite:openshift/conformance/parallel]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Suite:openshift/conformance/serial][Serial]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]", func() {
 		ValidateMCNScopeHappyPathTest(oc)
 	})
 })

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -71,11 +71,11 @@ var Annotations = map[string]string{
 
 	"[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/parallel]Should properly block MCN updates from a MCD that is not the associated one [apigroup:machineconfiguration.openshift.io]": "",
 
-	"[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/parallel]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]": "",
-
 	"[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/serial][Serial]Should have MCN properties matching associated node properties for nodes in custom MCPs [apigroup:machineconfiguration.openshift.io]": "",
 
 	"[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/serial][Serial]Should properly transition through MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io]": "",
+
+	"[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/serial][Serial]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]": "",
 
 	"[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container should pass podman localsystem test in baseline mode": "",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -185,14 +185,14 @@ spec:
         [Suite:openshift/conformance/parallel]Should properly block MCN updates from
         a MCD that is not the associated one [apigroup:machineconfiguration.openshift.io]'
     - testName: '[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes]
-        [Suite:openshift/conformance/parallel]Should properly update the MCN from
-        the associated MCD [apigroup:machineconfiguration.openshift.io]'
-    - testName: '[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes]
         [Suite:openshift/conformance/serial][Serial]Should have MCN properties matching
         associated node properties for nodes in custom MCPs [apigroup:machineconfiguration.openshift.io]'
     - testName: '[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes]
         [Suite:openshift/conformance/serial][Serial]Should properly transition through
         MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io]'
+    - testName: '[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes]
+        [Suite:openshift/conformance/serial][Serial]Should properly update the MCN
+        from the associated MCD [apigroup:machineconfiguration.openshift.io]'
   - featureGate: ManagedBootImages
     tests:
     - testName: '[Suite:openshift/machine-config-operator/disruptive][Suite:openshift/conformance/serial][sig-mco][OCPFeatureGate:ManagedBootImages][Serial]


### PR DESCRIPTION
**Work included:**
_OCPBUGS-59203_
This updates the MCN happy scope path test, `Should properly update the MCN from the associated MCD`, to be a part of the serial test suite instead of the parallel test suite. This update is necessary since the test makes changes to MCN objects that can cause interference with other MCN tests when run in parallel.

_OCPBUGS-57524_
This does two things to improve the stability of the slow, disruptive MCN tests
- Increase the node readiness timeout to reduce failures in the `Should properly create and remove MCN on node creation and deletion` due to the newly provisioned node not becoming ready within two minutes.
- Add debugging logs to help with troubleshooting in the occasionally flaky `Should properly report MCN conditions on node degrade` test.

**Test locally:**
To run the updated tests locally, run it against any 4.20 cluster with the following command.

```
./openshift-tests run-test "[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Suite:openshift/conformance/serial][Serial]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]"
```

```
./openshift-tests run-test "[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Serial][Slow]Should properly report MCN conditions on node degrade [apigroup:machineconfiguration.openshift.io]"
```

```
./openshift-tests run-test "[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Serial][Slow]Should properly create and remove MCN on node creation and deletion [apigroup:machineconfiguration.openshift.io]"
```

**Test with payload:**
All MCN tests should consistently pass in the MCO disruptive test suite.