### PR TITLE
OTA-1637: ClusterOperators should not go Progressing only for cluster scaling

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -237,13 +237,30 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	g.AfterEach(func() {
 		helper.DeleteAllExtraWorkers()
 
+		except := func(co string) string {
+			switch co {
+			case "dns":
+				return "https://issues.redhat.com/browse/OCPBUGS-62623"
+			case "image-registry":
+				return "https://issues.redhat.com/browse/OCPBUGS-62626"
+			case "network":
+				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+			case "node-tuning":
+				return "https://issues.redhat.com/browse/OCPBUGS-62632"
+			case "storage":
+				return "https://issues.redhat.com/browse/OCPBUGS-62633"
+			default:
+				return ""
+			}
+		}
+
 		// No cluster operator should leave Progressing=False only up to cluster scaling
 		// https://github.com/openshift/api/blob/61248d910ff74aef020492922d14e6dadaba598b/config/v1/types_cluster_operator.go#L163-L164
 		operatorsNotProgressingAfter := getOperatorsNotProgressing(configClient)
 		var violations []string
 		for operator, t1 := range operatorsNotProgressing {
 			t2, ok := operatorsNotProgressingAfter[operator]
-			if !ok || t1.Unix() != t2.Unix() {
+			if reason := except(operator); reason == "" && (!ok || t1.Unix() != t2.Unix()) {
 				violations = append(violations, operator)
 			}
 		}


### PR DESCRIPTION
This is to cover the cluster scaling case from the rule [1] that is introduced recently:

```
Operators should not report Progressing only because DaemonSets
owned by them are adjusting to a new node from cluster scaleup or
a node rebooting from cluster upgrade.
```

The test plugs into the existing scaling test. It checks each CO's Progressing condition before and after the test, and identifies every CO that either left Progressing=False or re-entered Progressing=False with a different LastTransitionTime.

The bugs are created for the case of node rebooting. The condition
goes to Progressing=True with the same reason that we found for the
cluster scaling up/down. Thus, we re-use the bugs instead of
recreating a new set of bugs that might be closed as duplicates.

[1]. https://github.com/openshift/api/blob/61248d910ff74aef020492922d14e6dadaba598b/config/v1/types_cluster_operator.go#L163-L164