### PR TITLE
OCPBUGS-60530: Fix panics in inclusterapi disruption during  ROSA jobs

### DIFF
--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -312,6 +312,7 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 		_, hcpNamespace, err := exutil.GetHypershiftManagementClusterConfigAndNamespace()
 		if err != nil {
 			logrus.WithError(err).Error("failed to get hypershift management cluster config and namespace")
+			return err
 		}
 
 		// For Hypershift, only skip if it's specifically ARO HCP
@@ -351,6 +352,7 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	i.adminRESTConfig = adminRESTConfig
 	i.kubeClient, err = kubernetes.NewForConfig(i.adminRESTConfig)
 	if err != nil {
+		log.WithError(err).Error("error constructing kube client in disruptionclusterapiserver monitortest")
 		return fmt.Errorf("error constructing kube client: %v", err)
 	}
 
@@ -494,6 +496,10 @@ func (i *InvariantInClusterDisruption) WriteContentToStorage(ctx context.Context
 func (i *InvariantInClusterDisruption) Cleanup(ctx context.Context) error {
 	log := logrus.WithField("monitorTest", "apiserver-incluster-availability").WithField("namespace", i.namespaceName).WithField("func", "Cleanup")
 	if len(i.notSupportedReason) > 0 {
+		return nil
+	}
+
+	if i.kubeClient == nil {
 		return nil
 	}
 

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -226,6 +226,7 @@ func NewCLIForMonitorTest(project string) *CLI {
 // allowed inside an `It` block. `AfterEach` and `BeforeEach` are not allowed there though.
 func NewHypershiftManagementCLI(project string) *CLI {
 	kubeconfig, _, err := GetHypershiftManagementClusterConfigAndNamespace()
+	// TODO: this is assuming to be executing within ginkgo, which is not always the case (monitortests)
 	o.Expect(err).NotTo(o.HaveOccurred())
 	return &CLI{
 		kubeFramework: &framework.Framework{


### PR DESCRIPTION
Not certain I've got them all. I think this will fix:

[Jira:"kube-apiserver"] monitor test apiserver-incluster-availability collection
and
[Jira:"kube-apiserver"] monitor test apiserver-incluster-availability collection

But I think this one may still fail due to this:
[Jira:"kube-apiserver"] monitor test apiserver-incluster-availability setup

time="2025-08-18T10:04:26Z" level=error msg="failed to get hypershift management cluster config and namespace" error="both the HYPERSHIFT_MANAGEMENT_CLUSTER_KUBECONFIG and the HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE env var must be set"