### PR TITLE
Revert "Fix endpoint admission test namespace creation for ROSA"

### DIFF
--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -186,15 +186,9 @@ func testOneEndpointSlice(oc *exutil.CLI, client kubernetes.Interface, addrType,
 }
 
 func getClientForServiceAccount(adminClient kubernetes.Interface, clientConfig *rest.Config, namespace, name string) (*kubernetes.Clientset, *rest.Config, error) {
-	_, err := adminClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, nil, err
-		}
-		_, err = adminClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
-		if err != nil {
-			return nil, nil, err
-		}
+	_, err := adminClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, nil, err
 	}
 
 	_, err = adminClient.CoreV1().ServiceAccounts(namespace).Create(context.Background(), &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})


### PR DESCRIPTION
Avoid attempting to create existing namespaces like kube-system which triggers managed-cluster-validating-webhooks in ROSA.

This reverts commit 46bbe12a32ecae26b339e9168e0cdcf1a426ff25.
Follows https://github.com/openshift/origin/pull/30352

Resolves: [SREP-2020](https://issues.redhat.com/browse/SREP-2020)