### PR TITLE
OPRUN-3964: [olmv1] - Remove test [sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed migrated to operator-controller repository/OTE

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -31,48 +31,6 @@ const (
 	reasonRetrying = "Retrying"
 )
 
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs", func() {
-	defer g.GinkgoRecover()
-	oc := exutil.NewCLIWithoutNamespace("default")
-
-	g.It("should be installed", func(ctx g.SpecContext) {
-		checkFeatureCapability(oc)
-
-		providedAPIs := []struct {
-			group   string
-			version []string
-			plural  string
-		}{
-			{
-				group:   olmv1GroupName,
-				version: []string{"v1"},
-				plural:  "clusterextensions",
-			},
-			{
-				group:   olmv1GroupName,
-				version: []string{"v1"},
-				plural:  "clustercatalogs",
-			},
-		}
-
-		for _, api := range providedAPIs {
-			g.By(fmt.Sprintf("checking %s at version %s [apigroup:%s]", api.plural, api.version, api.group))
-			// Ensure expected version exists in spec.versions and is both served and stored
-			var err error
-			var raw string
-			for _, ver := range api.version {
-				raw, err = oc.AsAdmin().Run("get").Args("crds", fmt.Sprintf("%s.%s", api.plural, api.group), fmt.Sprintf("-o=jsonpath={.spec.versions[?(@.name==%q)]}", ver)).Output()
-				if err == nil {
-					break
-				}
-			}
-			o.Expect(err).NotTo(o.HaveOccurred())
-			o.Expect(raw).To(o.MatchRegexp(`served.?:true`))
-			o.Expect(raw).To(o.MatchRegexp(`storage.?:true`))
-		}
-	})
-})
-
 var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation", func() {
 	defer g.GinkgoRecover()
 

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1981,8 +1981,6 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLMPreflightPermissionChecks][Skipped:Disconnected] OLMv1 operator preflight checks should report error when {services} are not specified": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs should be installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New Catalog Install should fail to install if it has an invalid reference": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -952,7 +952,6 @@ spec:
         when the VMI attached to a secondary UDN is migrated between nodes'
   - featureGate: NewOLM
     tests:
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM] OLMv1 CRDs should be installed'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 Catalogs
         should be installed'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 New


### PR DESCRIPTION
The test was migrated in the PR: https://github.com/openshift/operator-framework-operator-controller/pull/415