### PR TITLE
OCPBUGS-63040: Add imagestream update dryrun test

### DIFF
--- a/test/extended/images/dryrun.go
+++ b/test/extended/images/dryrun.go
@@ -7,8 +7,8 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
-	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )

--- a/test/extended/util/compat_otp/testdata/opm/render/validate/catalog-error/operator-2/index.json
+++ b/test/extended/util/compat_otp/testdata/opm/render/validate/catalog-error/operator-2/index.json
@@ -1,8 +1,9 @@
+[
 {
     "schema": "olm.package",
     "name": "operator-2",
     "defaultChannel": "beta"
-}
+},
 {
     "schema": "olm.channel",
     "name": "4.7",
@@ -15,7 +16,7 @@
             ]
         }
     ]
-}
+},
 {
     "schema": "olm.channel",
     "name": "4.8",
@@ -30,7 +31,7 @@
             "replaces": "operator-2.v0.4.0"
         }
     ]
-}
+},
 {
     "schema": "olm.channel",
     "name": "4.9",
@@ -41,7 +42,7 @@
             "skipRange": ">=0.1.0 <0.6.0"
         }
     ]
-}
+},
 {
     "schema": "olm.channel",
     "name": "alpha",
@@ -55,7 +56,7 @@
             "replaces": "operator-2.v0.1.1"
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.1.0",
@@ -78,7 +79,7 @@
             }
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.2.0",
@@ -101,7 +102,7 @@
             }
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.3.0",
@@ -124,7 +125,7 @@
             }
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.4.0",
@@ -147,7 +148,7 @@
             }
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.5.0",
@@ -170,7 +171,7 @@
             }
         }
     ]
-}
+},
 {
     "schema": "olm.bundle",
     "name": "operator-2.v0.6.0",
@@ -194,3 +195,4 @@
         }
     ]
 }
+]


### PR DESCRIPTION
**What does this do?**
1. PR https://github.com/openshift/openshift-apiserver/pull/511 fixed imagestream with --dry-run=server bug. which includes creation/update/deletion operations.
But newly discovered that, creation of imagestream with `--dry-run=server` doesn't work as expected, filed one bug https://issues.redhat.com/browse/OCPBUGS-62875 for this.
```
$ oc create imagestream dryrun-test --dry-run=server -o yaml -n test1

$ oc get is dryrun-test -n test1
NAME          IMAGE REPOSITORY                                                     TAGS   UPDATED
dryrun-test   image-registry.xxxxxx.svc:5000/test1/dryrun-test  
```
so only add update of imagestream with `--dry-run=server`  test.

2. Fixed the error in disconection cluster we see from `sippy`, use an existing internal image stream tag `openshift/cli:latest`  instead.
```
fail [github.com/openshift/origin/test/extended/images/dryrun.go:26]: Unexpected error:
    <*errors.errorString | 0xc00773a040>: 
    timed out while waiting of an image stream tag e2e-test-image-dry-run-d8lks/test:latest
    {
        s: "timed out while waiting of an image stream tag e2e-test-image-dry-run-d8lks/test:latest",
    }
occurred
```
3. For verify job,
- Fix gofmt import ordering in test/extended/images/dryrun.go
- Fix invalid JSON format in test/extended/util/compat_otp/testdata/opm/render/validate/catalog-error/operator-2/index.json