### PR TITLE
NO-JIRA: implement WithoutKubeconf method to clear config path

### DIFF
--- a/test/extended/util/util_otp.go
+++ b/test/extended/util/util_otp.go
@@ -63,7 +63,7 @@ func (c *CLI) GuestConfig() *rest.Config {
 // WithoutKubeconf simulates running commands without kubeconfig - OTP compatibility
 // This is a no-op in origin but needed for OTP compatibility
 func (c *CLI) WithoutKubeconf() *CLI {
-	// OTP expects this method but origin doesn't need special handling
+	c.configPath = ""
 	return c
 }
 


### PR DESCRIPTION
The `WithoutKubeconf` method was previously a no-op but now properly clears the configPath field to ensure OTP compatibility. This change makes the method functional by actually removing kubeconfig references when called, aligning with OTP's expected behavior.

link jira ticket https://issues.redhat.com/browse/OCPERT-173