### PR TITLE
OCPBUGS-56506: Don't check for remote node subnet BGP routes

### DIFF
--- a/test/extended/networking/route_advertisements.go
+++ b/test/extended/networking/route_advertisements.go
@@ -1159,8 +1159,6 @@ spec:
 // verifyLearnedBgpRoutesForNode encapsulates the verification of learned BGP routes for a node.
 func verifyLearnedBgpRoutesForNode(oc *exutil.CLI, nodeName string, network string) {
 	var lastErr error
-	nodeSubnets, err := getNodeSubnets(oc, network)
-	o.Expect(err).NotTo(o.HaveOccurred())
 
 	g.By(fmt.Sprintf("Checking routes for node %s in network %s", nodeName, network))
 	o.Eventually(func() bool {
@@ -1174,12 +1172,6 @@ func verifyLearnedBgpRoutesForNode(oc *exutil.CLI, nodeName string, network stri
 			lastErr = fmt.Errorf("missing external routes")
 			return false
 		}
-
-		if !verifyNodeSubnetRoutes(nodeName, nodeSubnets, bgpV4Routes, bgpV6Routes) {
-			lastErr = fmt.Errorf("missing node subnet routes")
-			return false
-		}
-
 		return true
 	}, 3*timeOut, interval).Should(o.BeTrue(), func() string {
 		return fmt.Sprintf("Route verification failed for node %s: %v", nodeName, lastErr)
@@ -1194,28 +1186,6 @@ func verifyExternalRoutes(v4Routes, v6Routes map[string]string) bool {
 	if _, ok := v6Routes[v6ExternalCIDR]; !ok {
 		framework.Logf("Missing v6 external route %s in %v", v6ExternalCIDR, v6Routes)
 		return false
-	}
-	return true
-}
-
-func verifyNodeSubnetRoutes(nodeName string, nodeSubnets map[string][]net.IPNet, v4Routes, v6Routes map[string]string) bool {
-	for node, subnets := range nodeSubnets {
-		if node == nodeName {
-			continue
-		}
-		for _, subnet := range subnets {
-			if subnet.IP.To4() != nil {
-				if _, ok := v4Routes[subnet.String()]; !ok {
-					framework.Logf("Missing v4 route for node %s subnet %s", node, subnet.String())
-					return false
-				}
-			} else {
-				if _, ok := v6Routes[subnet.String()]; !ok {
-					framework.Logf("Missing v6 route for node %s subnet %s", node, subnet.String())
-					return false
-				}
-			}
-		}
 	}
 	return true
 }


### PR DESCRIPTION
In https://github.com/ovn-kubernetes/ovn-kubernetes/pull/5140 we are removing receiving the remote node pod subnet routes for advertised networks.

In the e2e setup, we seem to be checking for these routes which won't be there.
See sample failure:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2651/pull-ci-openshift-ovn-kubernetes-master-e2e-metal-ipi-ovn-dualstack-bgp-local-gw/1950264479669293056 https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/2693/pull-ci-openshift-ovn-kubernetes-master-e2e-metal-ipi-ovn-dualstack-bgp-local-gw/1948808636629258240

We need this change before we bring in 5140 downstream.