### PR TITLE
[release-4.20] OCPBUGS-63171: Add imagestream update dryrun test

### DIFF
--- a/test/extended/images/dryrun.go
+++ b/test/extended/images/dryrun.go
@@ -7,8 +7,8 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
-	admissionapi "k8s.io/pod-security-admission/api"
 	"k8s.io/apimachinery/pkg/util/wait"
+	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1305,6 +1305,8 @@ var Annotations = map[string]string{
 
 	"[sig-imageregistry] Image --dry-run should not delete resources [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
 
+	"[sig-imageregistry] Image --dry-run should not update resources [apigroup:image.openshift.io]": " [Suite:openshift/conformance/parallel]",
+
 	"[sig-imageregistry] Image registry [apigroup:route.openshift.io] should redirect on blob pull [apigroup:image.openshift.io]": " [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",
 
 	"[sig-imageregistry][Feature:ImageAppend] Image append should create images by appending them [apigroup:image.openshift.io]": " [Skipped:Disconnected] [Skipped:NoOptionalCapabilities] [Suite:openshift/conformance/parallel]",


### PR DESCRIPTION
**What did it do?**

Backport PR https://github.com/openshift/origin/pull/30357 to 4.20 manually.
1. Add more images dryrun tests
2. [make update to generate case annotation](https://github.com/openshift/origin/pull/30389/commits/4a70ca809cba3dad9fbd7db2c99179143a465dae)