### PR TITLE
CORENET-6373: ovn-k, virt, preconfigured udn addresses: Test MAC conflict detection

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -332,6 +332,20 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 								preconfiguredIPs: []string{"203.203.0.100", "2014:100:200::100"},
 							},
 						),
+						Entry(
+							"[OCPFeatureGate:PreconfiguredUDNAddresses] when the VM with preconfigured MAC address is created when the address is already taken",
+							networkAttachmentConfigParams{
+								name:               nadName,
+								topology:           "layer2",
+								role:               "primary",
+								allowPersistentIPs: true,
+							},
+							kubevirt.FedoraVMWithPreconfiguredPrimaryUDNAttachment,
+							duplicateVM,
+							workloadNetworkConfig{
+								preconfiguredMAC: "02:00:00:22:22:22",
+							},
+						),
 					)
 				},
 				Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) {
@@ -588,6 +602,21 @@ func duplicateVM(cli *kubevirt.Client, vmNamespace, vmName string) {
 			)
 		})
 	}
+
+	mac, err := cli.GetJSONPath("vmi", vmName, "{.spec.domain.devices.interfaces[0].macAddress}")
+	Expect(err).NotTo(HaveOccurred())
+	if len(mac) > 0 {
+		vmiExpectations = append(vmiExpectations, func() {
+			waitForVMPodEventWithMessage(
+				cli,
+				vmNamespace,
+				duplicateVMName,
+				"MAC address already in use",
+				2*time.Minute,
+			)
+		})
+	}
+
 	Expect(cli.CreateVMIFromSpec(vmNamespace, duplicateVMName, vmiSpec, vmiCreationOptions...)).To(Succeed())
 	for _, expectation := range vmiExpectations {
 		expectation()


### PR DESCRIPTION
This PR is a followup PR to https://github.com/openshift/origin/pull/30010 https://github.com/openshift/origin/pull/30197, adding tests to check MAC conflict detection:
    create VM with Preconfigured MAC, assert MAC conflict are detected