### PR TITLE
NO-JIRA: Add a new exception for CO's Available=False in non-upgrade tests

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -97,6 +97,14 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "image-registry" {
 				return "Image-registry operator is allowed to have Available=False on a non-upgrade scenario for now", nil
 			}
+			if operator == "openshift-apiserver" &&
+				(condition.Reason == "APIServerDeployment_NoDeployment" ||
+					condition.Reason == "APIServerDeployment_NoPod" ||
+					condition.Reason == "APIServerDeployment_PreconditionNotFulfilled" ||
+					condition.Reason == "APIServerDeployment_UnavailablePod" ||
+					condition.Reason == "APIServices_Error") {
+				return "https://issues.redhat.com/browse/OCPBUGS-23746", nil
+			}
 			return "", nil
 		}
 		if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {


### PR DESCRIPTION
OCPBUGS-23746 has been an exception [1] for CO/openshift-apiserver's Available=False in upgrade tests.

Now it is identified in non-upgrade tests too [2]. This pull acts on it accordingly.

Although we found `APIServices_Error` as the only reason at the moment, others get duplicated here as well for less disruptions for the payload tests.

[1]. https://github.com/openshift/origin/blob/7e4d34a4bb3b00b763a9f2fcdb72fc289d3920d5/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go#L413-L421 

[2]. https://issues.redhat.com/browse/OCPBUGS-23746?focusedId=28549492&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-28549492