### PR TITLE
Revert "NO-JIRA: Add olm into the known operator set"

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/operator_mapping.go
+++ b/pkg/monitortestlibrary/platformidentification/operator_mapping.go
@@ -111,7 +111,6 @@ var (
 		"monitoring",
 		"network",
 		"node-tuning",
-		"olm",
 		"openshift-apiserver",
 		"openshift-controller-manager",
 		"openshift-samples",
@@ -155,7 +154,6 @@ func init() {
 	utilruntime.Must(addOperatorMapping("monitoring", "Monitoring"))
 	utilruntime.Must(addOperatorMapping("network", "Networking"))
 	utilruntime.Must(addOperatorMapping("node-tuning", "Node Tuning Operator"))
-	utilruntime.Must(addOperatorMapping("olm", "OLM"))
 	utilruntime.Must(addOperatorMapping("openshift-apiserver", "openshift-apiserver"))
 	utilruntime.Must(addOperatorMapping("openshift-controller-manager", "openshift-controller-manager"))
 	utilruntime.Must(addOperatorMapping("openshift-samples", "Samples"))


### PR DESCRIPTION
Reverts openshift/origin#30308

This is causing payload failures in upgrade minor GCP jobs. [Example](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-gcp-ovn-upgrade-4.21-micro-release-openshift-release-analysis-aggregator/1972561250676117504)

Verify correct functionality during the un-revert with:
```
/payload-aggregate periodic-ci-openshift-release-master-ci-4.21-e2e-gcp-ovn-upgrade 10
```