### PR TITLE
OCPBUGS-61224: Create flake test to catch router health check failure while haproxy …

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
@@ -49,6 +49,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, TestMultipleSingleSecondDisruptions(finalIntervals, w.adminRESTConfig)...)
 	junits = append(junits, testDNSOverlapDisruption(finalIntervals)...)
 	junits = append(junits, testNoTooManyNetlinkEventLogs(finalIntervals)...)
+	junits = append(junits, testRouterHealthCheckFailureWhenHAProxyUP(finalIntervals)...)
 
 	return junits, nil
 }


### PR DESCRIPTION
…is up