### PR TITLE
NO-JIRA: Don't treat dry-run special for empty test_provider

### DIFF
--- a/pkg/clioptions/clusterdiscovery/provider.go
+++ b/pkg/clioptions/clusterdiscovery/provider.go
@@ -98,11 +98,10 @@ func InitializeTestFramework(context *e2e.TestContextType, config *ClusterConfig
 	return nil
 }
 
-func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterState *ClusterState) (*ClusterConfiguration, error) {
+func DecodeProvider(providerTypeOrJSON string, discover bool, clusterState *ClusterState) (*ClusterConfiguration, error) {
 	log := logrus.WithField("func", "DecodeProvider")
 	log.WithFields(logrus.Fields{
 		"providerType": providerTypeOrJSON,
-		"dryRun":       dryRun,
 		"discover":     discover,
 		"clusterState": clusterState,
 	}).Debug("Decoding provider")
@@ -132,18 +131,13 @@ func DecodeProvider(providerTypeOrJSON string, dryRun, discover bool, clusterSta
 		}
 
 		return config, nil
-
 	case "":
 		if _, ok := os.LookupEnv("KUBE_SSH_USER"); ok {
 			if _, ok := os.LookupEnv("LOCAL_SSH_KEY"); ok {
 				return &ClusterConfiguration{ProviderName: "local"}, nil
 			}
 		}
-		if dryRun {
-			return &ClusterConfiguration{ProviderName: "skeleton"}, nil
-		}
 		fallthrough
-
 	case "azure", "aws", "baremetal", "gce", "vsphere", "alibabacloud", "external":
 		if clusterState == nil {
 			clientConfig, err := e2e.LoadConfig(true)

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -65,7 +65,7 @@ func (o *RunUpgradeSuiteOptions) TestCommandEnvironment() []string {
 // UpgradeTestPreSuite validates the test options and gathers data useful prior to launching the upgrade and it's
 // related tests.
 func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
-	config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), o.GinkgoRunSuiteOptions.DryRun, false, nil)
+	config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), false, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/openshift-tests/run/flags.go
+++ b/pkg/cmd/openshift-tests/run/flags.go
@@ -50,7 +50,7 @@ func NewRunSuiteFlags(streams genericclioptions.IOStreams, fromRepository string
 //  2. ensures that the suite filters out tests from providers that aren't relevant (see exutilcluster.ClusterConfig.MatchFn) by
 //     loading the provider info from the cluster or flags, including API groups and feature gates.
 func (f *RunSuiteFlags) SuiteWithKubeTestInitializationPreSuite() (*clusterdiscovery.ClusterConfiguration, error) {
-	providerConfig, err := clusterdiscovery.DecodeProvider(f.ProviderTypeOrJSON, f.GinkgoRunSuiteOptions.DryRun, true, nil)
+	providerConfig, err := clusterdiscovery.DecodeProvider(f.ProviderTypeOrJSON, true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -98,7 +98,7 @@ func InitializeOpenShiftTestsExtensionFramework() (*extension.Registry, *extensi
 	})
 
 	specs.AddBeforeAll(func() {
-		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), false, false, nil)
+		config, err := clusterdiscovery.DecodeProvider(os.Getenv("TEST_PROVIDER"), false, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -779,7 +779,7 @@ func determineEnvironmentFlags(ctx context.Context, upgrade bool, dryRun bool) (
 	if clusterState == nil { // If we know we cannot discover the clusterState, the provider must be set to "none" in order for the config to be loaded without error
 		provider = "none"
 	}
-	config, err := clusterdiscovery.DecodeProvider(provider, dryRun, true, clusterState)
+	config, err := clusterdiscovery.DecodeProvider(provider, true, clusterState)
 	if err != nil {
 		logrus.WithError(err).Error("error determining information about the cluster")
 		return nil, err


### PR DESCRIPTION
We should still attempt to learn about the cluster state so we can
accurately report available tests (e.g. feature gated tests).