### PR TITLE
NO-JIRA: fix: update arbiter test

### DIFF
--- a/test/extended/two_node/arbiter_topology.go
+++ b/test/extended/two_node/arbiter_topology.go
@@ -26,7 +26,7 @@ var expectedPods = map[string]int{
 	"openshift-dns":                          1,
 	"openshift-etcd":                         2,
 	"openshift-image-registry":               1,
-	"openshift-kni-infra":                    3,
+	"openshift-kni-infra":                    1,
 	"openshift-machine-config-operator":      2,
 	"openshift-monitoring":                   1,
 	"openshift-multus":                       3,


### PR DESCRIPTION
recent MCO changes removed two pods from the kni-infra namespace on the arbiter node, updating test to reflect change