### PR TITLE
OCPBUGS-39026: Remove exception for monitoring operator going degraded during upgrade

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -309,10 +309,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				} else {
 					return ""
 				}
-			case "monitoring":
-				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-					return "https://issues.redhat.com/browse/OCPBUGS-39026"
-				}
 			case "network":
 				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 					logrus.Infof("Operator %s is in Degraded=True state outside of upgrade window, but we will check for exceptions", operator)
@@ -396,9 +392,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 						condition.Reason == "UpdatingPrometheusOperatorFailed")) ||
 				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23745"
-			}
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-				return "https://issues.redhat.com/browse/OCPBUGS-39026"
 			}
 		case "olm":
 			if condition.Type == configv1.OperatorAvailable &&


### PR DESCRIPTION
We believe this is fixed via https://issues.redhat.com/browse/OCPBUGS-57215

Removing this exception will help us see if the problem is full eliminated in CI not just *after* upgrade, but also anywhere during.

0.4% flake rate with the exception in place over 6k+ runs this week. 0.0% flake rate last week. 
