### PR TITLE
NO-JIRA: Fix compat_otp.DebugNode() to support guest kubeconfig for HyperShift

### DIFF
--- a/test/extended/util/compat_otp/nodes.go
+++ b/test/extended/util/compat_otp/nodes.go
@@ -174,7 +174,7 @@ func debugNode(oc *exutil.CLI, nodeName string, cmdOptions []string, needChroot 
 		cargs = append(cargs, "--")
 	}
 	cargs = append(cargs, cmd...)
-	return oc.AsAdmin().WithoutNamespace().Run("debug").Args(cargs...).Outputs()
+	return determineExecCLI(oc).WithoutNamespace().Run("debug").Args(cargs...).Outputs()
 }
 
 // DeleteLabelFromNode delete the custom label from the node
@@ -390,7 +390,7 @@ func GetNodeArchByName(oc *exutil.CLI, nodeName string) string {
 
 // GetNodeListByLabel gets the node list by label
 func GetNodeListByLabel(oc *exutil.CLI, labelKey string) []string {
-	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-l", labelKey, "-o=jsonpath={.items[*].metadata.name}").Output()
+	output, err := determineExecCLI(oc).WithoutNamespace().Run("get").Args("node", "-l", labelKey, "-o=jsonpath={.items[*].metadata.name}").Output()
 	o.Expect(err).NotTo(o.HaveOccurred(), "Fail to get node with label %v, got error: %v\n", labelKey, err)
 	nodeNameList := strings.Fields(output)
 	return nodeNameList
@@ -398,7 +398,7 @@ func GetNodeListByLabel(oc *exutil.CLI, labelKey string) []string {
 
 // IsDefaultNodeSelectorEnabled judges whether the test cluster enabled the defaultNodeSelector
 func IsDefaultNodeSelectorEnabled(oc *exutil.CLI) bool {
-	defaultNodeSelector, getNodeSelectorErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("scheduler", "cluster", "-o=jsonpath={.spec.defaultNodeSelector}").Output()
+	defaultNodeSelector, getNodeSelectorErr := determineExecCLI(oc).WithoutNamespace().Run("get").Args("scheduler", "cluster", "-o=jsonpath={.spec.defaultNodeSelector}").Output()
 	if getNodeSelectorErr != nil && strings.Contains(defaultNodeSelector, `the server doesn't have a resource type`) {
 		e2e.Logf("WARNING: The scheduler API is not supported on the test cluster")
 		return false

--- a/test/extended/util/compat_otp/resource_op.go
+++ b/test/extended/util/compat_otp/resource_op.go
@@ -56,7 +56,7 @@ func AddAnnotationsToSpecificResource(oc *exutil.CLI, resourceKindAndName, resou
 	cargs = append(cargs, resourceKindAndName)
 	cargs = append(cargs, annotations...)
 	cargs = append(cargs, "--overwrite")
-	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(cargs...).Output()
+	return determineExecCLI(oc).WithoutNamespace().Run("annotate").Args(cargs...).Output()
 }
 
 // RemoveAnnotationFromSpecificResource removes the specified annotation from the resource
@@ -67,7 +67,7 @@ func RemoveAnnotationFromSpecificResource(oc *exutil.CLI, resourceKindAndName, r
 	}
 	cargs = append(cargs, resourceKindAndName)
 	cargs = append(cargs, annotationName+"-")
-	return oc.AsAdmin().WithoutNamespace().Run("annotate").Args(cargs...).Output()
+	return determineExecCLI(oc).WithoutNamespace().Run("annotate").Args(cargs...).Output()
 }
 
 // GetAnnotationsFromSpecificResource gets the annotations from the specific resource
@@ -77,7 +77,7 @@ func GetAnnotationsFromSpecificResource(oc *exutil.CLI, resourceKindAndName, res
 		cargs = append(cargs, "-n", resourceNamespace)
 	}
 	cargs = append(cargs, resourceKindAndName, "--list")
-	annotationsStr, getAnnotationsErr := oc.AsAdmin().WithoutNamespace().Run("annotate").Args(cargs...).Output()
+	annotationsStr, getAnnotationsErr := determineExecCLI(oc).WithoutNamespace().Run("annotate").Args(cargs...).Output()
 	if getAnnotationsErr != nil {
 		e2e.Logf(`Failed to get annotations from /%s in namespace %s: "%v"`, resourceKindAndName, resourceNamespace, getAnnotationsErr)
 	}


### PR DESCRIPTION
## Summary

Fix `compat_otp.DebugNode()` and helper functions to support HyperShift hosted clusters by automatically using guest kubeconfig when configured.

## Problem

The `DebugNode()` function and its helper functions were hardcoded to use `AsAdmin()`, preventing them from working with HyperShift hosted clusters when a guest kubeconfig is configured via `SetGuestKubeconf()`.

## Solution

Introduced a centralized `determineExecCLI()` function that automatically selects the appropriate CLI config (guest or admin) based on whether a guest kubeconfig is set. All helper functions now use this function instead of hardcoded `AsAdmin()`.

## Changes

- Add `determineExecCLI()` to automatically select guest or admin config
- Update all helper functions to use `determineExecCLI()`:
  - `IsNamespacePrivileged()`
  - `SetNamespacePrivileged()`
  - `RecoverNamespaceRestricted()`
  - `GetNodeListByLabel()`
  - `IsDefaultNodeSelectorEnabled()`
  - `AddAnnotationsToSpecificResource()`
  - `RemoveAnnotationFromSpecificResource()`
  - `GetAnnotationsFromSpecificResource()`
- Update `debugNode()` final debug command to use `determineExecCLI()`

## Backward Compatibility

This change is fully backward compatible:
- Existing callers continue to work as-is (they get admin config as before)
- HyperShift scenarios now work correctly when guest kubeconfig is set
- No API changes or breaking changes

## Testing

All affected helper functions are only used within `debugNode()` - verified no external dependencies that would break.

Fixes: [OCPERT-222](https://issues.redhat.com//browse/OCPERT-222)