### PR TITLE
OCPBUGS-63519: flake the missing port 9194 and 9193 once the team will fix will remove it

### DIFF
--- a/test/extended/networking/commatrix.go
+++ b/test/extended/networking/commatrix.go
@@ -25,6 +25,7 @@ import (
 	listeningsockets "github.com/openshift-kni/commatrix/pkg/listening-sockets"
 	matrixdiff "github.com/openshift-kni/commatrix/pkg/matrix-diff"
 	"github.com/openshift-kni/commatrix/pkg/utils"
+	"github.com/openshift/origin/pkg/test/ginkgo/result"
 )
 
 const (
@@ -138,7 +139,23 @@ var _ = Describe("[sig-network][Feature:commatrix][apigroup:config.openshift.io]
 		}
 
 		missingEPSMat := diff.GetUniqueSecondary()
+
+		// flake if only any of the temporary approver ports are missing.
+		// once the approver ports are officially added, this can be removed.
 		if len(missingEPSMat.Matrix) > 0 {
+			isOnlyApproverPorts := true
+			for _, cd := range missingEPSMat.Matrix {
+				if cd.Port != 9193 && cd.Port != 9194 {
+					isOnlyApproverPorts = false
+					break
+				}
+			}
+
+			if isOnlyApproverPorts {
+				result.Flakef("temporary approver ports missing endpointslice: %s", missingEPSMat)
+				return
+			}
+
 			err := fmt.Errorf("the following ports are used but don't have an endpointslice: \n %s", missingEPSMat)
 			Expect(err).ToNot(HaveOccurred())
 		}


### PR DESCRIPTION
flake the missing port 9194 and 9193 once the team will fix will remove it