### PR TITLE
OCPBUGS-60881: Exclude RHEL nodes in verifying that nodes have no unexpected reboots test

### DIFF
--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -117,8 +117,10 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 	g.It("should verify that nodes have no unexpected reboots [Late]", func() {
 		ctx := context.Background()
 
-		// List all nodes
-		nodes, err := oc.KubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		// List all non-RHEL nodes
+		nodes, err := oc.KubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: "node.openshift.io/os_id!=rhel",
+		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(nodes.Items).NotTo(o.HaveLen(0))
 


### PR DESCRIPTION
`[sig-node] Managed cluster should verify that nodes have no unexpected reboots [Late] [Suite:openshift/conformance/parallel]` permafailing in 4.18-e2e-aws-ovn-workers-rhel8 jobs:

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-aws-ovn-workers-rhel8/1960162804954566656

RHEL nodes are not totally managed by the MCO, so there would be rebooting happened without rebootRequest event, so skipping RHEL node in this test.