### PR TITLE
OCPBUGS-61229: images/tests: Remove rteval

### DIFF
--- a/images/tests/Dockerfile.rhel
+++ b/images/tests/Dockerfile.rhel
@@ -9,7 +9,7 @@ FROM registry.ci.openshift.org/ocp/4.15:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
 RUN PACKAGES="git gzip util-linux" && \
     if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
-    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES rt-tests rteval"; fi && \
+    if [ $HOSTTYPE = x86_64 ]; then PACKAGES="$PACKAGES rt-tests"; fi && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && \
     yum update -y python3-six && \
     yum clean all && rm -rf /var/cache/yum/* && \


### PR DESCRIPTION
It was added and to be used by realtime tests however that's never happened and this package pulls in 80+ dependencies and ~350MiB