### PR TITLE
OCPBUGS-64927: update telemtery limit for 4.17 e2e case

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -386,7 +386,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		tests := map[string]bool{
 			// We want to limit the number of total series sent, the cluster:telemetry_selected_series:count
 			// rule contains the count of the all the series that are sent via telemetry. It is permissible
-			// for some scenarios to generate more series than 760, we just want the basic state to be below
+			// for some scenarios to generate more series than 780, we just want the basic state to be below
 			// a threshold.
 			//
 			// The following query can be executed against the telemetry server
@@ -401,7 +401,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 			//     )[30m:1m]
 			//   )
 			// )
-			fmt.Sprintf(`avg_over_time(cluster:telemetry_selected_series:count[%s]) >= 760`, testDuration):  false,
+			fmt.Sprintf(`avg_over_time(cluster:telemetry_selected_series:count[%s]) >= 780`, testDuration):  false,
 			fmt.Sprintf(`max_over_time(cluster:telemetry_selected_series:count[%s]) >= 1200`, testDuration): false,
 		}
 		err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), tests, oc)


### PR DESCRIPTION
see from https://issues.redhat.com/browse/OCPBUGS-64927, 4.17 e2e case "Alerts shouldn't exceed the series limit of
 total series sent via telemetry from each cluster" for e2e-aws-ovn-techpreview job failed frequently, bump the limit to 780 as the same value set for [4.18](https://github.com/openshift/origin/blob/release-4.18/test/extended/prometheus/prometheus.go#L426) would make the case pass