### PR TITLE
OCPNODE-3823: Migrating test case from Openshift-test-private to origin

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -39,6 +39,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/node"
+	_ "github.com/openshift/origin/test/extended/node/node_e2e"
 	_ "github.com/openshift/origin/test/extended/node_tuning"
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"

--- a/test/extended/node/node_e2e/OWNERS
+++ b/test/extended/node/node_e2e/OWNERS
@@ -1,0 +1,12 @@
+reviewers:
+  - lyman9966
+  - asahay19
+  - cpmeadors
+  - sairameshv
+  - mrunalp
+  - BhargaviGudi
+approvers:
+  - lyman9966
+  - cpmeadors
+  - sairameshv
+  - mrunalp

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -1,0 +1,77 @@
+package node
+
+import (
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager", func() {
+	var (
+		oc = exutil.NewCLIWithoutNamespace("node").AsAdmin()
+	)
+
+	//author: asahay@redhat.com
+	g.It("[OTP] validate KUBELET_LOG_LEVEL", func() {
+		var kubeservice string
+		var kublet string
+		var err error
+
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		if err != nil {
+			o.Expect(err).NotTo(o.HaveOccurred(), "error determining if running on MicroShift: %v", err)
+		}
+		if isMicroShift {
+			g.Skip("This test case is not supported in micoshift cluster ")
+		}
+
+		g.By("Polling to check kubelet log level on ready nodes")
+		waitErr := wait.Poll(10*time.Second, 1*time.Minute, func() (bool, error) {
+			g.By("Getting all node names in the cluster")
+			nodeName, nodeErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-o=jsonpath={.items[*].metadata.name}").Output()
+			o.Expect(nodeErr).NotTo(o.HaveOccurred())
+			e2e.Logf("\nNode Names are %v", nodeName)
+			nodes := strings.Fields(nodeName)
+
+			for _, node := range nodes {
+				g.By("Checking if node " + node + " is Ready")
+				nodeStatus, statusErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", node, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
+				o.Expect(statusErr).NotTo(o.HaveOccurred())
+				e2e.Logf("\nNode %s Status is %s\n", node, nodeStatus)
+
+				if nodeStatus == "True" {
+					g.By("Checking KUBELET_LOG_LEVEL in kubelet.service on node " + node)
+					kubeservice, err = oc.AsAdmin().WithoutNamespace().Run("debug").Args("node/"+node, "-ndefault", "--", "chroot", "/host", "/bin/bash", "-c", "systemctl show kubelet.service | grep KUBELET_LOG_LEVEL").Output()
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					g.By("Checking kubelet process for --v=2 flag on node " + node)
+					kublet, err = oc.AsAdmin().WithoutNamespace().Run("debug").Args("node/"+node, "-ndefault", "--", "chroot", "/host", "/bin/bash", "-c", "ps aux | grep kubelet").Output()
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					g.By("Verifying KUBELET_LOG_LEVEL is set and kubelet is running with --v=2")
+					if strings.Contains(string(kubeservice), "KUBELET_LOG_LEVEL") && strings.Contains(string(kublet), "--v=2") {
+						e2e.Logf("KUBELET_LOG_LEVEL is 2.\n")
+						return true, nil
+					} else {
+						e2e.Logf("KUBELET_LOG_LEVEL is not 2.\n")
+						return false, nil
+					}
+				} else {
+					e2e.Logf("\nNode %s is not Ready, Skipping\n", node)
+				}
+			}
+			return false, nil
+		})
+
+		if waitErr != nil {
+			e2e.Logf("Kubelet Log level is:\n %v\n", kubeservice)
+			e2e.Logf("Running Process of kubelet are:\n %v\n", kublet)
+		}
+		o.Expect(waitErr).NotTo(o.HaveOccurred(), "KUBELET_LOG_LEVEL is not expected, timed out")
+	})
+})


### PR DESCRIPTION
This case is about checking the Kubelet log level is 2.
Here is the test case link : https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-55033

It is duplicate of PR: https://github.com/openshift/origin/pull/30460 
PR: 30460 got closed because I had to delete repo, so creating new PR again with addressing all the comments.

PTAL @sairameshv @lyman9966 @cpmeadors 

Here is the output for this PR . It got passed successfully while executing it on my local :

**./openshift-tests run-test "[sig-node] Kubelet, CRI-O, CPU manager validate KUBELET_LOG_LEVEL [Suite:openshift/conformance/parallel]"**

  Running Suite:  - /Users/asahay/newOCP-55033/origin
  ===================================================
  Random Seed: 1764311478 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] Kubelet, CRI-O, CPU manager validate KUBELET_LOG_LEVEL
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:20
    STEP: Creating a kubernetes client @ 11/28/25 12:01:22.453
  I1128 12:01:22.455698   58826 discovery.go:214] Invalidating discovery information
    STEP: Polling to check kubelet log level on ready nodes @ 11/28/25 12:01:22.455
    STEP: Getting all node names in the cluster @ 11/28/25 12:01:32.457
  I1128 12:01:35.246189 58826 node.go:30]
  Node Names are ip-10-0-21-47.us-east-2.compute.internal ip-10-0-29-148.us-east-2.compute.internal ip-10-0-43-146.us-east-2.compute.internal ip-10-0-53-99.us-east-2.compute.internal ip-10-0-76-236.us-east-2.compute.internal ip-10-0-87-5.us-east-2.compute.internal
    STEP: Checking if node ip-10-0-21-47.us-east-2.compute.internal is Ready @ 11/28/25 12:01:35.246
  I1128 12:01:36.338169 58826 node.go:37]
  Node ip-10-0-21-47.us-east-2.compute.internal Status is True

    STEP: Checking KUBELET_LOG_LEVEL in kubelet.service on node ip-10-0-21-47.us-east-2.compute.internal @ 11/28/25 12:01:36.338
    STEP: Checking kubelet process for --v=2 flag on node ip-10-0-21-47.us-east-2.compute.internal @ 11/28/25 12:01:44.469
    STEP: Verifying KUBELET_LOG_LEVEL is set and kubelet is running with --v=2 @ 11/28/25 12:01:47.469
  I1128 12:01:47.470106 58826 node.go:50] KUBELET_LOG_LEVEL is 2.

  • [25.041 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 25.042 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-node] Kubelet, CRI-O, CPU manager validate KUBELET_LOG_LEVEL [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 25042,
    "startTime": "2025-11-28 06:31:22.430978 UTC",
    "endTime": "2025-11-28 06:31:47.473486 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 11/28/25 12:01:22.453\n  STEP: Polling to check kubelet log level on ready nodes @ 11/28/25 12:01:22.455\n  STEP: Getting all node names in the cluster @ 11/28/25 12:01:32.457\nI1128 12:01:35.246189 58826 node.go:30] \nNode Names are ip-10-0-21-47.us-east-2.compute.internal ip-10-0-29-148.us-east-2.compute.internal ip-10-0-43-146.us-east-2.compute.internal ip-10-0-53-99.us-east-2.compute.internal ip-10-0-76-236.us-east-2.compute.internal ip-10-0-87-5.us-east-2.compute.internal\n  STEP: Checking if node ip-10-0-21-47.us-east-2.compute.internal is Ready @ 11/28/25 12:01:35.246\nI1128 12:01:36.338169 58826 node.go:37] \nNode ip-10-0-21-47.us-east-2.compute.internal Status is True\n\n  STEP: Checking KUBELET_LOG_LEVEL in kubelet.service on node ip-10-0-21-47.us-east-2.compute.internal @ 11/28/25 12:01:36.338\n  STEP: Checking kubelet process for --v=2 flag on node ip-10-0-21-47.us-east-2.compute.internal @ 11/28/25 12:01:44.469\n  STEP: Verifying KUBELET_LOG_LEVEL is set and kubelet is running with --v=2 @ 11/28/25 12:01:47.469\nI1128 12:01:47.470106 58826 node.go:50] KUBELET_LOG_LEVEL is 2.\n\n"
  }
]%