### PR TITLE
OCPBUGS-60881: extended/machines: add --no-pager to journalctl cmds

### DIFF
--- a/test/extended/machines/display_reboots_pod.yaml
+++ b/test/extended/machines/display_reboots_pod.yaml
@@ -11,7 +11,7 @@ spec:
     - command: ['/bin/bash', '-ec']
       args:
         - |
-          chroot /host-root journalctl --list-boots
+          chroot /host-root journalctl --list-boots --no-pager
       image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       name: list-boots
       terminationMessagePolicy: FallbackToLogsOnError
@@ -24,7 +24,7 @@ spec:
     - command: ['/bin/bash', '-ec']
       args:
         - |
-          chroot /host-root journalctl -o short-iso -t 'systemd-logind' -g "rebooting" -q || true
+          chroot /host-root journalctl -o short-iso -t 'systemd-logind' -g "rebooting" -q --no-pager || true
       image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
       name: reboots
       terminationMessagePolicy: FallbackToLogsOnError


### PR DESCRIPTION
When trying to determine what's different between RHEL8 and RHEL9 I stumbled across the fact that if the terminal is narrow you'll get a unicode emdash which may be the extra character we're seeing. This assumes that for some reason the terminal in a pod running on RHEL8 is more narrow than that on RHEL9.