### PR TITLE
MCO-1828: Fix pathological tests for disruptive suite

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -199,7 +199,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("additional-events-collector", "Test Framework", additionaleventscollector.NewIntervalSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("known-image-checker", "Test Framework", knownimagechecker.NewEnsureValidImages())
 	monitorTestRegistry.AddMonitorTestOrDie("e2e-test-analyzer", "Test Framework", e2etestanalyzer.NewAnalyzer())
-	monitorTestRegistry.AddMonitorTestOrDie("event-collector", "Test Framework", watchevents.NewEventWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("event-collector", "Test Framework", watchevents.NewEventWatcher(info))
 	monitorTestRegistry.AddMonitorTestOrDie("clusteroperator-collector", "Test Framework", watchclusteroperators.NewOperatorWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("initial-and-final-operator-log-scraper", "Test Framework", operatorloganalyzer.InitialAndFinalOperatorLogScraper())
 	monitorTestRegistry.AddMonitorTestOrDie("lease-checker", "Test Framework", operatorloganalyzer.OperatorLeaseCheck())

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 	"github.com/sirupsen/logrus"
 
@@ -21,8 +22,12 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func TestDuplicatedEventForUpgrade(events monitorapi.Intervals, kubeClientConfig *rest.Config) []*junitapi.JUnitTestCase {
-	registry := NewUpgradePathologicalEventMatchers(kubeClientConfig, events)
+func TestDuplicatedEventForUpgrade(
+	events monitorapi.Intervals,
+	kubeClientConfig *rest.Config,
+	clusterStabilityDuringTest *monitortestframework.ClusterStabilityDuringTest,
+) []*junitapi.JUnitTestCase {
+	registry := NewUpgradePathologicalEventMatchers(kubeClientConfig, events, clusterStabilityDuringTest)
 
 	evaluator := duplicateEventsEvaluator{
 		registry: registry,
@@ -43,8 +48,12 @@ func TestDuplicatedEventForUpgrade(events monitorapi.Intervals, kubeClientConfig
 	return tests
 }
 
-func TestDuplicatedEventForStableSystem(events monitorapi.Intervals, clientConfig *rest.Config) []*junitapi.JUnitTestCase {
-	registry := NewUniversalPathologicalEventMatchers(clientConfig, events)
+func TestDuplicatedEventForStableSystem(
+	events monitorapi.Intervals,
+	clientConfig *rest.Config,
+	clusterStabilityDuringTest *monitortestframework.ClusterStabilityDuringTest,
+) []*junitapi.JUnitTestCase {
+	registry := NewUniversalPathologicalEventMatchers(clientConfig, events, clusterStabilityDuringTest)
 
 	evaluator := duplicateEventsEvaluator{
 		registry: registry,

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_disruptive.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_disruptive.go
@@ -1,0 +1,100 @@
+package pathologicaleventlibrary
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/sirupsen/logrus"
+)
+
+type DisruptivePeriod struct {
+	start time.Time
+	end   time.Time
+}
+
+func (p *DisruptivePeriod) In(interval monitorapi.Interval) bool {
+	return interval.From.After(p.start) && interval.To.Before(p.end)
+}
+
+func (p *DisruptivePeriod) String() string {
+	return fmt.Sprintf("Disruptive Period from %s to %s", p.start.Format(time.RFC3339Nano), p.end.Format(time.RFC3339Nano))
+}
+
+type DisruptivePeriodList []DisruptivePeriod
+
+func (l *DisruptivePeriodList) GetMatchingPeriod(interval monitorapi.Interval) *DisruptivePeriod {
+	for _, disruptionPeriod := range *l {
+		if disruptionPeriod.In(interval) {
+			return &disruptionPeriod
+		}
+	}
+	return nil
+}
+
+type DisruptionAwarePathologicalEventMatcher struct {
+	// delegate is a normal event matcher.
+	delegate *SimplePathologicalEventMatcher
+
+	disruptivePeriodList DisruptivePeriodList
+}
+
+func (ade *DisruptionAwarePathologicalEventMatcher) Name() string {
+	return ade.delegate.Name()
+}
+
+func (ade *DisruptionAwarePathologicalEventMatcher) Matches(i monitorapi.Interval) bool {
+	return ade.delegate.Matches(i)
+}
+
+func (ade *DisruptionAwarePathologicalEventMatcher) Allows(i monitorapi.Interval, topology v1.TopologyMode) bool {
+
+	// Check the delegate matcher first, if it matches, proceed to additional checks
+	if !ade.delegate.Allows(i, topology) {
+		return false
+	}
+
+	// Match the pathological event if it happens in-between a disruption period
+	disruptionPeriod := ade.disruptivePeriodList.GetMatchingPeriod(i)
+	if disruptionPeriod != nil {
+		logrus.Infof("ignoring %s pathological event as they fall within range of the disruption period: %s", i, disruptionPeriod)
+		return true
+	}
+
+	return false
+}
+
+func NewDisruptivePeriodList(startMatcher EventMatcher, stopMatcher EventMatcher, events monitorapi.Intervals) DisruptivePeriodList {
+	periods := DisruptivePeriodList{}
+	var currentPeriod *DisruptivePeriod
+	for _, event := range events {
+		if startMatcher.Matches(event) {
+			currentPeriod = &DisruptivePeriod{
+				start: event.From,
+			}
+		} else if stopMatcher.Matches(event) {
+			if currentPeriod != nil {
+				currentPeriod.end = event.To
+				periods = append(periods, *currentPeriod)
+			}
+			currentPeriod = nil
+		}
+	}
+	return periods
+}
+
+func NewDisruptivePeriodListCordonedPeriods(events monitorapi.Intervals) DisruptivePeriodList {
+	startMatcher := &SimplePathologicalEventMatcher{
+		name:               "CordonStartMatcher",
+		messageReasonRegex: regexp.MustCompile(`^Cordon$`),
+		messageHumanRegex:  regexp.MustCompile(`^Cordoned node to apply update$`),
+	}
+	stopMatcher := &SimplePathologicalEventMatcher{
+		name:               "CordonStartMatcher",
+		messageReasonRegex: regexp.MustCompile(`^Uncordon$`),
+		messageHumanRegex:  regexp.MustCompile(`and node has been uncordoned$`),
+	}
+	return NewDisruptivePeriodList(startMatcher, stopMatcher, events)
+}

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -176,7 +176,7 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		registry := NewUpgradePathologicalEventMatchers(nil, nil)
+		registry := NewUpgradePathologicalEventMatchers(nil, nil, nil)
 		t.Run(test.name, func(t *testing.T) {
 			i := monitorapi.Interval{
 				Condition: monitorapi.Condition{
@@ -387,7 +387,7 @@ func TestPathologicalEventsWithNamespaces(t *testing.T) {
 			events := monitorapi.Intervals(test.intervals)
 
 			// Using upgrade for now, this has everything:
-			registry := NewUpgradePathologicalEventMatchers(nil, test.intervals)
+			registry := NewUpgradePathologicalEventMatchers(nil, test.intervals, nil)
 
 			evaluator := duplicateEventsEvaluator{
 				registry: registry,
@@ -645,7 +645,7 @@ func TestPathologicalEventsTopologyAwareHintsDisabled(t *testing.T) {
 
 			events := monitorapi.Intervals(test.intervals)
 			evaluator := duplicateEventsEvaluator{
-				registry: NewUniversalPathologicalEventMatchers(nil, events),
+				registry: NewUniversalPathologicalEventMatchers(nil, events, nil),
 			}
 
 			testName := "events should not repeat"

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/monitortest.go
@@ -57,11 +57,11 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
-		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForUpgrade(finalIntervals, w.adminRESTConfig)...)
+		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForUpgrade(finalIntervals, w.adminRESTConfig, w.clusterStabilityDuringTest)...)
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringUpgrade, jobType, w.clusterStabilityDuringTest,
 			w.adminRESTConfig, w.duration, w.recordedResources)...)
 	} else {
-		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForStableSystem(finalIntervals, w.adminRESTConfig)...)
+		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForStableSystem(finalIntervals, w.adminRESTConfig, w.clusterStabilityDuringTest)...)
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringConformance, jobType, w.clusterStabilityDuringTest,
 			w.adminRESTConfig, w.duration, w.recordedResources)...)
 	}

--- a/pkg/monitortests/testframework/watchevents/event_test.go
+++ b/pkg/monitortests/testframework/watchevents/event_test.go
@@ -145,7 +145,7 @@ func Test_recordAddOrUpdateEvent(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			significantlyBeforeNow := now.UTC().Add(-15 * time.Minute)
-			recordAddOrUpdateEvent(tt.args.ctx, tt.args.m, "", nil, significantlyBeforeNow, tt.args.kubeEvent)
+			recordAddOrUpdateEvent(tt.args.ctx, tt.args.m, "", nil, significantlyBeforeNow, tt.args.kubeEvent, nil)
 			intervals := tt.args.m.Intervals(now.Add(-10*time.Minute), now.Add(10*time.Minute))
 			assert.Equal(t, 1, len(intervals))
 			interval := intervals[0]

--- a/pkg/monitortests/testframework/watchevents/monitortest.go
+++ b/pkg/monitortests/testframework/watchevents/monitortest.go
@@ -13,10 +13,11 @@ import (
 )
 
 type eventWatcher struct {
+	info monitortestframework.MonitorTestInitializationInfo
 }
 
-func NewEventWatcher() monitortestframework.MonitorTest {
-	return &eventWatcher{}
+func NewEventWatcher(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
+	return &eventWatcher{info: info}
 }
 
 func (w *eventWatcher) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
@@ -29,7 +30,7 @@ func (w *eventWatcher) StartCollection(ctx context.Context, adminRESTConfig *res
 		return err
 	}
 
-	startEventMonitoring(ctx, recorder, adminRESTConfig, kubeClient)
+	startEventMonitoring(ctx, recorder, adminRESTConfig, kubeClient, w.info)
 
 	return nil
 }


### PR DESCRIPTION
This commit adds a behavior change to the way matchers work to allow some matchers to apply during "disruptive periods" in disruptive runs. During disruptive periods (delimited by start-end matchers) a new type of matcher can target a given set of events to "skip" its occurence.