### PR TITLE
CNTRLPLANE-1248: Enable OTE for cluster-kube-apiserver Operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -185,6 +185,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-monitoring-operator",
 		binaryPath: "/usr/bin/cluster-monitoring-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "cluster-kube-apiserver-operator",
+		binaryPath: "/usr/bin/cluster-kube-apiserver-operator-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Cluster-kube-apiserver-opeator side setup: https://github.com/openshift/cluster-kube-apiserver-operator/pull/1892