### PR TITLE
NO-JIRA: Extend project deletion timeout

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -235,7 +235,7 @@ func waitForDelete(projectName string, w watch.Interface) {
 					return
 				}
 
-			case <-time.After(5 * time.Minute):
+			case <-time.After(10 * time.Minute):
 				g.Fail(fmt.Sprintf("timeout: %v", projectName))
 			}
 		}
@@ -326,7 +326,7 @@ func waitForOnlyDelete(projectName string, w watch.Interface) {
 				}
 				g.Fail(fmt.Sprintf("got unexpected project %v", project.Name))
 
-			case <-time.After(3 * time.Minute): // namespace deletions can take a while during busy e2e runs
+			case <-time.After(10 * time.Minute): // namespace deletions can take a while during busy e2e runs
 				g.Fail(fmt.Sprintf("timeout: %v", projectName))
 			}
 		}


### PR DESCRIPTION
Analysis of audit logs / namespace controller shows succesful deletion 6 minutes after DELETE API. The namespace controller is extremely active with other activity during this period.