### PR TITLE
OCPBUGS-60454: Update the Control Plane Machine name pattern to support the master's names used on OpenStack

### DIFF
--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -124,7 +124,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).ToNot(o.HaveOccurred())
 
-		pattern := `^([a-zA-Z0-9]+-)+master-\d+$`
+		pattern := `^([a-zA-Z0-9]+-)+master(?:-[a-zA-Z0-9]+)?-\d+$`
 
 		g.By("checking for the openshift machine api operator")
 		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())


### PR DESCRIPTION
**What does this PR do?**
Update the Control Plane Machine name pattern to also support the master's names with the format `[cluster-id]-master-[instance-id]-[final-index]` used by OpenShift on platforms like OpenStack.

**Why do we need it?**
To solve the [OCPBUGS-60454](https://issues.redhat.com/browse/OCPBUGS-60454) bug, where the `[sig-scheduling][Early] control plane machine set operator should not cause an early rollout` test fails at using the current pattern https://github.com/openshift/origin/blob/4ad9050f8cf7ddc835135ee9ab8a91b5893769fe/test/extended/machines/machines.go#L127, because the regex engine determines that the string `master-[instance-id]-[final-index]` does not match the pattern `master-\d+` due to `[instance-id]` is not a sequence of digits and the [MatchString](https://github.com/openshift/origin/blob/4ad9050f8cf7ddc835135ee9ab8a91b5893769fe/test/extended/machines/machines.go#L142) function returns false.

`mq6cnk8l-e3290-468r7-master-hbggj-2` is an example of the master's names used in OpenStack platforms. 