### PR TITLE
OCPBUGS-62359: Check more operatorsProgressing

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -73,14 +73,14 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 
 	failures := []string{}
 	flakes := []string{}
-	networkOperatorProgressing := events.Filter(func(ev monitorapi.Interval) bool {
+	// Any disruption during cluster's upgrading, such as node restarts, CNI/OVN/DNS outages, or API lookups used by the CNI, can result in a FailedCreatePodSandBox error.
+	operatorsProgressing := events.Filter(func(ev monitorapi.Interval) bool {
 		annotations := ev.Message.Annotations
 		if annotations[monitorapi.AnnotationCondition] != string(configv1.OperatorProgressing) {
 			return false
 		}
-		isNetwork := ev.Locator.Keys[monitorapi.LocatorClusterOperatorKey] == "network"
-		isMCO := ev.Locator.Keys[monitorapi.LocatorClusterOperatorKey] == "machine-config"
-		if isNetwork || isMCO {
+		switch ev.Locator.Keys[monitorapi.LocatorClusterOperatorKey] {
+		case "network", "machine-config", "dns", "kube-apiserver", "etcd":
 			return true
 		}
 		return false
@@ -183,22 +183,23 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 
 		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
 		if deletionTime := getPodDeletionTime(eventsForPods[partialLocator], event.Locator); deletionTime == nil {
-			// mark sandboxes errors as flakes if networking is being updated
-			match := -1
-			for i := range networkOperatorProgressing {
-				matchesFrom := event.From.After(networkOperatorProgressing[i].From)
-				matchesTo := event.To.Before(networkOperatorProgressing[i].To)
-				if matchesFrom && matchesTo {
-					match = i
+			var progressingOperatorName string
+			for _, operatorProgressingInterval := range operatorsProgressing {
+				if event.From.After(operatorProgressingInterval.From) &&
+					event.To.Before(operatorProgressingInterval.To) {
+					progressingOperatorName = operatorProgressingInterval.Locator.Keys[monitorapi.LocatorClusterOperatorKey]
 					break
 				}
 			}
-			if match != -1 {
-				flakes = append(flakes, fmt.Sprintf("%v - never deleted - network rollout - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
+			if len(progressingOperatorName) > 0 {
+				flakes = append(flakes, fmt.Sprintf(
+					"%v - never deleted - operator:%s was progressing which may cause pod sandbox creation errors - %v",
+					event.Locator.OldLocator(), progressingOperatorName, event.Message.OldMessage()))
 			} else {
-				failures = append(failures, fmt.Sprintf("%v - never deleted - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
+				failures = append(failures, fmt.Sprintf(
+					"%v - never deleted - operator:%s was progressing which may cause pod sandbox creation errors - %v",
+					event.Locator.OldLocator(), progressingOperatorName, event.Message.OldMessage()))
 			}
-
 		} else {
 			timeBetweenDeleteAndFailure := event.From.Sub(*deletionTime)
 			switch {


### PR DESCRIPTION
[OCPBUGS-62359](https://issues.redhat.com/browse/OCPBUGS-62359) failed for different reasons across multiple test runs

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-upgrade-from-stable-4.19-e2e-metal-ipi-ovn-upgrade-network-flow-matrix/1971288846830145536
dial tcp: lookup api-int.ostest.test.metalkube.org on 192.168.111.1:53: no such host

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.20-upgrade-from-stable-4.19-e2e-metal-ipi-upgrade-ovn-ipv6/1970880061380759552
dial tcp: lookup api-int.ostest.test.metalkube.org on [fd2e:6f44:5dd8:c956::1]:53: no such host

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-upgrade-from-stable-4.19-e2e-azure-ovn-upgrade/1975088922878808064
SetNetworkStatus: failed to update the pod prometheus-k8s-1 in out of cluster comm: status update failed for pod openshift-monitoring/prometheus-k8s-1: etcdserver: request timed out

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-e2e-vsphere-runc-upgrade/1971834599860342784
etNetworkStatus: failed to update the pod alertmanager-main-1 in out of cluster comm: status update failed for pod /: Get "https://api-int.ci-op-rky0hgt1-3e3a9.vmc-ci.devcluster.openshift.com:6443/api/v1/namespaces/openshift-monitoring/pods/alertmanager-main-1?timeout=1m0s": http2: client connection force closed via ClientConn.Close

Pod sandbox creation in OpenShift follows this sequence: kubelet → CRI (crio/containerd) → CNI (Multus + OVN-Kubernetes). Any disruption in this chain during cluster's upgrading, such as node restarts, CNI/OVN outages, or API lookups used by the CNI, can result in a FailedCreatePodSandBox error.

Added checks for DNS, etcd and kube-apiserver health during pod creation to filter sandbox creation failures during upgrades.