### PR TITLE
OCPNODE-3720: Add auto-sizing-reversed test to origin

### DIFF
--- a/test/extended/node/node_sizing.go
+++ b/test/extended/node/node_sizing.go
@@ -177,10 +177,10 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][Suite:o
 		err = oc.AdminKubeClient().CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "Should be able to delete test pod")
 
-		// Now apply KubeletConfig and verify NODE_SIZING_ENABLED=true
+		// Now apply KubeletConfig and verify NODE_SIZING_ENABLED=false
 
-		g.By("Creating KubeletConfig with autoSizingReserved=true")
-		autoSizingReserved := true
+		g.By("Creating KubeletConfig with autoSizingReserved=false")
+		autoSizingReserved := false
 		kubeletConfig := &mcfgv1.KubeletConfig{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machineconfiguration.openshift.io/v1",
@@ -226,7 +226,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][Suite:o
 		}, 30*time.Second, 5*time.Second).Should(o.Succeed(), "KubeletConfig should be created")
 
 		o.Expect(createdKC.Spec.AutoSizingReserved).NotTo(o.BeNil(), "AutoSizingReserved should not be nil")
-		o.Expect(*createdKC.Spec.AutoSizingReserved).To(o.BeTrue(), "AutoSizingReserved should be true")
+		o.Expect(*createdKC.Spec.AutoSizingReserved).To(o.BeFalse(), "AutoSizingReserved should be false")
 
 		g.By(fmt.Sprintf("Waiting for %s MCP to start updating", testMCPName))
 		o.Eventually(func() bool {


### PR DESCRIPTION
Added test for the dev work in [OCPNODE-3719](https://issues.redhat.com/browse/OCPNODE-3719)
The e2e Jira is [OCPNODE-3720](https://issues.redhat.com//browse/OCPNODE-3720)
Adds a test to make sure that node sizing enabled is set correctly on the node. The test is written in similar lines to 4.20 PR: https://github.com/openshift/origin/pull/30467

This PR introduces a new E2E test case to verify the behavior of the NODE_SIZING_ENABLED feature flag following the changes in https://github.com/openshift/machine-config-operator/pull/5390. The primary goal is to ensure that while the patch introduces a new MachineConfig, it does not automatically disable a user's ability to disable node autosizing for reserved resources.

NOTE: [Suite:openshift/machine-config-operator/disruptive] will ensure that the container restart failures are not recorded for this test. Its a common pattern used for machine config tests.