### PR TITLE
CORENET-5670: add GA placeholder test for FG PreconfiguredUDNAddresses

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -337,6 +337,12 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][Suite:openshift/net
 	})
 })
 
+var _ = Describe("[sig-network][OCPFeatureGate:PreconfiguredUDNAddresses][Suite:openshift/network/virtualization] Kubevirt Virtual Machines", func() {
+	It("Placeholder test for GA of PreconfiguredUDNAddresses", func() {
+		Expect(1).To(Equal(1)) // we just need a test to run to ensure the platform comes up correctly
+	})
+})
+
 type VirtualMachineInstanceConditionType string
 
 const VirtualMachineInstanceConditionReady VirtualMachineInstanceConditionType = "Ready"


### PR DESCRIPTION
This PR adds a placeholder test for checking PreconfiguredUDNAddresses