### PR TITLE
OCPNODE-3004: Accept ErrImagePull for non-existent image volume test.

### DIFF
--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -56,11 +56,12 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 		_, err := oc.AdminKubeClient().CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("Waiting for pod to be ImagePullBackOff")
+		g.By("Waiting for pod to be ErrImagePull or ImagePullBackOff")
 		err = e2epod.WaitForPodCondition(ctx, oc.AdminKubeClient(), pod.Namespace, pod.Name, "ImagePullBackOff", 60*time.Second, func(pod *v1.Pod) (bool, error) {
 			return len(pod.Status.ContainerStatuses) > 0 &&
-				pod.Status.ContainerStatuses[0].State.Waiting != nil &&
-				pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff", nil
+					pod.Status.ContainerStatuses[0].State.Waiting != nil &&
+					(pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" || pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ErrImagePull"),
+				nil
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})


### PR DESCRIPTION
Following up #30015

Fix the flaky `Waiting for pod to be ImagePullBackOff` test.
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30024/pull-ci-openshift-origin-main-e2e-gcp-ovn-techpreview/1950018871981248512