### PR TITLE
OCPBUGS-66073: net(virt) remove virtctl if not correctly retrieved

### DIFF
--- a/test/extended/networking/kubevirt/client.go
+++ b/test/extended/networking/kubevirt/client.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/yaml"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 	e2ekubectl "k8s.io/kubernetes/test/e2e/framework/kubectl"
 
 	consolev1client "github.com/openshift/client-go/console/clientset/versioned"
@@ -175,13 +177,31 @@ func ensureVirtctl(oc *exutil.CLI, dir string) (string, error) {
 	_, err := os.Stat(filepath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			url, err := discoverVirtctlURL(oc)
+			backoff := wait.Backoff{
+				Steps:    5,
+				Duration: 2 * time.Second,
+				Factor:   2.0,
+				Jitter:   0.1,
+			}
+			var url string
+			allErrors := func(_ error) bool { return true }
+			err := retry.OnError(backoff, allErrors, func() error {
+				var err error
+				url, err = discoverVirtctlURL(oc)
+				if err != nil {
+					return err
+				}
+
+				if err := downloadFile(url, filepath); err != nil {
+					return err
+				}
+
+				return nil
+			})
 			if err != nil {
-				return "", err
+				return "", fmt.Errorf("failed to setup virtctl after retries: %w", err)
 			}
-			if err := downloadFile(url, filepath); err != nil {
-				return "", err
-			}
+
 			if err := os.Chmod(filepath, 0755); err != nil {
 				log.Fatal(err)
 			}
@@ -210,6 +230,14 @@ func discoverVirtctlURL(oc *exutil.CLI) (string, error) {
 }
 
 func downloadFile(url string, filepath string) error {
+	success := false
+	// Ensure cleanup on error - remove the file if we don't complete successfully
+	defer func() {
+		if !success {
+			os.Remove(filepath)
+		}
+	}()
+
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	client := &http.Client{Transport: transport}
@@ -224,7 +252,7 @@ func downloadFile(url string, filepath string) error {
 		return err
 	}
 	tarReader := tar.NewReader(gzipReader)
-	for true {
+	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
 			break
@@ -243,5 +271,6 @@ func downloadFile(url string, filepath string) error {
 			}
 		}
 	}
+	success = true
 	return nil
 }


### PR DESCRIPTION
If the virtctl download/unpack fails in the middle the downloadFile can leave a corrupted file behind, this change ensure file is removed if function do not correctly finish.