### PR TITLE
OTA-1581: Skip `UpgradeStatus` test on HyperShift

### DIFF
--- a/test/extended/cli/adm_upgrade/status.go
+++ b/test/extended/cli/adm_upgrade/status.go
@@ -1,6 +1,8 @@
 package adm_upgrade
 
 import (
+	"context"
+
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -16,6 +18,15 @@ var _ = g.Describe("[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade statu
 	oc := exutil.NewCLIWithoutNamespace("oc-adm-upgrade-status").AsAdmin()
 
 	g.It("reports correctly when the cluster is not updating", func() {
+
+		// CLI-side oc adm upgrade status does not support HyperShift (assumes MCPs, ignores NodePools, has no knowledge of
+		// management / hosted cluster separation)
+		isHyperShift, err := exutil.IsHypershift(context.TODO(), oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isHyperShift {
+			g.Skip("oc adm upgrade status is not supported on HyperShift")
+		}
+
 		cmd := oc.Run("adm", "upgrade", "status").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
 		out, err := cmd.Output()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
The `oc adm upgrade status` has no support for HyperShift where update procedure is different especially around nodes:

- assumes MCP existence
- no NodePool knowledge
- no knowledge of separate management / hosted cluster
