### PR TITLE
Skip ServiceCIDR in etcd_storage_path test

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -194,10 +194,14 @@ var kindWhiteList = sets.NewString(
 	"ImageStreamTag",
 	"ImageTag",
 	"UserIdentityMapping",
+
 	// these are now served using CRDs
 	"ClusterResourceQuota",
 	"SecurityContextConstraints",
 	"RoleBindingRestriction",
+
+	// blocked by VAP in OCP
+	"ServiceCIDR",
 )
 
 type helperT struct {


### PR DESCRIPTION
We (will) block use of that API in OCP, so the test fails.
