### PR TITLE
OCPERT-151: add oap testdata to hotfix for test panic: Asset test/extended/testdata/oap/mustgather not found

### DIFF
--- a/test/extended/testdata/oap/certmanager/cert-generic.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-generic.yaml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: certificate-generic-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: "${CERT_NAME}"
+    spec:
+      commonName: "${COMMON_NAME}"
+      dnsNames:
+        - "${DNS_NAME}"
+      usages:
+        - server auth
+      issuerRef:
+        group: "${ISSUER_GROUP}"
+        kind: "${ISSUER_KIND}"
+        name: "${ISSUER_NAME}"
+      secretName: "${SECRET_NAME}"
+      duration: "${DURATION}" 
+      renewBefore: "${RENEW_BEFORE}"
+parameters:
+  - name: CERT_NAME
+  - name: COMMON_NAME
+  - name: DNS_NAME
+    value: "svc.cluster.local"
+  - name: SECRET_NAME
+  - name: ISSUER_GROUP
+    value: cert-manager.io
+  - name: ISSUER_KIND
+    value: Issuer
+  - name: ISSUER_NAME
+  - name: DURATION
+    value: 1h
+  - name: RENEW_BEFORE
+    value: 58m

--- a/test/extended/testdata/oap/certmanager/cert-match-test-1.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-match-test-1.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-match-test-1
+  labels:
+    use-http01-solver: "true"
+spec:
+  secretName: cert-match-test-1
+  issuerRef:
+    kind: ClusterIssuer
+    name: acme-multiple-solvers
+  dnsNames:
+  - xxia-test-1.test-example.com

--- a/test/extended/testdata/oap/certmanager/cert-match-test-2.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-match-test-2.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-match-test-2
+spec:
+  secretName: cert-match-test-2
+  issuerRef:
+    kind: ClusterIssuer
+    name: acme-multiple-solvers
+  dnsNames:
+  - xxia-test-2.test-example.com

--- a/test/extended/testdata/oap/certmanager/cert-match-test-3.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-match-test-3.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cert-match-test-3
+spec:
+  secretName: cert-match-test-3
+  issuerRef:
+    kind: ClusterIssuer
+    name: acme-multiple-solvers
+  dnsNames:
+  - xxia-test-3.test-example.com
+  - '*.xxia-test-3.test-example.com'

--- a/test/extended/testdata/oap/certmanager/cert-selfsigned-vault.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-selfsigned-vault.yaml
@@ -1,0 +1,38 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: cert-selfsigned-vault-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      name: "${CERT_NAME}"
+    spec:
+      isCA: false
+      commonName: "${CERT_NAME}"
+      dnsNames:
+        - ${VAULT_SERVICE}
+        - ${VAULT_SERVICE}.${VAULT_NAMESPACE}
+        - ${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc
+        - ${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc.cluster.local
+      ipAddresses:
+        - 127.0.0.1
+      usages:
+        - key encipherment
+        - digital signature
+        - server auth
+        - client auth
+      privateKey:
+        algorithm: RSA
+        encoding: PKCS1
+        size: 2048
+      issuerRef:
+        name: "${ISSUER_NAME}"
+        kind: Issuer
+      secretName: vault-server-tls
+parameters:
+  - name: CERT_NAME
+  - name: VAULT_SERVICE
+  - name: VAULT_NAMESPACE
+  - name: ISSUER_NAME
+  - name: SECRET_NAME

--- a/test/extended/testdata/oap/certmanager/cert-selfsigned.yaml
+++ b/test/extended/testdata/oap/certmanager/cert-selfsigned.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: default-selfsigned-cert
+spec:
+  isCA: true
+  commonName: default-selfsigned-cert
+  subject:
+    organizations:
+      - OpenShift QE
+  issuerRef:
+    kind: Issuer
+    name: default-selfsigned
+  secretName: selfsigned-ca-tls
+  privateKey:
+    algorithm: ECDSA
+    size: 256

--- a/test/extended/testdata/oap/certmanager/cluster-monitoring-config.yaml
+++ b/test/extended/testdata/oap/certmanager/cluster-monitoring-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-clouddns-ambient.yaml
+++ b/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-clouddns-ambient.yaml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: clusterissuer-acme-dns01-clouddns-ambient-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      acme:
+        server: "${ACME_SERVER}"
+        skipTLSVerify: true
+        privateKeySecretRef:
+          name: acme-account-key
+        solvers:
+          - dns01:
+              cloudDNS:
+                project: "${PROJECT_ID}"
+parameters:
+  - name: ISSUER_NAME
+  - name: ACME_SERVER
+  - name: PROJECT_ID

--- a/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-route53-ambient.yaml
+++ b/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-route53-ambient.yaml
@@ -1,0 +1,29 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: clusterissuer-acme-dns01-route53-ambient-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      acme:
+        server: "${ACME_SERVER}"
+        skipTLSVerify: true
+        privateKeySecretRef:
+          name: acme-account-key
+        solvers:
+        - selector:
+            dnsZones:
+              - "${DNS_ZONE}"
+          dns01:
+            route53:
+              region: "${AWS_REGION}"
+              hostedZoneID: "${ROUTE53_HOSTED_ZONE_ID}"
+parameters:
+  - name: ISSUER_NAME
+  - name: ACME_SERVER
+  - name: DNS_ZONE
+  - name: AWS_REGION
+  - name: ROUTE53_HOSTED_ZONE_ID

--- a/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-route53.yaml
+++ b/test/extended/testdata/oap/certmanager/clusterissuer-acme-dns01-route53.yaml
@@ -1,0 +1,34 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: clusterissuer-acme-dns01-route53-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      acme:
+        server: "${ACME_SERVER}"
+        skipTLSVerify: true
+        privateKeySecretRef:
+          name: acme-account-key
+        solvers:
+        - selector:
+            dnsZones:
+              - "${DNS_ZONE}"
+          dns01:
+            route53:
+              region: "${AWS_REGION}"
+              accessKeyID: "${AWS_ACCESS_KEY_ID}"
+              hostedZoneID: "${ROUTE53_HOSTED_ZONE_ID}"
+              secretAccessKeySecretRef:
+                name: test-secret
+                key: secret-access-key
+parameters:
+  - name: ISSUER_NAME
+  - name: ACME_SERVER
+  - name: DNS_ZONE
+  - name: AWS_REGION
+  - name: AWS_ACCESS_KEY_ID
+  - name: ROUTE53_HOSTED_ZONE_ID

--- a/test/extended/testdata/oap/certmanager/clusterissuer-acme-multiple-solvers.yaml
+++ b/test/extended/testdata/oap/certmanager/clusterissuer-acme-multiple-solvers.yaml
@@ -1,0 +1,52 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: clusterissuer-acme-multiple-solvers-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: ClusterIssuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      acme:
+        server: "${ACME_SERVER}"
+        skipTLSVerify: true
+        privateKeySecretRef:
+          name: acme-account-key
+        solvers:
+        - http01:
+            ingress:
+              ingressClassName: openshift-default
+          selector:
+            matchLabels:
+              use-http01-solver: "true"
+            dnsZones:
+              - test-example.com
+        - dns01:
+            azureDNS:
+              clientID: aaaa-aaaa-aaaa-aaaa
+              clientSecretSecretRef:
+                name: azuredns-config-dummy
+                key: client-secret
+              subscriptionID: bbbb-bbbb-bbbb-bbbb
+              tenantID: cccc-cccc-cccc-cccc
+              resourceGroupName: rg-dummy
+              hostedZoneName: test-example.com
+              environment: AzurePublicCloud
+          selector:
+            dnsNames:
+            - xxia-test-2.test-example.com
+        - dns01:
+            route53:
+              region: us-east-1
+              accessKeyID: DUMMYKEYID
+              hostedZoneID: DUMMYZONEID
+              secretAccessKeySecretRef:
+                name: test-secret-dummy
+                key: secret-access-key
+          selector:
+            dnsZones:
+              - test-example.com
+parameters:
+  - name: ISSUER_NAME
+  - name: ACME_SERVER

--- a/test/extended/testdata/oap/certmanager/deploy-hello-openshift.yaml
+++ b/test/extended/testdata/oap/certmanager/deploy-hello-openshift.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-openshift
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hello-openshift
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hello-openshift
+    spec:
+      containers:
+        - image: quay.io/openshifttest/hello-openshift:1.2.0
+          imagePullPolicy: IfNotPresent
+          name: hello-openshift
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-openshift
+spec:
+  ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: hello-openshift
+  type: ClusterIP

--- a/test/extended/testdata/oap/certmanager/deploy-pebble-server.yaml
+++ b/test/extended/testdata/oap/certmanager/deploy-pebble-server.yaml
@@ -1,0 +1,76 @@
+# xref: https://github.com/letsencrypt/pebble/tree/main/test/config
+# xref: https://github.com/cert-manager/cert-manager/blob/master/make/config/pebble
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pebble
+data:
+  pebble-config.json: |
+    {
+      "pebble": {
+        "listenAddress": "0.0.0.0:14000",
+        "managementListenAddress": "0.0.0.0:15000",
+        "certificate": "test/certs/localhost/cert.pem",
+        "privateKey": "test/certs/localhost/key.pem",
+        "httpPort": 80,
+        "tlsPort": 443,
+        "ocspResponderURL": "",
+        "externalAccountBindingRequired": false
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pebble
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pebble
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: pebble
+    spec:
+      volumes:
+        - name: config-volume
+          configMap:
+            name: pebble
+            items:
+              - key: pebble-config.json
+                path: pebble-config.json
+      containers:
+        - image: quay.io/openshifttest/letsencrypt-pebble:2.7.0
+          imagePullPolicy: IfNotPresent
+          name: pebble
+          ports:
+            - name: http
+              containerPort: 14000
+              protocol: TCP
+          volumeMounts:
+            - name: config-volume
+              mountPath: /test/config/pebble-config.json
+              subPath: pebble-config.json
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pebble
+spec:
+  type: ClusterIP
+  ports:
+    - port: 14000
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: pebble

--- a/test/extended/testdata/oap/certmanager/exec-curl-helper.yaml
+++ b/test/extended/testdata/oap/certmanager/exec-curl-helper.yaml
@@ -1,0 +1,39 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: exec-curl-helper-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      labels:
+        name: "${POD_NAME}"
+        pod-name: "${POD_NAME}"
+      name: "${POD_NAME}"
+    spec:
+      volumes:
+        - name: ca-cert
+          secret:
+            secretName: "${SECRET_NAME}"
+      containers:
+        - name: exec-curl
+          image: quay.io/openshifttest/hello-openshift:1.2.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sleep"
+            - "600"
+          volumeMounts:
+            - name: ca-cert
+              mountPath: "${SECRET_MOUNT_PATH}"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      restartPolicy: Never
+parameters:
+  - name: POD_NAME
+  - name: SECRET_NAME
+  - name: SECRET_MOUNT_PATH

--- a/test/extended/testdata/oap/certmanager/exec-helm-helper.yaml
+++ b/test/extended/testdata/oap/certmanager/exec-helm-helper.yaml
@@ -1,0 +1,56 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: exec-helm-helper-template
+objects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: "${SA_NAME}"
+      namespace: "${NAMESPACE}"
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: "${ROLEBINDING_NAME}"
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+      - kind: ServiceAccount
+        name: "${SA_NAME}"
+        namespace: "${NAMESPACE}"
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      labels:
+        name: "${POD_NAME}"
+      name: "${POD_NAME}"
+      namespace: "${NAMESPACE}"
+    spec:
+      serviceAccount: "${SA_NAME}"
+      containers:
+        - name: helm
+          image: quay.io/openshifttest/helm:3.17.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sh"
+            - "-c"
+            - ${HELM_CMD}
+          volumeMounts:
+            - name: values-volume
+              mountPath: /helm
+          securityContext:
+            privileged: true
+      volumes:
+        - name: values-volume
+          configMap:
+            name: "${CONFIGMAP_NAME}"
+      restartPolicy: Never
+parameters:
+  - name: SA_NAME
+  - name: ROLEBINDING_NAME
+  - name: POD_NAME
+  - name: NAMESPACE
+  - name: HELM_CMD
+  - name: CONFIGMAP_NAME

--- a/test/extended/testdata/oap/certmanager/helm-vault-tls-config.yaml
+++ b/test/extended/testdata/oap/certmanager/helm-vault-tls-config.yaml
@@ -1,0 +1,40 @@
+# xref: https://developer.hashicorp.com/vault/docs/platform/k8s/helm/examples/standalone-tls#3-helm-configuration Configurations to setup a TLS-protected Vault server
+# xref: https://github.com/hashicorp/vault-helm/blob/main/values.yaml All available parameters and default values for the Vault chart.
+# Set 'server.dataStorage.size' to 1Gi as the default 10Gi is too expensive and unnecessary for testing propose in CI.
+global:
+  enabled: true
+  tlsDisable: false
+  openshift: true
+injector:
+  enabled: false
+server:
+  image:
+    repository: "quay.io/openshifttest/vault"
+    tag: "1.19.0"
+  dataStorage:
+    enabled: true
+    size: 1Gi
+  extraEnvironmentVars:
+    VAULT_CACERT: /vault/userconfig/vault-server-tls/ca.crt
+  volumes:
+    - name: userconfig-vault-server-tls
+      secret:
+        defaultMode: 420
+        secretName: vault-server-tls
+  volumeMounts:
+    - mountPath: /vault/userconfig/vault-server-tls
+      name: userconfig-vault-server-tls
+      readOnly: true
+  standalone:
+    enabled: true
+    config: |
+      listener "tcp" {
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+        tls_cert_file = "/vault/userconfig/vault-server-tls/tls.crt"
+        tls_key_file  = "/vault/userconfig/vault-server-tls/tls.key"
+        tls_client_ca_file = "/vault/userconfig/vault-server-tls/ca.crt"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }

--- a/test/extended/testdata/oap/certmanager/issuer-acme-http01.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-acme-http01.yaml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-acme-http01-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      acme:
+        server: "${ACME_SERVER}"
+        skipTLSVerify: true
+        privateKeySecretRef:
+          name: acme-account-key
+        solvers:
+        - http01:
+            ingress:
+              ingressClassName: openshift-default
+parameters:
+  - name: ISSUER_NAME
+  - name: ACME_SERVER

--- a/test/extended/testdata/oap/certmanager/issuer-ca.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-ca.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: default-ca
+spec:
+  ca:
+    secretName: selfsigned-ca-tls

--- a/test/extended/testdata/oap/certmanager/issuer-google-cas.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-google-cas.yaml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-google-cas-template
+objects:
+  - apiVersion: cas-issuer.jetstack.io/v1beta1
+    kind: GoogleCASIssuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      project: "${PROJECT}"
+      location: "${LOCATION}"
+      caPoolId: "${CAPOOL_ID}"
+      credentials:
+        name: "${SA_SECRET}"
+        key: key.json
+parameters:
+  - name: ISSUER_NAME
+  - name: PROJECT
+  - name: LOCATION
+  - name: CAPOOL_ID
+  - name: SA_SECRET

--- a/test/extended/testdata/oap/certmanager/issuer-selfsigned.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-selfsigned.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: default-selfsigned
+spec:
+  selfSigned: {}

--- a/test/extended/testdata/oap/certmanager/issuer-vault-approle.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-vault-approle.yaml
@@ -1,0 +1,29 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-vault-approle-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      vault:
+        server: https://${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc:8200
+        caBundleSecretRef:
+          name: vault-server-tls
+          key: ca.crt
+        path: pki_int/sign/cluster-dot-local
+        auth:
+          appRole:
+            path: approle
+            roleId: "${ROLE_ID}"
+            secretRef:
+              name: "${SECRET_NAME}"
+              key: secretId
+parameters:
+  - name: ISSUER_NAME
+  - name: VAULT_SERVICE
+  - name: VAULT_NAMESPACE
+  - name: ROLE_ID
+  - name: SECRET_NAME

--- a/test/extended/testdata/oap/certmanager/issuer-vault-bound-sa.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-vault-bound-sa.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-vault-bound-sa-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      vault:
+        server: https://${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc:8200
+        caBundleSecretRef:
+          name: vault-server-tls
+          key: ca.crt
+        path: pki_int/sign/cluster-dot-local
+        auth:
+          kubernetes:
+            mountPath: /v1/auth/${VAULT_AUTH_PATH}
+            role: issuer
+            serviceAccountRef:
+              name: "${SA_NAME}"
+parameters:
+  - name: ISSUER_NAME
+  - name: VAULT_SERVICE
+  - name: VAULT_NAMESPACE
+  - name: VAULT_AUTH_PATH
+  - name: SA_NAME

--- a/test/extended/testdata/oap/certmanager/issuer-vault-static-sa.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-vault-static-sa.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-vault-static-sa-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      vault:
+        server: https://${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc:8200
+        caBundleSecretRef:
+          name: vault-server-tls
+          key: ca.crt
+        path: pki_int/sign/cluster-dot-local
+        auth:
+          kubernetes:
+            mountPath: /v1/auth/kubernetes
+            role: issuer
+            secretRef:
+              name: "${SECRET_NAME}"
+              key: token
+parameters:
+  - name: ISSUER_NAME
+  - name: VAULT_SERVICE
+  - name: VAULT_NAMESPACE
+  - name: SECRET_NAME

--- a/test/extended/testdata/oap/certmanager/issuer-vault-token.yaml
+++ b/test/extended/testdata/oap/certmanager/issuer-vault-token.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: issuer-vault-token-template
+objects:
+  - apiVersion: cert-manager.io/v1
+    kind: Issuer
+    metadata:
+      name: "${ISSUER_NAME}"
+    spec:
+      vault:
+        server: https://${VAULT_SERVICE}.${VAULT_NAMESPACE}.svc:8200
+        caBundleSecretRef:
+          name: vault-server-tls
+          key: ca.crt
+        path: pki_int/sign/cluster-dot-local
+        auth:
+          tokenSecretRef:
+            name: "${SECRET_NAME}"
+            key: token
+parameters:
+  - name: ISSUER_NAME
+  - name: VAULT_SERVICE
+  - name: VAULT_NAMESPACE
+  - name: SECRET_NAME

--- a/test/extended/testdata/oap/certmanager/konflux-fbc.yaml
+++ b/test/extended/testdata/oap/certmanager/konflux-fbc.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: konflux-fbc-template
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: "${NAME}"
+      namespace: "${NAMESPACE}"
+    spec:
+      sourceType: grpc
+      image: "${IMAGE_INDEX}"
+parameters:
+  - name: NAME
+  - name: NAMESPACE
+  - name: IMAGE_INDEX

--- a/test/extended/testdata/oap/certmanager/namespace.yaml
+++ b/test/extended/testdata/oap/certmanager/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-operator

--- a/test/extended/testdata/oap/certmanager/operatorgroup.yaml
+++ b/test/extended/testdata/oap/certmanager/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cert-manager-operator-og
+  namespace: cert-manager-operator

--- a/test/extended/testdata/oap/certmanager/rapidast-config.yaml
+++ b/test/extended/testdata/oap/certmanager/rapidast-config.yaml
@@ -1,0 +1,43 @@
+# source: https://docs.engineering.redhat.com/display/PRODSEC/RapiDAST+QuickStart+Guide#RapiDASTQuickStartGuide-SampleConfiguration
+# full configuration options: https://github.com/RedHatProductSecurity/rapidast/blob/development/config/config-template-zap-long.yaml
+config:
+  # WARNING: `configVersion` indicates the schema version of the config file.
+  # This value tells RapiDAST what schema should be used to read this configuration.
+  # Therefore you should only change it if you update the configuration to a newer schema
+  # It is intended to keep backward compatibility (newer RapiDAST running an older config)
+  configVersion: 5
+
+# `application` contains data related to the application, not to the scans.
+application:
+  shortName: "cert-manager" # should not contain non-printable characters, such as spaces
+  url: "https://kubernetes.default.svc" # to be replaced with your cluster API server URL
+
+# `general` is a section that will be applied to all scanners.
+general:
+  authentication:
+    type: "http_header"
+    parameters:
+      name: "Authorization"
+      value: "Bearer AUTH_TOKEN"
+  container:
+    # currently supported: `podman` and `none`. To run a scan using the RapiDAST container image(e.g. using Helm) on the cluster, this must be `none`
+    type: "none"
+  passiveScan:
+    # optional list of passive rules to disable
+    disabledRules: "2,10015,10027,10096,10024"
+  activeScan:
+    # If no policy is chosen, a default ("API-scan-minimal") will be selected
+    policy: "Kubernetes-API-scan"
+
+# `scanners' is a section that configures scanning options.
+scanners:
+  zap:
+    # define a scan through the ZAP scanner for API Group 'cert-manager.io/v1'
+    apiScan:
+      apis:
+        apiUrl: "https://kubernetes.default.svc/openapi/v3/apis/cert-manager.io/v1"
+  zap_acme:
+    # define a scan through the ZAP scanner for API Group 'acme.cert-manager.io/v1'
+    apiScan:
+      apis:
+        apiUrl: "https://kubernetes.default.svc/openapi/v3/apis/acme.cert-manager.io/v1"

--- a/test/extended/testdata/oap/certmanager/rapidast-pod.yaml
+++ b/test/extended/testdata/oap/certmanager/rapidast-pod.yaml
@@ -1,0 +1,52 @@
+# DO NOT MODIFY DIRECTLY
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rapidast-pod-template
+objects:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: "${PVC_NAME}"
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 100M
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: "${POD_NAME}"
+    spec:
+      serviceAccount: "${SA_NAME}"
+      volumes:
+        - name: config-volume
+          configMap:
+            name: "${CONFIGMAP_NAME}"
+        - name: results-volume
+          persistentVolumeClaim:
+            claimName: "${PVC_NAME}"
+      containers:
+        - name: rapidast
+          image: quay.io/redhatproductsecurity/rapidast:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sh"
+            - "-c"
+            - >
+              rapidast.py --config /helm/config/rapidastconfig.yaml &&
+              find /opt/rapidast/results -name zap-report.json -exec cat {} \;
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: config-volume
+              mountPath: "/helm/config"
+            - name: results-volume
+              mountPath: "/opt/rapidast/results"
+      restartPolicy: Never
+parameters:
+  - name: POD_NAME
+  - name: SA_NAME
+  - name: CONFIGMAP_NAME
+  - name: PVC_NAME

--- a/test/extended/testdata/oap/certmanager/rapidast-privileged-sa.yaml
+++ b/test/extended/testdata/oap/certmanager/rapidast-privileged-sa.yaml
@@ -1,0 +1,26 @@
+# DO NOT MODIFY DIRECTLY
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rapidast-rbac-template
+objects:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: "${NAME}"
+      namespace: "${NAMESPACE}"
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: rapidast-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:openshift:scc:privileged
+    subjects:
+      - kind: ServiceAccount
+        name: "${NAME}"
+        namespace: "${NAMESPACE}"
+parameters:
+  - name: NAME
+  - name: NAMESPACE

--- a/test/extended/testdata/oap/certmanager/rapidast-results-sync-helper.yaml
+++ b/test/extended/testdata/oap/certmanager/rapidast-results-sync-helper.yaml
@@ -1,0 +1,32 @@
+# DO NOT MODIFY DIRECTLY
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rapidast-results-sync-helper-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      labels:
+        name: "${POD_NAME}"
+      name: "${POD_NAME}"
+    spec:
+      volumes:
+        - name: results-volume
+          persistentVolumeClaim:
+            claimName: "${PVC_NAME}"
+      containers:
+        - name: busybox
+          image: quay.io/openshifttest/busybox:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - "sleep"
+            - "600"
+          volumeMounts:
+            - name: results-volume
+              mountPath: "${VOLUME_MOUNT_PATH}"
+      restartPolicy: Never
+parameters:
+  - name: POD_NAME
+  - name: VOLUME_MOUNT_PATH
+  - name: PVC_NAME

--- a/test/extended/testdata/oap/certmanager/rbac-secret-reader.yaml
+++ b/test/extended/testdata/oap/certmanager/rbac-secret-reader.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: route-secret-reader-role-template
+objects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: secret-reader
+    rules:
+      - apiGroups: [""]
+        resources: ["secrets"]
+        verbs: ["get", "list", "watch"]
+        resourceNames: ["${SECRET_NAME}"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: secret-reader-binding
+    subjects:
+      - kind: ServiceAccount
+        name: router
+        namespace: openshift-ingress
+    roleRef:
+      kind: Role
+      name: secret-reader
+      apiGroup: rbac.authorization.k8s.io
+parameters:
+  - name: SECRET_NAME

--- a/test/extended/testdata/oap/certmanager/rbac-vault-bound-sa.yaml
+++ b/test/extended/testdata/oap/certmanager/rbac-vault-bound-sa.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rbac-vault-bound-sa-template
+objects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: ${SA_NAME}-role
+    rules:
+      - apiGroups: [""]
+        resources: ["serviceaccounts/token"]
+        resourceNames: ["${SA_NAME}"]
+        verbs: ["create"]
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: ${SA_NAME}-rolebinding
+    subjects:
+      - kind: ServiceAccount
+        name: cert-manager
+        namespace: cert-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ${SA_NAME}-role
+parameters:
+  - name: SA_NAME

--- a/test/extended/testdata/oap/certmanager/secret-vault-static-sa-token.yaml
+++ b/test/extended/testdata/oap/certmanager/secret-vault-static-sa-token.yaml
@@ -1,0 +1,14 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: secret-vault-static-sa-token-template
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${SA_NAME}
+      annotations:
+        kubernetes.io/service-account.name: ${SA_NAME}
+    type: kubernetes.io/service-account-token
+parameters:
+  - name: SA_NAME

--- a/test/extended/testdata/oap/certmanager/servicemonitor.yaml
+++ b/test/extended/testdata/oap/certmanager/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: cert-manager
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/name: cert-manager
+  name: cert-manager
+spec:
+  endpoints:
+    - interval: 30s
+      port: tcp-prometheus-servicemonitor
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/name: cert-manager

--- a/test/extended/testdata/oap/certmanager/subscription.yaml
+++ b/test/extended/testdata/oap/certmanager/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: "${NAME}"
+    spec:
+      channel: "${CHANNEL}"
+      installPlanApproval: Automatic
+      name: "${NAME}"
+      source: "${SOURCE}"
+      sourceNamespace: "${SOURCE_NAMESPACE}"
+parameters:
+  - name: NAME
+  - name: SOURCE
+  - name: SOURCE_NAMESPACE
+  - name: CHANNEL

--- a/test/extended/testdata/oap/eso/clustergenerator-password.yaml
+++ b/test/extended/testdata/oap/eso/clustergenerator-password.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: generator-template
+objects:
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    kind: ClusterGenerator
+    metadata:
+      name: "${NAME}"
+    spec:
+      kind: Password
+      generator:
+        passwordSpec:
+          length: 16
+          digits: 5
+          symbols: 5
+          symbolCharacters: "-_$@"
+          noUpper: false
+          allowRepeat: true
+parameters:
+  - name: NAME

--- a/test/extended/testdata/oap/eso/externalsecret-awsps.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-awsps.yaml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRef:
+        name: "${SECRETSTORENAME}"
+        kind: SecretStore
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+      data:
+      - secretKey: "${SECRETKEY}"
+        remoteRef:
+          key: "${KEY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-from-awssm"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: SECRETKEY
+    value: "secret-value-from-awssm"
+  - name: KEY
+    value: "esoSecret"
+  
+  
+

--- a/test/extended/testdata/oap/eso/externalsecret-awssm.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-awssm.yaml
@@ -1,0 +1,45 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRef:
+        name: "${SECRETSTORENAME}"
+        kind: SecretStore
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+        deletionPolicy: "${DELPOLICY}"
+      data:
+      - secretKey: "${SECRETKEY}"
+        remoteRef:
+          key: "${KEY}"
+          property: "${PROPERTY}"
+      dataFrom:
+      - extract:
+          key: "${KEY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-from-awssm"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: DELPOLICY
+    value: "Retain"
+  - name: SECRETKEY
+    value: "secret-value-from-awssm"
+  - name: KEY
+    value: "jitliSecret"
+  - name: PROPERTY
+  
+  
+

--- a/test/extended/testdata/oap/eso/externalsecret-gcpsm-version.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-gcpsm-version.yaml
@@ -1,0 +1,44 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRef:
+        name: "${SECRETSTORENAME}"
+        kind: SecretStore
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+        deletionPolicy: "${DELETEPOLICY}"
+      data:
+      - secretKey: "${SECRETKEY}"
+        remoteRef:
+          key: "${KEY}"
+          version: "${VERSION}"
+      dataFrom:
+      - extract:
+          key: "${FROMKEY}"
+          version: "${FROMVERSION}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-from-awssm"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: DELETEPOLICY
+    value: "Retain"
+  - name: SECRETKEY
+    value: "secret-value-from-awssm"
+  - name: KEY
+  - name: VERSION
+  - name: FROMKEY
+  - name: FROMVERSION

--- a/test/extended/testdata/oap/eso/externalsecret-gcpsm.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-gcpsm.yaml
@@ -1,0 +1,40 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRef:
+        name: "${SECRETSTORENAME}"
+        kind: SecretStore
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+        deletionPolicy: "${DELETEPOLICY}"
+      data:
+      - secretKey: "${SECRETKEY}"
+        remoteRef:
+          key: "${KEY}"
+      dataFrom:
+      - extract:
+          key: "${FROMKEY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-from-awssm"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: DELETEPOLICY
+    value: "Retain"
+  - name: SECRETKEY
+    value: "secret-value-from-awssm"
+  - name: KEY
+  - name: FROMKEY

--- a/test/extended/testdata/oap/eso/externalsecret-generator.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-generator.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+      dataFrom:
+      - sourceRef:
+          generatorRef:
+            apiVersion: generators.external-secrets.io/v1alpha1
+            kind: "${GENERATORKIND}"
+            name: "${GENERATOR}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETNAME
+    value: "secret-from-generator"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: GENERATORKIND
+  - name: GENERATOR

--- a/test/extended/testdata/oap/eso/externalsecret-vault.yaml
+++ b/test/extended/testdata/oap/eso/externalsecret-vault.yaml
@@ -1,0 +1,35 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRef:
+        name: "${SECRETSTORENAME}"
+        kind: SecretStore
+      target:
+        name: "${SECRETNAME}"
+        creationPolicy: "${CREATIONPOLICY}"
+      data:
+      - secretKey: "${SECRETKEY}"
+        remoteRef:
+          key: "${KEY}"
+          property: "${PROPERTY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-from-vault"
+  - name: CREATIONPOLICY
+    value: "Owner"
+  - name: SECRETKEY
+    value: "secret-value-from-vault"
+  - name: KEY
+  - name: PROPERTY

--- a/test/extended/testdata/oap/eso/generator-password.yaml
+++ b/test/extended/testdata/oap/eso/generator-password.yaml
@@ -1,0 +1,18 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: generator-template
+objects:
+  - apiVersion: generators.external-secrets.io/v1alpha1
+    kind: Password
+    metadata:
+      name: "${NAME}"
+    spec:
+      length: 16
+      digits: 5
+      symbols: 5
+      symbolCharacters: "-_$@"
+      noUpper: false
+      allowRepeat: true
+parameters:
+  - name: NAME

--- a/test/extended/testdata/oap/eso/helm-vault-config.yaml
+++ b/test/extended/testdata/oap/eso/helm-vault-config.yaml
@@ -1,0 +1,30 @@
+# xref: https://github.com/hashicorp/vault-helm/blob/main/values.yaml All available parameters and default values for the Vault chart.
+# Set 'server.dataStorage.size' to 1Gi as the default 10Gi is too expensive and unnecessary for testing propose in CI.
+global:
+  enabled: true
+  tlsDisable: true
+  openshift: true
+injector:
+  enabled: false
+server:
+  ui:
+    enabled: true
+  image:
+    repository: "quay.io/openshifttest/vault"
+    tag: "1.19.0"
+  dataStorage:
+    enabled: true
+    size: 1Gi
+  extraEnvironmentVars: {}
+  standalone:
+    enabled: true
+    config: |
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+      ui = true

--- a/test/extended/testdata/oap/eso/namespace.yaml
+++ b/test/extended/testdata/oap/eso/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets-operator

--- a/test/extended/testdata/oap/eso/operandConfig.yaml
+++ b/test/extended/testdata/oap/eso/operandConfig.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecrets
+metadata:
+  labels:
+    app.kubernetes.io/name: external-secrets-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+spec: {}

--- a/test/extended/testdata/oap/eso/operatorgroup.yaml
+++ b/test/extended/testdata/oap/eso/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: external-secrets-og
+  namespace: external-secrets-operator

--- a/test/extended/testdata/oap/eso/pushsecret-aws-secretkey.yaml
+++ b/test/extended/testdata/oap/eso/pushsecret-aws-secretkey.yaml
@@ -1,0 +1,31 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1alpha1
+    kind: PushSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRefs:
+        - name: "${SECRETSTORENAME}"
+          kind: SecretStore
+      selector:
+        secret: 
+          name: "${SECRETNAME}"
+      data:
+        - match:
+            secretKey: "${SECRETKEY}"
+            remoteRef:
+              remoteKey: "${KEY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-push-parameter-store"
+  - name: SECRETKEY
+  - name: KEY  

--- a/test/extended/testdata/oap/eso/pushsecret-aws.yaml
+++ b/test/extended/testdata/oap/eso/pushsecret-aws.yaml
@@ -1,0 +1,29 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: externalsecret-template
+objects:
+  - apiVersion: external-secrets.io/v1alpha1
+    kind: PushSecret
+    metadata:
+      name: "${NAME}"
+    spec:
+      refreshInterval: "${REFREASHINTERVAL}"
+      secretStoreRefs:
+        - name: "${SECRETSTORENAME}"
+          kind: SecretStore
+      selector:
+        secret: 
+          name: "${SECRETNAME}"
+      data:
+        - match:
+            remoteRef:
+              remoteKey: "${KEY}"
+parameters:
+  - name: NAME
+  - name: REFREASHINTERVAL
+    value: "1m"
+  - name: SECRETSTORENAME
+  - name: SECRETNAME
+    value: "secret-push-parameter-store"
+  - name: KEY  

--- a/test/extended/testdata/oap/eso/secretstore-awssm.yaml
+++ b/test/extended/testdata/oap/eso/secretstore-awssm.yaml
@@ -1,0 +1,32 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: secretstore-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: "${NAME}"
+    spec:
+      provider:
+        aws:
+          service: "${SERVICE}"
+          region: "${REGION}"
+          auth:
+            secretRef:
+              accessKeyIDSecretRef:
+                name: "${SECRETNAME}"
+                key: "${ACCESSKEY}"
+              secretAccessKeySecretRef:
+                name: "${SECRETNAME}"
+                key: "${SECRETACCESSKEY}"
+parameters:
+  - name: NAME
+  - name: SERVICE
+    value: "SecretsManager"
+  - name: REGION
+  - name: SECRETNAME
+  - name: ACCESSKEY
+    value: "access-key"
+  - name: SECRETACCESSKEY
+    value: "secret-access-key"

--- a/test/extended/testdata/oap/eso/secretstore-gcpsm.yaml
+++ b/test/extended/testdata/oap/eso/secretstore-gcpsm.yaml
@@ -1,0 +1,26 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: secretstore-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: "${NAME}"
+    spec:
+      provider:
+        gcpsm:
+          projectID: "${PROJECTID}"
+          auth:
+            secretRef:
+              secretAccessKeySecretRef:
+                name: "${SECRETNAME}"
+                key: "${SECRETACCESSKEY}"
+parameters:
+  - name: NAME
+  - name: PROJECTID
+    value: "openshift-qe"
+  - name: SECRETNAME
+    value: "google-eso-sa-key"
+  - name: SECRETACCESSKEY
+    value: "key.json"

--- a/test/extended/testdata/oap/eso/secretstore-vault.yaml
+++ b/test/extended/testdata/oap/eso/secretstore-vault.yaml
@@ -1,0 +1,30 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: secretstore-template
+objects:
+  - apiVersion: external-secrets.io/v1
+    kind: SecretStore
+    metadata:
+      name: "${NAME}"
+    spec:
+      provider:
+        vault:
+          server: "${SERVER}"
+          path: "${PATH}"
+          version: "${VERSION}"
+          auth:
+            tokenSecretRef:
+              name: "${SECRETNAME}"
+              key: "${ACCESSKEY}"
+              
+parameters:
+  - name: NAME
+  - name: SERVER
+  - name: PATH
+  - name: VERSION
+    value: "v2"
+  - name: SECRETNAME
+    value: "vault-token"
+  - name: ACCESSKEY
+    value: "token"

--- a/test/extended/testdata/oap/eso/subscription.yaml
+++ b/test/extended/testdata/oap/eso/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: "${NAME}"
+    spec:
+      channel: "${CHANNEL}"
+      installPlanApproval: Automatic
+      name: "${NAME}"
+      source: "${SOURCE}"
+      sourceNamespace: "${SOURCE_NAMESPACE}"
+parameters:
+  - name: NAME
+  - name: SOURCE
+  - name: SOURCE_NAMESPACE
+  - name: CHANNEL

--- a/test/extended/testdata/oap/mustgather/mustgather.yaml
+++ b/test/extended/testdata/oap/mustgather/mustgather.yaml
@@ -1,0 +1,26 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: mustgather-template
+objects:
+  - apiVersion: managed.openshift.io/v1alpha1
+    kind: MustGather
+    metadata:
+      name: "${NAME}"
+      namespace: "${NAMESPACE}"
+    spec:
+      caseID: "${CASEID}"
+      caseManagementAccountSecretRef:
+        name:  "${CASESECRET}"
+      serviceAccountRef:
+        name:  "${SA}"
+parameters:
+  - name: NAME
+  - name: NAMESPACE
+  - name: CASEID
+    value: "04230315"
+  - name: CASESECRET
+    value: "mustgather-creds"
+  - name: SA
+    value: "must-gather-operator"
+

--- a/test/extended/testdata/oap/mustgather/namespace.yaml
+++ b/test/extended/testdata/oap/mustgather/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: must-gather-operator

--- a/test/extended/testdata/oap/mustgather/operatorgroup.yaml
+++ b/test/extended/testdata/oap/mustgather/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: must-gather-og
+  namespace: must-gather-operator

--- a/test/extended/testdata/oap/mustgather/subscription.yaml
+++ b/test/extended/testdata/oap/mustgather/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: "${NAME}"
+    spec:
+      channel: "${CHANNEL}"
+      installPlanApproval: Automatic
+      name: "${NAME}"
+      source: "${SOURCE}"
+      sourceNamespace: "${SOURCE_NAMESPACE}"
+parameters:
+  - name: NAME
+  - name: SOURCE
+  - name: SOURCE_NAMESPACE
+  - name: CHANNEL

--- a/test/extended/testdata/oap/sscsi/73739/spc_vault_pod.yaml
+++ b/test/extended/testdata/oap/sscsi/73739/spc_vault_pod.yaml
@@ -1,0 +1,23 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: secrets-store-inline
+spec:
+  containers:
+  - image: registry.k8s.io/e2e-test-images/busybox:1.29-4
+    name: busybox
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/sleep"
+    - "10000"
+    volumeMounts:
+    - name: secrets-store-inline
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+  volumes:
+    - name: secrets-store-inline
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: "vault-foo"

--- a/test/extended/testdata/oap/sscsi/73739/vault_v1_secretproviderclass.yaml
+++ b/test/extended/testdata/oap/sscsi/73739/vault_v1_secretproviderclass.yaml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: secretproviderclass-vaultfoo-template
+objects:
+- apiVersion: secrets-store.csi.x-k8s.io/v1
+  kind: SecretProviderClass
+  metadata:
+    name: "vault-foo"
+  spec:
+    provider: vault
+    parameters:
+      roleName: "csi"
+      vaultAddress: "${VAULT_URL}"
+      objects:  |
+        - secretPath: "secret/data/foo"
+          objectName: "bar"
+          secretKey: "bar"
+        - secretPath: "secret/data/foo1"
+          objectName: "bar1"
+          secretKey: "bar1"
+parameters:
+  - name: VAULT_URL

--- a/test/extended/testdata/oap/sscsi/73739/vaultproviderplugin.yaml
+++ b/test/extended/testdata/oap/sscsi/73739/vaultproviderplugin.yaml
@@ -1,0 +1,155 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-k8s-auth-secret
+  namespace: openshift-cluster-csi-drivers
+  annotations:
+    kubernetes.io/service-account.name: vault
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-sa-tokenreview-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: openshift-cluster-csi-drivers
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-csi-provider
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vault-csi-provider-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-csi-provider-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vault-csi-provider-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: vault-csi-provider
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: vault-csi-provider-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]
+  resourceNames:
+  - vault-csi-provider-hmac-key
+# 'create' permissions cannot be restricted by resource name:
+# https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: vault-csi-provider-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vault-csi-provider-role
+subjects:
+- kind: ServiceAccount
+  name: vault-csi-provider
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: vault-csi-provider
+  name: vault-csi-provider
+  namespace: openshift-cluster-csi-drivers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vault-csi-provider
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vault-csi-provider
+    spec:
+      serviceAccountName: vault-csi-provider
+      tolerations:
+      containers:
+        - name: provider-vault-installer
+          image: docker.io/hashicorp/vault-csi-provider:1.4.1
+          securityContext:
+            privileged: true
+          imagePullPolicy: Always
+          args:
+            - -endpoint=/provider/vault.sock
+            - -debug=false
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          volumeMounts:
+            - name: providervol
+              mountPath: "/provider"
+          livenessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/extended/testdata/oap/sscsi/75963/gcpproviderplugin.yaml
+++ b/test/extended/testdata/oap/sscsi/75963/gcpproviderplugin.yaml
@@ -1,0 +1,111 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-gcp
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-gcp-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-gcp-role
+subjects:
+  - kind: ServiceAccount
+    name: csi-secrets-store-provider-gcp
+    namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-gcp-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - get
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: csi-secrets-store-provider-gcp
+  name: csi-secrets-store-provider-gcp
+  namespace: openshift-cluster-csi-drivers
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-gcp
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-gcp
+    spec:
+      serviceAccountName: csi-secrets-store-provider-gcp
+      initContainers:
+      - name: chown-provider-mount
+        image: busybox
+        command:
+        - chown
+        - "1000:1000"
+        - /etc/kubernetes/secrets-store-csi-providers
+        volumeMounts:
+        - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+          name: providervol
+        securityContext:
+          privileged: true
+      hostNetwork: false
+      hostPID: false
+      hostIPC: false
+      containers:
+        - name: provider
+          image: us-docker.pkg.dev/secretmanager-csi/secrets-store-csi-driver-provider-gcp/plugin@sha256:a493a78bbb4ebce5f5de15acdccc6f4d19486eae9aa4fa529bb60ac112dd6650
+          securityContext:
+            privileged: true
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          env:
+            - name: TARGET_DIR
+              value: "/etc/kubernetes/secrets-store-csi-providers"
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+              mountPropagation: None
+              readOnly: false
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /live
+              port: 8095
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: providervol
+          hostPath:
+            path: /etc/kubernetes/secrets-store-csi-providers
+      tolerations:
+        - key: kubernetes.io/arch
+          operator: Equal
+          value: amd64
+          effect: NoSchedule
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/test/extended/testdata/oap/sscsi/75963/invalid_sc_pod.yaml
+++ b/test/extended/testdata/oap/sscsi/75963/invalid_sc_pod.yaml
@@ -1,0 +1,41 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: invalid-app-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "invalid/../secrets/testsecret1/versions/1"
+        path: "testsecret1.txt"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: invalidmypod
+spec:
+  serviceAccountName: mypodserviceaccount
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: invalidmypod2
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+      - mountPath: "/mnt/secrets-store"
+        name: mysecret
+  volumes:
+  - name: mysecret
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "invalid-app-secrets"
+      nodePublishSecretRef:
+        name: secret75963

--- a/test/extended/testdata/oap/sscsi/75963/sc_pod.yaml
+++ b/test/extended/testdata/oap/sscsi/75963/sc_pod.yaml
@@ -1,0 +1,50 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: app-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/openshift-qe/secrets/testsecret1/versions/1"
+        path: "testsecret1.txt"
+      - resourceName: "projects/openshift-qe/secrets/testsecret2/versions/1"
+        path: "testsecret2.txt"
+      - resourceName: "projects/openshift-qe/secrets/secret75970/versions/2"
+        path: "secret75970"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mypodserviceaccount
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+spec:
+  serviceAccountName: mypodserviceaccount
+  containers:
+  - image: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: mypod2
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+      - mountPath: "/mnt/secrets-store"
+        name: mysecret
+  volumes:
+  - name: mysecret
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "app-secrets"
+      nodePublishSecretRef:
+        name: secret75963

--- a/test/extended/testdata/oap/sscsi/75970/sc_pod.yaml
+++ b/test/extended/testdata/oap/sscsi/75970/sc_pod.yaml
@@ -1,0 +1,60 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: app-secrets
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/openshift-qe/secrets/secret75970/versions/2"
+        path: "secret75970"
+  secretObjects:
+    - secretName: opaquesecret75970
+      type: Opaque
+      labels:
+        environment: "secret75970"
+      data:
+      - objectName: secret75970
+        key: test-secret-contents
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mypodserviceaccount
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mypod
+spec:
+  serviceAccountName: mypodserviceaccount
+  containers:
+  - image: quay.io/olmqe/cloud-sdk:slim
+    imagePullPolicy: IfNotPresent
+    name: mypod2
+    env:
+    - name: SECRET_OPAQUE
+      valueFrom:
+        secretKeyRef:
+          name: opaquesecret75970 
+          key: test-secret-contents
+    resources:
+      requests:
+        cpu: 100m
+    stdin: true
+    stdinOnce: true
+    terminationMessagePath: /dev/termination-log
+    terminationMessagePolicy: File
+    tty: true
+    volumeMounts:
+      - mountPath: "/mnt/secrets-store"
+        name: mysecret
+  volumes:
+  - name: mysecret
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "app-secrets"
+      nodePublishSecretRef:
+        name: secret75970

--- a/test/extended/testdata/oap/sscsi/drivers.yaml
+++ b/test/extended/testdata/oap/sscsi/drivers.yaml
@@ -1,0 +1,8 @@
+apiVersion: operator.openshift.io/v1
+kind: ClusterCSIDriver
+metadata:
+  name: secrets-store.csi.k8s.io
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Trace

--- a/test/extended/testdata/oap/sscsi/helm-vault-config.yaml
+++ b/test/extended/testdata/oap/sscsi/helm-vault-config.yaml
@@ -1,0 +1,30 @@
+# xref: https://github.com/hashicorp/vault-helm/blob/main/values.yaml All available parameters and default values for the Vault chart.
+# Set 'server.dataStorage.size' to 1Gi as the default 10Gi is too expensive and unnecessary for testing propose in CI.
+global:
+  enabled: true
+  tlsDisable: true
+  openshift: true
+injector:
+  enabled: false
+server:
+  ui:
+    enabled: true
+  image:
+    repository: "quay.io/openshifttest/vault"
+    tag: "1.19.0"
+  dataStorage:
+    enabled: true
+    size: 1Gi
+  extraEnvironmentVars: {}
+  standalone:
+    enabled: true
+    config: |
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "file" {
+        path = "/vault/data"
+      }
+      ui = true

--- a/test/extended/testdata/oap/sscsi/operatorgroup.yaml
+++ b/test/extended/testdata/oap/sscsi/operatorgroup.yaml
@@ -1,0 +1,5 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sscsi-drivers-og
+  namespace: openshift-cluster-csi-drivers

--- a/test/extended/testdata/oap/sscsi/subscription.yaml
+++ b/test/extended/testdata/oap/sscsi/subscription.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: "${NAME}"
+    spec:
+      channel: "${CHANNEL}"
+      installPlanApproval: Automatic
+      name: "${NAME}"
+      source: "${SOURCE}"
+      sourceNamespace: "${SOURCE_NAMESPACE}"
+parameters:
+  - name: NAME
+  - name: SOURCE
+  - name: SOURCE_NAMESPACE
+  - name: CHANNEL


### PR DESCRIPTION
After https://github.com/openshift/openshift-tests-private/pull/26954 merged, test will meet Test Panicked: Asset test/extended/testdata/oap/mustgather not found.
The solution is working on https://issues.redhat.com/browse/OCPERT-169.
And this is a hotfix to add test data of oap to do a quickly resolve.