### PR TITLE
deflake kubelet metrics endpoints should always be reachable

### DIFF
--- a/pkg/monitortests/testframework/metricsendpointdown/monitortest.go
+++ b/pkg/monitortests/testframework/metricsendpointdown/monitortest.go
@@ -85,10 +85,6 @@ func (*metricsEndpointDown) EvaluateTestsFromConstructedIntervals(ctx context.Co
 			},
 		})
 	}
-	// Add a success so this is marked as a flake at worst, no idea what this will unleash in the wild.
-	junits = append(junits, &junitapi.JUnitTestCase{
-		Name: testName,
-	})
 	return junits, nil
 }
 


### PR DESCRIPTION
Testing this out.

This test seems to show a lot of down endpoints. I want to deflake this and run it on our jobs and see if it shows anything.