### PR TITLE
OCPNODE-3591: Implementing OTE Extension for Node Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ vendor/github.com/prometheus/procfs/fixtures/26231/exe
 /openshift-tests
 /disruption
 /update-tls-artifacts
+/node-tests-ext

--- a/.openshift-tests-extension/node.json
+++ b/.openshift-tests-extension/node.json
@@ -1,0 +1,12 @@
+{
+  "component": "node",
+  "generated": "2025-08-20T07:54:08Z",
+  "tests": [
+    {
+      "name": "[Jira:node][sig-node] node test should always pass [Suite:openshift/node/conformance/parallel]",
+      "originalName": "",
+      "source": "openshift:payload:node"
+    }
+  ],
+  "removedTests": []
+}

--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,13 @@ test: test-tools
 # It will generate targets {update,verify}-bindata-$(1) logically grouping them in unsuffixed versions of these targets
 # and also hooked into {update,verify}-generated for broader integration.
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
+
+# Build the node openshift-tests-extension binary
+node-tests-ext-build:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
+	go build -o node-tests-ext \
+	-ldflags "-X 'main.CommitFromGit=$(shell git rev-parse --short HEAD)' \
+	-X 'main.BuildDate=$(shell date -u +%Y-%m-%dT%H:%M:%SZ)' \
+	-X 'main.GitTreeState=$(shell if git diff-index --quiet HEAD --; then echo clean; else echo dirty; fi)'" \
+	./cmd/node-tests-ext
+.PHONY: node-tests-ext-build

--- a/cmd/node-tests-ext/main.go
+++ b/cmd/node-tests-ext/main.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/spf13/cobra"
+
+	// Import the component tests
+	_ "github.com/openshift/origin/test/extended/node"
+)
+
+var (
+	CommitFromGit string
+	BuildDate     string
+	GitTreeState  string
+)
+
+// GinkgoTestingT implements the minimal TestingT interface needed by Ginkgo
+type GinkgoTestingT struct{}
+
+func (GinkgoTestingT) Errorf(format string, args ...interface{}) {}
+func (GinkgoTestingT) Fail()                                     {}
+func (GinkgoTestingT) FailNow()                                  { os.Exit(1) }
+
+// NewGinkgoTestingT creates a new testing.T compatible instance for Ginkgo
+func NewGinkgoTestingT() *GinkgoTestingT {
+	return &GinkgoTestingT{}
+}
+
+// escapeRegexChars escapes special regex characters in test names for Ginkgo focus
+func escapeRegexChars(s string) string {
+	// Only escape the problematic characters that cause regex parsing issues
+	// We need to escape [ and ] which are treated as character classes
+	s = strings.ReplaceAll(s, "[", "\\[")
+	s = strings.ReplaceAll(s, "]", "\\]")
+	return s
+}
+
+// createTestSpec creates a test spec with proper execution functions
+func createTestSpec(name, source string, codeLocations []string) *extensiontests.ExtensionTestSpec {
+	return &extensiontests.ExtensionTestSpec{
+		Name:          name,
+		Source:        source,
+		CodeLocations: codeLocations,
+		Lifecycle:     extensiontests.LifecycleBlocking,
+		Resources: extensiontests.Resources{
+			Isolation: extensiontests.Isolation{},
+		},
+		EnvironmentSelector: extensiontests.EnvironmentSelector{},
+		Run: func(ctx context.Context) *extensiontests.ExtensionTestResult {
+			return runGinkgoTest(ctx, name)
+		},
+		RunParallel: func(ctx context.Context) *extensiontests.ExtensionTestResult {
+			return runGinkgoTest(ctx, name)
+		},
+	}
+}
+
+// runGinkgoTest runs a Ginkgo test in-process
+func runGinkgoTest(ctx context.Context, testName string) *extensiontests.ExtensionTestResult {
+	startTime := time.Now()
+
+	// Configure Ginkgo to run specific test
+	gomega.RegisterFailHandler(ginkgo.Fail)
+
+	// Run the test suite with focus on specific test
+	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	suiteConfig.FocusStrings = []string{escapeRegexChars(testName)}
+
+	passed := ginkgo.RunSpecs(NewGinkgoTestingT(), "OpenShift node Test Suite", suiteConfig, reporterConfig)
+
+	endTime := time.Now()
+	duration := endTime.Sub(startTime)
+
+	result := extensiontests.ResultPassed
+	if !passed {
+		result = extensiontests.ResultFailed
+	}
+
+	return &extensiontests.ExtensionTestResult{
+		Name:      testName,
+		Result:    result,
+		StartTime: dbtime.Ptr(startTime),
+		EndTime:   dbtime.Ptr(endTime),
+		Duration:  int64(duration.Seconds()),
+		Output:    "",
+	}
+}
+
+func main() {
+	// Create a new registry
+	registry := extension.NewRegistry()
+
+	// Create extension for this component
+	ext := extension.NewExtension("openshift", "payload", "node")
+
+	// Set source information
+	ext.Source = extension.Source{
+		Commit:       CommitFromGit,
+		BuildDate:    BuildDate,
+		GitTreeState: GitTreeState,
+	}
+
+	// Add test suites for node
+	ext.AddGlobalSuite(extension.Suite{
+		Name:        "openshift/node/conformance/parallel",
+		Description: "",
+		Parents:     []string{"openshift/conformance/parallel"},
+		Qualifiers:  []string{"(source == \"openshift:payload:node\") && (!(name.contains(\"[Serial]\") || name.contains(\"[Slow]\")))"},
+	})
+
+	ext.AddGlobalSuite(extension.Suite{
+		Name:        "openshift/node/conformance/serial",
+		Description: "",
+		Parents:     []string{"openshift/conformance/serial"},
+		Qualifiers:  []string{"(source == \"openshift:payload:node\") && (name.contains(\"[Serial]\"))"},
+	})
+
+	ext.AddGlobalSuite(extension.Suite{
+		Name:        "openshift/node/optional/slow",
+		Description: "",
+		Parents:     []string{"openshift/optional/slow"},
+		Qualifiers:  []string{"(source == \"openshift:payload:node\") && (name.contains(\"[Slow]\"))"},
+	})
+
+	ext.AddGlobalSuite(extension.Suite{
+		Name:        "openshift/node/all",
+		Description: "",
+		Qualifiers:  []string{"source == \"openshift:payload:node\""},
+	})
+
+	// Add sample test spec (you'll need to add actual tests based on existing test/extended/node/)
+	testSpecs := extensiontests.ExtensionTestSpecs{
+		createTestSpec(
+			"[Jira:node][sig-node] node test should always pass [Suite:openshift/node/conformance/parallel]",
+			"openshift:payload:node",
+			[]string{
+				"/test/extended/node/node.go:10",
+				"/test/extended/node/node.go:11",
+			},
+		),
+	}
+	ext.AddSpecs(testSpecs)
+
+	// Register the extension
+	registry.Register(ext)
+
+	// Create root command with default extension commands
+	rootCmd := &cobra.Command{
+		Use:   "node-tests-ext",
+		Short: "OpenShift node tests extension",
+	}
+
+	// Add all the default extension commands (info, list, run-test, run-suite, update)
+	rootCmd.AddCommand(cmd.DefaultExtensionCommands(registry)...)
+
+	// Execute the command
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.37.0
 	github.com/opencontainers/go-digest v1.0.0
-	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8
+	github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292
 	github.com/openshift-kni/commatrix v0.0.4-0.20250604173218-064b4004e9fb
 	github.com/openshift/api v0.0.0-20250710004639-926605d3338b
 	github.com/openshift/apiserver-library-go v0.0.0-20250710132015-f0d44ef6e53b

--- a/go.sum
+++ b/go.sum
@@ -811,8 +811,8 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jDMcgULaH8=
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8 h1:D+Qga9nujuIcrAjcAuKPukoUcVBl6ZDEbtgNLgKKlgY=
-github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292 h1:3athg6KQ+TaNfW4BWZDlGFt1ImSZEJWgzXtPC1VPITI=
+github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292/go.mod h1:6gkP5f2HL0meusT0Aim8icAspcD1cG055xxBZ9yC68M=
 github.com/openshift-kni/commatrix v0.0.4-0.20250604173218-064b4004e9fb h1:+owPvmRBKN5dYuVQ7/CROW0h6wL6Hk8MJlf2vnZQfSM=
 github.com/openshift-kni/commatrix v0.0.4-0.20250604173218-064b4004e9fb/go.mod h1:R8JhlXqlLwe3N6nQheK2KpMEESIlDVCUw5TOLKiZ08s=
 github.com/openshift/api v0.0.0-20250710004639-926605d3338b h1:A8OY6adT2aZNp7tsGsilHuQ3RqhzrFx5dzGr/UwXfJg=

--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -2,11 +2,14 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS 
 WORKDIR /go/src/github.com/openshift/origin
 COPY . .
 RUN make; \
+    make node-tests-ext-build; \
     mkdir -p /tmp/build; \
-    cp /go/src/github.com/openshift/origin/openshift-tests /tmp/build/openshift-tests
+    cp /go/src/github.com/openshift/origin/openshift-tests /tmp/build/openshift-tests; \
+    gzip -c /go/src/github.com/openshift/origin/node-tests-ext > /tmp/build/node-tests-ext.gz
 
 FROM registry.ci.openshift.org/ocp/4.20:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
+COPY --from=builder /tmp/build/node-tests-ext.gz /usr/bin/
 RUN mkdir -p /manifests
 COPY --from=builder /go/src/github.com/openshift/origin/zz_generated.manifests/* /manifests
 

--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -193,6 +193,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-kube-apiserver-operator",
 		binaryPath: "/usr/bin/cluster-kube-apiserver-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "tests",
+		binaryPath: "/usr/bin/node-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.

--- a/test/extended/node/node.go
+++ b/test/extended/node/node.go
@@ -1,0 +1,12 @@
+package node
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+)
+
+var _ = g.Describe("[Jira:node][sig-node] node test", func() {
+	g.It("should always pass [Suite:openshift/node/conformance/parallel]", func() {
+		o.Expect(true).To(o.BeTrue())
+	})
+})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -29,6 +29,8 @@ var Annotations = map[string]string{
 
 	"[Conformance][sig-sno][Serial] Cluster should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]": " [Suite:openshift/conformance/serial/minimal]",
 
+	"[Jira:node][sig-node] node test should always pass [Suite:openshift/node/conformance/parallel]": "",
+
 	"[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io]": " [Suite:openshift/conformance/serial]",
 
 	"[Serial][sig-cli] oc adm upgrade recommend When the update service has conditional recommendations runs successfully when listing all updates": " [Suite:openshift/conformance/serial]",

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmd.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+)
+
+func DefaultExtensionCommands(registry *extension.Registry) []*cobra.Command {
+	return []*cobra.Command{
+		cmdrun.NewRunSuiteCommand(registry),
+		cmdrun.NewRunTestCommand(registry),
+		cmdlist.NewListCommand(registry),
+		cmdinfo.NewInfoCommand(registry),
+		cmdupdate.NewUpdateCommand(registry),
+		cmdimages.NewImagesCommand(registry),
+	}
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages/cmdimages.go
@@ -1,0 +1,36 @@
+package cmdimages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+func NewImagesCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "images",
+		Short:        "List test images",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			extension := registry.Get(componentFlags.Component)
+			if extension == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+			images, err := json.Marshal(extension.Images)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stdout, "%s\n", images)
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runtest.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun/runtest.go
@@ -2,8 +2,13 @@ package cmdrun
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
+	"errors"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -30,6 +35,32 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 		Short:        "Runs tests by name",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancelCause := context.WithCancelCause(context.Background())
+			defer cancelCause(errors.New("exiting"))
+
+			abortCh := make(chan os.Signal, 2)
+			go func() {
+				<-abortCh
+				fmt.Fprintf(os.Stderr, "Interrupted, terminating tests")
+				cancelCause(errors.New("interrupt received"))
+
+				select {
+				case sig := <-abortCh:
+					fmt.Fprintf(os.Stderr, "Interrupted twice, exiting (%s)", sig)
+					switch sig {
+					case syscall.SIGINT:
+						os.Exit(130)
+					default:
+						os.Exit(130) // if we were interrupted, never return zero.
+					}
+
+				case <-time.After(30 * time.Minute): // allow time for cleanup.  If we finish before this, we'll exit
+					fmt.Fprintf(os.Stderr, "Timed out during cleanup, exiting")
+					os.Exit(130) // if we were interrupted, never return zero.
+				}
+			}()
+			signal.Notify(abortCh, syscall.SIGINT, syscall.SIGTERM)
+
 			ext := registry.Get(opts.componentFlags.Component)
 			if ext == nil {
 				return fmt.Errorf("component not found: %s", opts.componentFlags.Component)
@@ -69,7 +100,7 @@ func NewRunTestCommand(registry *extension.Registry) *cobra.Command {
 			}
 			defer w.Flush()
 
-			return specs.Run(w, opts.concurrencyFlags.MaxConcurency)
+			return specs.Run(ctx, w, opts.concurrencyFlags.MaxConcurency)
 		},
 	}
 	opts.componentFlags.BindFlags(cmd.Flags())

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate/update.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate/update.go
@@ -1,0 +1,84 @@
+package cmdupdate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/flags"
+)
+
+const metadataDirectory = ".openshift-tests-extension"
+
+// NewUpdateCommand adds an "update" command used to generate and verify the metadata we keep track of. This should
+// be a black box to end users, i.e. we can add more criteria later they'll consume when revendoring.  For now,
+// we prevent a test to be renamed without updating other names, or a test to be deleted.
+func NewUpdateCommand(registry *extension.Registry) *cobra.Command {
+	componentFlags := flags.NewComponentFlags()
+
+	cmd := &cobra.Command{
+		Use:          "update",
+		Short:        "Update test metadata",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ext := registry.Get(componentFlags.Component)
+			if ext == nil {
+				return fmt.Errorf("couldn't find the component %q", componentFlags.Component)
+			}
+
+			// Create the metadata directory if it doesn't exist
+			if err := os.MkdirAll(metadataDirectory, 0755); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", metadataDirectory, err)
+			}
+
+			// Read existing specs
+			metadataPath := filepath.Join(metadataDirectory, fmt.Sprintf("%s.json", strings.ReplaceAll(ext.Component.Identifier(), ":", "_")))
+			var oldSpecs extensiontests.ExtensionTestSpecs
+			source, err := os.Open(metadataPath)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return fmt.Errorf("failed to open file: %s: %+w", metadataPath, err)
+				}
+			} else {
+				if err := json.NewDecoder(source).Decode(&oldSpecs); err != nil {
+					return fmt.Errorf("failed to decode file: %s: %+w", metadataPath, err)
+				}
+
+				missing, err := ext.FindRemovedTestsWithoutRename(oldSpecs)
+				if err != nil && len(missing) > 0 {
+					fmt.Fprintf(os.Stderr, "Missing Tests:\n")
+					for _, name := range missing {
+						fmt.Fprintf(os.Stdout, "  * %s\n", name)
+					}
+					fmt.Fprintf(os.Stderr, "\n")
+
+					return fmt.Errorf("missing tests, if you've renamed tests you must add their names to OriginalName, " +
+						"or mark them obsolete")
+				}
+			}
+
+			// no missing tests, write the results
+			newSpecs := ext.GetSpecs()
+			data, err := json.MarshalIndent(newSpecs, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal specs to JSON: %w", err)
+			}
+
+			// Write the JSON data to the file
+			if err := os.WriteFile(metadataPath, data, 0644); err != nil {
+				return fmt.Errorf("failed to write file %s: %w", metadataPath, err)
+			}
+
+			fmt.Printf("successfully updated metadata\n")
+			return nil
+		},
+	}
+	componentFlags.BindFlags(cmd.Flags())
+	return cmd
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extension.go
@@ -117,9 +117,15 @@ func (e *Extension) AddGlobalSuite(suite Suite) *Extension {
 // in its own extension.
 func (e *Extension) AddSuite(suite Suite) *Extension {
 	expr := fmt.Sprintf("source == %q", e.Component.Identifier())
-	for i := range suite.Qualifiers {
-		suite.Qualifiers[i] = fmt.Sprintf("(%s) && (%s)", expr, suite.Qualifiers[i])
+	if len(suite.Qualifiers) == 0 {
+		suite.Qualifiers = []string{expr}
+	} else {
+		for i := range suite.Qualifiers {
+			suite.Qualifiers[i] = fmt.Sprintf("(%s) && (%s)",
+				expr, suite.Qualifiers[i])
+		}
 	}
+
 	e.AddGlobalSuite(suite)
 	return e
 }

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests/types.go
@@ -1,6 +1,8 @@
 package extensiontests
 
 import (
+	"context"
+
 	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
 	"github.com/openshift-eng/openshift-tests-extension/pkg/util/sets"
 )
@@ -43,8 +45,13 @@ type ExtensionTestSpec struct {
 	// EnvironmentSelector allows for CEL expressions to be used to control test inclusion
 	EnvironmentSelector EnvironmentSelector `json:"environmentSelector,omitempty"`
 
-	// Run invokes a test
-	Run func() *ExtensionTestResult `json:"-"`
+	// Run invokes a test in-process.  It must not call back into `ote-binary run-test` because that will usually
+	// cause an infinite recursion.
+	Run func(ctx context.Context) *ExtensionTestResult `json:"-"`
+
+	// RunParallel invokes a test in parallel with other tests.  This is usually done by exec-ing out
+	// to the `ote-binary run-test "test name"` commmand and interpretting the result.
+	RunParallel func(ctx context.Context) *ExtensionTestResult `json:"-"`
 
 	// Hook functions
 	afterAll   []*OneTimeTask

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/logging.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/logging.go
@@ -1,0 +1,21 @@
+package ginkgo
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/onsi/ginkgo/v2"
+)
+
+// this is copied from ginkgo because ginkgo made it internal and then hardcoded an init block
+// using these functions to wire to os.stdout and we want to wire to stderr (or a different buffer) so we can
+// have json output.
+
+func GinkgoLogrFunc(writer ginkgo.GinkgoWriterInterface) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		if prefix == "" {
+			writer.Printf("%s\n", args)
+		} else {
+			writer.Printf("%s %s\n", prefix, args)
+		}
+	}, funcr.Options{})
+}

--- a/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/parallel.go
+++ b/vendor/github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo/parallel.go
@@ -1,0 +1,139 @@
+package ginkgo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/openshift-eng/openshift-tests-extension/pkg/dbtime"
+	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+)
+
+func SpawnProcessToRunTest(ctx context.Context, testName string, timeout time.Duration) *extensiontests.ExtensionTestResult {
+	// longerCtx is used to backstop the process, but leave termination up to us if possible to allow a double interrupt
+	longerCtx, longerCancel := context.WithTimeout(ctx, timeout+15*time.Minute)
+	defer longerCancel()
+	timeoutCtx, shorterCancel := context.WithTimeout(longerCtx, timeout)
+	defer shorterCancel()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	command := exec.CommandContext(longerCtx, os.Args[0], "run-test", "--output=json", testName)
+	command.Stdout = stdout
+	command.Stderr = stderr
+
+	start := time.Now()
+	err := command.Start()
+	if err != nil {
+		fmt.Fprintf(stderr, "Command Start Error: %v\n", err)
+		return newTestResult(testName, extensiontests.ResultFailed, start, time.Now(), stdout, stderr)
+	}
+
+	go func() {
+		select {
+		// interrupt tests after timeout, and abort if they don't complete quick enough
+		case <-time.After(timeout):
+			if command.Process != nil {
+				// we're not going to do anything with the err
+				_ = command.Process.Signal(syscall.SIGINT)
+			}
+			// if the process appears to be hung a significant amount of time after the timeout
+			// send an ABRT so we get a stack dump
+			select {
+			case <-time.After(time.Minute):
+				if command.Process != nil {
+					// we're not going to do anything with the err
+					_ = command.Process.Signal(syscall.SIGABRT)
+				}
+			case <-timeoutCtx.Done():
+				if command.Process != nil {
+					_ = command.Process.Signal(syscall.SIGABRT)
+				}
+			}
+		case <-timeoutCtx.Done():
+			if command.Process != nil {
+				_ = command.Process.Signal(syscall.SIGINT)
+			}
+		}
+	}()
+
+	result := extensiontests.ResultFailed
+	cmdErr := command.Wait()
+
+	subcommandResult, parseErr := newTestResultFromOutput(stdout)
+	if parseErr == nil {
+		// even if we have a cmdErr, if we were able to parse the result, trust the output
+		return subcommandResult
+	}
+
+	fmt.Fprintf(stderr, "Command Error: %v\n", cmdErr)
+	fmt.Fprintf(stderr, "Deserializaion Error: %v\n", parseErr)
+	return newTestResult(testName, result, start, time.Now(), stdout, stderr)
+}
+
+func newTestResultFromOutput(stdout *bytes.Buffer) (*extensiontests.ExtensionTestResult, error) {
+	if len(stdout.Bytes()) == 0 {
+		return nil, errors.New("no output from command")
+	}
+
+	// when the command runs correctly, we get json or json slice output
+	retArray := []extensiontests.ExtensionTestResult{}
+	if arrayItemErr := json.Unmarshal(stdout.Bytes(), &retArray); arrayItemErr == nil {
+		if len(retArray) != 1 {
+			return nil, errors.New("expected 1 result, got %v results")
+		}
+		return &retArray[0], nil
+	}
+
+	// when the command runs correctly, we get json output
+	ret := &extensiontests.ExtensionTestResult{}
+	if singleItemErr := json.Unmarshal(stdout.Bytes(), ret); singleItemErr != nil {
+		return nil, singleItemErr
+	}
+
+	return ret, nil
+}
+
+func newTestResult(name string, result extensiontests.Result, start, end time.Time, stdout, stderr *bytes.Buffer) *extensiontests.ExtensionTestResult {
+	duration := end.Sub(start)
+	dbStart := dbtime.DBTime(start)
+	dbEnd := dbtime.DBTime(start)
+	ret := &extensiontests.ExtensionTestResult{
+		Name:      name,
+		Lifecycle: "", // lifecycle is completed one level above this.
+		Duration:  int64(duration),
+		StartTime: &dbStart,
+		EndTime:   &dbEnd,
+		Result:    result,
+		Details:   nil,
+	}
+
+	if stdout != nil && stderr != nil {
+		stdoutStr := stdout.String()
+		stderrStr := stderr.String()
+
+		ret.Output = fmt.Sprintf("STDOUT:\n%s\n\nSTDERR:\n%s\n", stdoutStr, stderrStr)
+
+		// try to choose the best summary
+		switch {
+		case len(stderrStr) > 0 && len(stderrStr) < 5000:
+			ret.Error = stderrStr
+		case len(stderrStr) > 0 && len(stderrStr) >= 5000:
+			ret.Error = stderrStr[len(stderrStr)-5000:]
+
+		case len(stdoutStr) > 0 && len(stdoutStr) < 5000:
+			ret.Error = stdoutStr
+		case len(stdoutStr) > 0 && len(stdoutStr) >= 5000:
+			ret.Error = stdoutStr[len(stdoutStr)-5000:]
+		}
+	}
+
+	return ret
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1429,11 +1429,14 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalkdir
-# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250711173707-dc2a20e5a5f8
+# github.com/openshift-eng/openshift-tests-extension v0.0.0-20250804142706-7b3ab438a292
 ## explicit; go 1.23.0
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdimages
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdinfo
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdlist
 github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdrun
+github.com/openshift-eng/openshift-tests-extension/pkg/cmd/cmdupdate
 github.com/openshift-eng/openshift-tests-extension/pkg/dbtime
 github.com/openshift-eng/openshift-tests-extension/pkg/extension
 github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests


### PR DESCRIPTION
This PR is to implement Node Extension Binary for Node test cases to run on Openshift Extension Platform .  

It does the groundwork for moving tests or writing tests to be executed from this repository using OTE.

JIRA: https://issues.redhat.com/browse/OCPNODE-3591

Changes:

- Add cmd/node-tests-ext/ with main.go
- Created node.go file for node e2e test cases 
- Add test/extended/ directory with test framework and sanity test
- Update Makefile with tests-ext-build target
- Update Dockerfile.rhel7 to build and include test extension binary
- Update go.mod with required dependencies for ginkgo and openshift-tests-extension