### PR TITLE
OCPSTRAT-2371: image: add busybox to list of allowed images

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -53,8 +53,9 @@ var (
 
 		// allowed upstream kube images - index and value must match upstream or
 		// tests will fail (vendor/k8s.io/kubernetes/test/utils/image/manifest.go)
-		"registry.k8s.io/e2e-test-images/agnhost:2.53": 1,
-		"registry.k8s.io/e2e-test-images/nginx:1.15-4": 19,
+		"registry.k8s.io/e2e-test-images/agnhost:2.53":     1,
+		"registry.k8s.io/e2e-test-images/busybox:1.36.1-1": 7,
+		"registry.k8s.io/e2e-test-images/nginx:1.15-4":     19,
 
 		// used by KubeVirt test to start fedora VMs
 		"quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc": -1,


### PR DESCRIPTION
This image is used by sig-imageregistry tests and is currently returned by k8s-tests external binary. However, in k8s 1.34 the busybox image was updated and we'll need both versions to be mirrored.

Without this patch, only this image is returned by `openshift-tests images`:

```
registry.k8s.io/e2e-test-images/busybox:1.37.0-1 quay.io/openshift/community-e2e-images:e2e-7-registry-k8s-io-e2e-test-images-busybox-1-37-0-1-Z7zmmx9UlrNelUgv
```

And with this patch:

```
registry.k8s.io/e2e-test-images/busybox:1.36.1-1 quay.io/openshift/community-e2e-images:e2e-7-registry-k8s-io-e2e-test-images-busybox-1-36-1-1-n3BezCOfxp98l84K
registry.k8s.io/e2e-test-images/busybox:1.37.0-1 quay.io/openshift/community-e2e-images:e2e-7-registry-k8s-io-e2e-test-images-busybox-1-37-0-1-Z7zmmx9UlrNelUgv
```

Ultimately, this fixes the image pull errors from this job:

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2386/pull-ci-openshift-kubernetes-master-e2e-metal-ipi-ovn-ipv6/1968930677697024000

/assign @jacobsee 