### PR TITLE
Exclude intentionally invalid JSON test files from validation

### DIFF
--- a/hack/verify-jsonformat.sh
+++ b/hack/verify-jsonformat.sh
@@ -20,6 +20,7 @@ found=0
 excluded_files=(
   "test/extended/testdata/cmd/test/cmd/testdata/new-app/bc-from-imagestreamimage.json"
   "test/extended/testdata/cmd/test/cmd/testdata/new-app/invalid.json"
+  "test/extended/util/compat_otp/testdata/opm/render/validate/catalog-error/operator-2/index.json"
 )
 
 set +e
@@ -53,6 +54,6 @@ rm -rf ${tmp_dir}
 
 if [ "$found" == "1" ]; then
   echo -e "\nThere are problems with some JSON files, to verify them you can run:"
-  echo -e "$ go run ./hack/jsonformat.go <filename>\n"
+  echo -e "$ go run ./hack/jsonformat/main.go <filename>\n"
   exit
 fi


### PR DESCRIPTION
The [ci/prow/verify job](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30359/pull-ci-openshift-origin-main-verify/1976544408840966144) failed when I submitted a PR with the following error message:

```
hack/verify-jsonformat.sh
2025/10/10 07:43:14 ERROR: Invalid JSON file  'test/extended/util/compat_otp/testdata/opm/render/validate/catalog-error/operator-2/index.json': invalid character '{' after top-level value
exit status 1
```