### PR TITLE
[WIP]:Check operators state when Pod was deleted

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -182,38 +182,43 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 		}
 
 		partialLocator := monitorapi.NonUniquePodLocatorFrom(event.Locator)
+		progressingOperatorName := getProgressingOperatorName(event, operatorsProgressing)
+
 		if deletionTime := getPodDeletionTime(eventsForPods[partialLocator], event.Locator); deletionTime == nil {
-			var progressingOperatorName string
-			for _, operatorProgressingInterval := range operatorsProgressing {
-				if event.From.After(operatorProgressingInterval.From) &&
-					event.To.Before(operatorProgressingInterval.To) {
-					progressingOperatorName = operatorProgressingInterval.Locator.Keys[monitorapi.LocatorClusterOperatorKey]
-					break
-				}
-			}
+			// Pod was never deleted
 			if len(progressingOperatorName) > 0 {
 				flakes = append(flakes, fmt.Sprintf(
 					"%v - never deleted - operator:%s was progressing which may cause pod sandbox creation errors - %v",
 					event.Locator.OldLocator(), progressingOperatorName, event.Message.OldMessage()))
 			} else {
 				failures = append(failures, fmt.Sprintf(
-					"%v - never deleted - operator:%s was progressing which may cause pod sandbox creation errors - %v",
-					event.Locator.OldLocator(), progressingOperatorName, event.Message.OldMessage()))
+					"%v - never deleted - %v",
+					event.Locator.OldLocator(), event.Message.OldMessage()))
 			}
 		} else {
+			// Pod was deleted - check timing and operator status
 			timeBetweenDeleteAndFailure := event.From.Sub(*deletionTime)
-			switch {
-			case timeBetweenDeleteAndFailure < 1*time.Second:
-				// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
-			case timeBetweenDeleteAndFailure < 5*time.Second:
-				// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
-				flakes = append(flakes, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
-			case deletionTime.Before(event.From):
-				// something went wrong.  More than five seconds after the pod ws deleted, the CNI is trying to set up pod sandboxes and can't
-				failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
-			default:
-				// something went wrong.  deletion happend after we had a failure to create the pod sandbox
-				failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
+
+			if len(progressingOperatorName) > 0 {
+				// If an operator was progressing, treat as flake regardless of timing
+				flakes = append(flakes, fmt.Sprintf(
+					"%v - %0.2f seconds after deletion - operator:%s was progressing which may cause pod sandbox creation errors - %v",
+					event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), progressingOperatorName, event.Message.OldMessage()))
+			} else {
+				// No operator progressing, apply timing-based logic
+				switch {
+				case timeBetweenDeleteAndFailure < 1*time.Second:
+					// nothing here, one second is close enough to be ok, the kubelet and CNI just didn't know
+				case timeBetweenDeleteAndFailure < 5*time.Second:
+					// withing five seconds, it ought to be long enough to know, but it's close enough to flake and not fail
+					flakes = append(flakes, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
+				case deletionTime.Before(event.From):
+					// something went wrong.  More than five seconds after the pod was deleted, the CNI is trying to set up pod sandboxes and can't
+					failures = append(failures, fmt.Sprintf("%v - %0.2f seconds after deletion - %v", event.Locator.OldLocator(), timeBetweenDeleteAndFailure.Seconds(), event.Message.OldMessage()))
+				default:
+					// something went wrong.  deletion happened after we had a failure to create the pod sandbox
+					failures = append(failures, fmt.Sprintf("%v - deletion came AFTER sandbox failure - %v", event.Locator.OldLocator(), event.Message.OldMessage()))
+				}
 			}
 		}
 	}
@@ -316,6 +321,18 @@ func getPodDeletionTime(events monitorapi.Intervals, podLocator monitorapi.Locat
 		}
 	}
 	return nil
+}
+
+// getProgressingOperatorName checks if an event occurred during any operator's Progressing interval
+// and returns the name of the progressing operator, or empty string if none found.
+func getProgressingOperatorName(event monitorapi.Interval, operatorsProgressing monitorapi.Intervals) string {
+	for _, operatorProgressingInterval := range operatorsProgressing {
+		if event.From.After(operatorProgressingInterval.From) &&
+			event.To.Before(operatorProgressingInterval.To) {
+			return operatorProgressingInterval.Locator.Keys[monitorapi.LocatorClusterOperatorKey]
+		}
+	}
+	return ""
 }
 
 // bug is tracked here: https://bugzilla.redhat.com/show_bug.cgi?id=2057181


### PR DESCRIPTION
[sig-network] pods should successfully create sandboxes by adding pod to network - failed in two Prow jobs recently in https://issues.redhat.com/browse/OCPBUGS-63478

Prow Job1:
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.20-upgrade-from-stable-4.19-e2e-azure-ovn-upgrade/1980375618641989632

Test Log:
```
namespace/openshift-etcd node/ci-op-tz2f8kj9-fbbf2-j6brz-master-0 pod/etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0 hmsg/b1ad8ffd50 - 297.49 seconds after deletion - firstTimestamp/2025-10-20T22:22:31Z interesting/true lastTimestamp/2025-10-20T22:22:31Z reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0_openshift-etcd_4f678bb2-10f6-47f8-b080-36cbae9d50a4_0(09b24379f8fe8571b7a5eda9a668692a1f31d31d76772a7dabdb19c9778a43d0): error adding pod openshift-etcd_etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0 to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"09b24379f8fe8571b7a5eda9a668692a1f31d31d76772a7dabdb19c9778a43d0" Netns:"/var/run/netns/4ab6fd45-b6fa-4709-bb88-a4e7a81b8b3e" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=openshift-etcd;K8S_POD_NAME=etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0;K8S_POD_INFRA_CONTAINER_ID=09b24379f8fe8571b7a5eda9a668692a1f31d31d76772a7dabdb19c9778a43d0;K8S_POD_UID=4f678bb2-10f6-47f8-b080-36cbae9d50a4" Path:"" ERRORED: error configuring pod [openshift-etcd/etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0] networking: Multus: [openshift-etcd/etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0/4f678bb2-10f6-47f8-b080-36cbae9d50a4]: error waiting for pod: Get "https://api-int.ci-op-tz2f8kj9-fbbf2.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:6443/api/v1/namespaces/openshift-etcd/pods/etcd-guard-ci-op-tz2f8kj9-fbbf2-j6brz-master-0?timeout=1m0s": context deadline exceeded
': StdinData: {"auxiliaryCNIChainName":"vendor-cni-chain","binDir":"/var/lib/cni/bin","clusterNetwork":"/host/run/multus/cni/net.d/10-ovn-kubernetes.conf","cniVersion":"0.3.1","daemonSocketDir":"/run/multus/socket","globalNamespaces":"default,openshift-multus,openshift-sriov-network-operator,openshift-cnv","logLevel":"verbose","logToStderr":true,"name":"multus-cni-network","namespaceIsolation":true,"type":"multus-shim"}}
```

Prow job2: 
https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.21-upgrade-from-stable-4.20-e2e-metal-ipi-ovn-upgrade/1979889012780830720

Test log:
```
namespace/openshift-kube-apiserver node/master-2 pod/revision-pruner-9-master-2 hmsg/cde531b9d8 - 145.44 seconds after deletion - firstTimestamp/2025-10-19T15:01:26Z interesting/true lastTimestamp/2025-10-19T15:01:26Z reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_revision-pruner-9-master-2_openshift-kube-apiserver_a08d5e14-b027-4a1a-ac4e-1e58d9103c01_0(a6bb2c3a3e4af84920d82a41b695d764a677a86e4acc11d80669f9351228444a): error adding pod openshift-kube-apiserver_revision-pruner-9-master-2 to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"a6bb2c3a3e4af84920d82a41b695d764a677a86e4acc11d80669f9351228444a" Netns:"/var/run/netns/55eab7e4-f851-47ac-9317-af272dacca1b" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=openshift-kube-apiserver;K8S_POD_NAME=revision-pruner-9-master-2;K8S_POD_INFRA_CONTAINER_ID=a6bb2c3a3e4af84920d82a41b695d764a677a86e4acc11d80669f9351228444a;K8S_POD_UID=a08d5e14-b027-4a1a-ac4e-1e58d9103c01" Path:"" ERRORED: error configuring pod [openshift-kube-apiserver/revision-pruner-9-master-2] networking: Multus: [openshift-kube-apiserver/revision-pruner-9-master-2/a08d5e14-b027-4a1a-ac4e-1e58d9103c01]: error setting the networks status: SetPodNetworkStatusAnnotation: failed to update the pod revision-pruner-9-master-2 in out of cluster comm: SetNetworkStatus: failed to update the pod revision-pruner-9-master-2 in out of cluster comm: status update failed for pod /: Get "https://api-int.ostest.test.metalkube.org:6443/api/v1/namespaces/openshift-kube-apiserver/pods/revision-pruner-9-master-2?timeout=1m0s": dial tcp: lookup api-int.ostest.test.metalkube.org on 192.168.111.1:53: no such host
': StdinData: {"auxiliaryCNIChainName":"vendor-cni-chain","binDir":"/var/lib/cni/bin","clusterNetwork":"/host/run/multus/cni/net.d/10-ovn-kubernetes.conf","cniVersion":"0.3.1","daemonSocketDir":"/run/multus/socket","globalNamespaces":"default,openshift-multus,openshift-sriov-network-operator,openshift-cnv","logLevel":"verbose","logToStderr":true,"name":"multus-cni-network","namespaceIsolation":true,"type":"multus-shim"}
```

For deleted pods, the code never checks if the failure occurred during operator Progressing. It only checks the time difference, which results in a hard failure at > 5 seconds. According to the code's own logic, if the etcd/dns/network operator was Progressing, sandbox failures should be treated more leniently (as flakes), but this check is missing in the deleted pod branch.

The fix adds operator Progressing checks to the deleted pod branch
