### PR TITLE
TRT-2429: Revert "SPLAT-2337: Added OTE binary for ccm-aws"

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -243,10 +243,6 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-etcd-operator",
 		binaryPath: "/usr/bin/cluster-etcd-operator-tests-ext.gz",
 	},
-	{
-		imageTag:   "aws-cloud-controller-manager",
-		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
-	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Reverts openshift/origin#30235

The following tests are failing 10/10 times in all `aggregated-hypershift-ovn-conformance-4.21-release-openshift-release-analysis-aggregator` jobs since this external binary has been added.
```
[cloud-provider-aws-e2e] loadbalancer NLB should be reachable with target-node-labels [Suite:openshift/conformance/parallel]
[cloud-provider-aws-e2e] loadbalancer NLB internal should be reachable with hairpinning traffic [Suite:openshift/conformance/parallel] 
```

In order to reenable this, you must run the following command successfully:
```
/payload-aggregate periodic-ci-openshift-hypershift-release-4.21-periodics-e2e-aws-ovn-conformance 10
```