### PR TITLE
OCPBUGS-48186: Add kubelet and CRI-O panic detection invariant test

### DIFF
--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -363,6 +363,7 @@ const (
 	SourceUnexpectedReady           IntervalSource = "NodeUnexpectedNotReady"
 	SourceUnreachable               IntervalSource = "NodeUnreachable"
 	SourceKubeletLog                IntervalSource = "KubeletLog"
+	SourceCrioLog                   IntervalSource = "CrioLog"
 	SourceSystemdCoreDumpLog        IntervalSource = "SystemdCoreDumpLog"
 	SourcePodLog                    IntervalSource = "PodLog"
 	SourceEtcdLog                   IntervalSource = "EtcdLog"
@@ -393,9 +394,8 @@ const (
 	SourceEtcdDiskCommitDuration   IntervalSource = "EtcdDiskCommitDuration"
 	SourceEtcdDiskWalFsyncDuration IntervalSource = "EtcdDiskWalFsyncDuration"
 	SourceTestBucket               IntervalSource = "TestBucket"
-	KubeletPanic                  IntervalReason = "KubeletPanic"
-	CrioPanic                     IntervalReason = "CrioPanic"
-	SourceCrioLog                 IntervalSource = "CrioLog"
+	KubeletPanic                   IntervalReason = "KubeletPanic"
+	CrioPanic                      IntervalReason = "CrioPanic"
 )
 
 type Interval struct {

--- a/pkg/monitortests/node/kubeletlogcollector/monitortest.go
+++ b/pkg/monitortests/node/kubeletlogcollector/monitortest.go
@@ -176,7 +176,7 @@ func testNoSystemdCoreDumps(events monitorapi.Intervals) []*junitapi.JUnitTestCa
 }
 
 func nodeKubeletAndCrioPanicsInvariant(startedAt time.Time, finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
-	const testName = "[sig-node] kubelet-log-collector detects kubelet or CRI-O panics"
+	const testName = "[sig-node] node-system-log-collector detects kubelet or CRI-O panics"
 	var failures []string
 
 	intervalsToFailOn := findKubeletAndCrioPanics(finalIntervals)

--- a/pkg/monitortests/node/kubeletlogcollector/node_test.go
+++ b/pkg/monitortests/node/kubeletlogcollector/node_test.go
@@ -1250,7 +1250,7 @@ func TestKubeletPanicDetected(t *testing.T) {
 	nonPanicLog := "normal log line"
 
 	intervals := kubeletPanicDetected(nodeName, panicLog)
-	if intervals == nil || len(intervals) == 0 {
+	if len(intervals) == 0 {
 		t.Errorf("Expected interval for panic log, got none")
 	}
 	if intervals[0].Condition.Message.HumanMessage != "kubelet panic detected, check logs for details" {
@@ -1269,7 +1269,7 @@ func TestCrioPanicDetected(t *testing.T) {
 	nonPanicLog := "normal log line"
 
 	intervals := crioPanicDetected(nodeName, panicLog)
-	if intervals == nil || len(intervals) == 0 {
+	if len(intervals) == 0 {
 		t.Errorf("Expected interval for CRI-O panic log, got none")
 	}
 	if intervals[0].Condition.Message.HumanMessage != "CRI-O panic detected, check logs for details" {


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added panic detection and monitoring for kubelet and CRI-O components
  * Extended event classification system to track kubelet and CRI-O panic events
  * Enhanced system diagnostics with improved panic event tracking and reporting

* **Tests**
  * Added test coverage for panic detection mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->