### PR TITLE
OCPBUGS-60429: Load our MCO's OTE binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -59,6 +59,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "machine-api-operator",
 		binaryPath: "/machine-api-tests-ext.gz",
 	},
+	{
+		imageTag:   "machine-config-operator",
+		binaryPath: "/usr/bin/machine-config-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.

--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -447,6 +447,7 @@ var staticSuites = []ginkgo.TestSuite{
 			}
 			return strings.Contains(name, "[Suite:openshift/machine-config-operator/disruptive")
 		},
-		TestTimeout: 120 * time.Minute,
+		TestTimeout:                120 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
 }


### PR DESCRIPTION
This is a manual backport of the content applied by https://github.com/openshift/origin/pull/29922.
This backport needs to be manual mainly because the support for external declared tests-suites was not backported to 4.19.