### PR TITLE
TRT-2346: Fix not initializing adminRESTConfig

### DIFF
--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events_monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/pathological_events_monitortest.go
@@ -31,6 +31,7 @@ func (w *legacyPathologicalMonitorTests) PrepareCollection(ctx context.Context, 
 }
 
 func (w *legacyPathologicalMonitorTests) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	w.adminRESTConfig = adminRESTConfig
 	return nil
 }
 


### PR DESCRIPTION
In [MCO-1828](https://issues.redhat.com//browse/MCO-1828) a regression was introduced as the `legacyPathologicalMonitorTests` code migrated from the previous `legacyAlertsMonitorTests` monitor test didn't properly initialize the pointer to the adminRESTConfig, leading to wrong exception list that doesn't match the one used before the change.