### PR TITLE
Fix image signature test on FIPS environments

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51649,8 +51649,8 @@ items:
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: RSA \n\
             Key-Length: 2048 \n\
-            Subkey-Type: ELG-E \n\
-            Subkey-Length: 1024 \n\
+            Subkey-Type: RSA \n\
+            Subkey-Length: 2048 \n\
             Name-Real: Joe Tester \n\
             Name-Comment: with stupid passphrase \n\
             Name-Email: joe@foo.bar \n\

--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -28,8 +28,8 @@ items:
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: RSA \n\
             Key-Length: 2048 \n\
-            Subkey-Type: ELG-E \n\
-            Subkey-Length: 1024 \n\
+            Subkey-Type: RSA \n\
+            Subkey-Length: 2048 \n\
             Name-Real: Joe Tester \n\
             Name-Comment: with stupid passphrase \n\
             Name-Email: joe@foo.bar \n\


### PR DESCRIPTION
`[sig-imageregistry][Serial] Image signature workflow can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/serial]` uses El-Gamal which is not a FIPS complaint algorithm, migrate to RSA for the sub-key to make this test pass on FIPS.