### PR TITLE
OTA-1626: Fail CI if alert/ClusterOperatorDegraded is fired

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/all.go
+++ b/pkg/monitortestlibrary/allowedalerts/all.go
@@ -79,5 +79,7 @@ func AllAlertTests(jobType *platformidentification.JobType, clusterStability *mo
 
 	ret = append(ret, newAlertTest("bz-apiserver-auth", "PodSecurityViolation", jobType).firing().toTests()...)
 
+	ret = append(ret, newAlertTest("bz-Cluster Version Operator", "ClusterOperatorDegraded", jobType).firing().alwaysFail().toTests()...)
+
 	return ret
 }


### PR DESCRIPTION
The alert ClusterOperatorDegraded is fatal because it indicates

- cluster version operator is working (reporting Avaiable=True) but sad (not reporting Failing=False), or
- some cluster operator is sad (not reporting Degraded=False)

We do not want any of those to happen in the CI upgrade tests.

When a test fails up to the alert, we can check the ClusterVersion manifest usually collected as an artifact of the test to figure out the reason that triggered the alert.

If it was caused by some CO, we should file a bug for the component that CO belongs to.
Otherwise, it is a bug for CVO.

[1]. https://github.com/openshift/cluster-version-operator/blob/d81848ae818b277bdaffa5375ad6366111c4143c/install/0000_90_cluster-version-operator_02_servicemonitor.yaml#L106