### PR TITLE
NO-JIRA: oc idle: Increase timeout of endpointslice status check

### DIFF
--- a/test/extended/cli/idle.go
+++ b/test/extended/cli/idle.go
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("wait until endpoint addresses are scaled to %s", scaledReplicaCount))
-		err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			out, err := oc.Run("get").Args("endpointslices", "-l", "kubernetes.io/service-name=idling-echo", "--template={{ len (index .items 0).endpoints }}", "--output=go-template").Output()
 			if err != nil || out != scaledReplicaCount {
 				return false, nil
@@ -242,7 +242,7 @@ var _ = g.Describe("[sig-cli] oc idle Deployments [apigroup:route.openshift.io][
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("wait until endpoint addresses are scaled to %s", scaledReplicaCount))
-		err = wait.PollUntilContextTimeout(ctx, time.Second, 60*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
 			out, err := oc.Run("get").Args("endpointslices", "-l", "kubernetes.io/service-name=idling-echo", "--template={{ len (index .items 0).endpoints }}", "--output=go-template").Output()
 			if err != nil || out != scaledReplicaCount {
 				return false, nil


### PR DESCRIPTION
It looks like oc idle tests are very flaky ([ref](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.20/runs?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22flaked_test_names%22%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22%5Bsig-cli%5D%20oc%20idle%20%5Bapigroup%3Aapps.openshift.io%5D%5Bapigroup%3Aroute.openshift.io%5D%5Bapigroup%3Aproject.openshift.io%5D%5Bapigroup%3Aimage.openshift.io%5D%20by%20checking%20previous%20scale%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22never-stable%22%7D%2C%7B%22columnField%22%3A%22variants%22%2C%22not%22%3Atrue%2C%22operatorValue%22%3A%22contains%22%2C%22value%22%3A%22aggregated%22%7D%5D%2C%22linkOperator%22%3A%22and%22%7D&sortField=timestamp&sort=desc)).

But it has needed our attention when it fails in some occasions https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-gcp-ovn-upgrade-4.20-micro-release-openshift-release-analysis-aggregator/1945539163545669632.

Take https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-gcp-ovn-upgrade/1945476055359819776 as an example;

* Test started in `STEP: Creating a kubernetes client @ 07/16/25 16:11:24.242`
* Test successfully queried first endpoint of endpointslice in `2025-07-16T16:11:56`
* Test ended up checking the other expected endpoint of this endpointslice in `I0716 16:12:27.488872`
* Second endpoint of endpointslice is updated in `2025-07-16T16:12:29.256761Z`

When I checked the audit logs of this cluster, endpointslice controller updated the status of endpoint slice in `2025-07-16T16:11:56.409881Z` for the first endpoint. The other one apparently took longer.

As a result, this PR increases the wait time from 1 minute to 5 minute to fix the flaky behavior.

