### PR TITLE
NO-JIRA: Add showInfo flag to control CLI command logging

### DIFF
--- a/test/extended/util/util_otp.go
+++ b/test/extended/util/util_otp.go
@@ -23,15 +23,13 @@ import (
 
 // NotShowInfo disables showing info in CLI output
 func (c *CLI) NotShowInfo() *CLI {
-	// OTP tracks this with a showInfo field, but origin doesn't have this field
-	// For now, this is a no-op in origin
+	c.showInfo = false
 	return c
 }
 
 // SetShowInfo enables showing info in CLI output
 func (c *CLI) SetShowInfo() *CLI {
-	// OTP tracks this with a showInfo field, but origin doesn't have this field
-	// For now, this is a no-op in origin
+	c.showInfo = true
 	return c
 }
 


### PR DESCRIPTION
## Summary

Add a `showInfo` flag to the CLI struct to prevent sensitive data exposure in test logs when executing commands.

## Problem

Currently, `framework.Logf()` always prints command execution details. While `RedactBearerToken()` helps with tokens, commands like:
```bash
oc set data secret mysecret --from-literal=password=supersecret
```
Still expose sensitive data (passwords, API keys) directly in test logs.

## Solution

- Add `showInfo bool` field to CLI struct (defaults to `true` for backward compatibility)
- Conditionally call `framework.Logf()` only when `showInfo` is enabled
- Implement `NotShowInfo()` and `SetShowInfo()` methods for control

## Usage

```go
// Suppress logging for sensitive operations
cli.NotShowInfo().Run("set", "data", "secret", "mysecret", "--from-literal=password=secret").Execute()

// Re-enable logging
cli.SetShowInfo().Run("get", "pods").Execute()
```

Fixes: https://issues.redhat.com/browse/OCPERT-201