### PR TITLE
NO-JIRA: OTE - increase debug on errors

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -679,7 +679,7 @@ func (binaries TestBinaries) ListImages(ctx context.Context, parallelism int) ([
 
 					imageConfig, err := binary.ListImages(ctx)
 					if err != nil {
-						errCh <- err
+						errCh <- fmt.Errorf("failed to list images for binary %s (%s): %w", binary.imageTag, binary.binaryPath, err)
 					}
 					mu.Lock()
 					allImages = append(allImages, imageConfig)


### PR DESCRIPTION
Added more information when OTE binary extraction failed.

Observing issues in the job which we don't know which binary is raising due parallel extraction: 
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/30235/pull-ci-openshift-origin-main-e2e-metal-ipi-ovn-ipv6/1988259550255386624#1:build-log.txt%3A174-177