### PR TITLE
OCPNODE-3004: Run ImageVolume tests in all clusters.

### DIFF
--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -30,9 +30,11 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 	)
 
 	g.BeforeEach(func() {
-		// Skip if ImageVolume feature is not enabled
-		if !exutil.IsTechPreviewNoUpgrade(context.TODO(), oc.AdminConfigClient()) {
-			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
+		// Microshift doesn't inherit OCP feature gates, and ImageVolume won't work either
+		isMicroshift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroshift {
+			g.Skip("Not supported on Microshift")
 		}
 	})
 


### PR DESCRIPTION
This must be merged after https://github.com/openshift/api/pull/2453

It won't work in microshift so disabling it.
https://redhat-internal.slack.com/archives/C03DP9PABNC/p1755789772265079?thread_ts=1755768360.420069&cid=C03DP9PABNC