### PR TITLE
OCPBUGS-70249:Unrevert tls tests with fixes

### DIFF
--- a/test/extended/apiserver/tls.go
+++ b/test/extended/apiserver/tls.go
@@ -165,8 +165,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 					return err
 				}
 				expectFailure := !defaultCiphers[cipher]
-				// Constrain to TLS 1.2 to prevent Go 1.23+ from silently ignoring
-				// deprecated ciphers and falling back to TLS 1.3 with secure defaults
+				// Constrain to TLS 1.2 because the intermediate profile allows both TLS 1.2 and TLS 1.3.
+				// If MaxVersion is unspecified, the client negotiates TLS 1.3 when the server supports it.
+				// TLS 1.3 does not support configuring cipher suites (predetermined by the spec), so
+				// specifying any cipher suite (RC4 or otherwise) has no effect with TLS 1.3.
+				// By forcing TLS 1.2, we can actually test the cipher suite restrictions.
 				cfg := &tls.Config{
 					CipherSuites:       []uint16{cipher},
 					MinVersion:         tls.VersionTLS12,


### PR DESCRIPTION
**### What Was Fixed:**

This PR unrereverts the TLS 1.3 / Modern profile tests that were previously reverted in PR #30533 due to test failures. The original implementation was in PR #29611 for OCPBUGS-64799.

After investigation, the test failures were caused by two distinct bugs in the TLS tests:

### Bug 1: TestTLSDefaults used direct connection instead of port-forwarding

**Problem:** The test attempted to connect directly to the external API server hostname from the kubeconfig (e.g., `api.cluster5.ocpci.eng.rdu2.redhat.com`). When running as a pod in the cluster (CI environment), the pod's internal DNS cannot resolve this external hostname, resulting in:
```
dial tcp: lookup api.cluster5.ocpci.eng.rdu2.redhat.com on 172.30.0.10:53: no such host
```

**Fix:** Updated `TestTLSDefaults` to use the same `forwardPortAndExecute()` approach as `TestTLSMinimumVersions`, which creates an `oc port-forward` tunnel to the apiserver service. This approach:
- Works both in-cluster (CI) and externally (with kubeconfig)
- Eliminates DNS resolution issues entirely
- Is consistent with the `TestTLSMinimumVersions` pattern
- Includes built-in retry logic (3 attempts)

### Bug 2: TLS 1.3 doesn't support cipher suite configuration

**Problem:** The intermediate TLS profile allows both TLS 1.2 and TLS 1.3. When the client doesn't specify `MaxVersion`, it negotiates TLS 1.3 if the server supports it. TLS 1.3 does not support configuring cipher suites (they're predetermined by the spec), so specifying any cipher suite (RC4 or modern ciphers) has no effect. This caused the cipher suite validation test to incorrectly succeed when connecting with deprecated ciphers that should have been rejected.

Example observed behavior:
- Client requests: `TLS_ECDHE_ECDSA_WITH_RC4_128_SHA` (0xC007)
- With TLS 1.3 negotiated: Connection succeeds using `TLS_AES_128_GCM_SHA256` (0x1301)

**Fix:** Constrain the cipher test to TLS 1.2 only to ensure cipher suite restrictions are actually tested:
```go
cfg := &tls.Config{
    CipherSuites:       []uint16{cipher},
    MinVersion:         tls.VersionTLS12,
    MaxVersion:         tls.VersionTLS12,  // Forces TLS 1.2 so cipher suites are evaluated
    InsecureSkipVerify: true,
}
```

### Additional fixes:
- Fixed variable shadowing where `err := conn.Close()` shadowed the outer `err` from `tls.Dial()`, making the test check the wrong error
- Renamed to `dialErr` and `closeErr` for clarity

## IPv6 Support

Removed the IPv4-only restriction to enable tests on IPv6 clusters:
- ✅ Tests now run on **IPv4-only** clusters
- ✅ Tests now run on **IPv6-only** clusters
- ✅ Tests now run on **dual-stack (IPv4+IPv6)** clusters

The tests use port-forwarding to `localhost`, which resolves appropriately in both IPv4 (`127.0.0.1`) and IPv6 (`::1`) environments.

## Testing

Tested against live OpenShift cluster with both single-stack IPv4 and dual-stack IPv6 configurations:
```
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
```

## Related Issues

- Fixes: OCPBUGS-64799
- Reverts: PR #30533 (the revert)
- Original implementation: PR #29611
- Related: [TRT-2439](https://issues.redhat.com//browse/TRT-2439)

## References

- TLS 1.3 RFC 8446 - Cipher suites are predefined and not configurable
- [k8s.io/client-go/rest.Config documentation](https://pkg.go.dev/k8s.io/client-go/rest#Config)
- [openshift/library-go DefaultCiphers()](https://github.com/openshift/library-go/blob/master/pkg/crypto/crypto.go) - deliberately excludes RC4 and weak ciphers