### PR TITLE
WIP: OTA-1580: [6/x] Update lifecycle test

### DIFF
--- a/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
@@ -84,7 +84,7 @@ func snapshotOcAdmUpgradeStatus(ch chan *snapshot) {
 	var err error
 	// retry on brief apiserver unavailability
 	if errWait := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 2*time.Minute, true, func(context.Context) (bool, error) {
-		cmd := oc.Run("adm", "upgrade", "status").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
+		cmd := oc.Run("adm", "upgrade", "status", "--details=all").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
 		out, err = cmd.Output()
 		if err != nil {
 			return false, nil
@@ -112,7 +112,7 @@ func (w *monitor) StartCollection(ctx context.Context, adminRESTConfig *rest.Con
 			w.collectionDone <- struct{}{}
 		}()
 		// TODO: Configurable interval?
-		// TODO: Collect multiple invocations (--details)? Would need more another producer/consumer pair and likely
+		// TODO: Collect multiple invocations (without --details)? Would need more another producer/consumer pair and likely
 		//       collectionDone would need to be a WaitGroup
 
 		wait.UntilWithContext(ctx, func(ctx context.Context) { snapshotOcAdmUpgradeStatus(snapshots) }, time.Minute)

--- a/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
@@ -165,6 +165,7 @@ func (w *monitor) CollectData(ctx context.Context, storageDir string, beginning,
 	return nil, []*junitapi.JUnitTestCase{
 		w.noFailures(),
 		w.expectedLayout(),
+		w.updateLifecycle(ctx),
 	}, nil
 }
 

--- a/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
@@ -162,10 +162,18 @@ func (w *monitor) CollectData(ctx context.Context, storageDir string, beginning,
 
 	// TODO: Maybe utilize Intervals somehow and do tests in ComputeComputedIntervals and EvaluateTestsFromConstructedIntervals
 
+	wasUpdated := func() (bool, error) {
+		cv, err := w.configv1client.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get cluster version: %w", err)
+		}
+		return len(cv.Status.History) > len(w.initialClusterVersion.Status.History), nil
+	}
+
 	return nil, []*junitapi.JUnitTestCase{
 		w.noFailures(),
 		w.expectedLayout(),
-		w.updateLifecycle(ctx),
+		w.updateLifecycle(wasUpdated),
 	}, nil
 }
 

--- a/pkg/monitortests/cli/adm_upgrade/status/outputmodel.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/outputmodel.go
@@ -1,0 +1,505 @@
+package admupgradestatus
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type ControlPlaneStatus struct {
+	Updated      bool
+	Summary      map[string]string
+	Operators    []string
+	NodesUpdated bool
+	Nodes        []string
+}
+
+type WorkersStatus struct {
+	Pools []string
+	Nodes map[string][]string
+}
+
+type Health struct {
+	Detailed bool
+	Messages []string
+}
+
+type upgradeStatusOutput struct {
+	rawOutput    string
+	updating     bool
+	controlPlane *ControlPlaneStatus
+	workers      *WorkersStatus
+	health       *Health
+}
+
+var unableToFetchAlerts = regexp.MustCompile(`^Unable to fetch alerts.*`)
+
+func newUpgradeStatusOutput(output string) (*upgradeStatusOutput, error) {
+	output = strings.TrimSpace(output)
+
+	if output == "The cluster is not updating." {
+		return &upgradeStatusOutput{
+			rawOutput:    output,
+			updating:     false,
+			controlPlane: nil,
+			workers:      nil,
+		}, nil
+	}
+
+	lines := strings.Split(output, "\n")
+	parser := &parser{lines: lines, pos: 0}
+
+	if parser.tryRegex(unableToFetchAlerts) {
+		_ = parser.eatRegex(unableToFetchAlerts)
+	}
+
+	controlPlane, err := parser.parseControlPlaneSection()
+	if err != nil {
+		return nil, err
+	}
+
+	workers, err := parser.parseWorkerUpgradeSection()
+	if err != nil {
+		return nil, err
+	}
+
+	health, err := parser.parseHealthSection()
+	if err != nil {
+		return nil, err
+	}
+
+	return &upgradeStatusOutput{
+		rawOutput:    output,
+		updating:     true,
+		controlPlane: controlPlane,
+		workers:      workers,
+		health:       health,
+	}, nil
+}
+
+type parser struct {
+	lines []string
+	pos   int
+}
+
+var (
+	updatingOperatorsHeaderPattern = regexp.MustCompile(`^NAME\s+SINCE\s+REASON\s+MESSAGE$`)
+	nodesHeaderPattern             = regexp.MustCompile(`^NAME\s+ASSESSMENT\s+PHASE\s+VERSION\s+EST\s+MESSAGE$`)
+	workerPoolsHeaderPattern       = regexp.MustCompile(`^WORKER POOL\s+ASSESSMENT\s+COMPLETION\s+STATUS$`)
+	healthHeaderPattern            = regexp.MustCompile(`^SINCE\s+LEVEL\s+IMPACT\s+MESSAGE$`)
+
+	workerUpgradeHeaderPattern      = regexp.MustCompile(`^= Worker Upgrade =$`)
+	controlPlaneUpdatedPattern      = regexp.MustCompile(`^Update to .* successfully completed at .*$`)
+	controlPlaneNodesUpdatedPattern = regexp.MustCompile(`^All control plane nodes successfully updated to .*`)
+)
+
+type nextOption int
+
+const (
+	preserveLeadingWhitespace nextOption = iota
+)
+
+func (p *parser) next(opts ...nextOption) (string, bool) {
+	if p.pos >= len(p.lines) {
+		return "", true
+	}
+
+	line := p.lines[p.pos]
+	p.pos++
+
+	// Check if we should preserve leading whitespace
+	preserveLeading := false
+	for _, opt := range opts {
+		if opt == preserveLeadingWhitespace {
+			preserveLeading = true
+			break
+		}
+	}
+
+	if preserveLeading {
+		return strings.TrimRight(line, " \t\r\n"), false
+	} else {
+		return strings.TrimSpace(line), false
+	}
+}
+
+func (p *parser) eatEmptyLines() {
+	for {
+		line, done := p.next()
+		if done {
+			return
+		}
+		if line != "" {
+			p.pos--
+			return
+		}
+	}
+}
+
+func (p *parser) tryRegex(what *regexp.Regexp) bool {
+	line, done := p.next()
+	p.pos--
+
+	return !done && what.MatchString(line)
+}
+
+func (p *parser) eat(what string) error {
+	line, done := p.next()
+	if done {
+		return fmt.Errorf("expected '%s' but reached end of input", what)
+	}
+
+	if line != what {
+		return fmt.Errorf("expected '%s' but got '%s'", what, line)
+	}
+
+	return nil
+}
+
+func (p *parser) eatRegex(what *regexp.Regexp) error {
+	line, done := p.next()
+	if done {
+		return fmt.Errorf("expected '%s' but reached end of input", what)
+	}
+
+	if !what.MatchString(line) {
+		return fmt.Errorf("expected '%s' but got '%s'", what, line)
+	}
+
+	return nil
+}
+
+func (p *parser) parseControlPlaneSection() (*ControlPlaneStatus, error) {
+	if err := p.eat("= Control Plane ="); err != nil {
+		return nil, err
+	}
+
+	var status ControlPlaneStatus
+
+	if p.tryRegex(controlPlaneUpdatedPattern) {
+		_ = p.eatRegex(controlPlaneUpdatedPattern)
+		status.Updated = true
+		p.eatEmptyLines()
+		if err := p.eatRegex(controlPlaneNodesUpdatedPattern); err != nil {
+			return nil, fmt.Errorf("expected 'All control plane nodes successfully updated to' message, got: %w", err)
+		}
+		status.NodesUpdated = true
+
+		return &status, nil
+	}
+
+	summary, err := p.parseControlPlaneSummary()
+	if err != nil {
+		return nil, err
+	}
+	status.Summary = summary
+
+	operators, err := p.parseControlPlaneOperators()
+	if err != nil {
+		return nil, err
+	}
+	status.Operators = operators
+
+	p.eatEmptyLines()
+
+	if p.tryRegex(controlPlaneNodesUpdatedPattern) {
+		_ = p.eatRegex(controlPlaneNodesUpdatedPattern)
+		status.NodesUpdated = true
+	} else {
+		nodes, err := p.parseControlPlaneNodes()
+		if err != nil {
+			return nil, err
+		}
+		status.Nodes = nodes
+	}
+
+	return &status, nil
+}
+
+func (p *parser) parseControlPlaneSummary() (map[string]string, error) {
+	p.eatEmptyLines()
+
+	summary := map[string]string{}
+	for {
+		line, done := p.next()
+		if done || line == "" {
+			break
+		}
+
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("expected 'Key: Value' format, got: %s", line)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		summary[key] = value
+	}
+
+	if len(summary) == 0 {
+		return nil, errors.New("found no entries in control plane summary section")
+	}
+
+	return summary, nil
+}
+
+func (p *parser) parseControlPlaneOperators() ([]string, error) {
+	p.eatEmptyLines()
+
+	if line, _ := p.next(); line != "Updating Cluster Operators" {
+		// section is optional, put back the line and return nil
+		p.pos--
+		return nil, nil
+	}
+
+	if err := p.eatRegex(updatingOperatorsHeaderPattern); err != nil {
+		return nil, fmt.Errorf("expected Updating Cluster Operators table header, got: %w", err)
+	}
+
+	var operators []string
+
+	for {
+		line, done := p.next()
+		if done || line == "" {
+			break
+		}
+
+		operators = append(operators, line)
+	}
+
+	if len(operators) == 0 {
+		return nil, errors.New("found no entries in Updating Cluster Operators section")
+	}
+
+	return operators, nil
+}
+
+func (p *parser) parseControlPlaneNodes() ([]string, error) {
+	p.eatEmptyLines()
+
+	if p.eat("Control Plane Nodes") != nil {
+		return nil, errors.New("expected 'Control Plane Nodes' section")
+	}
+
+	if err := p.eatRegex(nodesHeaderPattern); err != nil {
+		return nil, fmt.Errorf("expected Control Plane Nodes table header: %w", err)
+	}
+
+	var nodes []string
+	for {
+		line, done := p.next()
+		if done || line == "" {
+			break
+		}
+
+		nodes = append(nodes, line)
+	}
+
+	if len(nodes) == 0 {
+		return nil, errors.New("no nodes found in Control Plane Nodes section")
+	}
+
+	return nodes, nil
+}
+
+func (p *parser) parseWorkerUpgradeSection() (*WorkersStatus, error) {
+	p.eatEmptyLines()
+
+	if !p.tryRegex(workerUpgradeHeaderPattern) {
+		return nil, nil
+	}
+
+	if err := p.eat("= Worker Upgrade ="); err != nil {
+		return nil, err
+	}
+
+	pools, err := p.parseWorkerPools()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := p.parseWorkerPoolNodes()
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkersStatus{
+		Pools: pools,
+		Nodes: nodes,
+	}, nil
+}
+
+func (p *parser) parseWorkerPools() ([]string, error) {
+	p.eatEmptyLines()
+
+	if err := p.eatRegex(workerPoolsHeaderPattern); err != nil {
+		return nil, fmt.Errorf("expected Worker Upgrade table header: %w", err)
+	}
+
+	var pools []string
+	for {
+		line, done := p.next()
+		if done || line == "" {
+			break
+		}
+
+		pools = append(pools, line)
+	}
+
+	if len(pools) == 0 {
+		return nil, errors.New("no worker pools found in Worker Upgrade section")
+	}
+
+	return pools, nil
+}
+
+func (p *parser) parseWorkerPoolNodes() (map[string][]string, error) {
+	nodes := make(map[string][]string)
+
+	for {
+		p.eatEmptyLines()
+
+		name, entries, err := p.tryParseWorkerNodeTable()
+		if err != nil {
+			return nil, err
+		}
+
+		if name == "" {
+			break
+		}
+
+		nodes[name] = entries
+	}
+
+	if len(nodes) == 0 {
+		return nil, errors.New("no worker pool nodes found in Worker Upgrade section")
+	}
+
+	return nodes, nil
+}
+
+func (p *parser) tryParseWorkerNodeTable() (string, []string, error) {
+	p.eatEmptyLines()
+
+	line, done := p.next()
+	if done {
+		return "", nil, errors.New("expected 'Worker Pool Nodes:' section but reached end of input")
+	}
+	if !strings.HasPrefix(line, "Worker Pool Nodes:") {
+		p.pos-- // put it back
+		return "", nil, nil
+	}
+
+	name := strings.TrimPrefix(line, "Worker Pool Nodes: ")
+
+	if err := p.eatRegex(nodesHeaderPattern); err != nil {
+		return "", nil, fmt.Errorf("expected worker pool nodes table header for pool '%s': %w", name, err)
+	}
+
+	// Read node entries
+	var nodeEntries []string
+	for {
+		line, done := p.next()
+		if done || line == "" {
+			break
+		}
+
+		nodeEntries = append(nodeEntries, line)
+	}
+
+	if len(nodeEntries) == 0 {
+		return "", nil, fmt.Errorf("no nodes found for worker pool '%s'", name)
+	}
+
+	return name, nodeEntries, nil
+}
+
+func (p *parser) parseHealthSection() (*Health, error) {
+	p.eatEmptyLines()
+
+	if err := p.eat("= Update Health ="); err != nil {
+		return nil, err
+	}
+
+	var health Health
+
+	line, done := p.next()
+	if done {
+		return nil, errors.New("expected 'Update Health' section but reached end of input")
+	}
+
+	var getMessage func() (string, error)
+	if strings.HasPrefix(line, "Message: ") {
+		getMessage = p.parseHealthMessage
+		health.Detailed = true
+		p.pos--
+	} else if healthHeaderPattern.MatchString(line) {
+		getMessage = p.parseHealthMessageLine
+	} else {
+		return nil, fmt.Errorf("expected 'Update Health' to start with either a table header or a 'Message: ' line, got %s", line)
+	}
+
+	for {
+		message, err := getMessage()
+		if err != nil {
+			return nil, err
+		}
+
+		if message == "" {
+			// No more messages
+			break
+		}
+
+		health.Messages = append(health.Messages, message)
+	}
+
+	if len(health.Messages) == 0 {
+		return nil, errors.New("no health messages found in Update Health section")
+	}
+
+	return &health, nil
+}
+
+func (p *parser) parseHealthMessageLine() (string, error) {
+	line, _ := p.next()
+	return line, nil
+}
+
+func (p *parser) parseHealthMessage() (string, error) {
+	var messageBuilder strings.Builder
+
+	line, done := p.next()
+	if done {
+		return "", nil // No more input
+	}
+
+	if !strings.HasPrefix(line, "Message: ") {
+		return "", fmt.Errorf("expected health message to start with 'Message: ', got: %s", line)
+	}
+
+	messageBuilder.WriteString(line)
+
+	// Read continuation lines until we hit the next "Message: " or end of input
+	for {
+		line, done := p.next(preserveLeadingWhitespace)
+		if done {
+			break
+		}
+
+		if line == "" {
+			peek, done := p.next()
+			if done {
+				break
+			}
+			p.pos--
+			if strings.HasPrefix(peek, "Message: ") {
+				break
+			}
+		}
+
+		messageBuilder.WriteString("\n" + line)
+	}
+
+	return strings.TrimSpace(messageBuilder.String()), nil
+}

--- a/pkg/monitortests/cli/adm_upgrade/status/outputmodel_test.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/outputmodel_test.go
@@ -1,0 +1,519 @@
+package admupgradestatus
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	emptyLine          = ""
+	clusterNotUpdating = `The cluster is not updating.`
+
+	controlPlaneHeader = `= Control Plane =`
+
+	genericControlPlane = `Update to 4.16.0-ec.3 successfully completed at 2024-02-27T15:42:58Z (duration: 3h31m)
+
+All control plane nodes successfully updated to 4.16.0-ec.3`
+
+	controlPlaneSummary = `Assessment:      Stalled
+Target Version:  4.14.1 (from 4.14.0-rc.3)
+Completion:      97% (32 operators updated, 1 updating, 0 waiting)
+Duration:        1h59m (Est. Time Remaining: N/A; estimate duration was 1h24m)
+Operator Health: 28 Healthy, 1 Unavailable, 4 Available but degraded`
+
+	controlPlaneSummaryWithUpdating = `Assessment:      Stalled
+Target Version:  4.14.1 (from 4.14.0-rc.3)
+Updating:        machine-config
+Completion:      97% (32 operators updated, 1 updating, 0 waiting)
+Duration:        1h59m (Est. Time Remaining: N/A; estimate duration was 1h24m)
+Operator Health: 28 Healthy, 1 Unavailable, 4 Available but degraded`
+
+	controlPlaneUpdated = `Update to 4.16.0-ec.3 successfully completed at 2024-02-27T15:42:58Z (duration: 3h31m)`
+
+	expectedControlPlaneSummaries = map[string]map[string]string{
+		controlPlaneSummary: {
+			"Assessment":      "Stalled",
+			"Target Version":  "4.14.1 (from 4.14.0-rc.3)",
+			"Completion":      "97% (32 operators updated, 1 updating, 0 waiting)",
+			"Duration":        "1h59m (Est. Time Remaining: N/A; estimate duration was 1h24m)",
+			"Operator Health": "28 Healthy, 1 Unavailable, 4 Available but degraded",
+		},
+		controlPlaneSummaryWithUpdating: {
+			"Assessment":      "Stalled",
+			"Target Version":  "4.14.1 (from 4.14.0-rc.3)",
+			"Updating":        "machine-config",
+			"Completion":      "97% (32 operators updated, 1 updating, 0 waiting)",
+			"Duration":        "1h59m (Est. Time Remaining: N/A; estimate duration was 1h24m)",
+			"Operator Health": "28 Healthy, 1 Unavailable, 4 Available but degraded",
+		},
+		controlPlaneUpdated: nil, // No summary for updated control plane
+	}
+
+	controlPlaneOperators = `Updating Cluster Operators
+NAME             SINCE     REASON   MESSAGE
+machine-config   1h4m41s   -        Working towards 4.14.1`
+
+	expectedControlPlaneOperators = map[string][]string{
+		controlPlaneOperators: {"machine-config   1h4m41s   -        Working towards 4.14.1"},
+	}
+
+	controlPlaneThreeNodes = `Control Plane Nodes
+NAME                                        ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     `
+
+	controlPlaneNodesUpdated = `All control plane nodes successfully updated to 4.16.0-ec.3`
+
+	expectedControlPlaneNodes = map[string][]string{
+		controlPlaneThreeNodes: {
+			"ip-10-0-30-217.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?",
+			"ip-10-0-53-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?",
+			"ip-10-0-92-180.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?",
+		},
+		controlPlaneNodesUpdated: nil,
+	}
+
+	workerSectionHeader = `= Worker Upgrade =`
+
+	genericWorkerPool  = oneWorkerPool
+	genericWorkerNodes = oneWorkerPoolNodes
+
+	oneWorkerPool = `WORKER POOL   ASSESSMENT   COMPLETION   STATUS
+worker        Pending      0% (0/3)     3 Available, 0 Progressing, 0 Draining`
+
+	twoPools = `WORKER POOL   ASSESSMENT    COMPLETION   STATUS
+worker        Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining
+infra         Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining`
+
+	twoPoolsOneEmpty = `WORKER POOL   ASSESSMENT   COMPLETION   STATUS
+worker        Pending      0% (0/3)     3 Available, 0 Progressing, 0 Draining
+zbeast        Empty                     0 Total`
+
+	expectedPools = map[string][]string{
+		oneWorkerPool: {"worker        Pending      0% (0/3)     3 Available, 0 Progressing, 0 Draining"},
+		twoPools: {
+			"worker        Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining",
+			"infra         Progressing   0% (0/2)     1 Available, 1 Progressing, 1 Draining",
+		},
+		twoPoolsOneEmpty: {
+			"worker        Pending      0% (0/3)     3 Available, 0 Progressing, 0 Draining",
+			"zbeast        Empty                     0 Total",
+		},
+	}
+
+	oneWorkerPoolNodes = `Worker Pool Nodes: worker
+NAME                                        ASSESSMENT   PHASE     VERSION       EST   MESSAGE
+ip-10-0-20-162.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     
+ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?     `
+
+	twoPoolsWorkerNodes = `Worker Pool Nodes: worker
+NAME                                       ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-4-159.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m   
+ip-10-0-99-40.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?      `
+
+	twoPoolsInfraNodes = `Worker Pool Nodes: infra
+NAME                                             ASSESSMENT    PHASE      VERSION   EST    MESSAGE
+ip-10-0-4-159-infra.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m   
+ip-10-0-20-162.us-east-2.compute.internal        Outdated      Pending    4.14.0    ?      `
+
+	expectedPoolNodes = map[string]map[string][]string{
+		oneWorkerPool: {
+			"worker": {
+				"ip-10-0-20-162.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?",
+				"ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?",
+				"ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?",
+			},
+		},
+		twoPools: {
+			"worker": {
+				"ip-10-0-4-159.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m",
+				"ip-10-0-99-40.us-east-2.compute.internal   Outdated      Pending    4.14.0    ?",
+			},
+			"infra": {
+				"ip-10-0-4-159-infra.us-east-2.compute.internal   Progressing   Draining   4.14.0    +10m",
+				"ip-10-0-20-162.us-east-2.compute.internal        Outdated      Pending    4.14.0    ?",
+			},
+		},
+		twoPoolsOneEmpty: {
+			"worker": {
+				"ip-10-0-20-162.us-east-2.compute.internal   Outdated     Pending   4.14.0-rc.3   ?",
+				"ip-10-0-4-159.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?",
+				"ip-10-0-99-40.us-east-2.compute.internal    Outdated     Pending   4.14.0-rc.3   ?",
+			},
+		},
+	}
+
+	healthSectionHeader = `= Update Health = `
+
+	genericHealthSection = healthProceedingWell
+
+	healthProceedingWell = `SINCE    LEVEL   IMPACT   MESSAGE
+52m56s   Info    None     Update is proceeding well`
+
+	healthMultipleTable = `SINCE     LEVEL     IMPACT             MESSAGE
+58m18s    Error     API Availability   Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)
+now       Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)`
+
+	healthDetailed = `Message: Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)
+  Since:       58m18s
+  Level:       Error
+  Impact:      API Availability
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusteroperators.config.openshift.io: kube-apiserver
+  Description: NodeControllerDegraded: The master nodes not ready: node "ip-10-0-12-74.ec2.internal" not ready since 2023-11-03 16:28:43 +0000 UTC because KubeletNotReady (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?)
+
+Message: Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
+  Since:       now
+  Level:       Warning
+  Impact:      Update Stalled
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusterversions.config.openshift.io: version
+  Description: Cluster operators etcd, kube-apiserver are degraded`
+
+	expectedHealthMessages = map[string][]string{
+		healthProceedingWell: {"52m56s   Info    None     Update is proceeding well"},
+		healthMultipleTable: {
+			"58m18s    Error     API Availability   Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)",
+			"now       Warning   Update Stalled     Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)",
+		},
+		healthDetailed: {
+			`Message: Cluster Operator kube-apiserver is degraded (NodeController_MasterNodesReady)
+  Since:       58m18s
+  Level:       Error
+  Impact:      API Availability
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusteroperators.config.openshift.io: kube-apiserver
+  Description: NodeControllerDegraded: The master nodes not ready: node "ip-10-0-12-74.ec2.internal" not ready since 2023-11-03 16:28:43 +0000 UTC because KubeletNotReady (container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?)`,
+			`Message: Cluster Version version is failing to proceed with the update (ClusterOperatorsDegraded)
+  Since:       now
+  Level:       Warning
+  Impact:      Update Stalled
+  Reference:   https://github.com/openshift/runbooks/blob/master/alerts/cluster-monitoring-operator/ClusterOperatorDegraded.md
+  Resources:
+    clusterversions.config.openshift.io: version
+  Description: Cluster operators etcd, kube-apiserver are degraded`,
+		},
+	}
+)
+
+func TestUpgradeStatusOutput_Updating(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		segments []string
+		expected bool
+	}{
+		{
+			name:     "cluster not updating",
+			segments: []string{clusterNotUpdating},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			builder := strings.Builder{}
+			for _, input := range tc.segments {
+				builder.WriteString(input)
+				builder.WriteString("\n")
+			}
+
+			output, err := newUpgradeStatusOutput(builder.String())
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+
+			if output.updating != tc.expected {
+				t.Errorf("Expected IsUpdating() to return %v, got %v", tc.expected, output.updating)
+			}
+		})
+	}
+}
+
+func TestUpgradeStatusOutput_ControlPlane(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		segments    []string
+		expected    *ControlPlaneStatus
+		expectError string
+	}{
+		{
+			name:     "cluster not updating",
+			segments: []string{clusterNotUpdating},
+			expected: nil,
+		},
+		{
+			name: "control plane without updating operators line",
+			segments: []string{
+				controlPlaneHeader,
+				controlPlaneSummary,
+				emptyLine,
+				controlPlaneThreeNodes,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &ControlPlaneStatus{
+				Updated:      false,
+				Summary:      expectedControlPlaneSummaries[controlPlaneSummary],
+				Operators:    nil, // No operators line present
+				NodesUpdated: false,
+				Nodes:        expectedControlPlaneNodes[controlPlaneThreeNodes],
+			},
+		},
+		{
+			name: "control plane with updating",
+			segments: []string{
+				controlPlaneHeader,
+				controlPlaneSummaryWithUpdating,
+				emptyLine,
+				controlPlaneOperators,
+				emptyLine,
+				controlPlaneThreeNodes,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &ControlPlaneStatus{
+				Updated:      false,
+				Summary:      expectedControlPlaneSummaries[controlPlaneSummaryWithUpdating],
+				Operators:    expectedControlPlaneOperators[controlPlaneOperators],
+				NodesUpdated: false,
+				Nodes:        expectedControlPlaneNodes[controlPlaneThreeNodes],
+			},
+		},
+		{
+			name: "control plane with updated nodes",
+			segments: []string{
+				controlPlaneHeader,
+				controlPlaneSummary,
+				emptyLine,
+				controlPlaneNodesUpdated,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &ControlPlaneStatus{
+				Updated:      false,
+				Summary:      expectedControlPlaneSummaries[controlPlaneSummary],
+				Operators:    nil,
+				NodesUpdated: true,
+				Nodes:        nil,
+			},
+		},
+		{
+			name: "updated control plane",
+			segments: []string{
+				controlPlaneHeader,
+				controlPlaneUpdated,
+				emptyLine,
+				controlPlaneNodesUpdated,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &ControlPlaneStatus{
+				Updated:      true,
+				Summary:      nil,
+				Operators:    nil,
+				NodesUpdated: true,
+				Nodes:        nil,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			builder := strings.Builder{}
+			for _, input := range tc.segments {
+				builder.WriteString(input)
+				builder.WriteString("\n")
+			}
+
+			output, err := newUpgradeStatusOutput(builder.String())
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected, output.controlPlane); diff != "" {
+				t.Errorf("ControlPlane mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeStatusOutput_Workers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		segments []string
+		expected *WorkersStatus
+	}{
+		{
+			name:     "cluster not updating",
+			segments: []string{clusterNotUpdating},
+			expected: nil,
+		},
+		{
+			name: "worker section is optional (SNO & compact)",
+			segments: []string{
+				controlPlaneHeader,
+				genericControlPlane,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: nil,
+		},
+		{
+			name: "one pool with three nodes",
+			segments: []string{
+				controlPlaneHeader,
+				genericControlPlane,
+				emptyLine,
+				workerSectionHeader,
+				emptyLine,
+				oneWorkerPool,
+				emptyLine,
+				oneWorkerPoolNodes,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &WorkersStatus{
+				Pools: expectedPools[oneWorkerPool],
+				Nodes: expectedPoolNodes[oneWorkerPool],
+			},
+		},
+		{
+			name: "two pools with two nodes each",
+			segments: []string{
+				controlPlaneHeader,
+				genericControlPlane,
+				emptyLine,
+				workerSectionHeader,
+				emptyLine,
+				twoPools,
+				emptyLine,
+				twoPoolsWorkerNodes,
+				emptyLine,
+				twoPoolsInfraNodes,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &WorkersStatus{
+				Pools: expectedPools[twoPools],
+				Nodes: expectedPoolNodes[twoPools],
+			},
+		},
+		{
+			name: "two pools, one of them empty",
+			segments: []string{
+				controlPlaneHeader,
+				genericControlPlane,
+				emptyLine,
+				workerSectionHeader,
+				emptyLine,
+				twoPoolsOneEmpty,
+				emptyLine,
+				oneWorkerPoolNodes,
+				emptyLine,
+				healthSectionHeader,
+				genericHealthSection,
+			},
+			expected: &WorkersStatus{
+				Pools: expectedPools[twoPoolsOneEmpty],
+				Nodes: expectedPoolNodes[twoPoolsOneEmpty],
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			builder := strings.Builder{}
+			for _, input := range tc.segments {
+				builder.WriteString(input)
+				builder.WriteString("\n")
+			}
+
+			output, err := newUpgradeStatusOutput(builder.String())
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected, output.workers); diff != "" {
+				t.Errorf("Workers mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUpgradeStatusOutput_Health(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		segments []string
+		expected *Health
+	}{
+		{
+			name:     "cluster not updating",
+			segments: []string{clusterNotUpdating},
+			expected: nil,
+		},
+		{
+			name: "Update is proceeding well",
+			segments: []string{
+				controlPlaneHeader,
+				genericControlPlane,
+				emptyLine,
+				workerSectionHeader,
+				genericWorkerPool,
+				emptyLine,
+				genericWorkerNodes,
+				emptyLine,
+				healthSectionHeader,
+				healthProceedingWell,
+			},
+			expected: &Health{
+				Detailed: false,
+				Messages: expectedHealthMessages[healthProceedingWell],
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			builder := strings.Builder{}
+			for _, input := range tc.segments {
+				builder.WriteString(input)
+				builder.WriteString("\n")
+			}
+
+			output, err := newUpgradeStatusOutput(builder.String())
+			if err != nil {
+				t.Fatalf("Expected no error, got: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expected, output.health); diff != "" {
+				t.Errorf("Health mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle.go
@@ -68,6 +68,9 @@ func (w *monitor) updateLifecycle(wasUpdated wasUpdatedFn) *junitapi.JUnitTestCa
 		},
 		afterUpdate: {
 			notUpdating: afterUpdate,
+			// TODO: MCO churn sometimes briefly tricks our code into thinking the cluster is updating, we'll tolerate for
+			// now but we should try fixing this
+			controlPlaneObservedNodesUpdated: controlPlaneUpdated,
 		},
 	}
 
@@ -93,9 +96,11 @@ func (w *monitor) updateLifecycle(wasUpdated wasUpdatedFn) *junitapi.JUnitTestCa
 		}
 
 		if !clusterUpdated {
-			if observed.output.updating || observed.output.controlPlane != nil || observed.output.workers != nil || observed.output.health != nil {
-				fail("Cluster did not update but oc adm upgrade status reported that it is updating")
-			}
+			// TODO: MCO churn sometimes briefly tricks our code into thinking the cluster is updating, we'll tolerate for
+			// now but we should try fixing this
+			// if observed.output.updating || observed.output.controlPlane != nil || observed.output.workers != nil || observed.output.health != nil {
+			// 	fail("Cluster did not update but oc adm upgrade status reported that it is updating")
+			// }
 			continue
 		}
 

--- a/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle_test.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle_test.go
@@ -184,9 +184,29 @@ func TestMonitor_UpdateLifecycle(t *testing.T) {
 			wasUpdated: false,
 			expected: &junitapi.JUnitTestCase{
 				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
-				FailureOutput: &junitapi.FailureOutput{
-					Message: "observed unexpected update lifecycle transition in oc adm upgrade status",
-				},
+				// TODO: MCO churn sometimes briefly tricks our code into thinking the cluster is updating, we'll tolerate for
+				// now but we should try fixing this
+				// FailureOutput: &junitapi.FailureOutput{
+				// 	Message: "observed unexpected update lifecycle transition in oc adm upgrade status",
+				// },
+			},
+		},
+		{
+
+			name: "completed update goes back to updating",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle03controlPlaneNodesUpdated},
+				{when: time.Now(), out: lifecycle05after},
+				{when: time.Now(), out: lifecycle03controlPlaneNodesUpdated},
+			},
+			wasUpdated: true,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+				// TODO: MCO churn sometimes briefly tricks our code into thinking the cluster is updating, we'll tolerate for
+				// now but we should try fixing this
+				// FailureOutput: &junitapi.FailureOutput{
+				// 	Message: "observed unexpected update lifecycle transition in oc adm upgrade status",
+				// },
 			},
 		},
 	}

--- a/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle_test.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/updatelifecycle_test.go
@@ -1,0 +1,216 @@
+package admupgradestatus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+var (
+	lifecycle01before = `The cluster is not updating.`
+
+	lifecycle02updating = `Unable to fetch alerts, ignoring alerts in 'Update Health':  failed to get alerts from Thanos: no token is currently in use for this session
+= Control Plane =
+Assessment:      Progressing
+Target Version:  4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest (from 4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial)
+Updating:        etcd, kube-apiserver
+Completion:      3% (1 operators updated, 2 updating, 31 waiting)
+Duration:        3m51s (Est. Time Remaining: 1h7m)
+Operator Health: 34 Healthy
+
+Updating Cluster Operators
+NAME             SINCE   REASON          MESSAGE
+etcd             2m53s   NodeInstaller   NodeInstallerProgressing: 2 nodes are at revision 8; 1 node is at revision 9
+kube-apiserver   2m21s   NodeInstaller   NodeInstallerProgressing: 3 nodes are at revision 7; 0 nodes have achieved new revision 8
+
+Control Plane Nodes
+NAME                                        ASSESSMENT   PHASE     VERSION                                                     EST   MESSAGE
+ip-10-0-111-19.us-west-1.compute.internal   Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+ip-10-0-53-218.us-west-1.compute.internal   Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+ip-10-0-99-189.us-west-1.compute.internal   Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+
+= Worker Upgrade =
+
+WORKER POOL   ASSESSMENT   COMPLETION   STATUS
+worker        Pending      0% (0/3)     3 Available, 0 Progressing, 0 Draining
+
+Worker Pool Nodes: worker
+NAME                                         ASSESSMENT   PHASE     VERSION                                                     EST   MESSAGE
+ip-10-0-0-72.us-west-1.compute.internal      Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+ip-10-0-100-255.us-west-1.compute.internal   Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+ip-10-0-106-212.us-west-1.compute.internal   Outdated     Pending   4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial   ?     
+
+= Update Health =
+SINCE   LEVEL   IMPACT   MESSAGE
+3m51s   Info    None     Update is proceeding well`
+
+	lifecycle03controlPlaneNodesUpdated = `Unable to fetch alerts, ignoring alerts in 'Update Health':  failed to get alerts from Thanos: no token is currently in use for this session
+= Control Plane =
+Assessment:      Progressing - Slow
+Target Version:  4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest (from 4.20.0-0.ci-2025-08-13-114210-test-ci-op-njttt0ww-initial)
+Updating:        machine-config
+Completion:      97% (33 operators updated, 1 updating, 0 waiting)
+Duration:        1h1m (Est. Time Remaining: <10m)
+Operator Health: 30 Healthy, 4 Available but degraded
+
+Updating Cluster Operators
+NAME             SINCE    REASON   MESSAGE
+machine-config   22m21s   -        Working towards 4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest
+
+All control plane nodes successfully updated to 4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest
+
+= Worker Upgrade =
+
+WORKER POOL   ASSESSMENT   COMPLETION   STATUS
+worker        Completed    100% (3/3)   3 Available, 0 Progressing, 0 Draining
+
+Worker Pool Nodes: worker
+NAME                                         ASSESSMENT   PHASE     VERSION                                                    EST   MESSAGE
+ip-10-0-0-72.us-west-1.compute.internal      Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+ip-10-0-100-255.us-west-1.compute.internal   Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+ip-10-0-106-212.us-west-1.compute.internal   Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+
+= Update Health =
+SINCE     LEVEL   IMPACT   MESSAGE
+1h1m36s   Info    None     Update is proceeding well`
+
+	lifecycle04controlPlaneUpdated = `Unable to fetch alerts, ignoring alerts in 'Update Health':  failed to get alerts from Thanos: no token is currently in use for this session
+= Control Plane =
+Update to 4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest successfully completed at 2025-08-13T14:15:18Z (duration: 1h2m)
+
+All control plane nodes successfully updated to 4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest
+
+= Worker Upgrade =
+
+WORKER POOL   ASSESSMENT   COMPLETION   STATUS
+worker        Completed    100% (3/3)   3 Available, 0 Progressing, 0 Draining
+
+Worker Pool Nodes: worker
+NAME                                         ASSESSMENT   PHASE     VERSION                                                    EST   MESSAGE
+ip-10-0-0-72.us-west-1.compute.internal      Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+ip-10-0-100-255.us-west-1.compute.internal   Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+ip-10-0-106-212.us-west-1.compute.internal   Completed    Updated   4.20.0-0.ci-2025-08-13-121604-test-ci-op-njttt0ww-latest   -     
+
+= Update Health =
+SINCE     LEVEL   IMPACT   MESSAGE
+1h1m36s   Info    None     Update is proceeding well`
+
+	lifecycle05after = `The cluster is not updating.`
+)
+
+func TestMonitor_UpdateLifecycle(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		snapshots  []snapshot
+		wasUpdated bool
+		expected   *junitapi.JUnitTestCase
+	}{
+		{
+			name: "no snapshots -> test skipped",
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+				SkipMessage: &junitapi.SkipMessage{
+					Message: "Test skipped because no oc adm upgrade status output was successfully collected",
+				},
+			},
+		},
+		{
+			name: "model update",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle02updating},
+				{when: time.Now(), out: lifecycle03controlPlaneNodesUpdated},
+				{when: time.Now(), out: lifecycle04controlPlaneUpdated},
+				{when: time.Now(), out: lifecycle05after},
+			},
+			wasUpdated: true,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+			},
+		},
+		{
+			name: "sometimes we miss the control plane updated state, this is okay",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle02updating},
+				{when: time.Now(), out: lifecycle05after},
+			},
+			wasUpdated: true,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+			},
+		},
+		{
+			name: "completed control plane nodes went back to updating",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle02updating},
+				{when: time.Now(), out: lifecycle03controlPlaneNodesUpdated},
+				{when: time.Now(), out: lifecycle02updating},
+				{when: time.Now(), out: lifecycle05after},
+			},
+			wasUpdated: true,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+				FailureOutput: &junitapi.FailureOutput{
+					Message: "observed unexpected update lifecycle transition in oc adm upgrade status",
+				},
+			},
+		},
+		{
+			name: "no update observed when cluster was not updated",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle01before},
+			},
+			wasUpdated: false,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+			},
+		},
+		{
+			name: "update observed when cluster was not updated",
+			snapshots: []snapshot{
+				{when: time.Now(), out: lifecycle01before},
+				{when: time.Now(), out: lifecycle02updating},
+				{when: time.Now(), out: lifecycle01before},
+			},
+			wasUpdated: false,
+			expected: &junitapi.JUnitTestCase{
+				Name: "[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade status snapshots reflect the cluster upgrade lifecycle",
+				FailureOutput: &junitapi.FailureOutput{
+					Message: "observed unexpected update lifecycle transition in oc adm upgrade status",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := NewOcAdmUpgradeStatusChecker().(*monitor)
+			m.ocAdmUpgradeStatus = append(m.ocAdmUpgradeStatus, tc.snapshots...)
+
+			ignoreOutput := cmpopts.IgnoreFields(junitapi.FailureOutput{}, "Output")
+
+			// Process snapshots into models for the health check to work with
+			_ = m.expectedLayout()
+
+			wasUpdated := func() (bool, error) {
+				return tc.wasUpdated, nil
+			}
+
+			result := m.updateLifecycle(wasUpdated)
+			if diff := cmp.Diff(tc.expected, result, ignoreOutput); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- **Refactor the noFailures case**
- **upgrade status CLI monitortest: use slice instead of map**
- **upgrade status CLI monitortest: snapshot --details=all**
- **Add a simple "page object"-like parser for `oc adm upgrade status` outputs**
- **upgrade status CLI monitortest: parse all outputs into models**
- **upgrade status CLI monitortest: save initial ClusterVersion**
- **upgrade status CLI monitortest: add update lifecycle check**
