### PR TITLE
OCPEDGE-1969: add recovery tests for TNA

### DIFF
--- a/test/extended/two_node/arbiter_topology.go
+++ b/test/extended/two_node/arbiter_topology.go
@@ -21,21 +21,19 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var (
-	expectedPods = map[string]int{
-		"openshift-cluster-node-tuning-operator": 1,
-		"openshift-dns":                          1,
-		"openshift-etcd":                         2,
-		"openshift-image-registry":               1,
-		"openshift-kni-infra":                    3,
-		"openshift-machine-config-operator":      2,
-		"openshift-monitoring":                   1,
-		"openshift-multus":                       3,
-		"openshift-network-diagnostics":          1,
-		"openshift-network-operator":             1,
-		"openshift-ovn-kubernetes":               1,
-	}
-)
+var expectedPods = map[string]int{
+	"openshift-cluster-node-tuning-operator": 1,
+	"openshift-dns":                          1,
+	"openshift-etcd":                         2,
+	"openshift-image-registry":               1,
+	"openshift-kni-infra":                    3,
+	"openshift-machine-config-operator":      2,
+	"openshift-monitoring":                   1,
+	"openshift-multus":                       3,
+	"openshift-network-diagnostics":          1,
+	"openshift-network-operator":             1,
+	"openshift-ovn-kubernetes":               1,
+}
 
 var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] expected Master and Arbiter node counts", func() {
 	defer g.GinkgoRecover()
@@ -70,15 +68,12 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:High
 var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] required pods on the Arbiter node", func() {
 	defer g.GinkgoRecover()
 
-	var (
-		oc = exutil.NewCLIWithoutNamespace("")
-	)
+	oc := exutil.NewCLIWithoutNamespace("")
 
 	g.BeforeEach(func() {
 		skipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 	g.It("Should verify that the correct number of pods are running on the Arbiter node", func() {
-
 		g.By("Retrieving the Arbiter node name")
 		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 			LabelSelector: labelNodeRoleArbiter,
@@ -404,22 +399,4 @@ func createDaemonSetDeployment(oc *exutil.CLI) (*appv1.DaemonSet, error) {
 
 func isPodRunning(pod corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodRunning
-}
-
-func isClusterOperatorAvailable(operator *v1.ClusterOperator) bool {
-	for _, cond := range operator.Status.Conditions {
-		if cond.Type == v1.OperatorAvailable && cond.Status == v1.ConditionTrue {
-			return true
-		}
-	}
-	return false
-}
-
-func isClusterOperatorDegraded(operator *v1.ClusterOperator) bool {
-	for _, cond := range operator.Status.Conditions {
-		if cond.Type == v1.OperatorDegraded && cond.Status == v1.ConditionTrue {
-			return true
-		}
-	}
-	return false
 }

--- a/test/extended/two_node/common.go
+++ b/test/extended/two_node/common.go
@@ -24,3 +24,21 @@ func skipIfNotTopology(oc *exutil.CLI, wanted v1.TopologyMode) {
 		e2eskipper.Skip(fmt.Sprintf("Cluster is not in %v topology, skipping test", wanted))
 	}
 }
+
+func isClusterOperatorAvailable(operator *v1.ClusterOperator) bool {
+	for _, cond := range operator.Status.Conditions {
+		if cond.Type == v1.OperatorAvailable && cond.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isClusterOperatorDegraded(operator *v1.ClusterOperator) bool {
+	for _, cond := range operator.Status.Conditions {
+		if cond.Type == v1.OperatorDegraded && cond.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/test/extended/two_node/tna_recovery.go
+++ b/test/extended/two_node/tna_recovery.go
@@ -1,0 +1,168 @@
+package two_node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	v1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Single node outage is handled seamlessly", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("").AsAdmin()
+
+	g.BeforeEach(func() {
+		skipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
+	})
+
+	g.It("should maintain etcd quorum and workloads with one master node down", func() {
+		ctx := context.Background()
+
+		g.By("Identifying one master node to simulate failure")
+		masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: labelNodeRoleMaster,
+		})
+		o.Expect(err).To(o.BeNil())
+		o.Expect(len(masterNodes.Items)).To(o.Equal(2))
+		targetNode := masterNodes.Items[0].Name
+
+		g.By(fmt.Sprintf("Gracefully rebooting %s to simulate failure", targetNode))
+		shutdownOrRebootNode(oc, targetNode, "openshift-etcd", "shutdown", "-r", "+1")
+
+		g.By("Waiting for the node to become NotReady")
+		waitForNodeCondition(oc, targetNode, corev1.NodeReady, corev1.ConditionFalse, "NotReady", 10*time.Minute)
+
+		g.By("Validating etcd quorum is met while the node is still NotReady")
+		err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, targetNode, metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			stillNotReady := false
+			for _, cond := range node.Status.Conditions {
+				if cond.Type == corev1.NodeReady && cond.Status != corev1.ConditionTrue {
+					stillNotReady = true
+					break
+				}
+			}
+			if !stillNotReady {
+				return false, nil
+			}
+
+			operator, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, "etcd", metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return isClusterOperatorAvailable(operator), nil
+		})
+		o.Expect(err).To(o.BeNil(), "Expected etcd operator to remain healthy while one master node is NotReady")
+	})
+	g.AfterEach(func() {
+		ctx := context.Background()
+		g.By("Ensuring all cluster nodes are back to Ready state")
+
+		nodeList, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		o.Expect(err).To(o.BeNil(), "Failed to list cluster nodes")
+
+		for _, node := range nodeList.Items {
+			waitForNodeCondition(oc, node.Name, corev1.NodeReady, corev1.ConditionTrue, "Ready", 15*time.Minute)
+		}
+	})
+})
+
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Recovery after arbiter down and master node restart", func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLIWithoutNamespace("").AsAdmin()
+	var arbiterNodeName string
+	g.BeforeEach(func() {
+		skipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
+	})
+	g.It("should regain quorum after arbiter down and master nodes restart", func() {
+		ctx := context.Background()
+
+		g.By("Getting arbiter node")
+		arbiterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: labelNodeRoleArbiter,
+		})
+		o.Expect(err).To(o.BeNil())
+		o.Expect(len(arbiterNodes.Items)).To(o.Equal(1))
+		arbiterNode := arbiterNodes.Items[0]
+		arbiterNodeName = arbiterNode.Name
+
+		g.By("Triggering 15-minute simulated shutdown on arbiter node by stopping kubelet")
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, arbiterNodeName, "openshift-etcd",
+			"bash", "-c", `systemd-run --on-active=10s --unit=delayed-reboot.service bash -c "sleep 5; systemctl stop kubelet; sleep 900; reboot"`)
+		o.Expect(err).To(o.BeNil(), "Expected arbiter shutdown simulation to succeed")
+
+		g.By("Waiting for arbiter to become status uknown due to kubelet stopped")
+		waitForNodeCondition(oc, arbiterNodeName, corev1.NodeReady, corev1.ConditionUnknown, "Unknown", 5*time.Minute)
+
+		g.By("Rebooting both master nodes")
+		masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: labelNodeRoleMaster,
+		})
+		o.Expect(err).To(o.BeNil())
+		for _, node := range masterNodes.Items {
+			shutdownOrRebootNode(oc, node.Name, "openshift-etcd", "shutdown", "-r", "+1")
+		}
+
+		g.By("Waiting for master nodes to become NotReady")
+		for _, node := range masterNodes.Items {
+			waitForNodeCondition(oc, node.Name, corev1.NodeReady, corev1.ConditionFalse, "NotReady", 5*time.Minute)
+		}
+
+		g.By("Waiting for master nodes to become Ready")
+		for _, node := range masterNodes.Items {
+			waitForNodeCondition(oc, node.Name, corev1.NodeReady, corev1.ConditionFalse, "Ready", 15*time.Minute)
+		}
+
+		g.By("Waiting for etcd quorum to be restored")
+		err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+			operator, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, "etcd", metav1.GetOptions{})
+			if err != nil {
+				return false, nil
+			}
+			return isClusterOperatorAvailable(operator), nil
+		})
+		o.Expect(err).To(o.BeNil(), "Expected etcd operator to become available again")
+	})
+	g.AfterEach(func() {
+		g.By("Ensuring arbiter node becomes ready again")
+		waitForNodeCondition(oc, arbiterNodeName, corev1.NodeReady, corev1.ConditionFalse, "NotReady", 15*time.Minute)
+	})
+})
+
+func shutdownOrRebootNode(oc *exutil.CLI, nodeName, component string, args ...string) {
+	_, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, nodeName, component, args...)
+	action := strings.Join(args, " ")
+	o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected node %s to execute '%s' successfully", nodeName, action))
+}
+
+func waitForNodeCondition(oc *exutil.CLI, nodeName string, conditionType corev1.NodeConditionType, expectStatus corev1.ConditionStatus, statusName string, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == conditionType && cond.Status == expectStatus {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected node %s to become %s", nodeName, statusName))
+}

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1213,9 +1213,9 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Recovery after arbiter down and master node restart should regain quorum after arbiter down and master nodes restart": " [Serial]",
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] One master node outage is handled seamlessly should maintain etcd quorum and workloads with one master node down": " [Serial]",
 
-	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Single node outage is handled seamlessly should maintain etcd quorum and workloads with one master node down": " [Serial]",
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Recovery when arbiter node is down and master nodes restart should regain quorum after arbiter down and master nodes restart": " [Serial]",
 
 	"[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][Serial] Should fail clusterimagepolicy signature validation root of trust does not match the identity in the signature": " [Suite:openshift/conformance/serial]",
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1213,6 +1213,10 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Recovery after arbiter down and master node restart should regain quorum after arbiter down and master nodes restart": " [Serial]",
+
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive] Single node outage is handled seamlessly should maintain etcd quorum and workloads with one master node down": " [Serial]",
+
 	"[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][Serial] Should fail clusterimagepolicy signature validation root of trust does not match the identity in the signature": " [Suite:openshift/conformance/serial]",
 
 	"[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][Serial] Should fail clusterimagepolicy signature validation when scope in allowedRegistries list does not skip signature verification": " [Suite:openshift/conformance/serial]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -392,6 +392,12 @@ spec:
     - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all
         etcd pods running and quorum met'
+    - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive]
+        Recovery after arbiter down and master node restart should regain quorum after
+        arbiter down and master nodes restart'
+    - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive]
+        Single node outage is handled seamlessly should maintain etcd quorum and workloads
+        with one master node down'
     - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         expected Master and Arbiter node counts Should validate that there are Master
         and Arbiter nodes as specified in the cluster'

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -393,11 +393,11 @@ spec:
         Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all
         etcd pods running and quorum met'
     - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive]
-        Recovery after arbiter down and master node restart should regain quorum after
-        arbiter down and master nodes restart'
+        One master node outage is handled seamlessly should maintain etcd quorum and
+        workloads with one master node down'
     - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Suite:openshift/two-node][Disruptive]
-        Single node outage is handled seamlessly should maintain etcd quorum and workloads
-        with one master node down'
+        Recovery when arbiter node is down and master nodes restart should regain
+        quorum after arbiter down and master nodes restart'
     - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter]
         expected Master and Arbiter node counts Should validate that there are Master
         and Arbiter nodes as specified in the cluster'


### PR DESCRIPTION
add recovery tests for TNA
update common.go
arbiter e2e [run](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30022/pull-ci-openshift-origin-main-e2e-metal-ovn-two-node-arbiter/1950567539113201664)