### PR TITLE
OCPBUGS-59372: revert: remove openshift/two-node suite from tna tests

### DIFF
--- a/test/extended/two_node/arbiter_topology.go
+++ b/test/extended/two_node/arbiter_topology.go
@@ -29,7 +29,7 @@ var (
 	}
 )
 
-var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] expected Master and Arbiter node counts", func() {
+var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] expected Master and Arbiter node counts", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("")
 
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:High
 	})
 })
 
-var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] required pods on the Arbiter node", func() {
+var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] required pods on the Arbiter node", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -100,7 +100,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:High
 	})
 })
 
-var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Deployments on HighlyAvailableArbiterMode topology", func() {
+var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Deployments on HighlyAvailableArbiterMode topology", func() {
 	defer g.GinkgoRecover()
 
 	oc := exutil.NewCLI("arbiter-pod-validation").SetManagedNamespace().AsAdmin()
@@ -195,7 +195,7 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 	})
 })
 
-var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Evaluate DaemonSet placement in HighlyAvailableArbiterMode topology", func() {
+var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Evaluate DaemonSet placement in HighlyAvailableArbiterMode topology", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("daemonset-pod-validation").SetManagedNamespace().AsAdmin()
 
@@ -245,7 +245,7 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 	})
 })
 
-var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Ensure etcd health and quorum in HighlyAvailableArbiterMode", func() {
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Ensure etcd health and quorum in HighlyAvailableArbiterMode", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("").AsAdmin()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -239,11 +239,11 @@ var Annotations = map[string]string{
 
 	"[sig-apps][Feature:OpenShiftControllerManager] TestTriggers_manual [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Deployments on HighlyAvailableArbiterMode topology should be created on arbiter nodes when arbiter node is selected": "",
+	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Deployments on HighlyAvailableArbiterMode topology should be created on arbiter nodes when arbiter node is selected": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Deployments on HighlyAvailableArbiterMode topology should be created on master nodes when no node selected": "",
+	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Deployments on HighlyAvailableArbiterMode topology should be created on master nodes when no node selected": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Evaluate DaemonSet placement in HighlyAvailableArbiterMode topology should not create a DaemonSet on the Arbiter node": "",
+	"[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Evaluate DaemonSet placement in HighlyAvailableArbiterMode topology should not create a DaemonSet on the Arbiter node": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-arch] Cluster topology single node tests Verify that OpenShift components deploy one replica in SingleReplica topology mode": " [Suite:openshift/conformance/parallel]",
 
@@ -1209,7 +1209,7 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery Should support a graceful node shutdown": " [Serial]",
 
-	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": "",
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][Serial] Should fail clusterimagepolicy signature validation root of trust does not match the identity in the signature": " [Suite:openshift/conformance/serial]",
 
@@ -1887,9 +1887,9 @@ var Annotations = map[string]string{
 
 	"[sig-node][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node] Two Node with Fencing topology Should validate the number of control-planes, arbiters as configured": "",
 
-	"[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] expected Master and Arbiter node counts Should validate that there are Master and Arbiter nodes as specified in the cluster": "",
+	"[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] expected Master and Arbiter node counts Should validate that there are Master and Arbiter nodes as specified in the cluster": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node] required pods on the Arbiter node Should verify that the correct number of pods are running on the Arbiter node": "",
+	"[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] required pods on the Arbiter node Should verify that the correct number of pods are running on the Arbiter node": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected] OLMv1 openshift-certified-operators Catalog should serve FBC via the /v1/api/metas endpoint": " [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -114,22 +114,22 @@ spec:
         set the hardware speed to Standard [Timeout:30m][apigroup:machine.openshift.io]'
   - featureGate: HighlyAvailableArbiter
     tests:
-    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         Deployments on HighlyAvailableArbiterMode topology should be created on arbiter
         nodes when arbiter node is selected'
-    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         Deployments on HighlyAvailableArbiterMode topology should be created on master
         nodes when no node selected'
-    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         Evaluate DaemonSet placement in HighlyAvailableArbiterMode topology should
         not create a DaemonSet on the Arbiter node'
-    - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all
         etcd pods running and quorum met'
-    - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         expected Master and Arbiter node counts Should validate that there are Master
         and Arbiter nodes as specified in the cluster'
-    - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node]
+    - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         required pods on the Arbiter node Should verify that the correct number of
         pods are running on the Arbiter node'
   - featureGate: HonorPVReclaimPolicy


### PR DESCRIPTION
We need to revert the addition of the two-node suite label to TNA test as it removed the tests from our regular runs.