### PR TITLE
OTA-1643: Add more exceptions for COs not reporting Progressing

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -664,8 +664,22 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 			return fmt.Sprintf("%s completing its update within less than two minutes: %s", co, d.String())
 		}
 		switch co {
+		case "cluster-autoscaler":
+			return "https://issues.redhat.com/browse/OCPBUGS-65578"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
+		case "cloud-credential":
+			return "https://issues.redhat.com/browse/OCPBUGS-65580"
+		case "insights":
+			return "https://issues.redhat.com/browse/OCPBUGS-65582"
+		case "marketplace":
+			return "https://issues.redhat.com/browse/OCPBUGS-65581"
+		case "olm":
+			return "https://issues.redhat.com/browse/OCPBUGS-65623"
+		case "operator-lifecycle-manager":
+			return "https://issues.redhat.com/browse/OCPBUGS-65583"
+		case "openshift-samples":
+			return "https://issues.redhat.com/browse/OCPBUGS-65647"
 		}
 		return ""
 	}


### PR DESCRIPTION
Follow up [an internal slack conversation](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1763036965938019).

I created the bugs for those COs violating the SLO in CI and use them as exceptions here.
Those tests will be flaky, to avoid failures of jobs.

/cc @dgoodwin 