### PR TITLE
CNTRLPLANE-945: monitor: auditloganalyzer: update watch channels count behavior

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -175,7 +175,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("etcd-log-analyzer", "etcd", etcdloganalyzer.NewEtcdLogAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-etcd-invariants", "etcd", legacyetcdmonitortests.NewLegacyTests())
 
-	monitorTestRegistry.AddMonitorTestOrDie("audit-log-analyzer", "kube-apiserver", auditloganalyzer.NewAuditLogAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("audit-log-analyzer", "kube-apiserver", auditloganalyzer.NewAuditLogAnalyzer(info))
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-kube-apiserver-invariants", "kube-apiserver", legacykubeapiservermonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("graceful-shutdown-analyzer", "kube-apiserver", apiservergracefulrestart.NewGracefulShutdownAnalyzer())
 

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking_test.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking_test.go
@@ -1,16 +1,23 @@
 package auditloganalyzer
 
 import (
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/stretchr/testify/assert"
 	authnv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	"testing"
-	"time"
 )
 
 func Test_WatchCountTrackerEventHandler(t *testing.T) {
-	handler := NewWatchCountTracking()
+	info := monitortestframework.MonitorTestInitializationInfo{
+		ClusterStabilityDuringTest: monitortestframework.Stable,
+	}
+	handler := NewWatchCountTracking(info)
 	mTime := metav1.NewMicroTime(time.Now())
 
 	// auditEvent.Verb != "watch" || auditEvent.Stage != auditv1.StageResponseComplete || !strings.HasSuffix(auditEvent.User.Username, "-operator")
@@ -69,4 +76,93 @@ func Test_WatchCountTrackerEventHandler(t *testing.T) {
 	assert.Equal(t, 1, len(watchRequestCounts))
 	assert.Equal(t, int64(2), watchRequestCounts[0].Count)
 	assert.Equal(t, "testNode", watchRequestCounts[0].NodeName)
+}
+
+func Test_boundsChecker(t *testing.T) {
+	bounds := map[string]int64{
+		"test-operator": 100,
+	}
+
+	operatorName := "system:serviceaccount:test-namespace:test-operator"
+
+	type testcase struct {
+		name         string
+		stability    monitortestframework.ClusterStabilityDuringTest
+		requestCount *RequestCount
+		err          error
+	}
+
+	testcases := []testcase{
+		{
+			name:      "stable cluster, requests does not exceed limit, no error",
+			stability: monitortestframework.Stable,
+			requestCount: &RequestCount{
+				Count:    150,
+				Operator: operatorName,
+			},
+			err: nil,
+		},
+		{
+			name:      "stable cluster, requests does exceed limit, error",
+			stability: monitortestframework.Stable,
+			requestCount: &RequestCount{
+				Count:    250,
+				Operator: operatorName,
+			},
+			err: errors.New("watchrequestcount=250, upperbound=200, ratio=1.25"),
+		},
+		{
+			name:      "disruptive cluster, requests does not exceed base limit, no error",
+			stability: monitortestframework.Disruptive,
+			requestCount: &RequestCount{
+				Count:    150,
+				Operator: operatorName,
+			},
+			err: nil,
+		},
+		{
+			name:      "disruptive cluster, requests does exceed base limit but falls within additional grace buffer, no error",
+			stability: monitortestframework.Disruptive,
+			requestCount: &RequestCount{
+				Count:    215,
+				Operator: operatorName,
+			},
+			err: nil,
+		},
+		{
+			name:      "disruptive cluster, requests does exceed limits with additional grace buffer, error",
+			stability: monitortestframework.Disruptive,
+			requestCount: &RequestCount{
+				Count:    300,
+				Operator: operatorName,
+			},
+			err: errors.New("watchrequestcount=300, upperbound=220, ratio=1.36"),
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			checker := boundsChecker{
+				Bounds: bounds,
+				// Platform doesn't matter for testing purposes, just set it to an arbitrary one.
+				Platform:         v1.AWSPlatformType,
+				ClusterStability: tc.stability,
+				UpperBoundMultiple: upperBoundMultiple{
+					Base:                  2.0,
+					DisruptiveGraceFactor: 0.2,
+				},
+			}
+
+			err := checker.ensureBoundNotExceeded(tc.requestCount)
+
+			switch {
+			case err != nil && tc.err != nil && err.Error() != tc.err.Error():
+				t.Fatalf("received error %v does not match expected error %v", err, tc.err)
+			case err != nil && tc.err == nil:
+				t.Fatalf("received error %v when no error was expected", err)
+			case err == nil && tc.err != nil:
+				t.Fatalf("no error received when error %v was expected", tc.err)
+			}
+		})
+	}
 }

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -37,14 +37,14 @@ type auditLogAnalyzer struct {
 	countsForInstall *CountsForRun
 }
 
-func NewAuditLogAnalyzer() monitortestframework.MonitorTest {
+func NewAuditLogAnalyzer(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
 	return &auditLogAnalyzer{
 		summarizer:                    NewAuditLogSummarizer(),
 		excessiveApplyChecker:         CheckForExcessiveApplies(),
 		invalidRequestsChecker:        CheckForInvalidMutations(),
 		requestsDuringShutdownChecker: CheckForRequestsDuringShutdown(),
 		violationChecker:              CheckForViolations(),
-		watchCountTracking:            NewWatchCountTracking(),
+		watchCountTracking:            NewWatchCountTracking(info),
 		latencyChecker:                CheckForLatency(),
 	}
 }


### PR DESCRIPTION
to better accommodate disruptive testing behavior, by adding a "disruptive job grace factor" to the upper bounds calculation.
When disruptive tests are run, it is possible that the Kubernetes API server undergoes revision rollouts which may cause an expected increase in watch requests being issued by platform operators.

We encountered this in various jobs for the ExternalOIDC feature we are creating tests for that is known to be a highly disruptive set of tests that triggers many revision rollouts (>20) due to the nature of how the feature is configured and the existing limitations of the `openshift-tests` binary not being able to share setup and teardown logic between individual test cases.

Example jobs:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1958846390285111296
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1959933892798451712
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-rollback-techpreview/1959571172710420480
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1959933892798451712