### PR TITLE
NO-JIRA: Add an exception for co/network

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -731,7 +731,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 				return "https://issues.redhat.com/browse/OCPBUGS-62629"
 			}
 		case "network":
-			if reason == "Deploying" {
+			if reason == "Deploying" || reason == "MachineConfig" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			}
 		case "node-tuning":


### PR DESCRIPTION
Follow up https://redhat-internal.slack.com/archives/C01CQA76KMX/p1762850845425419

CI found a new reason for co/network to become Progressing. [OCPBUGS-62630](https://issues.redhat.com/browse/OCPBUGS-62630) is updated and we add an exception for it.