### PR TITLE
NO-JIRA: Use a more general exception for co/olm becoming unavailable

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -404,8 +404,10 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "olm":
 			if condition.Type == configv1.OperatorAvailable &&
 				condition.Status == configv1.ConditionFalse &&
-				(condition.Reason == "OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying" ||
-					condition.Reason == "CatalogdDeploymentCatalogdControllerManager_Deploying") {
+				// "OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
+				// "CatalogdDeploymentCatalogdControllerManager_Deploying"
+				// "CatalogdDeploymentCatalogdControllerManager_Deploying::OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
+				strings.HasSuffix(condition.Reason, "ControllerManager_Deploying") {
 				return "https://issues.redhat.com/browse/OCPBUGS-62517", nil
 			}
 		case "openshift-apiserver":


### PR DESCRIPTION
See the failing job [1]:

```
: [Monitor:legacy-cvo-invariants][bz-OLM] clusteroperator/olm should not change condition/Available expand_less	2h10m52s
{  2 unexpected clusteroperator state transitions during e2e test run.  These did not match any known exceptions, so they cause this test-case to fail:

Nov 21 02:13:21.844 E clusteroperator/olm condition/Available reason/CatalogdDeploymentCatalogdControllerManager_Deploying::OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying status/False CatalogdDeploymentCatalogdControllerManagerAvailable: Waiting for Deployment\nOperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Waiting for Deployment
Nov 21 02:13:21.844 - 20s   E clusteroperator/olm condition/Available reason/CatalogdDeploymentCatalogdControllerManager_Deploying::OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying status/False CatalogdDeploymentCatalogdControllerManagerAvailable: Waiting for Deployment\nOperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Waiting for Deployment

4 unwelcome but acceptable clusteroperator state transitions during e2e test run.  These should not happen, but because they are tied to exceptions, the fact that they did happen is not sufficient to cause this test-case to fail:

Nov 21 01:53:57.961 E clusteroperator/olm condition/Available reason/OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying status/False OperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Waiting for Deployment (exception: https://issues.redhat.com/browse/OCPBUGS-62517)
Nov 21 01:53:57.961 - 189s  E clusteroperator/olm condition/Available reason/OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying status/False OperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Waiting for Deployment (exception: https://issues.redhat.com/browse/OCPBUGS-62517)
Nov 21 01:57:07.563 W clusteroperator/olm condition/Available reason/AsExpected status/True CatalogdDeploymentCatalogdControllerManagerAvailable: Deployment is available\nOperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Deployment is available (exception: Available=True is the happy case)
Nov 21 02:13:42.162 W clusteroperator/olm condition/Available reason/AsExpected status/True CatalogdDeploymentCatalogdControllerManagerAvailable: Deployment is available\nOperatorcontrollerDeploymentOperatorControllerControllerManagerAvailable: Deployment is available (exception: Available=True is the happy case)
}
```

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-e2e-azure-ovn-upgrade/1991653721427152896