### PR TITLE
NO-JIRA: Combine global and command args in BackgroundRC

### DIFF
--- a/test/extended/util/util_otp.go
+++ b/test/extended/util/util_otp.go
@@ -209,6 +209,7 @@ func (c *CLI) BackgroundRC() (*exec.Cmd, io.ReadCloser, error) {
 	if c.verbose {
 		fmt.Printf("DEBUG: oc %s\n", c.printCmd())
 	}
+	c.finalArgs = append(c.globalArgs, c.commandArgs...)
 	cmd := exec.Command(c.execPath, c.finalArgs...)
 	cmd.Stdin = c.stdin
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
The `BackgroundRC` function in the CLI test utility was not populating the `finalArgs` slice before creating the command. This resulted in the `exec.Command` being called without the necessary global and command-specific arguments.

This commit adds the missing line to combine `globalArgs` and `commandArgs` into `finalArgs`, ensuring that commands executed in the background are constructed correctly, consistent with other helper functions like `Run()`.

link jira card: https://issues.redhat.com/browse/OCPERT-178