### PR TITLE
NO-JIRA: test/extended: update auth-related test OWNERS

### DIFF
--- a/test/extended/authentication/OWNERS
+++ b/test/extended/authentication/OWNERS
@@ -1,7 +1,10 @@
 reviewers:
   - ibihim
-  - s-urbaniak
-  - slaskawi
-  - stlaz
+  - liouk
+  - everettraven
+  - jacobsee
+  - ShazaAldawamneh
 approvers:
-  - stlaz
+  - ibihim
+  - liouk
+  - everettraven

--- a/test/extended/authorization/OWNERS
+++ b/test/extended/authorization/OWNERS
@@ -1,8 +1,10 @@
 reviewers:
   - ibihim
-  - s-urbaniak
-  - slaskawi
-  - stlaz
   - liouk
+  - everettraven
+  - jacobsee
+  - ShazaAldawamneh
 approvers:
-  - stlaz
+  - ibihim
+  - liouk
+  - everettraven

--- a/test/extended/oauth/OWNERS
+++ b/test/extended/oauth/OWNERS
@@ -1,7 +1,10 @@
 reviewers:
   - ibihim
-  - s-urbaniak
-  - slaskawi
-  - stlaz
+  - liouk
+  - everettraven
+  - jacobsee
+  - ShazaAldawamneh
 approvers:
-  - stlaz
+  - ibihim
+  - liouk
+  - everettraven


### PR DESCRIPTION
to the set of folks currently responsible for the components associated with these tests.

All the folks removed from the set of OWNERS are no longer at Red Hat.