### PR TITLE
NO-JIRA: enhance TNF e2e test to handle quick member promotion

### DIFF
--- a/test/extended/two_node/common.go
+++ b/test/extended/two_node/common.go
@@ -1,10 +1,14 @@
 package two_node
 
 import (
+	"context"
 	"fmt"
 
 	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/test/extended/util"
 	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
@@ -41,4 +45,12 @@ func isClusterOperatorDegraded(operator *v1.ClusterOperator) bool {
 		}
 	}
 	return false
+}
+
+func hasNodeRebooted(oc *util.CLI, node *corev1.Node) (bool, error) {
+	if n, err := oc.AdminKubeClient().CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{}); err != nil {
+		return false, err
+	} else {
+		return n.Status.NodeInfo.BootID != node.Status.NodeInfo.BootID, nil
+	}
 }


### PR DESCRIPTION
Improve etcd recovery test validation to handle cases where member promotion from learner to voting happens faster than test observation (due to [RHEL-119495](https://issues.redhat.com//browse/RHEL-119495)).

Key changes:
- Add hasNodeRebooted() function using BootID comparison to detect node reboot
- Enhance validateEtcdRecoveryState() to check node reboot and so proving recovery occurred despite missing observation of the intermediate learner state
- Handle three scenarios: single reboot (expected), dual reboot (unexpected), no reboot (genuine failure)
- Improve test logging with timeout information for better debugging
- Simplify function signatures by removing hardcoded survived node expectations (survived node is always expected to be started and non-learner)

The promotion from learner to voting member can happen faster than the time it takes to establish etcd client connections and query cluster state. Node reboot detection provides proof that disruption and recovery occurred even when intermediate states are missed due to timing.


