### PR TITLE
OCPBUGS-62227: bump telemetry series limit to 1000

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -529,13 +529,10 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		// we only consider series sent since the beginning of the test
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
-		var averageSeriesLimit int
-		averageSeriesLimit = 1000
-
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
 			// rule contains the count of the all the series that are sent via telemetry. It is permissible
-			// for some scenarios to generate more series than 1000, we just want the basic state to be below
+			// for some scenarios to generate more series than the limit, we just want the basic state to be below
 			// a threshold.
 
 			// The following query can be executed against the telemetry server
@@ -550,8 +547,8 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 			//     )[30m:1m]
 			//   )
 			// )
-			fmt.Sprintf(`avg_over_time(cluster:telemetry_selected_series:count[%s]) >= %d`, testDuration, averageSeriesLimit): false,
-			fmt.Sprintf(`max_over_time(cluster:telemetry_selected_series:count[%s]) >= 1200`, testDuration):                   false,
+			fmt.Sprintf(`avg_over_time(cluster:telemetry_selected_series:count[%s]) >= 1000`, testDuration): false,
+			fmt.Sprintf(`max_over_time(cluster:telemetry_selected_series:count[%s]) >= 1200`, testDuration): false,
 		}
 		err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -535,7 +535,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
 			// rule contains the count of the all the series that are sent via telemetry. It is permissible
-			// for some scenarios to generate more series than 760, we just want the basic state to be below
+			// for some scenarios to generate more series than 1000, we just want the basic state to be below
 			// a threshold.
 
 			// The following query can be executed against the telemetry server

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -529,22 +529,15 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		// we only consider series sent since the beginning of the test
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
-		isManagedServiceCluster, err := exutil.IsManagedServiceCluster(ctx, oc.AdminKubeClient())
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
-		// rule contains the count of the all the series that are sent via telemetry. It is permissible
-		// for some scenarios to generate more series than 760, we just want the basic state to be below
-		// a threshold.
 		var averageSeriesLimit int
-		switch {
-		case isManagedServiceCluster:
-			averageSeriesLimit = 850
-		default:
-			averageSeriesLimit = 1000
-		}
+		averageSeriesLimit = 1000
 
 		tests := map[string]bool{
+			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
+			// rule contains the count of the all the series that are sent via telemetry. It is permissible
+			// for some scenarios to generate more series than 760, we just want the basic state to be below
+			// a threshold.
+
 			// The following query can be executed against the telemetry server
 			// to reevaluate the threshold value (replace the matcher on the version label accordingly):
 			//

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -541,7 +541,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		case isManagedServiceCluster:
 			averageSeriesLimit = 850
 		default:
-			averageSeriesLimit = 780
+			averageSeriesLimit = 1000
 		}
 
 		tests := map[string]bool{

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -553,7 +553,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 			fmt.Sprintf(`avg_over_time(cluster:telemetry_selected_series:count[%s]) >= %d`, testDuration, averageSeriesLimit): false,
 			fmt.Sprintf(`max_over_time(cluster:telemetry_selected_series:count[%s]) >= 1200`, testDuration):                   false,
 		}
-		err = helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
+		err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		e2e.Logf("Total number of series sent via telemetry is below the limit")


### PR DESCRIPTION
see from [OCPBUGS-62227](https://issues.redhat.com/browse/OCPBUGS-62227), case "Alerts shouldn't exceed the series limit of total series sent via telemetry from each cluster" failed on e2e-aws-ovn-techpreview job
this PR bumped the limit to 1000 to tolerate more series added to telemetry in the future