### PR TITLE
Automation of OCP-55033

### DIFF
--- a/test/extended/node/OWNERS
+++ b/test/extended/node/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - lyman9966
+  - asahay19
+  - cpmeadors
+  - sairameshv
+  - mrunalp
+  - BhargaviGudi
+approvers:
+  - lyman9966
+  - cpmeadors
+  - sairameshv
+  - mrunalp

--- a/test/extended/node/node.go
+++ b/test/extended/node/node.go
@@ -1,0 +1,18 @@
+package node
+
+import (
+	g "github.com/onsi/ginkgo/v2"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node] Kubelet, CRI-O, CPU manager", func() {
+	var (
+		oc = exutil.NewCLIWithoutNamespace("node").AsAdmin()
+	)
+
+	//author: asahay@redhat.com
+	g.It("check KUBELET_LOG_LEVEL is 2", func() {
+		g.By("check Kubelet Log Level\n")
+		assertKubeletLogLevel(oc)
+	})
+})

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -1,0 +1,53 @@
+package node
+
+import (
+	"strings"
+	"time"
+
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+func assertKubeletLogLevel(oc *exutil.CLI) {
+	var kubeservice string
+	var kublet string
+	var err error
+	waitErr := wait.Poll(10*time.Second, 1*time.Minute, func() (bool, error) {
+		nodeName, nodeErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[*].metadata.name}").Output()
+		o.Expect(nodeErr).NotTo(o.HaveOccurred())
+		e2e.Logf("\nNode Names are %v", nodeName)
+		nodes := strings.Fields(nodeName)
+
+		for _, node := range nodes {
+			nodeStatus, statusErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", node, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
+			o.Expect(statusErr).NotTo(o.HaveOccurred())
+			e2e.Logf("\nNode %s Status is %s\n", node, nodeStatus)
+
+			if nodeStatus == "True" {
+				kubeservice, err = compat_otp.DebugNodeWithChroot(oc, node, "/bin/bash", "-c", "systemctl show kubelet.service | grep KUBELET_LOG_LEVEL")
+				o.Expect(err).NotTo(o.HaveOccurred())
+				kublet, err = compat_otp.DebugNodeWithChroot(oc, node, "/bin/bash", "-c", "ps aux | grep kubelet")
+				o.Expect(err).NotTo(o.HaveOccurred())
+
+				if strings.Contains(string(kubeservice), "KUBELET_LOG_LEVEL") && strings.Contains(string(kublet), "--v=2") {
+					e2e.Logf(" KUBELET_LOG_LEVEL is 2. \n")
+					return true, nil
+				} else {
+					e2e.Logf(" KUBELET_LOG_LEVEL is not 2. \n")
+					return false, nil
+				}
+			} else {
+				e2e.Logf("\n Node %s is not Ready, Skipping\n ", node)
+			}
+		}
+		return false, nil
+	})
+	if waitErr != nil {
+		e2e.Logf("Kubelet Log level is:\n %v\n", kubeservice)
+		e2e.Logf("Running Proccess of kubelet are:\n %v\n", kublet)
+		o.Expect(waitErr).NotTo(o.HaveOccurred(), "KUBELET_LOG_LEVEL is not expected, timed out")
+	}
+}


### PR DESCRIPTION
This case is about checking the Kubelet log level is 2. 
Here is the test case link : https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-55033

I have ran that locally and it got passed: 

` ./openshift-tests run-test "[sig-node] NODE initContainer policy,volume,readines,quota check KUBELET_LOG_LEVEL is 2 [Suite:openshift/conformance/parallel]"
 
  Running Suite:  - /Users/asahay/OCP-55033/origin
  ================================================
  Random Seed: 1762945017 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] NODE initContainer policy,volume,readines,quota check KUBELET_LOG_LEVEL is 2
  github.com/openshift/origin/test/extended/node/node.go:15
    STEP: Creating a kubernetes client @ 11/12/25 16:27:01.774
  I1112 16:27:01.775613   60942 discovery.go:214] Invalidating discovery information
    STEP: check Kubelet Log Level
     @ 11/12/25 16:27:01.775
  I1112 16:27:13.581561 60942 node_utils.go:22]
  Node Names are ip-10-0-11-243.us-east-2.compute.internal ip-10-0-15-30.us-east-2.compute.internal ip-10-0-55-165.us-east-2.compute.internal ip-10-0-56-233.us-east-2.compute.internal ip-10-0-75-169.us-east-2.compute.internal ip-10-0-95-145.us-east-2.compute.internal
  I1112 16:27:14.689276 60942 node_utils.go:28]
  Node ip-10-0-11-243.us-east-2.compute.internal Status is True

  I1112 16:27:24.692931 60942 node_utils.go:37]  KUBELET_LOG_LEVEL is 2.

  • [22.939 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 22.939 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-node] NODE initContainer policy,volume,readines,quota check KUBELET_LOG_LEVEL is 2 [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 22939,
    "startTime": "2025-11-12 10:57:01.757463 UTC",
    "endTime": "2025-11-12 10:57:24.697116 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 11/12/25 16:27:01.774\n  STEP: check Kubelet Log Level\n   @ 11/12/25 16:27:01.775\nI1112 16:27:13.581561 60942 node_utils.go:22] \nNode Names are ip-10-0-11-243.us-east-2.compute.internal ip-10-0-15-30.us-east-2.compute.internal ip-10-0-55-165.us-east-2.compute.internal ip-10-0-56-233.us-east-2.compute.internal ip-10-0-75-169.us-east-2.compute.internal ip-10-0-95-145.us-east-2.compute.internal\nI1112 16:27:14.689276 60942 node_utils.go:28] \nNode ip-10-0-11-243.us-east-2.compute.internal Status is True\n\nI1112 16:27:24.692931 60942 node_utils.go:37]  KUBELET_LOG_LEVEL is 2. \n\n"
  }
]`