### PR TITLE
NO-JIRA: Add intervals and a test for systemd-coredumps

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -272,7 +272,8 @@ const (
 	ReasonHighGeneration    IntervalReason = "HighGeneration"
 	ReasonInvalidGeneration IntervalReason = "GenerationViolation"
 
-	ReasonEtcdBootstrap IntervalReason = "EtcdBootstrap"
+	ReasonEtcdBootstrap     IntervalReason = "EtcdBootstrap"
+	ReasonProcessDumpedCore IntervalReason = "ProcessDumpedCore"
 )
 
 type AnnotationKey string
@@ -358,6 +359,7 @@ const (
 	SourceUnexpectedReady           IntervalSource = "NodeUnexpectedNotReady"
 	SourceUnreachable               IntervalSource = "NodeUnreachable"
 	SourceKubeletLog                IntervalSource = "KubeletLog"
+	SourceSystemdCoreDumpLog        IntervalSource = "SystemdCoreDumpLog"
 	SourcePodLog                    IntervalSource = "PodLog"
 	SourceEtcdLog                   IntervalSource = "EtcdLog"
 	SourceEtcdLeadership            IntervalSource = "EtcdLeadership"


### PR DESCRIPTION
In https://issues.redhat.com/browse/OCPBUGS-61224 we found haproxy is core dumping right before we get disruption. Scanning journals for systemd-coredump lines seems like a good idea. 

Flake only for now, who knows what this might pick up initially.

Assisted-by: Cursor AI