### PR TITLE
OCPBUGS-61398: fix(test): prevent nil pointer dereference in ginkgo test runner

### DIFF
--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -3,6 +3,7 @@ package ginkgo
 import (
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"sync"
 )
@@ -37,6 +38,11 @@ func (s *testSuiteProgress) LogTestStart(out io.Writer, testName string) {
 func (s *testSuiteProgress) TestEnded(testName string, testRunResult *testRunResultHandle) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+
+	if testRunResult == nil {
+		fmt.Fprintln(os.Stderr, "testRunResult is nil")
+		return
+	}
 
 	if isTestFailed(testRunResult.testState) {
 		s.failures++

--- a/pkg/test/ginkgo/test_runner.go
+++ b/pkg/test/ginkgo/test_runner.go
@@ -221,6 +221,11 @@ func recordTestResultInLogWithoutOverlap(testRunResult *testRunResultHandle, tes
 }
 
 func recordTestResultInLog(testRunResult *testRunResultHandle, out io.Writer, includeSuccessfulOutput bool) {
+	if testRunResult == nil {
+		fmt.Fprintln(os.Stderr, "testRunResult is nil")
+		return
+	}
+
 	// output the status of the test
 	switch testRunResult.testState {
 	case TestFlaked:
@@ -257,6 +262,11 @@ func recordTestResultInLog(testRunResult *testRunResultHandle, out io.Writer, in
 }
 
 func recordTestResultInMonitor(testRunResult *testRunResultHandle, monitorRecorder monitorapi.Recorder) {
+	if testRunResult == nil {
+		fmt.Fprintln(os.Stderr, "testRunResult is nil")
+		return
+	}
+
 	eventLevel := monitorapi.Warning
 
 	msg := monitorapi.NewMessage().HumanMessage("e2e test finished")


### PR DESCRIPTION
Add nil checks to recordTestResultInMonitor, recordTestResultInLog, and TestEnded functions to prevent segmentation faults when testRunResult is nil during error conditions like network connectivity issues.

This is to prevent test failures like https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-azure-aks-ovn-conformance/1967830988788600832