### PR TITLE
OPRUN-4055: [OLMv1] Remove olmv1.go tests since those has been executed by OTE

### DIFF
--- a/test/extended/olm/olmv1.go
+++ b/test/extended/olm/olmv1.go
@@ -1,150 +1,25 @@
 package operators
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
-
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	configv1 "github.com/openshift/api/config/v1"
-	exutil "github.com/openshift/origin/test/extended/util"
+	"os"
+	"strings"
 )
 
 const (
-	olmv1GroupName                       = "olm.operatorframework.io"
-	typeIncompatibleOperatorsUpgradeable = "InstalledOLMOperatorsUpgradeable"
-	reasonIncompatibleOperatorsInstalled = "IncompatibleOperatorsInstalled"
-
 	typeInstalled   = "Installed"
 	typeProgressing = "Progressing"
 
 	reasonRetrying = "Retrying"
 )
-
-var _ = g.Describe("[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation", func() {
-	defer g.GinkgoRecover()
-
-	var (
-		baseDir = exutil.FixturePath("testdata", "olmv1")
-		ceFile  = filepath.Join(baseDir, "install-operator.yaml")
-	)
-	oc := exutil.NewCLI("openshift-operator-controller")
-
-	g.BeforeEach(func() {
-		exutil.PreTestDump()
-	})
-
-	g.AfterEach(func() {
-		if g.CurrentSpecReport().Failed() {
-			exutil.DumpPodLogsStartingWith("", oc)
-		}
-	})
-
-	g.It("should install a cluster extension", func(ctx g.SpecContext) {
-		checkFeatureCapability(oc)
-
-		const (
-			packageName = "quay-operator"
-			version     = "3.13.0"
-		)
-
-		cleanup, unique := applyResourceFile(oc, packageName, version, "", ceFile)
-		ceName := "install-test-ce-" + unique
-		g.DeferCleanup(cleanup)
-
-		g.By("waiting for the ClusterExtention to be installed")
-		var lastReason string
-		err := wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true,
-			func(ctx context.Context) (bool, error) {
-				b, err, s := waitForClusterExtensionReady(oc, ceName)
-				if lastReason != s {
-					g.GinkgoLogr.Info(fmt.Sprintf("waitForClusterExtensionReady: %q", s))
-					lastReason = s
-				}
-				return b, err
-			})
-		o.Expect(lastReason).To(o.BeEmpty())
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
-	g.It("should fail to install a non-existing cluster extension", func(ctx g.SpecContext) {
-		checkFeatureCapability(oc)
-
-		const (
-			packageName = "does-not-exist"
-			version     = "99.99.99"
-		)
-
-		cleanup, unique := applyResourceFile(oc, packageName, version, "", ceFile)
-		ceName := "install-test-ce-" + unique
-		g.DeferCleanup(cleanup)
-
-		g.By("waiting for the ClusterExtention to report failure")
-		var lastReason string
-		err := wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true,
-			func(ctx context.Context) (bool, error) {
-				b, err, s := waitForClusterExtensionFailure(oc, ceName)
-				if lastReason != s {
-					g.GinkgoLogr.Info(fmt.Sprintf("waitForClusterExtensionFailure: %q", s))
-					lastReason = s
-				}
-				return b, err
-			})
-		o.Expect(lastReason).To(o.BeEmpty())
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-
-	g.It("should block cluster upgrades if an incompatible operator is installed", func(ctx g.SpecContext) {
-		checkFeatureCapability(oc)
-
-		const (
-			packageName = "cluster-logging"
-			version     = "6.2.2"
-		)
-
-		cleanup, unique := applyResourceFile(oc, packageName, version, "", ceFile)
-		ceName := "install-test-ce-" + unique
-		g.DeferCleanup(cleanup)
-
-		g.By("waiting for the ClusterExtention to be installed")
-		var lastReason string
-		err := wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true,
-			func(ctx context.Context) (bool, error) {
-				b, err, s := waitForClusterExtensionReady(oc, ceName)
-				if lastReason != s {
-					g.GinkgoLogr.Info(fmt.Sprintf("waitForClusterExtensionReady: %q", s))
-					lastReason = s
-				}
-				return b, err
-			})
-		o.Expect(lastReason).To(o.BeEmpty())
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("ensuring the cluster is not upgradeable when olm.maxopenshiftversion is specified")
-		lastReason = ""
-		err = wait.PollUntilContextTimeout(ctx, time.Second, 5*time.Minute, true,
-			func(ctx context.Context) (bool, error) {
-				b, err, s := waitForUpgradableCondition(oc, false, ceName)
-				if lastReason != s {
-					g.GinkgoLogr.Info(fmt.Sprintf("waitForUpgradableCondition: %q", s))
-					lastReason = s
-				}
-				return b, err
-			})
-		o.Expect(lastReason).To(o.BeEmpty())
-		o.Expect(err).NotTo(o.HaveOccurred())
-	})
-})
 
 // Use the supplied |unique| value if provided, otherwise generate a unique string. The unique string is returned.
 // |unique| is used to combine common test elements and to avoid duplicate names, which can occur if, for instance,
@@ -203,75 +78,6 @@ func waitForClusterExtensionReady(oc *exutil.CLI, ceName string) (bool, error, s
 	}
 	if c.Status != metav1.ConditionTrue {
 		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
-	}
-	return true, nil, ""
-}
-
-func waitForClusterExtensionFailure(oc *exutil.CLI, ceName string) (bool, error, string) {
-	var conditions []metav1.Condition
-	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("clusterextensions.olm.operatorframework.io", ceName, "-o=jsonpath={.status.conditions}").Output()
-	if err != nil {
-		return false, err, ""
-	}
-	// no data yet, so try again
-	if output == "" {
-		return false, nil, "no output"
-	}
-	if err := json.Unmarshal([]byte(output), &conditions); err != nil {
-		return false, fmt.Errorf("error in json.Unmarshal(%v): %v", output, err), ""
-	}
-	c := meta.FindStatusCondition(conditions, typeProgressing)
-	if c == nil {
-		return false, nil, fmt.Sprintf("condition not present: %q", typeProgressing)
-	}
-	if c.Status != metav1.ConditionTrue {
-		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
-	}
-	if !strings.HasPrefix(c.Message, "no bundles found") {
-		return false, nil, fmt.Sprintf("expected message to contain %q: %+v", "no bundles found", c)
-	}
-	c = meta.FindStatusCondition(conditions, typeInstalled)
-	if c == nil {
-		return false, nil, fmt.Sprintf("condition not present: %q", typeInstalled)
-	}
-	if c.Status != metav1.ConditionFalse {
-		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionFalse, c)
-	}
-	return true, nil, ""
-}
-
-func waitForUpgradableCondition(oc *exutil.CLI, status bool, ceName string) (bool, error, string) {
-	var conditions []metav1.Condition
-	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("olms.operator.openshift.io", "cluster", "-o=jsonpath={.status.conditions}").Output()
-	if err != nil {
-		return false, err, ""
-	}
-	// no data yet, so try again
-	if output == "" {
-		return false, nil, "no output"
-	}
-	if err := json.Unmarshal([]byte(output), &conditions); err != nil {
-		return false, fmt.Errorf("error in json.Unmarshal(%v): %v", output, err), ""
-	}
-	c := meta.FindStatusCondition(conditions, typeIncompatibleOperatorsUpgradeable)
-	if c == nil {
-		return false, nil, fmt.Sprintf("condition not present: %q", typeIncompatibleOperatorsUpgradeable)
-	}
-	if status {
-		if c.Status != metav1.ConditionTrue {
-			return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionTrue, c)
-		}
-		return true, nil, ""
-	}
-	if c.Status != metav1.ConditionFalse {
-		return false, nil, fmt.Sprintf("expected status to be %q: %+v", metav1.ConditionFalse, c)
-	}
-	if c.Reason != reasonIncompatibleOperatorsInstalled {
-		return false, nil, fmt.Sprintf("expected reason to be %q: %+v", reasonIncompatibleOperatorsInstalled, c)
-	}
-	// Message should include "bundle %q for ClusterExtension %q"
-	if !strings.Contains(c.Message, ceName) {
-		return false, nil, fmt.Sprintf("expected message to contain %q: %+v", ceName, c)
 	}
 	return true, nil, ""
 }

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -2007,12 +2007,6 @@ var Annotations = map[string]string{
 
 	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators Catalog should serve FBC via the /v1/api/all endpoint": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should block cluster upgrades if an incompatible operator is installed": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should fail to install a non-existing cluster extension": " [Suite:openshift/conformance/parallel]",
-
-	"[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator installation should install a cluster extension": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-operator] OLM should Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-operator] OLM should be installed with catalogsources at version v1alpha1 [apigroup:operators.coreos.com]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -970,13 +970,6 @@ spec:
         Catalog should serve FBC via the /v1/api/all endpoint'
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 openshift-redhat-operators
         Catalog should serve FBC via the /v1/api/all endpoint'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
-        installation should block cluster upgrades if an incompatible operator is
-        installed'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
-        installation should fail to install a non-existing cluster extension'
-    - testName: '[sig-olmv1][OCPFeatureGate:NewOLM][Skipped:Disconnected] OLMv1 operator
-        installation should install a cluster extension'
   - featureGate: NewOLMCatalogdAPIV1Metas
     tests:
     - testName: '[sig-olmv1][OCPFeatureGate:NewOLMCatalogdAPIV1Metas][Skipped:Disconnected]


### PR DESCRIPTION
Blocked by: https://github.com/openshift/operator-framework-operator-controller/pull/418

Closes: https://github.com/openshift/origin/pull/30063