### PR TITLE
TRT-2275: minor update for e2e_analysis test

### DIFF
--- a/pkg/e2eanalysis/e2e_analysis.go
+++ b/pkg/e2eanalysis/e2e_analysis.go
@@ -133,7 +133,7 @@ func (opt *Options) Run() error {
 	tm := NewTestManager()
 	defer tm.GenerateReport(opt)
 
-	tcName := "verify the cluster can be connected"
+	tcName := "verify the cluster readiness and stability"
 	tc := NewTestCase(tcName)
 	cfg, err := e2e.LoadConfig()
 	if err != nil {
@@ -481,18 +481,18 @@ func checkClusterVersionStable(dc dynamic.Interface) (int, error) {
 	cv := objx.Map(obj.UnstructuredContent())
 
 	if cond := condition(cv, "Available"); cond.Get("status").String() != "True" {
-		err := fmt.Errorf("clusterversion not available")
-		logrus.WithError(err).Errorf("ClusterVersion Available=%s", getInfoFromCondition(cond))
+		err := fmt.Errorf("clusterversion not available: %s", getInfoFromCondition(cond))
+		logrus.WithError(err)
 		return 1, err
 	}
 	if cond := condition(cv, "Failing"); cond.Get("status").String() != "False" {
-		err := fmt.Errorf("clusterversion is failing")
-		logrus.WithError(err).Errorf("ClusterVersion Failing=%s", getInfoFromCondition(cond))
+		err := fmt.Errorf("clusterversion is failing: %s", getInfoFromCondition(cond))
+		logrus.WithError(err)
 		return 1, err
 	}
 	if cond := condition(cv, "Progressing"); cond.Get("status").String() != "False" {
-		err := fmt.Errorf("clusterversion is progressing")
-		logrus.WithError(err).Errorf("ClusterVersion Progressing=%s", getInfoFromCondition(cond))
+		err := fmt.Errorf("clusterversion is progressing: %s", getInfoFromCondition(cond))
+		logrus.WithError(err)
 		return 1, err
 	}
 


### PR DESCRIPTION
Update test case name to be more clear, also failure message.
When a cluster is unhealthy, the junit would be like:
```
<testsuite name="openshift-tests" tests="5" skipped="0" failures="3" time="1.838314112">
    <properties></properties>
    <testcase name="verify the cluster readiness and stability" time="0.955837342">
        <failure message="cluster version stability check failed: clusterversion is failing: True | MultipleErrors | Multiple errors are preventing progress:&#xA;* Cluster operator kube-controller-manager is degraded&#xA;* Cluster operators authentication, console, image-registry, ingress are not available"></failure>
    </testcase>
    <testcase name="verify all machines should be in Running state" time="0.321809975">
        <failure message="Found 1 out of 4 Machines not in Running state: Machine &#34;jialiu-sd9w6-worker-us-east-2c-5khqr&#34; is in &#34;Provisioning&#34; state"></failure>
    </testcase>
    <testcase name="verify all nodes should be ready" time="0.560536547"></testcase>
    <testcase name="verify node count should match or exceed machine count" time="3.0592e-05"></testcase>
    <testcase name="ensure 1 worker node at least gets ready" time="2.8276e-05">
        <failure message="No Schedulable worker nodes available"></failure>
    </testcase>
</testsuite>
```