### PR TITLE
OCPBUGS-60154: Update olmv1.go cluster-logging to 6.3.0

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -109,7 +109,7 @@ var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLM
 
 		const (
 			packageName = "cluster-logging"
-			version     = "6.2.2"
+			version     = "6.3.0"
 		)
 
 		cleanup, unique := applyResourceFile(oc, packageName, version, "", ceFile)


### PR DESCRIPTION
cluster-logging 6.2.2 set `maxOCPVersion` <= 4.20 so hopefully this bump to 6.3.0 will help