### PR TITLE
Fix Node NotReady intervals being left open when a node is deleted

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -223,6 +223,7 @@ const (
 	NodeFailedLeaseBackoff IntervalReason = "FailedToUpdateLeaseInBackoff"
 	NodeDiskPressure       IntervalReason = "NodeDiskPressure"
 	NodeNoDiskPressure     IntervalReason = "NodeNoDiskPressure"
+	NodeDeleted            IntervalReason = "Deleted"
 
 	MachineConfigChangeReason  IntervalReason = "MachineConfigChange"
 	MachineConfigReachedReason IntervalReason = "MachineConfigReached"

--- a/pkg/monitortests/node/nodestateanalyzer/node.go
+++ b/pkg/monitortests/node/nodestateanalyzer/node.go
@@ -61,7 +61,7 @@ func intervalsFromEvents_NodeChanges(events monitorapi.Intervals, _ monitorapi.R
 			if event.Source == monitorapi.SourceNodeMonitor {
 				nodeStateTracker.OpenInterval(nodeLocator, notReadyState, event.From)
 			}
-		case "Ready":
+		case "Ready", monitorapi.NodeDeleted:
 			if event.Source == monitorapi.SourceNodeMonitor {
 				mb := monitorapi.NewMessage().Reason(monitorapi.NodeNotReadyReason).
 					HumanMessage("node is not ready").

--- a/pkg/monitortests/node/watchnodes/node.go
+++ b/pkg/monitortests/node/watchnodes/node.go
@@ -278,6 +278,7 @@ func startNodeMonitoring(ctx context.Context, m monitorapi.RecorderWriter, clien
 						WithAnnotations(map[monitorapi.AnnotationKey]string{
 							monitorapi.AnnotationRoles: nodeRoles(node),
 						}).
+						Reason(monitorapi.NodeDeleted).
 						HumanMessage("deleted")).
 					Build(now, now)
 				m.AddIntervals(i)


### PR DESCRIPTION
Some tests stand up nodes, if they are deleted while not ready, the not
ready intervals stay open until the end of the job, causing a misleading
chart.
