### PR TITLE
 OCPNODE-3520: UserNamespaces: Increase build timeout duration

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1030,7 +1030,7 @@ func StartBuildAndWait(oc *CLI, args ...string) (result *BuildResult, err error)
 	return result, WaitForBuildResult(oc.BuildClient().BuildV1().Builds(oc.Namespace()), result)
 }
 
-// WaitForBuildResult updates result wit the state of the build
+// WaitForBuildResult updates result with the state of the build
 func WaitForBuildResult(c buildv1clienttyped.BuildInterface, result *BuildResult) error {
 	e2e.Logf("Waiting for %s to complete\n", result.BuildName)
 	err := WaitForABuild(c, result.BuildName,
@@ -1065,7 +1065,7 @@ func WaitForBuildResult(c buildv1clienttyped.BuildInterface, result *BuildResult
 
 // WaitForABuild waits for a Build object to match either isOK or isFailed conditions.
 func WaitForABuild(c buildv1clienttyped.BuildInterface, name string, isOK, isFailed, isCanceled func(*buildv1.Build) bool) error {
-	return WaitForABuildWithTimeout(c, name, 2*time.Minute, 10*time.Minute, isOK, isFailed, isCanceled)
+	return WaitForABuildWithTimeout(c, name, 2*time.Minute, 30*time.Minute, isOK, isFailed, isCanceled)
 }
 
 // WaitForABuild waits for a Build object to match either isOK or isFailed conditions.


### PR DESCRIPTION
Fixing this flakiness. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-gcp-ovn-usernamespace/1952200850893967360 

This is used here.
https://github.com/openshift/origin/blob/4bdcbed43bb02be8939be3a3ad8ca15857368812/test/extended/node/nested_container.go#L30-L37