### PR TITLE
OTA-1559: test/extended/cli/adm_upgrade/recommend: TestRiskA PromQL use max_over_time

### DIFF
--- a/test/extended/cli/adm_upgrade/recommend.go
+++ b/test/extended/cli/adm_upgrade/recommend.go
@@ -141,7 +141,7 @@ No updates available. You may still upgrade to a specific release image.*`)
           "url": "https://example.com/testRiskA",
           "name": "TestRiskA",
           "message": "This is a test risk.",
-          "matchingRules": [{"type": "PromQL", "promql": {"promql": "group(cluster_version)"}}]
+          "matchingRules": [{"type": "PromQL", "promql": {"promql": "group(max_over_time(cluster_version[1h]))"}}]
         }
       ]
     }


### PR DESCRIPTION
Avoid failing on rare flakes [like][1]:

    : [Serial][sig-cli] oc adm upgrade recommend When the update service has conditional recommendations runs successfully with conditional recommendations to the --version target [Suite:openshift/conformance/serial]	22s
    ...
    Could not evaluate exposure to update risk TestRiskA (invalid PromQL result length must be one, but is 0)

where there was presumably some kind of hiccup in scraping the cluster-version operator.  Instead of expecting to find `cluster_version` at the single point in time "now", accept it if we find that metric anywhere in the past hour.

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-aws-ovn-techpreview-serial/1959321955551154176