### PR TITLE
OCPBUGS-60489: monitoring: reapply separate type for localhost disruptions

### DIFF
--- a/pkg/disruption/backend/disruption/handler.go
+++ b/pkg/disruption/backend/disruption/handler.go
@@ -76,7 +76,7 @@ func (h *ciHandler) Unavailable(from, to *backend.SampleResult) {
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()},
 		nil, v1.EventTypeWarning, string(eventReason), "detected", message.BuildString())
 
-	interval := monitorapi.NewInterval(monitorapi.SourceDisruption, level).Locator(h.descriptor.DisruptionLocator()).
+	interval := monitorapi.NewInterval(h.getSource(), level).Locator(h.descriptor.DisruptionLocator()).
 		Display().
 		Message(message).Build(fs.StartedAt, time.Time{})
 	openIntervalID := h.monitorRecorder.StartInterval(interval)
@@ -100,8 +100,16 @@ func (h *ciHandler) Available(from, to *backend.SampleResult) {
 	h.eventRecorder.Eventf(
 		&v1.ObjectReference{Kind: "OpenShiftTest", Namespace: "kube-system", Name: h.descriptor.Name()}, nil,
 		v1.EventTypeNormal, string(monitorapi.DisruptionEndedEventReason), "detected", message.BuildString())
-	interval := monitorapi.NewInterval(monitorapi.SourceDisruption, monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
+	interval := monitorapi.NewInterval(h.getSource(), monitorapi.Info).Locator(h.descriptor.DisruptionLocator()).
 		Message(message).Build(fs.StartedAt, time.Time{})
 	openIntervalID := h.monitorRecorder.StartInterval(interval)
 	h.monitorRecorder.EndInterval(openIntervalID, ts.StartedAt)
+}
+
+// getSource returns the source of the interval based on the load balancer type. Localhost disruptions need to be separated, as in some cases these are expected
+func (h *ciHandler) getSource() monitorapi.IntervalSource {
+	if h.descriptor.GetLoadBalancerType() == backend.LocalhostType {
+		return monitorapi.SourceDisruptionLocalhost
+	}
+	return monitorapi.SourceDisruption
 }

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -348,6 +348,7 @@ const (
 	SourceAlert                     IntervalSource = "Alert"
 	SourceAPIServerShutdown         IntervalSource = "APIServerShutdown"
 	SourceDisruption                IntervalSource = "Disruption"
+	SourceDisruptionLocalhost       IntervalSource = "DisruptionLocalhost"
 	SourceE2ETest                   IntervalSource = "E2ETest"
 	SourceKubeEvent                 IntervalSource = "KubeEvent"
 	SourceNetworkManagerLog         IntervalSource = "NetworkMangerLog"


### PR DESCRIPTION
These are replaced by `pkg/monitortests/kubeapiserver/disruptionexternalapiserver` and `pkg/monitortests/kubeapiserver/disruptioninclusterapiserver`.

This also partially re-applies https://github.com/openshift/origin/pull/29710, reverted in https://github.com/openshift/origin/pull/30034 to make sure localhost disruptions have a separate source set:
```
        {
            "level": "Info",
            "source": "DisruptionLocalhost",
            "locator": {
                "type": "Disruption",
                "keys": {
                    "backend-disruption-name": "kube-api-http1-localhost-new-connections",
                    "connection": "new",
                    "disruption": "kube-api-http1-localhost",
                    "load-balancer": "localhost",
...
```