### PR TITLE
MCO-1870: Skip MCN condition transition test in clusters with `ImageModeStatusReporting` FeatureGate is enabled

### DIFF
--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -73,6 +73,10 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	})
 
 	g.It("[Serial]Should properly transition through MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io]", func() {
+		// Skip this test when the `ImageModeStatusReporting` FeatureGate is enabled, since its
+		// regression tests handle the different conditions list.
+		SkipWhenFeatureGateEnabled(oc.AdminConfigClient(), "ImageModeStatusReporting")
+
 		if IsSingleNode(oc) {
 			ValidateMCNConditionTransitionsOnRebootlessUpdateSNO(oc, nodeDisruptionFixture, nodeDisruptionEmptyFixture, masterMCFixture)
 		} else {


### PR DESCRIPTION
With the implementation of [MCO-1870](https://issues.redhat.com//browse/MCO-1870) being introduced in https://github.com/openshift/machine-config-operator/pull/5411, the MachineConfigNode conditions will be different when a cluster has the `ImageModeStatusReporting` FeatureGate enabled. The condition transitions for this situation are tested in the [ImageModeStatusReporting tests](https://github.com/openshift/machine-config-operator/blob/main/test/extended/image_mode_status_reporting.go), so this test can simply be skipped without losing test coverage.

To verify this change, confirm that the `Should properly transition through MCN conditions on rebootless node update` test is skipped in tech preview test clusters (`periodic-ci-openshift-release-master-ci-4.21-e2e-aws-ovn-techpreview-serial`) and not skipped in default clusters (`periodic-ci-openshift-release-master-nightly-4.21-e2e-aws-ovn-serial`).