### PR TITLE
OCPBUGS-57325: update machines scale test

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -287,8 +287,9 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		for _, machineSet := range machineSets {
 			newestMachine, err := getNewestMachineNameFromMachineSet(dc, machineName(machineSet))
 			o.Expect(err).NotTo(o.HaveOccurred())
-			err = markMachineForScaleDown(dc, newestMachine)
-			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Eventually(func() error {
+				return markMachineForScaleDown(dc, newestMachine)
+			}, 3*time.Minute, 5*time.Second).Should(o.Succeed(), "Unable to mark Machine %q for scale down", newestMachine)
 		}
 
 		g.By("scaling the machinesets back to their original size")


### PR DESCRIPTION
this change adds an extra retry period for marking machines to scale down. this change is being added to help improve API interactions when there might be network disruptions within the cluster, or in cases where the record has been updated by another controller.