### PR TITLE
Fix IPsec NNCP deployment failure

### DIFF
--- a/test/extended/networking/ipsec.go
+++ b/test/extended/networking/ipsec.go
@@ -57,6 +57,7 @@ const (
 var gvrNodeNetworkConfigurationPolicy = schema.GroupVersionResource{Group: "nmstate.io", Version: "v1", Resource: "nodenetworkconfigurationpolicies"}
 
 // TODO: consider bringing in the NNCP api.
+// Dummy comment
 var nodeIPsecConfigManifest = `
 kind: NodeNetworkConfigurationPolicy
 apiVersion: nmstate.io/v1


### PR DESCRIPTION
With the recent Konflux build migration for the nmstate operator deployment for [IPsec Lane](https://github.com/openshift/release/pull/70826), it now uses the latest NetworkManager-libreswan, which contains a regression that prevents libreswan configuration from being applied correctly. This change introduces a temporary workaround until the issue is resolved in the NetworkManager-libreswan package.