### PR TITLE
OCPBUGS-60244: Wait 30s after the upgrade is complete to validate workloads

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -188,6 +188,9 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 						clusterUpgrade(f, client, dynamicClient, config, upgCtx.Versions[i]),
 						fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
 				}
+				// Sleep to give some time to the workloads on the last upgraded
+				// node to restart.
+				time.Sleep(5 * time.Second)
 			},
 		)
 	})


### PR DESCRIPTION
This accounts for the fact that it occasionally takes 1-2s for workloads to become ready after the nodes are marked ready at the end of an upgrade.