### PR TITLE
SPLAT-2337: Added OTE binary for ccm-aws

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -243,6 +243,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-etcd-operator",
 		binaryPath: "/usr/bin/cluster-etcd-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "aws-cloud-controller-manager",
+		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Added binary to the OTE of a project cloud-provider-aws.

## Acceptance criteria

Changes that must be tested with the OTE:
- https://github.com/openshift/cloud-provider-aws/pull/121 (fix OTE for AWS)
- https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/391 (CCCMO)
- https://github.com/openshift/origin/pull/30235 (this) 

The following tests must be successful executed to validate the feature with OTE:
- Run OTE binary on AWS: `/testwith openshift/origin/main/e2e-aws-ovn openshift/cloud-provider-aws#121 openshift/cluster-cloud-controller-manager-operator#391`
- Run OTE binary on GCP: `/testwith openshift/origin/main/e2e-gcp-ovn openshift/cloud-provider-aws#121 openshift/cluster-cloud-controller-manager-operator#391`
- Run OTE binary on vSphere: `/testwith openshift/origin/main/e2e-vsphere-ovn openshift/cloud-provider-aws#121 openshift/cluster-cloud-controller-manager-operator#391`

To validate the passing scenario, we are using those conditionals:
1) The OTE binary `/usr/bin/aws-cloud-controller-manager-tests-ext.gz` must be extracted by openshift-tests in the step `openshift-e2e-test` (query string: `msg="Extracted /usr/bin/aws-cloud-controller-manager-tests-ext.gz`)
2) The OTE binary must return test count in the step. (Query string `ms" binary=aws-cloud-controller-manager-tests-ext`)
    - For AWS must return 7 tests. Example: `msg="Listed 7 tests in 57.89931ms" binary=aws-cloud-controller-manager-tests-ext`
    - For other providers must return 0 tests. Example: `msg="Listed 0 tests in 52.698354ms" binary=aws-cloud-controller-manager-tests-ext`
3) The OTE binary must run successfully all tests prefixed with `[cloud-provider-aws-e2] *` on AWS, or just run regular e2e without any CCM tests on other providers.
4) The execution (pass list) must have the following test count on AWS job:
- `[cloud-provider-aws-e2e] nodes` total of 2 tests. (query: `passed: * "[cloud-provider-aws-e2e] nodes`)`
- `[cloud-provider-aws-e2e] loadbalancer` total of 5 tests.  (query: `passed: * "[cloud-provider-aws-e2e] loadbalancer`)`)

Test results:

| Platform | Job ID/Step | Results | As Expected? |
| -- | -- | -- | -- |
| aws |  [1986444266678784000][1986444266678784000] / [step][aws-step] | All checked | Yes |
| vsphere | [1986476792151543808][1986476792151543808] / [step][step-vsphere]  | All passed | Yes |
| gcp | [1986497082852118528] / [step][step-gcp] | WIP healthy install | TBD |


[1986444266678784000]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-30235-openshift-cloud-provider-aws-121-openshift-cluster-cloud-controller-manager-operator-391-e2e-aws-ovn/1986444266678784000
[aws-step]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/multi-pr-openshift-origin-30235-openshift-cloud-provider-aws-121-openshift-cluster-cloud-controller-manager-operator-391-e2e-aws-ovn/1986444266678784000/artifacts/e2e-aws-ovn/openshift-e2e-test/build-log.txt

[1986497082852118528]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-30235-openshift-cloud-provider-aws-121-openshift-cluster-cloud-controller-manager-operator-391-e2e-gcp-ovn/1986497082852118528
[step-gcp]:  TBD

[1986476792151543808]: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-30235-openshift-cloud-provider-aws-121-openshift-cluster-cloud-controller-manager-operator-391-e2e-vsphere-ovn/1986476792151543808
[step-vsphere]:  https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/multi-pr-openshift-origin-30235-openshift-cloud-provider-aws-121-openshift-cluster-cloud-controller-manager-operator-391-e2e-vsphere-ovn/1986476792151543808/artifacts/e2e-vsphere-ovn/openshift-e2e-test/build-log.txt

Related to:
- https://issues.redhat.com/browse/SPLAT-2337
- https://github.com/openshift/cloud-provider-aws/pull/117
- https://github.com/openshift/cloud-provider-aws/pull/121