### PR TITLE
OCPBUGS-62987: Skip idling service with RC test on TechPreview clusters

### DIFF
--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -229,6 +229,9 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 
 		g.Context("with a single service and ReplicationController", func() {
 			g.BeforeEach(func() {
+				if exutil.IsTechPreviewNoUpgrade(context.Background(), oc.AdminConfigClient()) {
+					g.Skip("skipping, this test is only supported on Default featureset until https://issues.redhat.com/browse/NE-1984 is implemented")
+				}
 				fixture = echoServerRcFixture
 			})
 


### PR DESCRIPTION
This PR skips the test `Idling with a single service and ReplicationController should idle the service and ReplicationController properly` when the TechPreviewNoUpgrade feature set is enabled.

The router's Dynamic Configuration Manager (DCM) currently lacks full support for handling idled services, which causes this test to flake.

The support gap will be addressed in https://issues.redhat.com/browse/NE-1984.