### PR TITLE
OCPBUGS-46422: Skip ServiceCIDR in etcd_storage_path test (4.20)

### DIFF
--- a/test/extended/etcd/etcd_storage_path.go
+++ b/test/extended/etcd/etcd_storage_path.go
@@ -194,10 +194,14 @@ var kindWhiteList = sets.NewString(
 	"ImageStreamTag",
 	"ImageTag",
 	"UserIdentityMapping",
+
 	// these are now served using CRDs
 	"ClusterResourceQuota",
 	"SecurityContextConstraints",
 	"RoleBindingRestriction",
+
+	// blocked by VAP in OCP
+	"ServiceCIDR",
 )
 
 type helperT struct {


### PR DESCRIPTION
Backport to `release-4.20` of #30254

Note that there are a bunch of PRs that need to merge as part of this fix, but this one doesn't depend on any of the others (and one of the others depends on this).