### PR TITLE
NO-JIRA: Deflake oc observe test by using explicit port number

### DIFF
--- a/test/extended/cli/observe.go
+++ b/test/extended/cli/observe.go
@@ -105,7 +105,7 @@ var _ = g.Describe("[sig-cli] oc observe", func() {
 	})
 
 	g.It("works as expected with cluster operators [apigroup:config.openshift.io]", func() {
-		out, err := oc.Run("observe").Args("clusteroperators", "--once").Output()
+		out, err := oc.Run("observe").Args("clusteroperators", "--once", "--listen-addr=:11252").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("kube-apiserver"))
 	})


### PR DESCRIPTION
`oc observe` test serves an HTTP endpoint with a [static port](https://github.com/openshift/oc/blob/6edd9e45c39d56010dd8983b71782269b39aa217/pkg/cli/observe/observe.go#L200) (i.e. `:11251`). That means, running `oc observe` tests in parallel sometimes cause `listen tcp :11251: bind: address already in use` error. Because one of the test reserves this port number and the other one can not. [1][2]

In order to deflake this test, this PR uses an explicit port number in one of the tests to prevent the race condition. Thanks to that, this test will also exercise the validity of `--listen-addr` flag in observe command.

[1] https://search.dptools.openshift.org/?search=oc+observe+works+as+expected+with+cluster+operators&maxAge=48h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

[2] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-rosa-sts-ovn/1966275850189934592