### PR TITLE
Revert "Merge pull request #30134 from Amarthya-v/fix-endpoint-admission-namespace-creation"

### DIFF
--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -186,15 +186,9 @@ func testOneEndpointSlice(oc *exutil.CLI, client kubernetes.Interface, addrType,
 }
 
 func getClientForServiceAccount(adminClient kubernetes.Interface, clientConfig *rest.Config, namespace, name string) (*kubernetes.Clientset, *rest.Config, error) {
-	_, err := adminClient.CoreV1().Namespaces().Get(context.Background(), namespace, metav1.GetOptions{})
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, nil, err
-		}
-		_, err = adminClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
-		if err != nil {
-			return nil, nil, err
-		}
+	_, err := adminClient.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}, metav1.CreateOptions{})
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, nil, err
 	}
 
 	_, err = adminClient.CoreV1().ServiceAccounts(namespace).Create(context.Background(), &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})


### PR DESCRIPTION
This reverts commit cc8ae10f65d6223e4884b6b26f9f17ecd057ec9a, reversing changes made to 0dfa8e53141b20c419f9521ad7b79216a6b5eb3e.

The MCVW that was blocking namespace operations for cluster-admins is being reverted by the SRE team as it's more disruptive than intended. Since the webhook restriction is being removed, this test fix is no longer needed.


Resolves: [SREP-2020](https://issues.redhat.com/browse/SREP-2020)