### PR TITLE
NO-JIRA: Stop setting feature gate conditional

### DIFF
--- a/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
+++ b/pkg/monitortests/cli/adm_upgrade/status/monitortest.go
@@ -106,7 +106,7 @@ func snapshotOcAdmUpgradeStatus(ch chan *snapshot) {
 	var err error
 	// retry on brief apiserver unavailability
 	if errWait := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 2*time.Minute, true, func(context.Context) (bool, error) {
-		cmd := oc.Run("adm", "upgrade", "status", "--details=all").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
+		cmd := oc.Run("adm", "upgrade", "status", "--details=all")
 		out, err = cmd.Output()
 		if err != nil {
 			return false, nil

--- a/test/extended/cli/adm_upgrade/status.go
+++ b/test/extended/cli/adm_upgrade/status.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade statu
 			g.Skip("oc adm upgrade status is not supported on HyperShift")
 		}
 
-		cmd := oc.Run("adm", "upgrade", "status").EnvVar("OC_ENABLE_CMD_UPGRADE_STATUS", "true")
+		cmd := oc.Run("adm", "upgrade", "status")
 		out, err := cmd.Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.Equal("The cluster is not updating."))


### PR DESCRIPTION
https://github.com/openshift/oc/pull/2063 promoted `oc adm upgrade status` and removed the conditional check of the `OC_ENABLE_CMD_UPGRADE_STATUS` envvar, so the tests should no longer set it either.
