### PR TITLE
Revert "Revert "NO-JIRA: Add olm into the known operator set""

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/operator_mapping.go
+++ b/pkg/monitortestlibrary/platformidentification/operator_mapping.go
@@ -111,6 +111,7 @@ var (
 		"monitoring",
 		"network",
 		"node-tuning",
+		"olm",
 		"openshift-apiserver",
 		"openshift-controller-manager",
 		"openshift-samples",
@@ -154,6 +155,7 @@ func init() {
 	utilruntime.Must(addOperatorMapping("monitoring", "Monitoring"))
 	utilruntime.Must(addOperatorMapping("network", "Networking"))
 	utilruntime.Must(addOperatorMapping("node-tuning", "Node Tuning Operator"))
+	utilruntime.Must(addOperatorMapping("olm", "OLM"))
 	utilruntime.Must(addOperatorMapping("openshift-apiserver", "openshift-apiserver"))
 	utilruntime.Must(addOperatorMapping("openshift-controller-manager", "openshift-controller-manager"))
 	utilruntime.Must(addOperatorMapping("openshift-samples", "Samples"))

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -401,6 +401,13 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 				return "https://issues.redhat.com/browse/OCPBUGS-39026", nil
 			}
+		case "olm":
+			if condition.Type == configv1.OperatorAvailable &&
+				condition.Status == configv1.ConditionFalse &&
+				(condition.Reason == "OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying" ||
+					condition.Reason == "CatalogdDeploymentCatalogdControllerManager_Deploying") {
+				return "https://issues.redhat.com/browse/OCPBUGS-62517", nil
+			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
 				(condition.Reason == "APIServerDeployment_NoDeployment" ||


### PR DESCRIPTION
Revert https://github.com/openshift/origin/pull/30313 with an exception [OCPBUGS-62517](https://issues.redhat.com/browse/OCPBUGS-62517) for co/olm.

/hold

Let us run the aggregated job to avoid breaking payload again.