### PR TITLE
OCPBUGS-59218: feat(azure): skip metrics collection for ARO HCP hypershift

### DIFF
--- a/test/extended/util/managed_services.go
+++ b/test/extended/util/managed_services.go
@@ -1,6 +1,13 @@
 package util
 
-import "k8s.io/apimachinery/pkg/util/sets"
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+)
 
 // ManagedServiceNamespaces is the set of namespaces used by managed service platforms
 // like ROSA, ARO, etc. These are typically exempt from the requirements we impose on
@@ -51,3 +58,40 @@ var ManagedServiceNamespaces = sets.New[string](
 	"openshift-validation-webhook",
 	"openshift-velero",
 )
+
+// IsAroHCP checks if the HyperShift operator deployment has MANAGED_SERVICE=ARO-HCP environment variable.
+func IsAroHCP(ctx context.Context, namespace string, kubeClient kubernetes.Interface) (bool, error) {
+	// List deployments with the correct label that actually exists on the deployment
+	deployments, err := kubeClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "hypershift.openshift.io/managed-by=control-plane-operator",
+	})
+	if err != nil {
+		logrus.Infof("Failed to list deployments in namespace %s: %v", namespace, err)
+		return false, nil // Not an error if we can't list deployments, just means it's not ARO HCP
+	}
+
+	if len(deployments.Items) == 0 {
+		logrus.Infof("No control-plane-operator deployments found in namespace %s", namespace)
+		return false, nil
+	}
+
+	logrus.Infof("Found %d control-plane-operator deployments in namespace %s", len(deployments.Items), namespace)
+
+	// Look through all matching deployments
+	for _, deployment := range deployments.Items {
+
+		// Look for the control-plane-operator container directly in the deployment spec
+		for _, container := range deployment.Spec.Template.Spec.Containers {
+			if container.Name == "control-plane-operator" {
+				logrus.Infof("Found container 'control-plane-operator' in deployment %s", deployment.Name)
+
+				result := HasEnvVar(&container, "MANAGED_SERVICE", "ARO-HCP")
+				logrus.Infof("hasEnvVar result for MANAGED_SERVICE=ARO-HCP: %v", result)
+				return result, nil
+			}
+		}
+	}
+
+	logrus.Infof("No deployment found with control-plane-operator container in namespace %s", namespace)
+	return false, nil
+}

--- a/test/extended/util/managed_services_test.go
+++ b/test/extended/util/managed_services_test.go
@@ -1,0 +1,307 @@
+package util
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestIsAroHCP(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespace   string
+		deployments []appsv1.Deployment
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "no deployments found",
+			namespace:   "test-namespace",
+			deployments: []appsv1.Deployment{},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:      "deployment without control-plane-operator label",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"app": "other-app",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "other-container",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ARO-HCP"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:      "deployment with correct label but no control-plane-operator container",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hypershift-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "other-container",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ARO-HCP"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:      "deployment with control-plane-operator container but no ARO-HCP env var",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hypershift-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "OTHER_VAR", Value: "other-value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:      "deployment with control-plane-operator container and wrong MANAGED_SERVICE value",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hypershift-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ROSA"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:      "deployment with control-plane-operator container and correct ARO-HCP env var",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hypershift-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ARO-HCP"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:      "multiple deployments, one with ARO-HCP",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ROSA"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "aro-hcp-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ARO-HCP"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:      "deployment with multiple containers, control-plane-operator has ARO-HCP",
+			namespace: "test-namespace",
+			deployments: []appsv1.Deployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hypershift-deployment",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"hypershift.openshift.io/managed-by": "control-plane-operator",
+						},
+					},
+					Spec: appsv1.DeploymentSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name: "sidecar-container",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ROSA"},
+										},
+									},
+									{
+										Name: "control-plane-operator",
+										Env: []corev1.EnvVar{
+											{Name: "MANAGED_SERVICE", Value: "ARO-HCP"},
+											{Name: "OTHER_VAR", Value: "other-value"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected:    true,
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Create fake client
+			fakeClient := fake.NewClientset()
+
+			// Add deployments to fake client
+			for _, deployment := range test.deployments {
+				_, err := fakeClient.AppsV1().Deployments(test.namespace).Create(context.TODO(), &deployment, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create deployment: %v", err)
+				}
+			}
+
+			// Call the function
+			result, err := IsAroHCP(context.TODO(), test.namespace, fakeClient)
+
+			// Check error expectations
+			if test.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !test.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+
+			// Check result
+			if result != test.expected {
+				t.Errorf("IsAroHCP() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}

--- a/test/extended/util/pods.go
+++ b/test/extended/util/pods.go
@@ -26,6 +26,19 @@ const (
 	containerMachineConfigDaemon   = "machine-config-daemon"
 )
 
+// HasEnvVar checks if a container has an environment variable with a specific value
+func HasEnvVar(container *corev1.Container, name, expectedValue string) bool {
+	if container == nil {
+		return false
+	}
+	for _, env := range container.Env {
+		if env.Name == name {
+			return env.Value == expectedValue
+		}
+	}
+	return false
+}
+
 // WaitForNoPodsRunning waits until there are no (running) pods in the given namespace.
 // (The idling tests use a DeploymentConfig which will leave a "Completed" deploy pod
 // after deploying the service; we don't want to count that.)

--- a/test/extended/util/pods_test.go
+++ b/test/extended/util/pods_test.go
@@ -1,0 +1,100 @@
+package util
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestHasEnvVar(t *testing.T) {
+	tests := []struct {
+		name          string
+		container     *corev1.Container
+		envVarName    string
+		expectedValue string
+		expected      bool
+	}{
+		{
+			name:          "nil container",
+			container:     nil,
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      false,
+		},
+		{
+			name: "env var exists with matching value",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "TEST_VAR", Value: "test_value"},
+					{Name: "OTHER_VAR", Value: "other_value"},
+				},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      true,
+		},
+		{
+			name: "env var exists with non-matching value",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "TEST_VAR", Value: "wrong_value"},
+					{Name: "OTHER_VAR", Value: "other_value"},
+				},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      false,
+		},
+		{
+			name: "env var does not exist",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "OTHER_VAR", Value: "other_value"},
+				},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      false,
+		},
+		{
+			name: "empty env vars",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      false,
+		},
+		{
+			name: "env var with empty value matches empty expected value",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "TEST_VAR", Value: ""},
+				},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "",
+			expected:      true,
+		},
+		{
+			name: "env var with empty value does not match non-empty expected value",
+			container: &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "TEST_VAR", Value: ""},
+				},
+			},
+			envVarName:    "TEST_VAR",
+			expectedValue: "test_value",
+			expected:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := HasEnvVar(test.container, test.envVarName, test.expectedValue)
+			if result != test.expected {
+				t.Errorf("HasEnvVar() = %v, expected %v", result, test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add detection logic for ARO HCP hypershift deployments
- Skip metrics collection when MANAGED_SERVICE=ARO-HCP is detected
- Add helper functions hasEnvVar() and isAROHCP() for environment detection