### PR TITLE
OTA-1626: Handle unknown operators

### DIFF
--- a/pkg/monitortests/clusterversionoperator/clusterversionchecker/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/clusterversionchecker/monitortest.go
@@ -158,9 +158,6 @@ func (w *monitor) noFailingUnknownCondition(intervals monitorapi.Intervals) []*j
 
 	for _, coName := range platformidentification.KnownOperators.List() {
 		bzComponent := platformidentification.GetBugzillaComponentForOperator(coName)
-		if bzComponent == "Unknown" {
-			bzComponent = coName
-		}
 		name := fmt.Sprintf("[bz-%v] clusteroperator/%v must complete version change within limited time", bzComponent, coName)
 		m := 30
 		if coName == "machine-config" {
@@ -207,6 +204,9 @@ func parseClusterOperatorNames(message string) (sets.Set[string], error) {
 		for _, coName := range coNames {
 			ret.Insert(strings.TrimSpace(coName))
 		}
+	}
+	if diff := sets.List(ret.Difference(sets.New[string](platformidentification.KnownOperators.List()...))); len(diff) > 0 {
+		return nil, fmt.Errorf("found unknown operator names %q from %q", strings.Join(diff, ", "), message)
 	}
 	if len(ret) == 0 {
 		return nil, fmt.Errorf("failed to parse cluster operator names from %q", message)

--- a/pkg/monitortests/clusterversionoperator/clusterversionchecker/monitortest_test.go
+++ b/pkg/monitortests/clusterversionoperator/clusterversionchecker/monitortest_test.go
@@ -35,8 +35,8 @@ func Test_parseClusterOperatorNames(t *testing.T) {
 		{
 			name:     "one CO timeout",
 			reason:   "SlowClusterOperator",
-			message:  "waiting on co-timeout over 30 minutes which is longer than expected",
-			expected: sets.New[string]("co-timeout"),
+			message:  "waiting on network over 30 minutes which is longer than expected",
+			expected: sets.New[string]("network"),
 		},
 		{
 			name:     "mco timeout",
@@ -53,20 +53,26 @@ func Test_parseClusterOperatorNames(t *testing.T) {
 		{
 			name:     "two COs timeout",
 			reason:   "SlowClusterOperator",
-			message:  "waiting on co-timeout, co-bar-timeout over 30 minutes which is longer than expected",
-			expected: sets.New[string]("co-timeout", "co-bar-timeout"),
+			message:  "waiting on console, network over 30 minutes which is longer than expected",
+			expected: sets.New[string]("console", "network"),
 		},
 		{
 			name:     "one CO and mco timeout",
 			reason:   "SlowClusterOperator",
-			message:  "waiting on co-timeout over 30 minutes and machine-config over 90 minutes which is longer than expected",
-			expected: sets.New[string]("machine-config", "co-timeout"),
+			message:  "waiting on network over 30 minutes and machine-config over 90 minutes which is longer than expected",
+			expected: sets.New[string]("machine-config", "network"),
 		},
 		{
 			name:     "three COs timeout",
 			reason:   "SlowClusterOperator",
-			message:  "waiting on co-timeout, co-bar-timeout over 30 minutes and machine-config over 90 minutes which is longer than expected",
-			expected: sets.New[string]("machine-config", "co-timeout", "co-bar-timeout"),
+			message:  "waiting on console, network over 30 minutes and machine-config over 90 minutes which is longer than expected",
+			expected: sets.New[string]("machine-config", "console", "network"),
+		},
+		{
+			name:        "unknown operators",
+			reason:      "SlowClusterOperator",
+			message:     "waiting on unknown, bar, network over 30 minutes and machine-config over 90 minutes which is longer than expected",
+			expectedErr: fmt.Errorf(`found unknown operator names "bar, unknown" from "changed to Some=Unknown: SlowClusterOperator: waiting on unknown, bar, network over 30 minutes and machine-config over 90 minutes which is longer than expected"`),
 		},
 	}
 


### PR DESCRIPTION
Following up [1], the function `parseClusterOperatorNames`
raises up an error if it gets unknown operators which is a
result of CVO's producing a malformed message. It leads to
a failure associated to component "Cluster Version Operator".

[1]. https://github.com/openshift/origin/pull/30269#discussion_r2441079717

/hold

need to rebase after https://github.com/openshift/origin/pull/30269 gets in