### PR TITLE
OTA-1643: Skip a couple of ClusterOperator tests in a multi-upgrade test

### DIFF
--- a/pkg/monitortestlibrary/platformidentification/upgrade.go
+++ b/pkg/monitortestlibrary/platformidentification/upgrade.go
@@ -7,6 +7,11 @@ import (
 )
 
 func DidUpgradeHappenDuringCollection(intervals monitorapi.Intervals, beginning, end time.Time) bool {
+	return UpgradeNumberDuringCollection(intervals, beginning, end) > 0
+}
+
+func UpgradeNumberDuringCollection(intervals monitorapi.Intervals, beginning, end time.Time) int {
+	var ret int
 	pertinentIntervals := intervals.Slice(beginning, end)
 
 	for _, event := range pertinentIntervals {
@@ -15,8 +20,8 @@ func DidUpgradeHappenDuringCollection(intervals monitorapi.Intervals, beginning,
 		}
 		reason := event.Message.Reason
 		if reason == monitorapi.UpgradeStartedReason || reason == monitorapi.UpgradeRollbackReason {
-			return true
+			ret++
 		}
 	}
-	return false
+	return ret
 }


### PR DESCRIPTION
Those test cases does not work in multi-upgrade tests, [failing job example](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-upgrade-from-stable-4.20-from-stable-4.19-e2e-aws-ovn-upgrade/1991684715140091904).

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-upgrade-from-stable-4.20-from-stable-4.19-e2e-aws-ovn-upgrade/1991684715140091904/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/events_used_for_junits_20251121-023805.json | jq '[.items[]|select(.locator.type=="Kind" and .locator.keys["clusterversion"]=="cluster" and .message.reason=="UpgradeStarted"  and .source=="KubeEvent")]'
[
  {
    "level": "Info",
    "source": "KubeEvent",
    "locator": {
      "type": "Kind",
      "keys": {
        "clusterversion": "cluster",
        "hmsg": "e6350626fd",
        "namespace": "openshift-cluster-version"
      }
    },
    "message": {
      "reason": "UpgradeStarted",
      "cause": "",
      "humanMessage": "version/ image/registry.build09.ci.openshift.org/ci-op-v99qhjyz/release@sha256:733be64f28423c1306a4d7b39e360f92accf5ef1509f6747ff9cee27cfe2342b",
      "annotations": {
        "firstTimestamp": "0001-01-01T00:00:00Z",
        "lastTimestamp": "0001-01-01T00:00:00Z",
        "reason": "UpgradeStarted"
      }
    },
    "from": "2025-11-21T02:45:17Z",
    "to": "2025-11-21T02:45:17Z"
  },
  {
    "level": "Info",
    "source": "KubeEvent",
    "locator": {
      "type": "Kind",
      "keys": {
        "clusterversion": "cluster",
        "hmsg": "8e1f2b2a80",
        "namespace": "openshift-cluster-version"
      }
    },
    "message": {
      "reason": "UpgradeStarted",
      "cause": "",
      "humanMessage": "version/ image/registry.build09.ci.openshift.org/ci-op-v99qhjyz/release@sha256:dfae60d3656146cae87e2c112628ee29e24f7412f0dd6bf208aaf2704027a4ee",
      "annotations": {
        "firstTimestamp": "0001-01-01T00:00:00Z",
        "lastTimestamp": "0001-01-01T00:00:00Z",
        "reason": "UpgradeStarted"
      }
    },
    "from": "2025-11-21T04:00:04Z",
    "to": "2025-11-21T04:00:04Z"
  }
]
```

In this pull, we recognize a multi-upgrade test by counting the intervals like the above.
Then skip the relevant test cases if needed.