### PR TITLE
OCPEDGE-1483: Add TNF E2E tests for network failure

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1265,9 +1265,11 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node] Two Node with Fencing pods and podman containers Should verify the number of podman-etcd containers as configured": "",
 
-	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery Should recover from graceful node shutdown with etcd member re-addition": " [Serial]",
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery should recover from graceful node shutdown with etcd member re-addition": " [Serial]",
 
-	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery Should recover from ungraceful node shutdown with etcd member re-addition": " [Serial]",
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery should recover from network disruption with etcd member re-addition": " [Serial]",
+
+	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive] Two Node with Fencing etcd recovery should recover from ungraceful node shutdown with etcd member re-addition": " [Serial]",
 
 	"[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter] Ensure etcd health and quorum in HighlyAvailableArbiterMode should have all etcd pods running and quorum met": " [Suite:openshift/conformance/parallel]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -191,10 +191,13 @@ spec:
         Two Node with Fencing pods and podman containers Should verify the number
         of podman-etcd containers as configured'
     - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive]
-        Two Node with Fencing etcd recovery Should recover from graceful node shutdown
+        Two Node with Fencing etcd recovery should recover from graceful node shutdown
         with etcd member re-addition'
     - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive]
-        Two Node with Fencing etcd recovery Should recover from ungraceful node shutdown
+        Two Node with Fencing etcd recovery should recover from network disruption
+        with etcd member re-addition'
+    - testName: '[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Disruptive]
+        Two Node with Fencing etcd recovery should recover from ungraceful node shutdown
         with etcd member re-addition'
     - testName: '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node]
         Two Node with Fencing topology Should validate the number of control-planes,


### PR DESCRIPTION
This commit introduces a new e2e test for TNF to validate etcd recovery after a network disruption in a two-node cluster.

The test simulates a network partition by using iptables to block traffic between the two nodes for a short, configurable, duration.

It then verifies that the cluster correctly handles the split-brain scenario, with one node becoming the leader and the other rejoining as a learner before being promoted back to a voting member.

Additionally, the node disruption pod creation logic has been refactored from `triggerNodeReboot` to a more generic `createNodeDisruptionPod` to accommodate different types of disruptions, including network partitions and reboots.