### PR TITLE
OCPBUGS-63307: Add ConfigDriftMonitorStoppedTooOften matcher

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -502,6 +502,9 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	twoNodeEtcdEndpointsMatcher := newTwoNodeEtcdEndpointsConfigMissingEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(twoNodeEtcdEndpointsMatcher)
 
+	newConfigDriftMonitorStoppedTooOftenEventMatcher := newConfigDriftMonitorStoppedTooOftenEventMatcher(finalIntervals)
+	registry.AddPathologicalEventMatcherOrDie(newConfigDriftMonitorStoppedTooOftenEventMatcher)
+
 	return registry
 }
 
@@ -1205,5 +1208,25 @@ func newCrioReloadedTooOftenEventMatcher(finalInternals monitorapi.Intervals) Ev
 			jira:               "https://issues.redhat.com/browse/OCPBUGS-52260",
 		},
 		allowIfWithinIntervals: crioReloadedIntervals,
+	}
+}
+
+func newConfigDriftMonitorStoppedTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
+	configDriftMonitorStoppedIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Source == monitorapi.SourceE2ETest &&
+			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "imagepolicy signature validation")
+	})
+	for i := range configDriftMonitorStoppedIntervals {
+		configDriftMonitorStoppedIntervals[i].To = configDriftMonitorStoppedIntervals[i].To.Add(time.Minute * 10)
+		configDriftMonitorStoppedIntervals[i].From = configDriftMonitorStoppedIntervals[i].From.Add(time.Minute * -10)
+	}
+
+	return &OverlapOtherIntervalsPathologicalEventMatcher{
+		delegate: &SimplePathologicalEventMatcher{
+			name:               "ConfigDriftMonitorStoppedTooOften",
+			messageReasonRegex: regexp.MustCompile(`^ConfigDriftMonitorStopped$`),
+			jira:               "https://issues.redhat.com/browse/OCPBUGS-58376",
+		},
+		allowIfWithinIntervals: configDriftMonitorStoppedIntervals,
 	}
 }


### PR DESCRIPTION
Add ConfigDriftMonitorStoppedTooOften matcher for image signature validation tests. Fix the run failure

```
8 events happened too frequently

event happened 24 times, something is wrong: node/ci-op-7b9qs4mj-863c8-hkhwh-worker-a-bm2wt hmsg/8a96eaa4fd - reason/ConfigDriftMonitorStopped Config Drift Monitor stopped (19:47:32Z) result=reject
```