### PR TITLE
OCPBUGS-61398: fix(ginkgo): avoid nil deref and harden env var setup

### DIFF
--- a/pkg/test/ginkgo/status.go
+++ b/pkg/test/ginkgo/status.go
@@ -44,6 +44,11 @@ func (s *testSuiteProgress) TestEnded(testName string, testRunResult *testRunRes
 		return
 	}
 
+	if testRunResult.testRunResult == nil {
+		fmt.Fprintln(os.Stderr, "testRunResult.testRunResult is nil")
+		return
+	}
+
 	if isTestFailed(testRunResult.testState) {
 		s.failures++
 	}


### PR DESCRIPTION
This PR fixes(ginkgo): avoid nil deref and harden env var setup
    
- Initialize testRunResultHandle with a default inner struct to make defers safe
- Add nil checks for testRunResult and its inner value in status/log/monitor paths
- Make updateEnvVars robust: handle discovery/marshal errors and always set TEST_PROVIDER with a sane default

Prevents panics during early/failed test runs and improves resilience when cluster config is unavailable.

Refs: OCPBUGS-61398

Example test failure - https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-azure-aks-ovn-conformance/1970035697670688768