### PR TITLE
CORENET-6491: Delete test namesapces for UDN testing

### DIFF
--- a/test/extended/util/util_otp.go
+++ b/test/extended/util/util_otp.go
@@ -87,6 +87,7 @@ func (c *CLI) CreateNamespaceUDN() {
 	if err != nil {
 		FatalErr(err)
 	}
+	c.kubeFramework.AddNamespacesToDelete(namespace)
 }
 
 // CreateSpecificNamespaceUDN creates a specific namespace with required user defined network label during creation time only


### PR DESCRIPTION
The namesapces created for UDN testing will not be removed automatically now, call c.kubeFramework.AddNamespacesToDelete to remove the namespaces at the end of testing.
Run case 74921 locally to verify the fixing:
https://privatebin.corp.redhat.com/?ceee793a25da3fb7#2DjbofyE5CPbJJLyy3xRdWpiPTFToXJHFsrRgNaUCFsU 