### PR TITLE
OCPNODE-3004: Increase the time to wait until the pod becomes ImagePullBackOff

### DIFF
--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -57,7 +57,8 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Waiting for pod to be ErrImagePull or ImagePullBackOff")
-		err = e2epod.WaitForPodCondition(ctx, oc.AdminKubeClient(), pod.Namespace, pod.Name, "ImagePullBackOff", 60*time.Second, func(pod *v1.Pod) (bool, error) {
+		// wait for 5 mins so that the pod in metal-ovn-two-node-arbiter-ipv6-techpreview can become ImagePullBackOff.
+		err = e2epod.WaitForPodCondition(ctx, oc.AdminKubeClient(), pod.Namespace, pod.Name, "ImagePullBackOff", 5*time.Minute, func(pod *v1.Pod) (bool, error) {
 			return len(pod.Status.ContainerStatuses) > 0 &&
 					pod.Status.ContainerStatuses[0].State.Waiting != nil &&
 					(pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ImagePullBackOff" || pod.Status.ContainerStatuses[0].State.Waiting.Reason == "ErrImagePull"),


### PR DESCRIPTION
Fix the test failure in metal-ovn-two-node-arbiter-ipv6-techpreview.
https://testgrid.k8s.io/redhat-openshift-ocp-release-4.20-informing#periodic-ci-openshift-release-master-nightly-4.20-e2e-metal-ovn-two-node-arbiter-ipv6-techpreview