### PR TITLE
CNTRLPLANE-945: monitor: auditloganalyzer: skip watch channels processing when cluster stability is explicitly marked as `Disruptive`

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -175,7 +175,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("etcd-log-analyzer", "etcd", etcdloganalyzer.NewEtcdLogAnalyzer())
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-etcd-invariants", "etcd", legacyetcdmonitortests.NewLegacyTests())
 
-	monitorTestRegistry.AddMonitorTestOrDie("audit-log-analyzer", "kube-apiserver", auditloganalyzer.NewAuditLogAnalyzer())
+	monitorTestRegistry.AddMonitorTestOrDie("audit-log-analyzer", "kube-apiserver", auditloganalyzer.NewAuditLogAnalyzer(info))
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-kube-apiserver-invariants", "kube-apiserver", legacykubeapiservermonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("graceful-shutdown-analyzer", "kube-apiserver", apiservergracefulrestart.NewGracefulShutdownAnalyzer())
 


### PR DESCRIPTION
When disruptive tests are run, it is possible that the Kubernetes API server undergoes revision rollouts which may cause an expected increase in watch requests being issued by platform operators.

We encountered this in various jobs for the ExternalOIDC feature we are creating tests for that is known to be a highly disruptive set of tests that triggers many revision rollouts (>20) due to the nature of how the feature is configured and the existing limitations of the `openshift-tests` binary not being able to share setup and teardown logic between individual test cases.

Example jobs:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1958846390285111296
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1959933892798451712
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-rollback-techpreview/1959571172710420480
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-cluster-authentication-operator-release-4.20-periodics-e2e-gcp-external-oidc-configure-techpreview/1959933892798451712