### PR TITLE
WIP: Mark ImageStreamImportMode tests as disruptive

### DIFF
--- a/test/extended/images/tagimportmode.go
+++ b/test/extended/images/tagimportmode.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/operator"
 )
 
-var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial] ImageStream API", func() {
+var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive] ImageStream API", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 
@@ -64,9 +64,6 @@ func changeImportModeAndWaitForApiServer(ctx context.Context, t g.GinkgoTInterfa
 
 func TestImageStreamImportMode(t g.GinkgoTInterface, oc *exutil.CLI) {
 	ctx := context.Background()
-	if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
-		g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-	}
 
 	// Check desired.Architecture in the CV
 	configClient, err := configclient.NewForConfig(oc.AdminConfig())
@@ -104,12 +101,9 @@ func TestImageStreamImportMode(t g.GinkgoTInterface, oc *exutil.CLI) {
 
 func TestImageConfigImageStreamImportModeLegacy(t g.GinkgoTInterface, oc *exutil.CLI) {
 	ctx := context.Background()
-	if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
-		g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-	}
-	if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
+	/*if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
 		g.Skip("skipping this test for SNO as it involves an openshift-apiserver disruption")
-	}
+	}*/
 
 	clusterAdminConfigClient := oc.AdminConfigClient().ConfigV1()
 	imageConfig, err := clusterAdminConfigClient.Images().Get(ctx, "cluster", metav1.GetOptions{})
@@ -157,12 +151,9 @@ func TestImageConfigImageStreamImportModeLegacy(t g.GinkgoTInterface, oc *exutil
 
 func TestImageConfigImageStreamImportModePreserveOriginal(t g.GinkgoTInterface, oc *exutil.CLI) {
 	ctx := context.Background()
-	if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
-		g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-	}
-	if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
+	/*if isSNO, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient()); err == nil && isSNO {
 		g.Skip("skipping this test for SNO as it involves an openshift-apiserver disruption")
-	}
+	}*/
 
 	clusterAdminConfigClient := oc.AdminConfigClient().ConfigV1()
 	imageConfig, err := clusterAdminConfigClient.Images().Get(ctx, "cluster", metav1.GetOptions{})

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1403,11 +1403,11 @@ var Annotations = map[string]string{
 
 	"[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][apigroup:imageregistry.operator.openshift.io] Image Registry Config ChunkSizeMiB should set minimum valid ChunkSizeMiB value": " [Suite:openshift/conformance/serial]",
 
-	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial] ImageStream API import mode should be Legacy if the import mode specified in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]": " [Suite:openshift/conformance/serial]",
+	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive] ImageStream API import mode should be Legacy if the import mode specified in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]": " [Serial]",
 
-	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial] ImageStream API import mode should be PreserveOriginal if the import mode specified in image.config.openshift.io config is PreserveOriginal [apigroup:image.openshift.io]": " [Suite:openshift/conformance/serial]",
+	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive] ImageStream API import mode should be PreserveOriginal if the import mode specified in image.config.openshift.io config is PreserveOriginal [apigroup:image.openshift.io]": " [Serial]",
 
-	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial] ImageStream API import mode should be PreserveOriginal or Legacy depending on desired.architecture field in the CV [apigroup:image.openshift.io]": " [Suite:openshift/conformance/serial]",
+	"[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive] ImageStream API import mode should be PreserveOriginal or Legacy depending on desired.architecture field in the CV [apigroup:image.openshift.io]": " [Serial]",
 
 	"[sig-imageregistry][Serial] Image signature workflow can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]": " [Skipped:Disconnected] [Suite:openshift/conformance/serial]",
 

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -464,13 +464,13 @@ spec:
     - testName: '[sig-cluster-lifecycle][OCPFeatureGate:ImageStreamImportMode] ClusterVersion
         API desired architecture should be valid when architecture is set in release
         payload metadata [apigroup:config.openshift.io]'
-    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial]
+    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive]
         ImageStream API import mode should be Legacy if the import mode specified
         in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]'
-    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial]
+    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive]
         ImageStream API import mode should be PreserveOriginal if the import mode
         specified in image.config.openshift.io config is PreserveOriginal [apigroup:image.openshift.io]'
-    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Serial]
+    - testName: '[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Suite:openshift/conformance/serial][Disruptive]
         ImageStream API import mode should be PreserveOriginal or Legacy depending
         on desired.architecture field in the CV [apigroup:image.openshift.io]'
   - featureGate: ImageVolume


### PR DESCRIPTION
As they trigger a rollout of the openshift apiserver