### PR TITLE
NO-JIRA: Add more exceptions for CO degraded

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -458,17 +458,19 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-38661", nil
 			}
 		case "kube-controller-manager":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "NodeController_MasterNodesReady" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38662", nil
-			}
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "NodeController_MasterNodesReady::StaticPods_Error" {
+			if condition.Type == configv1.OperatorDegraded &&
+				condition.Status == configv1.ConditionTrue &&
+				(condition.Reason == "NodeController_MasterNodesReady" ||
+					condition.Reason == "NodeController_MasterNodesReady::StaticPods_Error" ||
+					condition.Reason == "StaticPods_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-38662", nil
 			}
 		case "kube-scheduler":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "NodeController_MasterNodesReady" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38663", nil
-			}
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "NodeController_MasterNodesReady::StaticPods_Error" {
+			if condition.Type == configv1.OperatorDegraded &&
+				condition.Status == configv1.ConditionTrue &&
+				(condition.Reason == "NodeController_MasterNodesReady" ||
+					condition.Reason == "NodeController_MasterNodesReady::StaticPods_Error" ||
+					condition.Reason == "GuardController_SyncError::NodeController_MasterNodesReady") {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663", nil
 			}
 		}


### PR DESCRIPTION
The failure jobs are in [1, 2] and linked in the relevant bugs.

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-multiarch-master-nightly-4.21-ocp-e2e-aws-ovn-upgrade-multi-x-ax/1991368329922613248

[2]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-upgrade-from-stable-4.20-e2e-aws-ovn-upgrade/1980279765138935808