### PR TITLE
NO-JIRA: known-image-checker: do nothing in WriteContentToStorage

### DIFF
--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -13,8 +12,6 @@ import (
 	"github.com/openshift/origin/pkg/monitortestframework"
 
 	"github.com/openshift/origin/test/extended/util/image"
-
-	monitorserialization "github.com/openshift/origin/pkg/monitor/serialization"
 
 	imagev1 "github.com/openshift/client-go/image/clientset/versioned/typed/image/v1"
 	"github.com/openshift/library-go/pkg/image/reference"
@@ -213,7 +210,7 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 }
 
 func (*clusterImageValidator) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return monitorserialization.EventsToFile(filepath.Join(storageDir, fmt.Sprintf("e2e-events%s.json", timeSuffix)), finalIntervals)
+	return nil
 }
 
 func (*clusterImageValidator) Cleanup(ctx context.Context) error {


### PR DESCRIPTION
The same content is written into the same file by interval-serializer [1].

[1]. https://github.com/openshift/origin/blob/a96df2d80ddf3429a6ed24ad0f3f412667fe1189/pkg/monitortests/testframework/intervalserializer/monitortest.go#L46