### PR TITLE
Restore retry for the flaky conntrack UDP test

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -160,9 +160,10 @@ func shouldRetryTest(ctx context.Context, test *testCase, permittedRetryImageTag
 	// were actually flaky and nobody knew. We attempted to fix these, a few did not make it in time. Restore
 	// retries for specific test names so the overall suite can continue to not retry.
 	retryTestNames := []string{
-		"[sig-instrumentation] Metrics should grab all metrics from kubelet /metrics/resource endpoint [Suite:openshift/conformance/parallel] [Suite:k8s]", // https://issues.redhat.com/browse/OCPBUGS-57477
-		"[sig-network] Services should be rejected for evicted pods (no endpoints exist) [Suite:openshift/conformance/parallel] [Suite:k8s]",               // https://issues.redhat.com/browse/OCPBUGS-57665
-		"[sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal [Suite:openshift/conformance/parallel] [Suite:k8s]",              // https://issues.redhat.com/browse/OCPBUGS-57658
+		"[sig-instrumentation] Metrics should grab all metrics from kubelet /metrics/resource endpoint [Suite:openshift/conformance/parallel] [Suite:k8s]",                // https://issues.redhat.com/browse/OCPBUGS-57477
+		"[sig-network] Services should be rejected for evicted pods (no endpoints exist) [Suite:openshift/conformance/parallel] [Suite:k8s]",                              // https://issues.redhat.com/browse/OCPBUGS-57665
+		"[sig-node] Pods Extended Pod Container lifecycle evicted pods should be terminal [Suite:openshift/conformance/parallel] [Suite:k8s]",                             // https://issues.redhat.com/browse/OCPBUGS-57658
+		"[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service [Suite:openshift/conformance/parallel] [Suite:k8s]", // https://issues.redhat.com/browse/OCPBUGS-59496
 	}
 	for _, rtn := range retryTestNames {
 		if test.name == rtn {


### PR DESCRIPTION
A new test case, "[sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service", is added to the list of tests that are retried on failure. This is to mitigate the impact of a known flake in this test.

OCPBUGS-59496