### PR TITLE
CNTRLPLANE-945: suites/external-oidc: explicitly mark cluster stability as disruptive

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -438,7 +438,8 @@ var staticSuites = []ginkgo.TestSuite{
 		Qualifiers: []string{
 			`name.contains("[Suite:openshift/auth/external-oidc") && !name.contains("[Skipped]")`,
 		},
-		TestTimeout: 120 * time.Minute,
+		TestTimeout:                120 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
 }
 


### PR DESCRIPTION
We noticed that we did not set the cluster stability to `Disruptive` for the `openshift/auth/external-oidc` test suite that we added. This is known to be a disruptive test suite as the feature we are testing results in configuring the kube-apiserver, triggering rollouts.

This PR sets the cluster stability for this suite to `Disruptive` to ensure we are filtering monitoring tests appropriately when running this suite.