### PR TITLE
TRT-2268: Add support for OTE test lifecycles

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -441,6 +441,16 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout:                120 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
+	{
+		Name: "openshift/ote",
+		Description: templates.LongDesc(`
+		This test suite runs tests to validate OpenShift Test Extension features are working.
+		`),
+		Qualifiers: []string{
+			`name.contains("[OTE]")`,
+		},
+		TestTimeout: 1 * time.Minute,
+	},
 }
 
 func withExcludedTestsFilter(baseExpr string) string {

--- a/test/extended/extension/extension.go
+++ b/test/extended/extension/extension.go
@@ -1,0 +1,17 @@
+package extension
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-ci] [OTE] OpenShift Tests Extension [Suite:openshift/ote]", func() {
+	defer g.GinkgoRecover()
+
+	_ = g.It("should support tests that succeed", func() {})
+
+	_ = g.It("should support tests with an informing lifecycle", ote.Informing(), func() {
+		e2e.Fail("This test is intended to fail.")
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/dns"
 	_ "github.com/openshift/origin/test/extended/dr"
 	_ "github.com/openshift/origin/test/extended/etcd"
+	_ "github.com/openshift/origin/test/extended/extension"
 	_ "github.com/openshift/origin/test/extended/idling"
 	_ "github.com/openshift/origin/test/extended/image_ecosystem"
 	_ "github.com/openshift/origin/test/extended/imageapis"

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -779,6 +779,10 @@ var Annotations = map[string]string{
 
 	"[sig-ci] [Early] prow job name should match security mode": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-ci] [OTE] OpenShift Tests Extension [Suite:openshift/ote] should support tests that succeed": "",
+
+	"[sig-ci] [OTE] OpenShift Tests Extension [Suite:openshift/ote] should support tests with an informing lifecycle": "",
+
 	"[sig-cli] oc --request-timeout works as expected [apigroup:apps.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-cli] oc --request-timeout works as expected for deployment": " [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
* Adds support for non-terminal test failures (lifecycle = informing is the only currrent one)
* Adds a test suite for OTE (will be used in jobs I'll create later)


```
$ ./openshift-tests run openshift/ote --junit-dir /tmp/junit
[...]
Informing test failures that don't prevent the overall suite from passing:

	* [sig-ci] [OTE] OpenShift Tests Extension should support tests with an informing lifecycle

Writing JUnit report to /tmp/junit/junit_e2e__20250827-142903.xml

Writing extension test results JSON to /tmp/junit/extension_test_result_e2e__20250827-142903.json
1 informing failures, 1 pass, 0 skip (11s): suite passes despite failures
```