### PR TITLE
OCPBUGS-60472: networking, override join subnets for UDN and CUDN

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -307,13 +307,13 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 				},
 				Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) {
 					netConfig := newNetworkAttachmentConfig(c)
-					nad := generateNAD(netConfig)
+					nad := generateNAD(oc, netConfig)
 					By(fmt.Sprintf("Creating NetworkAttachmentDefinitions %s/%s", nad.Namespace, nad.Name))
 					_, err := nadClient.NetworkAttachmentDefinitions(c.namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 					Expect(err).NotTo(HaveOccurred())
 				}),
 				Entry("[OCPFeatureGate:NetworkSegmentation] UserDefinedNetwork", func(c networkAttachmentConfigParams) {
-					udnManifest := generateUserDefinedNetworkManifest(&c)
+					udnManifest := generateUserDefinedNetworkManifest(oc, &c)
 					By(fmt.Sprintf("Creating UserDefinedNetwork %s/%s", c.namespace, c.name))
 					Expect(applyManifest(c.namespace, udnManifest)).To(Succeed())
 					Eventually(userDefinedNetworkReadyFunc(oc.AdminDynamicClient(), c.namespace, c.name), udnCrReadyTimeout, time.Second).Should(Succeed())
@@ -369,7 +369,7 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][OCPFeatureGate:Netw
 				cidr:               correctCIDRFamily(oc, cidrIPv4, cidrIPv6),
 			}
 
-			nad := generateNAD(newNetworkAttachmentConfig(netConfig))
+			nad := generateNAD(oc, newNetworkAttachmentConfig(netConfig))
 			By(fmt.Sprintf("Creating NetworkAttachmentDefinitions %s/%s", nad.Namespace, nad.Name))
 			_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
 				context.Background(),

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -167,12 +167,12 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			},
 			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(c)
-				nad := generateNAD(netConfig)
+				nad := generateNAD(oc, netConfig)
 				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(context.Background(), nad, metav1.CreateOptions{})
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
-				udnManifest := generateUserDefinedNetworkManifest(&c)
+				udnManifest := generateUserDefinedNetworkManifest(oc, &c)
 				cleanup, err := createManifest(f.Namespace.Name, udnManifest)
 				DeferCleanup(cleanup)
 				Eventually(userDefinedNetworkReadyFunc(oc.AdminDynamicClient(), f.Namespace.Name, c.name), 5*time.Second, time.Second).Should(Succeed())
@@ -260,12 +260,12 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			},
 			Entry("NetworkAttachmentDefinitions", func(c networkAttachmentConfigParams) error {
 				netConfig := newNetworkAttachmentConfig(c)
-				nad := generateNAD(netConfig)
+				nad := generateNAD(oc, netConfig)
 				_, err := nadClient.NetworkAttachmentDefinitions(c.namespace).Create(context.Background(), nad, metav1.CreateOptions{})
 				return err
 			}),
 			Entry("UserDefinedNetwork", func(c networkAttachmentConfigParams) error {
-				udnManifest := generateUserDefinedNetworkManifest(&c)
+				udnManifest := generateUserDefinedNetworkManifest(oc, &c)
 				cleanup, err := createManifest(c.namespace, udnManifest)
 				DeferCleanup(cleanup)
 				Eventually(userDefinedNetworkReadyFunc(oc.AdminDynamicClient(), c.namespace, c.name), 5*time.Second, time.Second).Should(Succeed())

--- a/test/extended/networking/network_segmentation_policy.go
+++ b/test/extended/networking/network_segmentation_policy.go
@@ -99,7 +99,7 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 				netConfig.namespace = f.Namespace.Name
 				_, err := nadClient.NetworkAttachmentDefinitions(f.Namespace.Name).Create(
 					context.Background(),
-					generateNAD(netConfig),
+					generateNAD(oc, netConfig),
 					metav1.CreateOptions{},
 				)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -205,7 +205,7 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 
 					_, err := nadClient.NetworkAttachmentDefinitions(namespace).Create(
 						context.Background(),
-						generateNAD(netConfig),
+						generateNAD(oc, netConfig),
 						metav1.CreateOptions{},
 					)
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/extended/networking/route_advertisements.go
+++ b/test/extended/networking/route_advertisements.go
@@ -421,7 +421,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 				framework.Logf("Allocated subnets %s %s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
 
 				nc.cidr = correctCIDRFamily(oc, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
-				cudnManifest := generateClusterUserDefinedNetworkManifest(nc)
+				cudnManifest := generateClusterUserDefinedNetworkManifest(oc, nc)
 				cleanup, err = createManifest("", cudnManifest)
 				o.Expect(err).NotTo(o.HaveOccurred())
 				o.Eventually(clusterUserDefinedNetworkReadyFunc(oc.AdminDynamicClient(), testCUDNName), 60*time.Second, time.Second).Should(o.Succeed())
@@ -722,7 +722,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 						framework.Logf("Allocated subnets %s %s", userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
 
 						nc.cidr = correctCIDRFamily(oc, userDefinedNetworkIPv4Subnet, userDefinedNetworkIPv6Subnet)
-						cudnManifest := generateClusterUserDefinedNetworkManifest(nc)
+						cudnManifest := generateClusterUserDefinedNetworkManifest(oc, nc)
 						cleanup, err = createManifest(targetNamespace, cudnManifest)
 
 						o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
At hypershift kubevirt hosted clusters the default network join subnet is changed so it will not collide with the infra cluster one, this change use a different join subnet for UDNs so it will never collide with normal or kubevirt hosted ovnk clusters.

Old PR changing the default network join subnet at hosted cluster: https://github.com/openshift/hypershift/pull/1783