### PR TITLE
NO-JIRA: oidc: ensure console and cli OIDC clients are available when enabling OIDC

### DIFF
--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -489,6 +489,14 @@ func generateOIDCProvider(ctx context.Context, client *exutil.CLI, namespace, oi
 					Name: oidcClientSecret,
 				},
 			},
+			{
+				ComponentName:      "cli",
+				ComponentNamespace: "openshift-console",
+				ClientID:           "openshift-cli-oidc-client",
+				ClientSecret: configv1.SecretNameReference{
+					Name: oidcClientSecret,
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
We found out that a fix for https://issues.redhat.com/browse/OCPBUGS-61432 that merged in the OpenShift Console led to a regression in the external OIDC behavior despite passing the existing suite of tests.

This is because we missed making sure that the status of both the OpenShift Console and OpenShift CLI clients are successfully reporting as `Available` when opting in to the External OIDC functionality.

This PR updates the testing logic to ensure both of these clients are reporting that they are available to prevent a regression related to this in the future.