### PR TITLE
OCPBUGS-58037: increase timeout of image extract test

### DIFF
--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	g "github.com/onsi/ginkgo/v2"
@@ -111,6 +112,6 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 			oc image extract --insecure %[1]s --file=/etc/shadow
 			[ -f /tmp/test3/shadow ]
 		`, extractImage)))
-		cli.WaitForSuccess(context.TODO(), pod.Name, podStartupTimeout)
+		cli.WaitForSuccess(context.TODO(), pod.Name, 5*time.Minute)
 	})
 })


### PR DESCRIPTION
3 minutes is not enough when running on compact metal clusters