### PR TITLE
[NE-2131] register CIO tests extension

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -217,6 +217,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-kube-storage-version-migrator-operator",
 		binaryPath: "/usr/bin/cluster-kube-storage-version-migrator-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "cluster-ingress-operator",
+		binaryPath: "/usr/bin/ingress-operator-ext-tests.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
This change enables cluster-ingress-operator OTE on origin.

CIO side: https://github.com/openshift/cluster-ingress-operator/pull/1284