### PR TITLE
SPLAT-2337: Added OTE binary for ccm-aws

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -267,6 +267,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cli",
 		binaryPath: "/usr/bin/oc-tests-ext.gz",
 	},
+	{
+		imageTag:   "aws-cloud-controller-manager",
+		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Re-adding OTE for CCM-AWS to validate hypershift: https://github.com/openshift/origin/pull/30235

CCM-AWS e2e (OTE) on hypershift workload cluster is working and must skip two tests that is failing due an possible issue on retries, documented in:
- https://github.com/openshift/release/pull/74032
- https://issues.redhat.com/browse/OCPBUGS-74537
