### PR TITLE
TRT-2226: Exclude ephemeral cni-sysctl-allowlist-ds from maxUnavailable/maxSurge check

### DIFF
--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -68,6 +68,10 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 			// Managed service exceptions https://issues.redhat.com/browse/OSD-26323
 			"openshift-security/splunkforwarder-ds",
 			"openshift-validation-webhook/validation-webhook",
+
+			// This is a temporary daemon set used to deploy a config to nodes, and then
+			// it is deleted later.
+			"openshift-multus/cni-sysctl-allowlist-ds",
 		)
 
 		var debug []string


### PR DESCRIPTION
This test started failing more often (15% drop) when we hardcoded the origin random seed. With the new deterministic ordering, this test is now more likely to run early enough to observe the ephemeral
openshift-multus/cni-sysctl-allowlist-ds before it is deleted.

It is pruned shortly after creation, so later runs of the same test pass.

Because this DS is transient and not part of the steady-state cluster, it should be excluded from the invariant check to avoid non-deterministic failures.