### PR TITLE
NO-ISSUE: test/extended/util/framework: Poll in IsMicroShiftCluster

### DIFF
--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2310,18 +2310,28 @@ func IsHypershift(ctx context.Context, configClient clientconfigv1.Interface) (b
 // IsMicroShiftCluster returns "true" if a cluster is MicroShift,
 // "false" otherwise. It needs kube-admin client as input.
 func IsMicroShiftCluster(kubeClient k8sclient.Interface) (bool, error) {
-	// MicroShift cluster contains "microshift-version" configmap in "kube-public" namespace
-	cm, err := kubeClient.CoreV1().ConfigMaps("kube-public").Get(context.Background(), "microshift-version", metav1.GetOptions{})
-	if err != nil {
+	ctx := context.Background()
+	var cm *corev1.ConfigMap
+	duration := 5 * time.Minute
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Second, duration, true, func(ctx context.Context) (bool, error) {
+		// MicroShift cluster contains "microshift-version" configmap in "kube-public" namespace
+		var err error
+		cm, err = kubeClient.CoreV1().ConfigMaps("kube-public").Get(ctx, "microshift-version", metav1.GetOptions{})
+		if err == nil {
+			return true, nil
+		}
 		if kapierrs.IsNotFound(err) {
-			e2e.Logf("microshift-version configmap not found")
-			return false, nil
+			cm = nil
+			return true, nil
 		}
 		e2e.Logf("error accessing microshift-version configmap: %v", err)
+		return false, nil
+	}); err != nil {
+		e2e.Logf("failed to find microshift-version configmap while polling for %s: %v", duration, err)
 		return false, err
 	}
 	if cm == nil {
-		e2e.Logf("microshift-version configmap is nil")
+		e2e.Logf("microshift-version configmap not found")
 		return false, nil
 	}
 	e2e.Logf("MicroShift cluster with version: %s", cm.Data["version"])


### PR DESCRIPTION
The ConfigMap retrieval occasionally fails:

```console
$ curl -s 'https://search.dptools.openshift.org/search?maxAge=24h&type=junit&context=0&search=error%20accessing%20microshift-version%20configmap' | jq -r 'to_entries[] | .key as $k | .value | to_entries[].value[].context[] | $k + "\n  " + .'
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.17-e2e-aws-ovn-techpreview/1959742094134218752
    I0824 23:53:47.495715 90800 framework.go:2294] error accessing microshift-version configmap: Get "https://api.ci-op-hfy5sixp-82aa7.origin-ci-int-aws.dev.rhcloud.com:6443/api/v1/namespaces/kube-public/configmaps/microshift-version": dial tcp: lookup api.ci-op-hfy5sixp-82aa7.origin-ci-int-aws.dev.rhcloud.com on 172.30.0.10:53: read udp 10.129.136.246:33085->172.30.0.10:53: i/o timeout
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-aws-ovn-cgroupsv2/1959742058285502464
    I0824 23:53:34.234531 68956 framework.go:2294] error accessing microshift-version configmap: Get "https://api.ci-op-950shpk8-29422.XXXXXXXXXXXXXXXXXXXXXX:6443/api/v1/namespaces/kube-public/configmaps/microshift-version": dial tcp: lookup api.ci-op-950shpk8-29422.XXXXXXXXXXXXXXXXXXXXXX on 172.30.0.10:53: read udp 10.130.176.97:35168->172.30.0.10:53: i/o timeout
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.14-to-4.15-to-4.16-to-4.17-ci/1959761685916946432
    I0825 04:30:25.015456 907 framework.go:2294] error accessing microshift-version configmap: Get "https://api.ci-op-wwl4bdif-d25a9.origin-ci-int-aws.dev.rhcloud.com:6443/api/v1/namespaces/kube-public/configmaps/microshift-version": dial tcp: lookup api.ci-op-wwl4bdif-d25a9.origin-ci-int-aws.dev.rhcloud.com on 172.30.0.10:53: no such host
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30067/pull-ci-openshift-origin-main-e2e-hypershift-conformance/1959846453614481408
    I0825 07:00:44.838632 72570 framework.go:2320] error accessing microshift-version configmap: Get "https://add640066b4a046d58cb9cc48def1e09-925574a45e949171.elb.us-east-1.amazonaws.com:6443/api/v1/namespaces/kube-public/configmaps/microshift-version": dial tcp: lookup add640066b4a046d58cb9cc48def1e09-925574a45e949171.elb.us-east-1.amazonaws.com on 172.30.0.10:53: read udp 172.24.238.50:43260->172.30.0.10:53: i/o timeout
```

Placing it within a poll loop will avoid failing test-cases while they try to decide if the cluster is MicroShift or not, which is likely to be part of setup (e.g. "skip this test-case if the cluster is MicroShift"), and not the fundamental thing the test-case is trying to exercise.

Ideally there would be no hard-coded duration, and `IsMicroShiftCluster` would take a `Context` argument set up with whatever the caller felt was a reasonable time to make that determination.  But I didn't want to get into adjusting all the `IsMicroShiftCluster` callers, so for now, I'm just hard-coding the duration.