### PR TITLE
[WIP] Revert "OCPNODE-3004: Run ImageVolume tests in all clusters."

### DIFF
--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -30,11 +30,9 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 	)
 
 	g.BeforeEach(func() {
-		// Microshift doesn't inherit OCP feature gates, and ImageVolume won't work either
-		isMicroshift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if isMicroshift {
-			g.Skip("Not supported on Microshift")
+		// Skip if ImageVolume feature is not enabled
+		if !exutil.IsTechPreviewNoUpgrade(context.TODO(), oc.AdminConfigClient()) {
+			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
 		}
 	})
 


### PR DESCRIPTION
Reverts openshift/origin#30122

Floating a revert to see if it helps metal IPv6 jobs