### PR TITLE
 CNTRLPLANE-1257: Enable OTE for apiserver Operators and servers

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -193,6 +193,26 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-kube-apiserver-operator",
 		binaryPath: "/usr/bin/cluster-kube-apiserver-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "cluster-openshift-apiserver-operator",
+		binaryPath: "/usr/bin/cluster-openshift-apiserver-operator-tests-ext.gz",
+	},
+	{
+		imageTag:   "openshift-apiserver",
+		binaryPath: "/usr/bin/openshift-apiserver-tests-ext.gz",
+	},
+	{
+		imageTag:   "oauth-apiserver",
+		binaryPath: "/usr/bin/oauth-apiserver-tests-ext.gz",
+	},
+	{
+		imageTag:   "service-ca-operator",
+		binaryPath: "/usr/bin/service-ca-operator-tests-ext.gz",
+	},
+	{
+		imageTag:   "cluster-kube-controller-manager-operator",
+		binaryPath: "/usr/bin/cluster-kube-controller-manager-operator-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Cluster-openshift-apiserver-operator side setup: https://github.com/openshift/cluster-openshift-apiserver-operator/pull/623
openshift-apiserver side setup: https://github.com/openshift/openshift-apiserver/pull/536
oauth-apiserver side setup: https://github.com/openshift/oauth-apiserver/pull/138
service-ca-operator side setup: https://github.com/openshift/service-ca-operator/pull/270
cluster-kube-controller-manager-operator side setup: https://github.com/openshift/cluster-kube-controller-manager-operator/pull/859