### PR TITLE
Create serial fast suite

### DIFF
--- a/pkg/test/util.go
+++ b/pkg/test/util.go
@@ -1,6 +1,10 @@
 package test
 
-import "regexp"
+import (
+	"regexp"
+
+	"github.com/onsi/ginkgo/v2"
+)
 
 // ansiRegex contains a regex for stripping out ANSI control sequences. See https://github.com/acarl005/stripansi/blob/master/stripansi.go
 var ansiRegex = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
@@ -8,4 +12,10 @@ var ansiRegex = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\
 // StripANSI removes ANSI control sequences from a string.
 func StripANSI(s []byte) []byte {
 	return ansiRegex.ReplaceAll(s, []byte(""))
+}
+
+// ExtendedDuration tests are tests that do not run in "fast" suites, e.g.
+// openshift/conformance/serial/fast.
+func ExtendedDuration() ginkgo.Labels {
+	return ginkgo.Label("ExtendedDuration")
 }

--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -12,6 +12,8 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/test/library"
+
+	"github.com/openshift/origin/pkg/test"
 	exutil "github.com/openshift/origin/test/extended/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func() {
+var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", test.ExtendedDuration(), func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-hardware-speed").AsAdmin()
 

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -10,9 +10,9 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	mcClient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	"github.com/openshift/origin/pkg/test"
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +63,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][Suite:o
 		}
 	})
 
-	g.It("All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]", test.ExtendedDuration(), func() {
 		// Skip this test on single node and two-node platforms since custom MCPs are not supported
 		// for clusters with only a master MCP
 		skipOnSingleNodeTopology(oc)

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -9,6 +9,7 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	"github.com/openshift/origin/pkg/test"
 	bmhelper "github.com/openshift/origin/test/extended/baremetal"
 	"github.com/stretchr/objx"
 	corev1 "k8s.io/api/core/v1"
@@ -221,7 +222,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	// provisioning the new host, while it could take approx another 10 minutes for deprovisioning
 	// and deleting it. The extra timeout amount should be enough to cover future slower execution
 	// environments.
-	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", func() {
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", test.ExtendedDuration(), func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -23,6 +23,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	cloudnetwork "github.com/openshift/client-go/cloudnetwork/clientset/versioned"
 
+	"github.com/openshift/origin/pkg/test"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -346,7 +347,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 		})
 
 		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
-		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", func() {
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", test.ExtendedDuration(), func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -7,15 +7,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	kapierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/storage/names"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/skipper"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	"github.com/openshift/origin/pkg/test"
 	exutil "github.com/openshift/origin/test/extended/util"
-	"k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
 var _ = Describe("[sig-network] services", func() {
@@ -23,7 +23,7 @@ var _ = Describe("[sig-network] services", func() {
 	var retryInterval = 1 * time.Minute
 
 	InIPv4ClusterContext(oc, func() {
-		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", func() {
+		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", test.ExtendedDuration(), func() {
 			// Check if the test can write to cluster/network.config.openshift.io
 			hasAccess, err := hasNetworkConfigWriteAccess(oc)
 			Expect(err).NotTo(HaveOccurred())
@@ -107,7 +107,7 @@ var _ = Describe("[sig-network] services", func() {
 	})
 
 	InBareMetalIPv4ClusterContext(oc, func() {
-		It("ensures external auto assign cidr is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", func() {
+		It("ensures external auto assign cidr is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", test.ExtendedDuration(), func() {
 			// Check if the test can write to cluster/network.config.openshift.io
 			hasAccess, err := hasNetworkConfigWriteAccess(oc)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -20,7 +20,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -33,6 +32,7 @@ import (
 	osinv1 "github.com/openshift/api/osin/v1"
 	clusteroperatorhelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 
+	"github.com/openshift/origin/pkg/test"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -61,7 +61,7 @@ type certAuthTest struct {
 var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP]", func() {
 	var oc = exutil.NewCLI("request-headers")
 
-	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io]", test.ExtendedDuration(), func() {
 
 		// In some rare cases, CAO might be damaged when entering this test. If it is - the results
 		// of this test might flaky. This check ensures that we capture such situation early and

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/allowedalerts"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/pkg/test"
+
 	"golang.org/x/sync/errgroup"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -95,7 +97,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Platform Prometheus targets", fu
 		}
 	})
 
-	g.It("should not be accessible without auth [Serial]", func() {
+	g.It("should not be accessible without auth [Serial]", test.ExtendedDuration(), func() {
 		expectedStatusCodes := sets.New(http.StatusUnauthorized, http.StatusForbidden)
 
 		g.By("checking that targets reject the requests with 401 or 403")


### PR DESCRIPTION
This creates `openshift/conformance/serial/fast` that excludes our slowest serial tests (those longer than 4 minutes).  These tests can remain in periodics and will continue to be monitored for regressions in Component  Readiness, but I'm going to suggest we don't run them on most repositories in presubmits, as it reduces ~90 minutes from those runs.

```
Duration (minutes) | Test Name
21.45 | [sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial] [Suite:openshift/conformance/serial]
19.20 | [sig-network] services when running openshift ipv4 cluster on bare metal [apigroup:config.openshift.io] ensures external auto assign cidr is configured correctly on the cluster [apigroup:config.openshift.io] [Serial] [Suite:openshift/conformance/serial]
16.17 | [sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to set the hardware speed to Slower [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]
8.21 | [sig-cluster-lifecycle][Feature:Machines][Serial] Managed cluster should grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]
7.85 | [Suite:openshift/machine-config-operator/disruptive][Suite:openshift/conformance/serial][sig-mco][OCPFeatureGate:PinnedImages][OCPFeatureGate:MachineConfigNodes][Serial] All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]
5.85 | [Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP] test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/serial]
5.16 | [sig-instrumentation][Late] Platform Prometheus targets should not be accessible without auth [Serial] [Suite:openshift/conformance/serial]
4.84 | [sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to set the hardware speed to Standard [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]
4.38 | [sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd is able to set the hardware speed to "" [Timeout:30m][apigroup:machine.openshift.io] [Suite:openshift/conformance/serial]
4.10 | [sig-network][Feature:EgressIP][apigroup:operator.openshift.io] [external-targets][apigroup:user.openshift.io][apigroup:security.openshift.io] pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io] [Suite:openshift/conformance/serial]
```