### PR TITLE
TRT-2349: Revert "make TLS registry tests required"

### DIFF
--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -269,9 +269,12 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		if len(newTLSRegistry.CertKeyPairs) > 0 || len(newTLSRegistry.CertificateAuthorityBundles) > 0 {
 			registryString, err := json.MarshalIndent(newTLSRegistry, "", "  ")
 			if err != nil {
-				g.Fail(fmt.Sprintf("Failed to marshal registry %#v: %v", newTLSRegistry, err))
+				//g.Fail("Failed to marshal registry %#v: %v", newTLSRegistry, err)
+				testresult.Flakef("Failed to marshal registry %#v: %v", newTLSRegistry, err)
 			}
-			g.Fail(fmt.Sprintf("Unregistered TLS certificates found:\n%s\nSee tls/ownership/README.md in origin repo", registryString))
+			// TODO: uncomment when test no longer fails and enhancement is merged
+			//g.Fail(fmt.Sprintf("Unregistered TLS certificates:\n%s", registryString))
+			testresult.Flakef("Unregistered TLS certificates found:\n%s\nSee tls/ownership/README.md in origin repo", registryString)
 		}
 	})
 
@@ -281,7 +284,9 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		if len(messages) > 0 {
-			g.Fail(strings.Join(messages, "\n"))
+			// TODO: uncomment when test no longer fails and enhancement is merged
+			//g.Fail(strings.Join(messages, "\n"))
+			testresult.Flakef("%s", strings.Join(messages, "\n"))
 		}
 	})
 


### PR DESCRIPTION
Reverts openshift/origin#29074

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Multiple payload failures due to ROSA ` all registered tls artifacts must have no metadata violation regressions` and ` all tls artifacts must be registered` failures

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert

Unfortunately for ROSA we can not payload test to verify


CC: @vrutkovs 