### PR TITLE
[TNF] Fix test suite filtering to include Disrupted tagged tests

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -426,7 +426,7 @@ var staticSuites = []ginkgo.TestSuite{
 		This test suite runs tests to validate two-node.
 		`),
 		Qualifiers: []string{
-			withExcludedTestsFilter(`name.contains("[Suite:openshift/two-node") || name.contains("[FeatureGate:DualReplica]") || name.contains("[FeatureGate:HighlyAvailableArbiter]")`),
+			`name.contains("[Suite:openshift/two-node") || name.contains("[FeatureGate:DualReplica]") || name.contains("[FeatureGate:HighlyAvailableArbiter]")`,
 		},
 		TestTimeout: 60 * time.Minute,
 	},


### PR DESCRIPTION
Remove withExcludedTestsFilter() wrapper from two-node suite qualifiers to properly include tests tagged with [Disrupted], instead of excluding them.