### PR TITLE
MCO-1828: Remove pathological test in disruptive

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -144,6 +144,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie(faultyloadbalancer.MonitorName, "kube-apiserver", faultyloadbalancer.NewMonitorTest())
 	monitorTestRegistry.AddMonitorTestOrDie(staticpodinstall.MonitorName, "kube-apiserver", staticpodinstall.NewStaticPodInstallMonitorTest())
 	monitorTestRegistry.AddMonitorTestOrDie(containerfailures.MonitorName, "Node / Kubelet", containerfailures.NewContainerFailuresTests())
+	monitorTestRegistry.AddMonitorTestOrDie(legacytestframeworkmonitortests.PathologicalMonitorName, "Test Framework", legacytestframeworkmonitortests.NewLegacyPathologicalMonitorTests(info))
 
 	return monitorTestRegistry
 }
@@ -193,7 +194,7 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-storage-invariants", "Storage", legacystoragemonitortests.NewLegacyTests())
 
-	monitorTestRegistry.AddMonitorTestOrDie("legacy-test-framework-invariants", "Test Framework", legacytestframeworkmonitortests.NewLegacyTests(info))
+	monitorTestRegistry.AddMonitorTestOrDie(legacytestframeworkmonitortests.AlertsMonitorName, "Test Framework", legacytestframeworkmonitortests.NewLegacyAlertsMonitorTests(info))
 	monitorTestRegistry.AddMonitorTestOrDie("timeline-serializer", "Test Framework", timelineserializer.NewTimelineSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("interval-serializer", "Test Framework", intervalserializer.NewIntervalSerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("tracked-resources-serializer", "Test Framework", trackedresourcesserializer.NewTrackedResourcesSerializer())

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
-	"github.com/openshift/origin/pkg/monitortestlibrary/pathologicaleventlibrary"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/origin/pkg/alerts"
@@ -16,37 +15,41 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-type legacyMonitorTests struct {
+const (
+	AlertsMonitorName = "legacy-test-framework-invariants-alerts"
+)
+
+type legacyAlertsMonitorTests struct {
 	adminRESTConfig            *rest.Config
 	duration                   time.Duration
 	recordedResources          monitorapi.ResourcesMap
 	clusterStabilityDuringTest *monitortestframework.ClusterStabilityDuringTest
 }
 
-func NewLegacyTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
-	return &legacyMonitorTests{clusterStabilityDuringTest: &info.ClusterStabilityDuringTest}
+func NewLegacyAlertsMonitorTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
+	return &legacyAlertsMonitorTests{clusterStabilityDuringTest: &info.ClusterStabilityDuringTest}
 }
 
-func (w *legacyMonitorTests) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+func (w *legacyAlertsMonitorTests) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
 	return nil
 }
 
-func (w *legacyMonitorTests) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+func (w *legacyAlertsMonitorTests) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
 	w.adminRESTConfig = adminRESTConfig
 	return nil
 }
 
-func (w *legacyMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+func (w *legacyAlertsMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
 	w.duration = end.Sub(beginning)
 	return nil, nil, nil
 }
 
-func (w *legacyMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+func (w *legacyAlertsMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
 	w.recordedResources = recordedResources
 	return nil, nil
 }
 
-func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+func (w *legacyAlertsMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 	jobType, err := platformidentification.GetJobType(context.TODO(), w.adminRESTConfig)
 	if err != nil {
 		// JobType will be nil here, but we want test cases to all fail if this is the case, so we rely on them to nil check
@@ -57,11 +60,9 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
-		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForUpgrade(finalIntervals, w.adminRESTConfig)...)
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringUpgrade, jobType, w.clusterStabilityDuringTest,
 			w.adminRESTConfig, w.duration, w.recordedResources)...)
 	} else {
-		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForStableSystem(finalIntervals, w.adminRESTConfig)...)
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringConformance, jobType, w.clusterStabilityDuringTest,
 			w.adminRESTConfig, w.duration, w.recordedResources)...)
 	}
@@ -69,10 +70,10 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	return junits, nil
 }
 
-func (*legacyMonitorTests) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+func (*legacyAlertsMonitorTests) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
 	return nil
 }
 
-func (*legacyMonitorTests) Cleanup(ctx context.Context) error {
+func (*legacyAlertsMonitorTests) Cleanup(ctx context.Context) error {
 	return nil
 }

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events.go
@@ -1,1 +1,0 @@
-package legacytestframeworkmonitortests

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events_monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events_monitortest.go
@@ -1,0 +1,64 @@
+package legacytestframeworkmonitortests
+
+import (
+	"context"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitortestframework"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/pathologicaleventlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	PathologicalMonitorName = "legacy-test-framework-invariants-pathological"
+)
+
+type legacyPathologicalMonitorTests struct {
+	adminRESTConfig *rest.Config
+	duration        time.Duration
+}
+
+func NewLegacyPathologicalMonitorTests(info monitortestframework.MonitorTestInitializationInfo) monitortestframework.MonitorTest {
+	return &legacyPathologicalMonitorTests{}
+}
+
+func (w *legacyPathologicalMonitorTests) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (w *legacyPathologicalMonitorTests) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (w *legacyPathologicalMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	w.duration = end.Sub(beginning)
+	return nil, nil, nil
+}
+
+func (w *legacyPathologicalMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (w *legacyPathologicalMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	junits := []*junitapi.JUnitTestCase{}
+	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
+	if isUpgrade {
+		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForUpgrade(finalIntervals, w.adminRESTConfig)...)
+	} else {
+		junits = append(junits, pathologicaleventlibrary.TestDuplicatedEventForStableSystem(finalIntervals, w.adminRESTConfig)...)
+	}
+
+	return junits, nil
+}
+
+func (*legacyPathologicalMonitorTests) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	return nil
+}
+
+func (*legacyPathologicalMonitorTests) Cleanup(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
For disruptive test suites like the MCO disruptive these tests doesn't make sense as the nodes reboot, are added and deleted, etc. It's not possible to reliably determine which events are fired because of node status changes and which one can be considered a failure so we just remove the tests for this type of suites.