### PR TITLE
Revert "CNF-17748: Add a comparing between static entry test"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,12 +97,6 @@ require (
 )
 
 require (
-	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a // indirect
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-)
-
-require (
 	cel.dev/expr v0.18.0 // indirect
 	git.sr.ht/~sbinet/gg v0.5.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
@@ -163,6 +157,7 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/felixge/fgprof v0.9.4 // indirect
@@ -179,6 +174,7 @@ require (
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-pdf/fpdf v0.8.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/gocarina/gocsv v0.0.0-20231116093920-b87c2d0e983a // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
@@ -295,6 +291,7 @@ require (
 	golang.org/x/text v0.23.0 // indirect
 	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240826202546-f6391c0de4c7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240924160255-9d4c2d233b61 // indirect

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1607,8 +1607,6 @@ var Annotations = map[string]string{
 
 	"[sig-network][Feature:bond] should create a pod with bond interface [apigroup:k8s.cni.cncf.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][Feature:commatrix][apigroup:config.openshift.io][Serial] Static entries should not overlap with those in the EndpointSlice; any shared entries must be removed": " [Suite:openshift/conformance/serial]",
-
 	"[sig-network][Feature:commatrix][apigroup:config.openshift.io][Serial] generated communication matrix should be equal to documented communication matrix": " [Suite:openshift/conformance/serial]",
 
 	"[sig-network][Feature:tap] should create a pod with a tap interface [apigroup:k8s.cni.cncf.io]": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
Reverts openshift/origin#29782; tracked by [TRT-2202](https://issues.redhat.com/browse/TRT-2202)  

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This test has exposed a chance of breaking payload when multiple endpointslice PR are involved. 

In the latest case, this payload failed: https://amd64.ocp.releases.ci.openshift.org/releasestream/4.20.0-0.nightly/release/4.20.0-0.nightly-2025-07-15-214716

Failed job:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-aws-ovn-serial/1945415340292837376

There is a slack discussion on possible solutions: https://redhat-internal.slack.com/archives/CDCP2LA9L/p1752668467636969?thread_ts=1752614736.467729&cid=CDCP2LA9L


  CC: @aabughosh 