### PR TITLE
OCPBUGS-57032: Add wait.Poll retry logic to checkUpgradeability with 30s timeout

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -195,7 +195,18 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		client := configv1client.NewForConfigOrDie(config)
-		err = checkUpgradeability(client)
+		var lastErr error
+		err = wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+			if err := checkUpgradeability(client); err != nil {
+				lastErr = err
+				framework.Logf("Upgradeability check failed, retrying: %v", err)
+				return false, nil // retry on error
+			}
+			return true, nil
+		})
+		if err != nil && lastErr != nil {
+			err = lastErr
+		}
 		framework.ExpectNoError(err)
 	})
 })


### PR DESCRIPTION
Based on Damien's analysis the test is failing because there wasn't enough time between when the upgrade completed and the DaemonSet pod to become ready. In the cases he reviewed there were single digit seconds between when the test checked and when pods became ready.

In https://github.com/openshift/origin/pull/29960 Damien added 30s sleep but Devan suggested a polling loop instead to limit downtime.