### PR TITLE
backport PR for Redact bearertoken in TestContext

### DIFF
--- a/pkg/cmd/openshift-tests/run-test/command.go
+++ b/pkg/cmd/openshift-tests/run-test/command.go
@@ -54,7 +54,10 @@ func NewRunTestCommand(streams genericclioptions.IOStreams) *cobra.Command {
 			if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, testOpt.DryRun); err != nil {
 				return err
 			}
-			klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
+			// Redact the bearer token exposure
+			testContextString := fmt.Sprintf("%#v", exutil.TestContext)
+			redactedTestContext := exutil.RedactBearerToken(testContextString)
+			klog.V(4).Infof("Loaded test configuration: %s", redactedTestContext)
 
 			exutil.TestContext.ReportDir = os.Getenv("TEST_JUNIT_DIR")
 

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -71,8 +71,10 @@ func (o *RunUpgradeSuiteOptions) UpgradeTestPreSuite() error {
 	if err := clusterdiscovery.InitializeTestFramework(exutil.TestContext, config, o.GinkgoRunSuiteOptions.DryRun); err != nil {
 		return err
 	}
-	klog.V(4).Infof("Loaded test configuration: %#v", exutil.TestContext)
-
+	// Redact the bearer token exposure
+	testContextString := fmt.Sprintf("%#v", exutil.TestContext)
+	redactedTestContext := exutil.RedactBearerToken(testContextString)
+	klog.V(4).Infof("Loaded test configuration: %s", redactedTestContext)
 	return nil
 }
 

--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -947,13 +947,10 @@ func (c *CLI) start(stdOutBuff, stdErrBuff *bytes.Buffer) (*exec.Cmd, error) {
 	return cmd, err
 }
 
+var reToken = regexp.MustCompile(`(?i)(Authorization:\s*Bearer\s+)[^\s"]+|((BearerToken:\s*")[^"]+)`)
+
 func RedactBearerToken(args string) string {
-	if strings.Contains(args, "Authorization: Bearer") {
-		// redact bearer token
-		re := regexp.MustCompile(`Authorization:\s+Bearer.*\s+`)
-		args = re.ReplaceAllString(args, "Authorization: Bearer <redacted> ")
-	}
-	return args
+	return reToken.ReplaceAllString(args, `${1}${3}<redacted>`)
 }
 
 // getStartingIndexForLastN calculates a byte offset in a byte slice such that when using


### PR DESCRIPTION
Backport PR for [release-4.20] OCPBUGS-63656: Redact bearertoken in TestContext #30435

