### PR TITLE
CCO-690: Register cloud-credential-operator tests extension

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -295,6 +295,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "aws-cloud-controller-manager",
 		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
 	},
+	{
+		imageTag:   "cloud-credential-operator",
+		binaryPath: "/usr/bin/cloud-credential-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
This PR registers the cloud-credential-operator test extension.

https://github.com/openshift/cloud-credential-operator/pull/886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test infrastructure for cloud credential operator functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->