### PR TITLE
CNTRLPLANE-945: oidc/keycloak: make keycloak client use environment proxy for HTTP requests

### DIFF
--- a/test/extended/authentication/keycloak_client.go
+++ b/test/extended/authentication/keycloak_client.go
@@ -31,6 +31,7 @@ func keycloakClientFor(keycloakURL string) (*keycloakClient, error) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
+		Proxy: http.ProxyFromEnvironment,
 	}
 
 	return &keycloakClient{


### PR DESCRIPTION
We encountered an issue in https://github.com/openshift/release/pull/68209 where requests to configure the Keycloak instance deployed for the OIDC tests failed to resolve the hostname of route for the Keycloak instance.

This appeared to be because all requests to routes on a baremetal cluster must go through a proxy. This PR updates the HTTP client we use for interacting with Keycloak instances to respect any proxies configured from the typical `HTTP_PROXY` `HTTPS_PROXY` and `NO_PROXY` environment variables.