### PR TITLE
OCPBUGS-64782 MCO-1930: add a monitor exception for control-plane-mac…

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -139,6 +139,9 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "cluster-autoscaler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42875", nil
 			}
+			if operator == "control-plane-machine-set" && condition.Reason == "UnmanagedNodes" {
+				return "https://issues.redhat.com/browse/OCPBUGS-64782", nil
+			}
 			return "", nil
 		}
 		return "We are not worried about other operator condition blips for stable-system tests yet.", nil


### PR DESCRIPTION
…hine-set

Add a monitor exception for for control-plane-machine-set.

The new  controlplanemachineset boot-images update tests  need to recreate the controlplane machines. When the controlplanemachineset recreates the contrlplane machines the operator blips reporting a temporary degradation.

This issue is tracked in https://issues.redhat.com/browse/OCPBUGS-64782

In this PR we add an exception to the monitor until the issue is fixed.