### PR TITLE
TRT-2072: remove skipped annotations synthetic test

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -218,28 +218,6 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 
 	logrus.Infof("Discovered %d total tests", len(specs))
 
-	// Temporarily check for the presence of the [Skipped:xyz] annotation in the test names, once this synthetic test
-	// begins to pass we can remove the annotation logic
-	var annotatedSkipped []string
-	for _, t := range specs {
-		if strings.Contains(t.Name, "[Skipped") {
-			annotatedSkipped = append(annotatedSkipped, t.Name)
-		}
-	}
-	var fallbackSyntheticTestResult []*junitapi.JUnitTestCase
-	var skippedAnnotationSyntheticTestResults []*junitapi.JUnitTestCase
-	skippedAnnotationSyntheticTestResult := junitapi.JUnitTestCase{
-		Name: "[sig-trt] Skipped annotations present",
-	}
-	if len(annotatedSkipped) > 0 {
-		skippedAnnotationSyntheticTestResult.FailureOutput = &junitapi.FailureOutput{
-			Message: fmt.Sprintf("Skipped Annotations present in tests: %s", strings.Join(annotatedSkipped, ", ")),
-		}
-	}
-	skippedAnnotationSyntheticTestResults = append(skippedAnnotationSyntheticTestResults, &skippedAnnotationSyntheticTestResult)
-	// If this fails, this additional run will make it flake
-	skippedAnnotationSyntheticTestResults = append(skippedAnnotationSyntheticTestResults, &junitapi.JUnitTestCase{Name: skippedAnnotationSyntheticTestResult.Name})
-
 	// skip tests due to newer k8s
 	restConfig, err := clusterinfo.GetMonitorRESTConfig()
 	if err != nil {
@@ -607,7 +585,6 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 	var syntheticTestResults []*junitapi.JUnitTestCase
 	var syntheticFailure bool
 	syntheticTestResults = append(syntheticTestResults, stableClusterTestResults...)
-	syntheticTestResults = append(syntheticTestResults, skippedAnnotationSyntheticTestResults...)
 
 	timeSuffix := fmt.Sprintf("_%s", start.UTC().Format("20060102-150405"))
 
@@ -624,12 +601,6 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 	wasMasterNodeUpdated := ""
 	if events := monitorEventRecorder.Intervals(start, end); len(events) > 0 {
 		buf := &bytes.Buffer{}
-		if !upgrade {
-			// the current mechanism for external binaries does not support upgrade
-			// tests, so don't report information there at all
-			syntheticTestResults = append(syntheticTestResults, fallbackSyntheticTestResult...)
-		}
-
 		if len(syntheticTestResults) > 0 {
 			// mark any failures by name
 			failingSyntheticTestNames, flakySyntheticTestNames := sets.NewString(), sets.NewString()


### PR DESCRIPTION
The annotation framework is now removed. This test will always flake as there are going to continue to be tests that have `[Skipped:xyz]` in the name (not via the annotation framework). We don't need to track that or force them to use the new environment selectors instead at this time.

Note: the `fallbackSyntheticTestResult` seems to have been dead code. removing it here as well.