### PR TITLE
NO-JIRA: Add olm into the known operator set

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/operator_mapping.go
+++ b/pkg/monitortestlibrary/platformidentification/operator_mapping.go
@@ -111,6 +111,7 @@ var (
 		"monitoring",
 		"network",
 		"node-tuning",
+		"olm",
 		"openshift-apiserver",
 		"openshift-controller-manager",
 		"openshift-samples",
@@ -154,6 +155,7 @@ func init() {
 	utilruntime.Must(addOperatorMapping("monitoring", "Monitoring"))
 	utilruntime.Must(addOperatorMapping("network", "Networking"))
 	utilruntime.Must(addOperatorMapping("node-tuning", "Node Tuning Operator"))
+	utilruntime.Must(addOperatorMapping("olm", "OLM"))
 	utilruntime.Must(addOperatorMapping("openshift-apiserver", "openshift-apiserver"))
 	utilruntime.Must(addOperatorMapping("openshift-controller-manager", "openshift-controller-manager"))
 	utilruntime.Must(addOperatorMapping("openshift-samples", "Samples"))


### PR DESCRIPTION
Spot the case by https://github.com/openshift/origin/pull/30296#issuecomment-3338621585

```
$ oc --kubeconfig /tmp/ota-stage.c get co kube-apiserver olm
NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
kube-apiserver   4.18.15   True        False         False      4y13d
olm              4.18.15   True        False         False      121d
```

Looking at the age, `co/olm` might become a cluster operator after the set was last updated.

The name of `bugzillaComponent` is taken from https://github.com/openshift/origin/blob/1c9a26121846f19099909bbdc445442ce65b06cb/pkg/monitortestlibrary/platformidentification/operator_mapping.go#L154