### PR TITLE
NO-JIRA: Revert "OCPBUGS-55238: spyglass: hide disruption events for localhost"

### DIFF
--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -419,7 +419,7 @@
         if (eventInterval.message.reason !== "DisruptionBegan" && eventInterval.message.reason !== "DisruptionSamplerOutageBegan") {
             return false
         }
-        if (eventInterval.source === "Disruption" || eventInterval.source === "DisruptionLocalhost") {
+        if (eventInterval.source === "Disruption") {
             return true
         }
         if (eventInterval.locator.keys["namespace"] === "e2e-k8s-service-lb-available") {

--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -76,7 +76,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message.BuildString())
 
-	interval := monitorapi.NewInterval(h.getSource(), level).Locator(h.descriptor.DisruptionLocator()).
+	interval := monitorapi.NewInterval(monitorapi.SourceDisruption, level).Locator(h.descriptor.DisruptionLocator()).
 		Display().
 		Message(message).Build(fs.StartedAt, time.Time{})
 	openIntervalID := h.monitorRecorder.StartInterval(interval)
@@ -100,16 +100,8 @@ func (h *ciHandler) Available(from, to *backend.SampleResult) {
 	h.eventRecorder.Eventf(
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()}, nil,
 		v1.EventTypeNormal, string(monitorapi.DisruptionEndedEventReason), "detected", message.BuildString())
-	interval := monitorapi.NewInterval(h.getSource(), monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
+	interval := monitorapi.NewInterval(monitorapi.SourceDisruption, monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
 		Message(message).Build(fs.StartedAt, time.Time{})
 	openIntervalID := h.monitorRecorder.StartInterval(interval)
 	h.monitorRecorder.EndInterval(openIntervalID, ts.StartedAt)
-}
-
-// getSource returns the source of the interval based on the load balancer type. Localhost disruptions need to be separated, as in some cases these are expected
-func (h *ciHandler) getSource() monitorapi.IntervalSource {
-	if h.descriptor.GetLoadBalancerType() == backend.LocalhostType {
-		return monitorapi.SourceDisruptionLocalhost
-	}
-	return monitorapi.SourceDisruption
 }

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -348,7 +348,6 @@ const (
 	SourceAlert                     IntervalSource = "Alert"
 	SourceAPIServerShutdown         IntervalSource = "APIServerShutdown"
 	SourceDisruption                IntervalSource = "Disruption"
-	SourceDisruptionLocalhost       IntervalSource = "DisruptionLocalhost"
 	SourceE2ETest                   IntervalSource = "E2ETest"
 	SourceKubeEvent                 IntervalSource = "KubeEvent"
 	SourceNetworkManagerLog         IntervalSource = "NetworkMangerLog"

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -58114,7 +58114,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         if (eventInterval.message.reason !== "DisruptionBegan" && eventInterval.message.reason !== "DisruptionSamplerOutageBegan") {
             return false
         }
-        if (eventInterval.source === "Disruption" || eventInterval.source === "DisruptionLocalhost") {
+        if (eventInterval.source === "Disruption") {
             return true
         }
         if (eventInterval.locator.keys["namespace"] === "e2e-k8s-service-lb-available") {


### PR DESCRIPTION
Reverts openshift/origin#29710

This change is breaking spyglass view for many jobs. We can see this in the presubmit jobs in the original PR. Here is an example:

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/29710/pull-ci-openshift-origin-main-e2e-gcp-ovn-techpreview-serial-2of2/1947614945747144704

Debugging a little further, you can see this error when the generated html is shown:

`TypeError: eventInterval.locator.keys.has is not a function
`
It hits this line: https://github.com/openshift/origin/blob/867bce8197b814cf425fd60e0f6400dd7b743556/e2echart/e2e-chart-template.html#L164

