### PR TITLE
OCPBUGS-63383: Fix empty operator name

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -209,10 +209,10 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
 				flakes = append(flakes, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
 			case deletionTime.Before(event.From):
-				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
+				// something went wrong.  More than five seconds after the pod was deleted, the CNI is trying to set up pod sandboxes and can't
 				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
 			default:
-				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
+				// something went wrong.  deletion happened after we had a failure to create the pod sandbox
 				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
 			}
 		}


### PR DESCRIPTION
There's actually a bug on line 200: it still references progressingOperatorName which would be empty in the else block, so the error message would show operator: with no operator name.

Prow CI Job: 
`https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-upgrade-from-stable-4.20-e2e-azure-ovn-upgrade/1980072090157453312`

Test Log:
```
namespace/openshift-insights node/ci-op-w0p8d153-53ca2-t757n-worker-centralus1-8gsmj pod/insights-runtime-extractor-7ksdk hmsg/e979fe1238 - never deleted - operator: was progressing which may cause pod sandbox creation errors - firstTimestamp/2025-10-20T02:22:18Z interesting/true lastTimestamp/2025-10-20T02:22:18Z reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_insights-runtime-extractor-7ksdk_openshift-insights_a2988964-4266-43b0-bcb8-e72879d1be3a_0(5af29f2c3f6269c7be21f1bb4501bf7f4cad9956f1bce5fea427f8ea65bb25bc): error adding pod openshift-insights_insights-runtime-extractor-7ksdk to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"5af29f2c3f6269c7be21f1bb4501bf7f4cad9956f1bce5fea427f8ea65bb25bc" Netns:"/var/run/netns/bd21c728-1476-4be1-8e36-9a7614f4306c" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=openshift-insights;K8S_POD_NAME=insights-runtime-extractor-7ksdk;K8S_POD_INFRA_CONTAINER_ID=5af29f2c3f6269c7be21f1bb4501bf7f4cad9956f1bce5fea427f8ea65bb25bc;K8S_POD_UID=a2988964-4266-43b0-bcb8-e72879d1be3a" Path:"" ERRORED: error configuring pod [openshift-insights/insights-runtime-extractor-7ksdk] networking: Multus: [openshift-insights/insights-runtime-extractor-7ksdk/a2988964-4266-43b0-bcb8-e72879d1be3a]: error setting the networks status: SetPodNetworkStatusAnnotation: failed to update the pod insights-runtime-extractor-7ksdk in out of cluster comm: SetNetworkStatus: failed to update the pod insights-runtime-extractor-7ksdk in out of cluster comm: status update failed for pod openshift-insights/insights-runtime-extractor-7ksdk: etcdserver: request timed out, possibly due to previous leader failure
': StdinData: {"auxiliaryCNIChainName":"vendor-cni-chain","binDir":"/var/lib/cni/bin","clusterNetwork":"/host/run/multus/cni/net.d/10-ovn-kubernetes.conf","cniVersion":"0.3.1","daemonSocketDir":"/run/multus/socket","globalNamespaces":"default,openshift-multus,openshift-sriov-network-operator,openshift-cnv","logLevel":"verbose","logToStderr":true,"name":"multus-cni-network","namespaceIsolation":true,"type":"multus-shim"}}
```
