### PR TITLE
Revert "TRT-2197: use fixed seed for test ordering"

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/pkg/errors"
@@ -278,13 +279,10 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		return errors.WithMessage(err, "could not convert test specs to origin test cases")
 	}
 
-	// TRT-2197 removing random seed for the time being
-	// belief is it works against us in the short term
-	// causing intermittent failures due to random test pairings.
-	// Plan is to add a set of seeds and be able to attribute
-	// the seed to individual jobs so compare results for
-	// the same seed and search for failure patterns.
-	r := rand.New(rand.NewSource(42))
+	// this ensures the tests are always run in random order to avoid
+	// any intra-tests dependencies
+	suiteConfig, _ := ginkgo.GinkgoConfiguration()
+	r := rand.New(rand.NewSource(suiteConfig.RandomSeed))
 	r.Shuffle(len(tests), func(i, j int) { tests[i], tests[j] = tests[j], tests[i] })
 
 	count := o.Count


### PR DESCRIPTION
Reverts openshift/origin#29997

Investigation into failures for jobs `periodic-ci-openshift-release-master-ci-4.20-upgrade-from-stable-4.19-e2e-aws-ovn-upgrade` and `periodic-ci-openshift-release-master-ci-4.20-e2e-azure-ovn-upgrade` to see if there is an increase in failures like [Metrics should grab all metrics from kubelet](https://sippy.dptools.openshift.org/sippy-ng/component_readiness/test_details?Architecture=amd64&FeatureSet=default&Installer=ipi&Network=ovn&Platform=aws&Suite=unknown&Topology=ha&Upgrade=minor&baseEndTime=2025-06-17%2023%3A59%3A59&baseRelease=4.19&baseStartTime=2025-05-18%2000%3A00%3A00&capability=Other&columnGroupBy=Architecture%2CNetwork%2CPlatform%2CTopology&component=Monitoring&confidence=95&dbGroupBy=Platform%2CArchitecture%2CNetwork%2CTopology%2CFeatureSet%2CUpgrade%2CSuite%2CInstaller&environment=Architecture%3Aamd64%20FeatureSet%3Adefault%20Installer%3Aipi%20Network%3Aovn%20Platform%3Aaws%20Suite%3Aunknown%20Topology%3Aha%20Upgrade%3Aminor&flakeAsFailure=false&ignoreDisruption=true&ignoreMissing=false&includeMultiReleaseAnalysis=true&includeVariant=Architecture%3Aamd64&includeVariant=CGroupMode%3Av2&includeVariant=ContainerRuntime%3Acrun&includeVariant=ContainerRuntime%3Arunc&includeVariant=FeatureSet%3Adefault&includeVariant=FeatureSet%3Atechpreview&includeVariant=Installer%3Ahypershift&includeVariant=Installer%3Aipi&includeVariant=Installer%3Aupi&includeVariant=JobTier%3Ablocking&includeVariant=JobTier%3Ainforming&includeVariant=JobTier%3Astandard&includeVariant=LayeredProduct%3Anone&includeVariant=LayeredProduct%3Avirt&includeVariant=Network%3Aovn&includeVariant=Owner%3Aeng&includeVariant=Owner%3Aservice-delivery&includeVariant=Platform%3Aaws&includeVariant=Platform%3Aazure&includeVariant=Platform%3Agcp&includeVariant=Platform%3Ametal&includeVariant=Platform%3Arosa&includeVariant=Platform%3Avsphere&includeVariant=Topology%3Aexternal&includeVariant=Topology%3Aha&includeVariant=Topology%3Amicroshift&minFail=3&passRateAllTests=0&passRateNewTests=95&pity=5&sampleEndTime=2025-08-18%2023%3A59%3A59&sampleRelease=4.20&sampleStartTime=2025-08-11%2000%3A00%3A00&testBasisRelease=4.18&testId=openshift-tests%3A92862fa69420cbb0148679c5bc393f7b&testName=%5Bsig-instrumentation%5D%20Metrics%20should%20grab%20all%20metrics%20from%20kubelet%20%2Fmetrics%2Fresource%20endpoint%20%5BSuite%3Aopenshift%2Fconformance%2Fparallel%5D%20%5BSuite%3Ak8s%5D) and disruption due to the tests now running in a more regularly defined grouping