### PR TITLE
NO-JIRA: Add exception for co/kube-scheduler on Progressing

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -672,6 +672,8 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 			return "https://issues.redhat.com/browse/OCPBUGS-65580"
 		case "insights":
 			return "https://issues.redhat.com/browse/OCPBUGS-65582"
+		case "kube-scheduler":
+			return "https://issues.redhat.com/browse/OCPBUGS-65941"
 		case "marketplace":
 			return "https://issues.redhat.com/browse/OCPBUGS-65581"
 		case "olm":


### PR DESCRIPTION
Follow up [an internal slack conversation](https://redhat-internal.slack.com/archives/C01CQA76KMX/p1764008836174789).
The details are provided in the linked bug.

[Failure job example](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-e2e-aws-upgrade-ovn-single-node/1992947521055363072):
```
: [Monitor:legacy-cvo-invariants][bz-kube-scheduler] clusteroperator/kube-scheduler must go Progressing=True during an upgrade test expand_less	31m40s
{  clusteroperator/kube-scheduler was never Progressing=True during the upgrade window from 2025-11-24T14:34:38Z to 2025-11-24T15:06:18Z and CVO waited for it over 2 minutes from 2025-11-24T14:35:31Z to 2025-11-24T14:39:01Z}
```

