### PR TITLE
OCPBUGS-14246: Remove exceptions for missing CVO alert runbook URLs

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -194,11 +194,6 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		// Issue: https://issues.redhat.com/browse/OCPBUGS-14057
 		"HAProxyDown",
 
-		// Repository: https://github.com/openshift/cluster-version-operator
-		// Issue: https://issues.redhat.com/browse/OCPBUGS-14246
-		"ClusterOperatorDown",
-		"ClusterVersionOperatorDown",
-
 		// Repository: https://github.com/openshift/managed-cluster-config
 		// Issue: https://issues.redhat.com/browse/OSD-21709
 		"AlertmanagerClusterCrashlooping",


### PR DESCRIPTION
The runbook URLs were added in https://github.com/openshift/cluster-version-operator/pull/1036 (`ClusterOperatorDown`) and https://github.com/openshift/cluster-version-operator/pull/1250 (`ClusterVersionOperatorDown`).

The verification was done in [OCPBUGS-14246](https://issues.redhat.com//browse/OCPBUGS-14246).