### PR TITLE
NO-JIRA: Increase request-timeout to deflake test

### DIFF
--- a/test/extended/cli/timeout.go
+++ b/test/extended/cli/timeout.go
@@ -25,11 +25,11 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 		// from server or from context it's ok
 		o.Expect(out).Should(o.SatisfyAny(o.ContainSubstring("request canceled"), o.ContainSubstring("context deadline exceeded")))
 
-		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=1s").Output()
+		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=2s").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
-		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=1").Output()
+		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=2").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
@@ -53,11 +53,11 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 		// from server or from context it's ok
 		o.Expect(out).Should(o.SatisfyAny(o.ContainSubstring("request canceled"), o.ContainSubstring("context deadline exceeded")))
 
-		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=1s").Output()
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=2s").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
-		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=1").Output()
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=2").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 


### PR DESCRIPTION
oc --request-timeout test expects the success in some execution after passing `--request-timeout` explicitly. After current value is 1 second which is very short for some environments and this causes flakiness. 

This PR increases to 2 seconds to deflake this test.

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-e2e-vsphere-static-ovn/1966224899647213568