### PR TITLE
Improve RedactBearerToken performance by moving regex compilation outside function

### DIFF
--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -72,7 +72,10 @@ func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
 	if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, o.GinkgoRunSuiteOptions.DryRun); err != nil {
 		return err
 	}
-	klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+	// Redact the bearer token exposure
+	testContextString := fmt.Sprintf("%#v", exutil.TestContext)
+	redactedTestContext := exutil.RedactBearerToken(testContextString)
+	klog.V(4).Infof("Loaded test configuration: %s", redactedTestContext)
 
 	return nil
 }

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -1040,11 +1040,16 @@ func (c *CLI) start(stdOutBuff, stdErrBuff *bytes.Buffer) (*exec.Cmd, error) {
 	return cmd, err
 }
 
+var (
+	reAuthorizationBearer = regexp.MustCompile(`Authorization:\s+Bearer.*\s+`)
+	reBearerToken         = regexp.MustCompile(`BearerToken:\s*\"[^\"]+\"`)
+)
+
 func RedactBearerToken(args string) string {
 	if strings.Contains(args, "Authorization: Bearer") {
-		// redact bearer token
-		re := regexp.MustCompile(`Authorization:\s+Bearer.*\s+`)
-		args = re.ReplaceAllString(args, "Authorization: Bearer <redacted> ")
+		args = reAuthorizationBearer.ReplaceAllString(args, "Authorization: Bearer <redacted> ")
+	} else if strings.Contains(args, "BearerToken") {
+		args = reBearerToken.ReplaceAllString(args, "BearerToken: <redacted> ")
 	}
 	return args
 }


### PR DESCRIPTION
### Summary

This PR is a follow-up to #29912 by @Shilpa-Gokul. It refactors the `RedactBearerToken` function to precompile regex patterns outside the function for better performance and readability.

### Details

- Avoids recompiling regex on each function call.

---

This improvement complements the changes in #29912. Please consider merging this after or alongside the original PR.

Thanks for reviewing!
