### PR TITLE
OCPBUGS-60067, OCPBUGS-60066: Don't check for isNoUpgrade

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -119,11 +119,11 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 					continue
 				}
 				// For 4.18 onwards the machine-config operator prevents upgrades when RHEL8 workers are present
-				if isNoUpgrade && name == "machine-config" && isMachineConfigOperatorUpgradableRHELNodesCondition(worstCondition) {
+				if name == "machine-config" && isMachineConfigOperatorUpgradableRHELNodesCondition(worstCondition) {
 					continue
 				}
 				// For 4.18 onwards the machine-config operator prevents upgrades when configured for cgroup v1
-				if isNoUpgrade && name == "machine-config" && isMachineConfigOperatorUpgradableClusterOnCgroupV1Condition(worstCondition) {
+				if name == "machine-config" && isMachineConfigOperatorUpgradableClusterOnCgroupV1Condition(worstCondition) {
 					continue
 				}
 


### PR DESCRIPTION
This is only set when featureSets are configured