### PR TITLE
OCPBUGS-61855: CRD Apply Alert Allowance

### DIFF
--- a/pkg/alerts/allowed_conformance.go
+++ b/pkg/alerts/allowed_conformance.go
@@ -19,6 +19,10 @@ func AllowedAlertsDuringConformance(featureSet configv1.FeatureSet) (allowedFiri
 			AlertName: "VirtControllerRESTErrorsHigh",
 			Text:      "https://issues.redhat.com/browse/CNV-50418",
 		},
+		{
+			AlertName: "InstallPlanStepAppliedWithWarnings",
+			Text:      "https://issues.redhat.com/browse/OSSM-10876",
+		},
 	}
 	allowedFiringAlerts := MetricConditions{
 		{


### PR DESCRIPTION
Adds an allowed alert for `InstallPlanStepAppliedWithWarnings` to unblock kubernetes 1.34 rebase efforts. The servicemeshoperator VirtualServices CRD is generating warnings from the api server because 1.34 now gives warnings for unknown string formats. Without this exception the rebase efforts may be blocked until the CRD can be fixed. This allowance will be removed once the issue has been resolved.

I don't yet know if the upgrade tests will need this as well, but I'm limiting the scope here for the time being.