### PR TITLE
OCPEDGE-1788: TNF add etcd cold boot recovery tests from graceful node shutdown

### DIFF
--- a/test/extended/two_node/utils/common.go
+++ b/test/extended/two_node/utils/common.go
@@ -5,19 +5,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"slices"
 	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/test/extended/etcd/helpers"
+	"github.com/openshift/origin/test/extended/util"
 	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/test/e2e/framework"
 	nodehelper "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
@@ -29,6 +36,9 @@ const (
 	LabelNodeRoleArbiter      = "node-role.kubernetes.io/arbiter"       // Arbiter node label
 	CLIPrivilegeNonAdmin      = false                                   // Standard user CLI
 	CLIPrivilegeAdmin         = true                                    // Admin CLI with cluster-admin permissions
+
+	clusterIsHealthyTimeout = 5 * time.Minute
+	pollInterval            = 5 * time.Second
 )
 
 // DecodeObject decodes YAML or JSON data into a Kubernetes runtime object using generics.
@@ -50,6 +60,23 @@ func SkipIfNotTopology(oc *exutil.CLI, wanted v1.TopologyMode) {
 	}
 	if *current != wanted {
 		e2eskipper.Skip(fmt.Sprintf("Cluster is not in %v topology, skipping test", wanted))
+	}
+}
+
+func SkipIfClusterIsNotHealthy(oc *util.CLI, ecf *helpers.EtcdClientFactoryImpl, nodes *corev1.NodeList) {
+	err := ensureEtcdPodsAreRunning(oc)
+	if err != nil {
+		e2eskipper.Skip(fmt.Sprintf("could not ensure etcd pods are running: %v", err))
+	}
+
+	err = ensureEtcdHasTwoVotingMembers(nodes, ecf)
+	if err != nil {
+		e2eskipper.Skip(fmt.Sprintf("could not ensure etcd has two voting members: %v", err))
+	}
+
+	err = ensureClusterOperatorHealthy(oc)
+	if err != nil {
+		e2eskipper.Skip(fmt.Sprintf("could not ensure cluster-operator is healthy: %v", err))
 	}
 }
 
@@ -316,4 +343,169 @@ func isNodeObjReady(node corev1.Node) bool {
 		}
 	}
 	return false
+}
+
+func GetMembers(etcdClientFactory helpers.EtcdClientCreator) ([]*etcdserverpb.Member, error) {
+	etcdClient, closeFn, err := etcdClientFactory.NewEtcdClient()
+	if err != nil {
+		return []*etcdserverpb.Member{}, errors.Wrap(err, "could not get a etcd client")
+	}
+	defer closeFn()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+	m, err := etcdClient.MemberList(ctx)
+	if err != nil {
+		return []*etcdserverpb.Member{}, errors.Wrap(err, "could not get the member list")
+	}
+	return m.Members, nil
+}
+
+func GetMemberState(node *corev1.Node, members []*etcdserverpb.Member) (started, learner bool, err error) {
+	// Etcd members that have been added to the member list but haven't
+	// joined yet will have an empty Name field. We can match them via Peer URL.
+	hostPort := net.JoinHostPort(node.Status.Addresses[0].Address, "2380")
+	peerURL := fmt.Sprintf("https://%s", hostPort)
+	var found bool
+	for _, m := range members {
+		if m.Name == node.Name {
+			found = true
+			started = true
+			learner = m.IsLearner
+			break
+		}
+		if slices.Contains(m.PeerURLs, peerURL) {
+			found = true
+			learner = m.IsLearner
+			break
+		}
+	}
+	if !found {
+		return false, false, fmt.Errorf("could not find node %v via peer URL %s", node.Name, peerURL)
+	}
+	return started, learner, nil
+}
+
+// ensureClusterOperatorHealthy checks if the cluster-etcd-operator is healthy before running etcd tests
+func ensureClusterOperatorHealthy(oc *util.CLI) error {
+	framework.Logf("Ensure cluster operator is healthy (timeout: %v)", clusterIsHealthyTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), clusterIsHealthyTimeout)
+	defer cancel()
+
+	for {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, "etcd", metav1.GetOptions{})
+		if err != nil {
+			err = fmt.Errorf("failed to retrieve ClusterOperator: %v", err)
+		} else {
+			// Check if etcd operator is Available
+			available := findClusterOperatorCondition(co.Status.Conditions, v1.OperatorAvailable)
+			if available == nil {
+				err = fmt.Errorf("ClusterOperator Available condition not found")
+			} else if available.Status != v1.ConditionTrue {
+				err = fmt.Errorf("ClusterOperator is not Available: %s", available.Message)
+			} else {
+				// Check if etcd operator is not Degraded
+				degraded := findClusterOperatorCondition(co.Status.Conditions, v1.OperatorDegraded)
+				if degraded != nil && degraded.Status == v1.ConditionTrue {
+					err = fmt.Errorf("ClusterOperator is Degraded: %s", degraded.Message)
+				} else {
+					framework.Logf("SUCCESS: Cluster operator is healthy")
+					return nil
+				}
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			return err
+		default:
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+func ensureEtcdPodsAreRunning(oc *util.CLI) error {
+	framework.Logf("Ensure Etcd pods are running (timeout: %v)", clusterIsHealthyTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), clusterIsHealthyTimeout)
+	defer cancel()
+	for {
+		etcdPods, err := oc.AdminKubeClient().CoreV1().Pods("openshift-etcd").List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app=etcd",
+		})
+		if err != nil {
+			err = fmt.Errorf("failed to retrieve etcd pods: %v", err)
+		} else {
+			runningPods := 0
+			for _, pod := range etcdPods.Items {
+				if pod.Status.Phase == corev1.PodRunning {
+					runningPods++
+				}
+			}
+			if runningPods < 2 {
+				return fmt.Errorf("expected at least 2 etcd pods running, found %d", runningPods)
+			}
+
+			framework.Logf("SUCCESS: found the 2 expected Etcd pods")
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return err
+		default:
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+// findClusterOperatorCondition finds a condition in ClusterOperator status
+func findClusterOperatorCondition(conditions []v1.ClusterOperatorStatusCondition, conditionType v1.ClusterStatusConditionType) *v1.ClusterOperatorStatusCondition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func ensureEtcdHasTwoVotingMembers(nodes *corev1.NodeList, ecf *helpers.EtcdClientFactoryImpl) error {
+	framework.Logf("Ensure Etcd member list has two voting members (timeout: %v)", clusterIsHealthyTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), clusterIsHealthyTimeout)
+	defer cancel()
+
+	for {
+		// Check all conditions sequentially
+		members, err := GetMembers(ecf)
+		if err == nil && len(members) != 2 {
+			err = fmt.Errorf("expected 2 members, found %d", len(members))
+		}
+
+		if err == nil {
+			for _, node := range nodes.Items {
+				isStarted, isLearner, checkErr := GetMemberState(&node, members)
+				if checkErr != nil {
+					err = checkErr
+				} else if !isStarted || isLearner {
+					err = fmt.Errorf("member %s is not a voting member (started=%v, learner=%v)",
+						node.Name, isStarted, isLearner)
+					break
+				}
+			}
+
+		}
+
+		// All checks passed - success!
+		if err == nil {
+			framework.Logf("SUCCESS: got membership with two voting members: %+v", members)
+			return nil
+		}
+
+		// Checks failed - evaluate timeout
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("etcd membership does not have two voters: %v, membership: %+v", err, members)
+		default:
+		}
+		time.Sleep(pollInterval)
+	}
 }


### PR DESCRIPTION
Add three new test cases to validate etcd cluster recovery from cold boot scenarios reached through different graceful/ungraceful shutdown combinations:

- Cold boot from double GNS: both nodes gracefully shut down simultaneously, then both restart (full cluster cold boot)
- Cold boot from sequential GNS: first node gracefully shut down, then second node gracefully shut down, then both restart
- Cold boot from mixed GNS/UGNS: first node gracefully shut down, surviving node then ungracefully shut down, then both restart

Note: The inverse case (UGNS first node, then GNS second) is not tested because in TNF clusters, an ungracefully shut down node is quickly recovered, preventing the ability to wait and gracefully shut down the second node later. The double UGNS scenario is already covered by existing tests.