### PR TITLE
OCPBUGS-61193: Limit connection timeout by 10s to access Prometheus targets

### DIFF
--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -302,7 +302,7 @@ func ExpectURLStatusCodeExecViaPod(ns, execPodName, url string, statusCodes ...i
 // URLStatusCodeExecViaPod attempts connection to url via exec pod and returns the status code
 // or an error if any errors happens during the process.
 func URLStatusCodeExecViaPod(ns, name, url string) (int, error) {
-	cmd := fmt.Sprintf("curl -k -s -o /dev/null -w '%%{http_code}' %q", url)
+	cmd := fmt.Sprintf("curl -k -s -o /dev/null -w '%%{http_code}' --connect-timeout 10 %q", url)
 	output, err := e2eoutput.RunHostCmd(ns, name, cmd)
 	if err != nil {
 		return 0, fmt.Errorf("host command failed: %v\n%s", err, output)


### PR DESCRIPTION
Checked a few failures, and they all have the pattern that the `curl` cmd failed with exit code 28 after about `2m10s`. The following is an example taken from [1]:

```text
I0828 11:58:41.027782 24213 prometheus.go:122] Checking via pod exec status code from the scrape url https://192.168.111.26:9100/metrics for pod openshift-monitoring/node-exporter-rth5k without authorization (skip=false)
I0828 11:58:41.027888 24213 builder.go:121] Running '/usr/bin/kubectl --server=https://api.ostest.test.metalkube.org:6443 --kubeconfig=/tmp/secret/kubeconfig --namespace=e2e-test-prometheus-bsgj5 exec execpod-targets-authorization -- /bin/sh -x -c curl -k -s -o /dev/null -w '%{http_code}' "https://192.168.111.26:9100/metrics"'
I0828 12:00:51.536294 24213 builder.go:135] rc: 28
I0828 12:00:51.536363 24213 prometheus.go:125] The scrape url https://192.168.111.26:9100/metrics for pod openshift-monitoring/node-exporter-rth5k without authorization returned 0, host command failed: error running /usr/bin/kubectl --server=https://api.ostest.test.metalkube.org:6443 --kubeconfig=/tmp/secret/kubeconfig --namespace=e2e-test-prometheus-bsgj5 exec execpod-targets-authorization -- /bin/sh -x -c curl -k -s -o /dev/null -w '%{http_code}' "https://192.168.111.26:9100/metrics":
Command stdout:
000
stderr:
+ curl -k -s -o /dev/null -w '%{http_code}' https://192.168.111.26:9100/metrics
command terminated with exit code 28

error:
exit status 28
000 (skip=false)
```

As the execution took too long so that it used up all the budget (`1m`) to retry [2].

The pull adds `--connect-timeout 10` [3] into the curl cmd, expecting it to fail earlier in those cases.

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-metal-ipi-ovn-serial-ipv4/1960965234776608768

[2]. https://github.com/openshift/origin/blob/255dd87f45d3bda1ee9350dd21aed4c715be3ecb/test/extended/prometheus/prometheus.go#L123

[3]. https://curl.se/docs/manpage.html#--connect-timeout