### PR TITLE
OCPBUGS-61196: Add test that the ServiceCIDR API is blocked

### DIFF
--- a/test/extended/networking/servicecidr.go
+++ b/test/extended/networking/servicecidr.go
@@ -1,0 +1,38 @@
+package networking
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-network] ServiceCIDR", func() {
+	oc := exutil.NewCLIWithoutNamespace("servicecidr")
+
+	g.BeforeEach(func() {
+		// The VAP is created by CNO, which doesn't run on MicroShift
+		isMicroshift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroshift {
+			g.Skip("Feature is not currently blocked on Microshift")
+		}
+	})
+
+	g.It("should be blocked", func() {
+		g.By("Trying to create a new ServiceCIDR")
+		yaml := exutil.FixturePath("testdata", "servicecidr.yaml")
+		err := oc.AsAdmin().Run("create").Args("-f", yaml).Execute()
+		if err == nil {
+			// This shouldn't have worked! We'll fail below, but delete the
+			// ServiceCIDR first because otherwise it may cause spurious
+			// failures throughout the rest of the test run.
+			_ = oc.AsAdmin().Run("delete").Args("newcidr1").Execute()
+		}
+		o.Expect(err).To(o.HaveOccurred(), "Creating a ServiceCIDR should have been blocked by ValidatingAdmissionPolicy")
+
+		g.By("Trying to modify an existing ServiceCIDR")
+		err = oc.AsAdmin().Run("annotate").Args("servicecidr", "kubernetes", "e2etest=success").Execute()
+		o.Expect(err).To(o.HaveOccurred(), "Modifying existing ServiceCIDR should have been blocked by ValidatingAdmissionPolicy")
+	})
+})

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -489,6 +489,7 @@
 // test/extended/testdata/sample-image-stream.json
 // test/extended/testdata/samplepipeline-withenvs.yaml
 // test/extended/testdata/service-serving-cert/nginx-serving-cert.conf
+// test/extended/testdata/servicecidr.yaml
 // test/extended/testdata/signer-buildconfig.yaml
 // test/extended/testdata/stable-busybox.yaml
 // test/extended/testdata/templates/crunchydata-pod.json
@@ -52437,6 +52438,30 @@ func testExtendedTestdataServiceServingCertNginxServingCertConf() (*asset, error
 	return a, nil
 }
 
+var _testExtendedTestdataServicecidrYaml = []byte(`apiVersion: networking.k8s.io/v1beta1
+kind: ServiceCIDR
+metadata:
+  name: newcidr1
+spec:
+  cidrs:
+  - 10.96.0.0/24
+`)
+
+func testExtendedTestdataServicecidrYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataServicecidrYaml, nil
+}
+
+func testExtendedTestdataServicecidrYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataServicecidrYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/servicecidr.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataSignerBuildconfigYaml = []byte(`kind: List
 apiVersion: v1
 items:
@@ -56644,6 +56669,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/sample-image-stream.json":                                                        testExtendedTestdataSampleImageStreamJson,
 	"test/extended/testdata/samplepipeline-withenvs.yaml":                                                    testExtendedTestdataSamplepipelineWithenvsYaml,
 	"test/extended/testdata/service-serving-cert/nginx-serving-cert.conf":                                    testExtendedTestdataServiceServingCertNginxServingCertConf,
+	"test/extended/testdata/servicecidr.yaml":                                                                testExtendedTestdataServicecidrYaml,
 	"test/extended/testdata/signer-buildconfig.yaml":                                                         testExtendedTestdataSignerBuildconfigYaml,
 	"test/extended/testdata/stable-busybox.yaml":                                                             testExtendedTestdataStableBusyboxYaml,
 	"test/extended/testdata/templates/crunchydata-pod.json":                                                  testExtendedTestdataTemplatesCrunchydataPodJson,
@@ -57465,6 +57491,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"service-serving-cert": {nil, map[string]*bintree{
 					"nginx-serving-cert.conf": {testExtendedTestdataServiceServingCertNginxServingCertConf, map[string]*bintree{}},
 				}},
+				"servicecidr.yaml":        {testExtendedTestdataServicecidrYaml, map[string]*bintree{}},
 				"signer-buildconfig.yaml": {testExtendedTestdataSignerBuildconfigYaml, map[string]*bintree{}},
 				"stable-busybox.yaml":     {testExtendedTestdataStableBusyboxYaml, map[string]*bintree{}},
 				"templates": {nil, map[string]*bintree{

--- a/test/extended/testdata/servicecidr.yaml
+++ b/test/extended/testdata/servicecidr.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: ServiceCIDR
+metadata:
+  name: newcidr1
+spec:
+  cidrs:
+  - 10.96.0.0/24


### PR DESCRIPTION
(Test should fail until https://github.com/openshift/cluster-network-operator/pull/2605 merges.)
