### PR TITLE
OCPBUGS-59398: Skip MCN's node degrade test on 4.19

### DIFF
--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -40,7 +40,6 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		nodeDisruptionEmptyFixture     = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
 		customMCFixture                = filepath.Join(MCOMachineConfigBaseDir, "0-infra-mc.yaml")
 		masterMCFixture                = filepath.Join(MCOMachineConfigBaseDir, "0-master-mc.yaml")
-		invalidWorkerMCFixture         = filepath.Join(MCOMachineConfigBaseDir, "1-worker-invalid-mc.yaml")
 		invalidMasterMCFixture         = filepath.Join(MCOMachineConfigBaseDir, "1-master-invalid-mc.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
@@ -74,7 +73,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		if IsSingleNode(oc) { //handle SNO clusters
 			ValidateMCNConditionOnNodeDegrade(oc, invalidMasterMCFixture, true)
 		} else { //handle standard, non-SNO, clusters
-			ValidateMCNConditionOnNodeDegrade(oc, invalidWorkerMCFixture, false)
+			g.Skip("Temporarily skipping MachineConfigNodes node degrade test.")
 		}
 	})
 


### PR DESCRIPTION
**Work included:**
This skips the MCN test `Should properly report MCN conditions on node degrade` to give the team an opportunity to debug and stabilize the test first.

**Test locally:**
When running the below test locally, the test should be skipped.

```
./openshift-tests run-test "[Suite:openshift/machine-config-operator/disruptive][sig-mco][OCPFeatureGate:MachineConfigNodes] [Serial][Slow]Should properly report MCN conditions on node degrade [apigroup:machineconfiguration.openshift.io]"
```

**Test with payload**
The `Should properly report MCN conditions on node degrade` should be skipped in the disruptive MCO test suite.