### PR TITLE
OCPEDGE-1485: Add initial version of etcd kill and recovery test

### DIFF
--- a/test/extended/two_node/tnf_recovery.go
+++ b/test/extended/two_node/tnf_recovery.go
@@ -376,9 +376,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	g.It("should recover from etcd process crash", func() {
 		// Note: This test kills the etcd process/container on one node to simulate
 		// a process crash, testing Pacemaker's ability to detect and restart etcd
-		survivedNode := peerNode
-		g.GinkgoT().Printf("Randomly selected %s (%s) for etcd process crash and %s (%s) to survive\n",
-			targetNode.Name, targetNode.Status.Addresses[0].Address, survivedNode.Name, survivedNode.Status.Addresses[0].Address)
+		recoveryNode := peerNode
+		g.GinkgoT().Printf("Randomly selected %s (%s) for etcd process crash and %s (%s) as recovery node\n",
+			targetNode.Name, targetNode.Status.Addresses[0].Address, recoveryNode.Name, recoveryNode.Status.Addresses[0].Address)
 
 		g.By(fmt.Sprintf("Killing etcd process/container on %s", targetNode.Name))
 		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, targetNode.Name, "openshift-etcd",
@@ -386,9 +386,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to kill etcd process without command errors")
 
 		g.By("Waiting for cluster to recover - both nodes become started voting members")
-		defer g.GinkgoRecover()
 		validateEtcdRecoveryState(oc, etcdClientFactory,
-			&survivedNode,
+			&recoveryNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			6*time.Minute, 45*time.Second)
 	})


### PR DESCRIPTION
## Add etcd process crash recovery test for TNF clusters

Add test to validate Two Node with Fencing (TNF) cluster recovery after etcd process crashes.

The test kills the etcd process/container on one node and validates that Pacemaker automatically detects the failure and restarts etcd, with the cluster returning to a healthy state (both nodes as started voting members).

**Test approach:**
- Kills etcd using podman 
- Retries validation every 2 minutes for up to 6 minutes total
- Uses `GinkgoRecover()` to properly handle validation panics within `Eventually` retry logic
- Validates both etcd member state and operator health

**Related:** OCPBUGS-59238 (etcd process crash recovery issue in TNF clusters)