### PR TITLE
OCPBUGS-60238: images/tests: Remove rteval

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -12,7 +12,7 @@ COPY --from=builder /go/src/github.com/openshift/origin/zz_generated.manifests/*
 
 RUN PACKAGES="git gzip util-linux" && \
     if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
-    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES realtime-tests rteval"; fi && \
+    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES realtime-tests"; fi && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && \
     yum update -y python3-six && \
     yum clean all && rm -rf /var/cache/yum/* && \


### PR DESCRIPTION
It was added and to be used by realtime tests however that's never happened and this package pulls in 80+ dependencies and ~350MiB