### PR TITLE
CNTRLPLANE-180: rm renamed PSA condition

### DIFF
--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -237,7 +237,6 @@ var (
 			"NodeInstallerDegraded",
 			"NodeInstallerProgressing",
 			"NodeKubeconfigControllerDegraded",
-			"PodSecurityCustomerEvaluationConditionsDetected",
 			"PodSecurityDisabledSyncerEvaluationConditionsDetected",
 			"PodSecurityOpenshiftEvaluationConditionsDetected",
 			"PodSecurityRunLevelZeroEvaluationConditionsDetected",


### PR DESCRIPTION
## What

Remove `PodSecurityCustomerEvaluationConditionsDetected`.

## Why

This condition is being renamed to PodSecurityUnknownEvaluationConditionsDetected in the kube-apiserver operator.
Remove from test expectations to prevent test failures during the transition period.

## Ref

https://github.com/openshift/cluster-kube-apiserver-operator/pull/1881