### PR TITLE
WIP: CNTRLPLANE-945: OIDC/enable skipped tests

### DIFF
--- a/test/extended/authentication/keycloak_client.go
+++ b/test/extended/authentication/keycloak_client.go
@@ -104,7 +104,7 @@ func (kc *keycloakClient) CreateUser(username, password string, groups ...string
 		Groups:        groups,
 		Credentials: []credential{
 			{
-				Temporary: true,
+				Temporary: false,
 				Type:      credentialTypePassword,
 				Value:     password,
 			},
@@ -131,8 +131,10 @@ func (kc *keycloakClient) CreateUser(username, password string, groups ...string
 }
 
 type authenticationResponse struct {
-	AccessToken string `json:"access_token"`
-	IDToken     string `json:"id_token"`
+	AccessToken      string `json:"access_token"`
+	IDToken          string `json:"id_token"`
+	Error            string `json:"error,omitempty"`
+	ErrorDescription string `json:"error_description,omitempty"`
 }
 
 func (kc *keycloakClient) Authenticate(clientID, username, password string) error {
@@ -157,6 +159,10 @@ func (kc *keycloakClient) Authenticate(clientID, username, password string) erro
 	err = json.NewDecoder(resp.Body).Decode(respBody)
 	if err != nil {
 		return fmt.Errorf("unmarshalling response data: %w", err)
+	}
+
+	if respBody.Error != "" {
+		return fmt.Errorf("%s: %s", respBody.Error, respBody.ErrorDescription)
 	}
 
 	kc.accessToken = respBody.AccessToken

--- a/test/extended/authentication/keycloak_helpers.go
+++ b/test/extended/authentication/keycloak_helpers.go
@@ -351,7 +351,7 @@ func createKeycloakRoute(ctx context.Context, service *corev1.Service, client ty
 }
 
 func waitForKeycloakAvailable(ctx context.Context, client *exutil.CLI, namespace string) error {
-	timeoutCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+	timeoutCtx, cancel := context.WithDeadline(ctx, time.Now().Add(10*time.Minute))
 	defer cancel()
 	err := wait.PollUntilContextCancel(timeoutCtx, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
 		deploy, err := client.AdminKubeClient().AppsV1().Deployments(namespace).Get(ctx, keycloakResourceName, metav1.GetOptions{})
@@ -364,6 +364,8 @@ func waitForKeycloakAvailable(ctx context.Context, client *exutil.CLI, namespace
 				return true, nil
 			}
 		}
+
+		fmt.Println("keycloak deployment is not yet available. status: ", deploy.Status)
 
 		return false, nil
 	})

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -364,9 +364,6 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 	})
 
 	g.AfterAll(func() {
-		err := removeResources(ctx, cleanups...)
-		o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error cleaning up keycloak resources")
-
 		err, modified := resetAuthentication(ctx, oc, originalAuth)
 		o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error reverting authentication to original state")
 
@@ -374,6 +371,9 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 		if modified {
 			waitForRollout(ctx, oc)
 		}
+
+		err = removeResources(ctx, cleanups...)
+		o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error cleaning up keycloak resources")
 	})
 })
 

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -113,15 +113,12 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				o.Expect(apiServerArgs["authentication-config"].([]interface{})[0].(string)).To(o.Equal("/etc/kubernetes/static-pod-resources/configmaps/auth-config/auth-config.json"))
 			})
 
-			g.It("[Skipped] should remove the OpenShift OAuth stack", func() {
-				g.Skip("functionality not yet implemented")
-				/*
-					o.Eventually(func(gomega o.Gomega) {
-						_, err := oc.AdminKubeClient().AppsV1().Deployments("openshift-authentication").Get(ctx, "oauth-openshift", metav1.GetOptions{})
-						gomega.Expect(err).NotTo(o.BeNil(), "should not be able to get the integrated oauth stack")
-						gomega.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "integrated oauth stack should not be present when OIDC authentication is configured")
-					}).WithTimeout(20 * time.Minute).WithPolling(30 * time.Second).Should(o.Succeed())
-				*/
+			g.It("should remove the OpenShift OAuth stack", func() {
+				o.Eventually(func(gomega o.Gomega) {
+					_, err := oc.AdminKubeClient().AppsV1().Deployments("openshift-authentication").Get(ctx, "oauth-openshift", metav1.GetOptions{})
+					gomega.Expect(err).NotTo(o.BeNil(), "should not be able to get the integrated oauth stack")
+					gomega.Expect(apierrors.IsNotFound(err)).To(o.BeTrue(), "integrated oauth stack should not be present when OIDC authentication is configured")
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 			})
 
 			g.It("should not accept tokens provided by the OAuth server", func() {
@@ -332,32 +329,26 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				})
 			})
 
-			g.Describe("[Skipped] with invalid specified UID or Extra claim mappings", func() {
+			g.Describe("with invalid specified UID or Extra claim mappings", func() {
 				g.It("should reject admission when UID claim expression is not compilable CEL", func() {
-					g.Skip("functionality not yet implemented")
-					/*
-						_, _, err := configureOIDCAuthentication(ctx, oc, func(o *configv1.OIDCProvider) {
-							o.ClaimMappings.UID = &configv1.TokenClaimOrExpressionMapping{
-								Expression: "!@&*#^",
-							}
-						})
-						o.Expect(err).To(o.HaveOccurred(), "should encounter an error configuring OIDC authentication")
-					*/
+					_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, func(o *configv1.OIDCProvider) {
+						o.ClaimMappings.UID = &configv1.TokenClaimOrExpressionMapping{
+							Expression: "!@&*#^",
+						}
+					})
+					o.Expect(err).To(o.HaveOccurred(), "should encounter an error configuring OIDC authentication")
 				})
 
 				g.It("should reject admission when Extra claim expression is not compilable CEL", func() {
-					g.Skip("functionality not yet implemented")
-					/*
-						_, _, err := configureOIDCAuthentication(ctx, oc, func(o *configv1.OIDCProvider) {
-							o.ClaimMappings.Extra = []configv1.ExtraMapping{
-								{
-									Key:             "payload/test",
-									ValueExpression: "!@*&#^!@(*&^",
-								},
-							}
-						})
-						o.Expect(err).To(o.HaveOccurred(), "should encounter an error configuring OIDC authentication")
-					*/
+					_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, func(o *configv1.OIDCProvider) {
+						o.ClaimMappings.Extra = []configv1.ExtraMapping{
+							{
+								Key:             "payload/test",
+								ValueExpression: "!@*&#^!@(*&^",
+							},
+						}
+					})
+					o.Expect(err).To(o.HaveOccurred(), "should encounter an error configuring OIDC authentication")
 				})
 			})
 		})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -455,17 +455,15 @@ var Annotations = map[string]string{
 
 	"[sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured [Skipped] with invalid specified UID or Extra claim mappings should reject admission when Extra claim expression is not compilable CEL": "",
+	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured with invalid specified UID or Extra claim mappings should reject admission when Extra claim expression is not compilable CEL": "",
 
-	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured [Skipped] with invalid specified UID or Extra claim mappings should reject admission when UID claim expression is not compilable CEL": "",
+	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured with invalid specified UID or Extra claim mappings should reject admission when UID claim expression is not compilable CEL": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured with valid specified UID or Extra claim mappings checking cluster identity mapping should map Extra correctly": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured with valid specified UID or Extra claim mappings checking cluster identity mapping should map UID correctly": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is configured without specified UID or Extra claim mappings should default UID to the 'sub' claim in the access token from the IdP": "",
-
-	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] external IdP is configured [Skipped] should remove the OpenShift OAuth stack": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] external IdP is configured should accept authentication via a certificate-based kubeconfig (break-glass)": "",
 
@@ -474,6 +472,8 @@ var Annotations = map[string]string{
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] external IdP is configured should map cluster identities correctly": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] external IdP is configured should not accept tokens provided by the OAuth server": "",
+
+	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] external IdP is configured should remove the OpenShift OAuth stack": "",
 
 	"[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive] [OCPFeatureGate:ExternalOIDC] reverting to IntegratedOAuth should accept tokens provided by the OpenShift OAuth server": "",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -337,9 +337,6 @@ spec:
   - featureGate: ExternalOIDC
     tests:
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
-        [OCPFeatureGate:ExternalOIDC] external IdP is configured [Skipped] should
-        remove the OpenShift OAuth stack'
-    - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDC] external IdP is configured should accept authentication
         via a certificate-based kubeconfig (break-glass)'
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
@@ -351,6 +348,9 @@ spec:
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDC] external IdP is configured should not accept
         tokens provided by the OAuth server'
+    - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
+        [OCPFeatureGate:ExternalOIDC] external IdP is configured should remove the
+        OpenShift OAuth stack'
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDC] reverting to IntegratedOAuth should accept tokens
         provided by the OpenShift OAuth server'
@@ -367,12 +367,12 @@ spec:
     tests:
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is
-        configured [Skipped] with invalid specified UID or Extra claim mappings should
-        reject admission when Extra claim expression is not compilable CEL'
+        configured with invalid specified UID or Extra claim mappings should reject
+        admission when Extra claim expression is not compilable CEL'
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is
-        configured [Skipped] with invalid specified UID or Extra claim mappings should
-        reject admission when UID claim expression is not compilable CEL'
+        configured with invalid specified UID or Extra claim mappings should reject
+        admission when UID claim expression is not compilable CEL'
     - testName: '[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]
         [OCPFeatureGate:ExternalOIDCWithUIDAndExtraClaimMappings] external IdP is
         configured with valid specified UID or Extra claim mappings checking cluster


### PR DESCRIPTION
Blocked on https://github.com/openshift/origin/pull/30040 merging.

Unskips the tests that were skipped pending their implementations that have since been implemented via https://github.com/openshift/cluster-authentication-operator/pull/740 and https://github.com/openshift/kubernetes/pull/2353