### PR TITLE
Upgradable=False is expected in 4.18 with RHEL8 Workers

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -118,6 +118,10 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 				if name == "network" && isNetworkOperatorUpgradableOpenShiftSDNConfiguredCondition(worstCondition) {
 					continue
 				}
+				// RHEL 8 worker support was removed in 4.18 therefore it's expected to not be upgradble when RHEL8 workers are present
+				if isNoUpgrade && name == "machine-config" && isMachineConfigOperatorUpgradableRHELNodesCondition(worstCondition) {
+					continue
+				}
 
 				unready = append(unready, fmt.Sprintf("%s (%s=%s %s: %s)",
 					name,
@@ -341,6 +345,13 @@ func isNetworkOperatorUpgradableKuryrConfiguredCondition(cond configv1.ClusterOp
 // OpenShiftSDN is removed from 4.17, and 4.16 CNO blocks upgrades if it's configured.
 func isNetworkOperatorUpgradableOpenShiftSDNConfiguredCondition(cond configv1.ClusterOperatorStatusCondition) bool {
 	return cond.Reason == "OpenShiftSDNConfigured" &&
+		cond.Status == "False" &&
+		cond.Type == "Upgradeable"
+}
+
+// RHEL8 Workers removed in 4.19, therefore Upgradeable=False is set by MCO in 4.18
+func isMachineConfigOperatorUpgradableRHELNodesCondition(cond configv1.ClusterOperatorStatusCondition) bool {
+	return cond.Reason == "RHELNodes" &&
 		cond.Status == "False" &&
 		cond.Type == "Upgradeable"
 }


### PR DESCRIPTION
We don't support RHEL8 workers in 4.19 onward and as such 4.18 clusters with them are Upgradable=False as expected