### PR TITLE
CORENET-6558: add test coverage for bug OCPBUGS-63348

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -564,6 +564,99 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
 			}
 		})
+
+		g.It("Restarting CNCC pod should not change the EgressIPs capacity", func() {
+			g.By("Get one Egress node")
+			egressNodeName := egressIPNodesOrderedNames[0]
+			for _, node := range egressIPNodesOrderedNames[1:] {
+				// Only keep one egress node, remove egress labels from other nodes
+				_, err := runOcWithRetry(oc.AsAdmin(), "label", "node", node, "k8s.ovn.org/egress-assignable-")
+				o.Expect(err).NotTo(o.HaveOccurred())
+			}
+
+			g.By("Get capacity of one Egress node before reboot")
+			egressNode, err := clientset.CoreV1().Nodes().Get(context.TODO(), egressNodeName, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			nodeEgressIPConfigs, err := getNodeEgressIPConfiguration(egressNode)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			capacityBeforeReboot := nodeEgressIPConfigs[0].Capacity
+			framework.Logf("The capacity of node %s before reboot is %v", egressNodeName, capacityBeforeReboot)
+
+			g.By("Getting a map of source nodes and potential EgressIPs for these nodes")
+			var egressIPsPerNode int
+			if capacityBeforeReboot.IPv4 == 0 {
+				// On OpenStack and GCP, the capacity per node is the number of IPs per node, not the number of IPv4 addresses, like "capacity":{"ip":8}
+				egressIPsPerNode = capacityBeforeReboot.IP
+			} else {
+				egressIPsPerNode = capacityBeforeReboot.IPv4
+			}
+			if egressIPsPerNode > 20 {
+				egressIPsPerNode = 20
+			}
+
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, []string{egressNodeName}, cloudType, egressIPsPerNode)
+			framework.Logf("%v", nodeEgressIPMap)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By(fmt.Sprintf("Creating %d EgressIPs objects for the Egress node", egressIPsPerNode))
+			createdEgressIPObjects := []string{}
+			createdEgressIPAddresses := []string{}
+			defer func() {
+				g.By("Deleting EgressIP objects created by this test")
+				for _, name := range createdEgressIPObjects {
+					_, err := runOcWithRetry(oc.AsAdmin(), "delete", "egressip", name, "--ignore-not-found=true")
+					o.Expect(err).NotTo(o.HaveOccurred())
+				}
+			}()
+			for i := 0; i < egressIPsPerNode; i++ {
+				egressIPSet := make(map[string]string)
+				egressIPAddress := nodeEgressIPMap[egressNodeName][i]
+				egressIPSet[egressIPAddress] = egressNodeName
+				createdEgressIPAddresses = append(createdEgressIPAddresses, egressIPAddress)
+
+				g.By(fmt.Sprintf("Creating %dth EgressIP object ", i))
+				egressIPObjectName := egressIPNamespace + fmt.Sprintf("-%d", i)
+				createdEgressIPObjects = append(createdEgressIPObjects, egressIPObjectName)
+				egressIPYamlPath := tmpDirEgressIP + "/" + fmt.Sprintf("egressip-%d.yaml", i)
+				createEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+
+				g.By(fmt.Sprintf("Applying %dth EgressIP object ", i))
+				applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPObjectName, egressIPSet, egressUpdateTimeout)
+
+			}
+
+			g.By("Restarting the CNCC pod")
+			restartCNCCPod(oc, clientset)
+
+			g.By("Wait for egressIPs status popluated")
+			err = waitAllEgressIPsAssigned(oc, createdEgressIPObjects, 15*time.Minute)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Get capacity of the Egress node after CNCC restart")
+			egressNodeAfter, err := clientset.CoreV1().Nodes().Get(context.TODO(), egressNodeName, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			nodeEgressIPConfigsAfterCNCCRestart, err := getNodeEgressIPConfiguration(egressNodeAfter)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			capacityAfterCNCCRestart := nodeEgressIPConfigsAfterCNCCRestart[0].Capacity
+			framework.Logf("The capacity of node %s after CNCC restart is %v", egressNodeName, capacityAfterCNCCRestart)
+
+			g.By("Comparing capacity before and after CNCC restart")
+			o.Expect(capacityAfterCNCCRestart).To(o.Equal(capacityBeforeReboot),
+				"EgressIP capacity should remain the same after CNCC restart. Before: %v, After: %v",
+				capacityBeforeReboot, capacityAfterCNCCRestart)
+
+			g.By("Checking CloudPrivateIPConfigs for CloudResponseError,should be 0, after CNCC restart")
+			errorCount, err := countCloudPrivateIPConfigsByReasonFiltered(oc, "CloudResponseError", createdEgressIPAddresses)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Found %d CloudPrivateIPConfigs with CloudResponseError", errorCount)
+			o.Expect(errorCount).To(o.Equal(0), "Expected no CloudPrivateIPConfigs with CloudResponseError, but found %d", errorCount)
+
+			g.By("Checking CloudPrivateIPConfigs for CloudResponseSuccess")
+			successCount, err := countCloudPrivateIPConfigsByReasonFiltered(oc, "CloudResponseSuccess", createdEgressIPAddresses)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Found %d CloudPrivateIPConfigs with CloudResponseSuccess", successCount)
+			o.Expect(successCount).To(o.Equal(egressIPsPerNode), "Expected %d CloudPrivateIPConfigs with CloudResponseSuccess, but found %d", egressIPsPerNode, successCount)
+		})
 	}) // end testing to external targets
 })
 

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	o "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -1737,4 +1738,113 @@ func getEgressIP(oc *exutil.CLI, name string) (*EgressIP, error) {
 		return nil, err
 	}
 	return egressip, nil
+}
+
+// restartCNCCPod restarts the CNCC pod by deleting it and waiting for it to become Ready again.
+func restartCNCCPod(oc *exutil.CLI, clientset kubernetes.Interface) {
+	framework.Logf("Restarting CNCC pod by deleting it")
+	cnccPodLabel := exutil.ParseLabelsOrDie("app=cloud-network-config-controller")
+	cnccNamespace := "openshift-cloud-network-config-controller"
+	cnccPodNames, err := exutil.GetPodNamesByFilter(clientset.CoreV1().Pods(cnccNamespace), cnccPodLabel, exutil.CheckPodIsRunning)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(cnccPodNames).NotTo(o.BeEmpty())
+	//Get old CNCC pod UID
+	oldCNCCPod, err := clientset.CoreV1().Pods(cnccNamespace).Get(context.TODO(), cnccPodNames[0], metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	framework.Logf("Old CNCC pod UID: %s", oldCNCCPod.UID)
+	_, err = runOcWithRetry(oc.AsAdmin(), "delete", "pod", cnccPodNames[0], "-n", cnccNamespace)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	framework.Logf("Waiting for the CNCC pod to become Ready again after restart")
+	_, err = exutil.WaitForPods(
+		clientset.CoreV1().Pods(cnccNamespace),
+		cnccPodLabel,
+		exutil.CheckPodIsReady,
+		1,
+		2*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify that the new CNCC pod is not the same as the old one
+	newPodNames, err := exutil.GetPodNamesByFilter(clientset.CoreV1().Pods(cnccNamespace), cnccPodLabel, exutil.CheckPodIsReady)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(newPodNames).NotTo(o.BeEmpty())
+	newCNCCPod, err := clientset.CoreV1().Pods(cnccNamespace).Get(context.TODO(), newPodNames[0], metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	framework.Logf("New CNCC pod UID: %s", newCNCCPod.UID)
+	o.Expect(newCNCCPod.UID).NotTo(o.Equal(oldCNCCPod.UID))
+	framework.Logf("CNCC pod restarted successfully")
+}
+
+// countCloudPrivateIPConfigsByReasonFiltered counts the number of CloudPrivateIPConfigs that have
+// a condition reason matching the specified reason, optionally filtered by a list of CPIC names.
+// If cpicNames is nil or empty, all CPICs are counted (cluster-wide).
+// If cpicNames is provided, only CPICs with names in the list are counted.
+func countCloudPrivateIPConfigsByReasonFiltered(oc *exutil.CLI, reason string, cpicNames []string) (int, error) {
+	output, err := runOcWithRetry(oc.AsAdmin(), "get", "cloudprivateipconfigs",
+		"-o", "custom-columns=NAME:.metadata.name,NODE:.spec.node,STATE:.status.conditions[].reason",
+		"--no-headers")
+	if err != nil {
+		return 0, fmt.Errorf("failed to get cloudprivateipconfigs: %v", err)
+	}
+
+	trimmedOutput := strings.TrimSpace(output)
+	if trimmedOutput == "" {
+		return 0, nil
+	}
+
+	var filterMap map[string]bool
+	if len(cpicNames) > 0 {
+		filterMap = make(map[string]bool)
+		for _, name := range cpicNames {
+			filterMap[name] = true
+		}
+	}
+
+	lines := strings.Split(trimmedOutput, "\n")
+	count := 0
+	for _, line := range lines {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine != "" && strings.Contains(trimmedLine, reason) {
+			fields := strings.Fields(trimmedLine)
+			if len(fields) > 0 {
+				cpicName := fields[0]
+				if filterMap == nil || filterMap[cpicName] {
+					count++
+				}
+			}
+		}
+	}
+	return count, nil
+}
+
+// waitAllEgressIPsAssigned waits for the specified EgressIP objects to have status.Items populated.
+// egressIPNames is a list of EgressIP object names to wait for.
+// If egressIPNames is empty, no waiting is performed.
+func waitAllEgressIPsAssigned(oc *exutil.CLI, egressIPNames []string, timeout time.Duration) error {
+	if len(egressIPNames) == 0 {
+		return nil
+	}
+
+	for _, name := range egressIPNames {
+		err := wait.PollUntilContextTimeout(context.TODO(), 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			egressip, err := getEgressIP(oc, name)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					framework.Logf("EgressIP %s not found, will retry", name)
+					return false, nil
+				}
+				return false, err
+			}
+			if len(egressip.Status.Items) == 0 {
+				framework.Logf("EgressIP %s has no status items yet, will retry", name)
+				return false, nil
+			}
+			framework.Logf("EgressIP %s has %d status items assigned", name, len(egressip.Status.Items))
+			return true, nil
+		})
+		if err != nil {
+			return fmt.Errorf("timeout waiting for EgressIP %s to be assigned: %v", name, err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Test Coverage for Bug: https://issues.redhat.com/browse/OCPBUGS-63348 

Test steps :
1. Check the node capacity
```
Annotations:        cloud.network.openshift.io/egress-ipconfig:
                      [{"interface":"eni-018a493be1e8adf3f","ifaddr":{"ipv4":"10.0.0.0/18"},"capacity":{"ipv4":14,"ipv6":15}}]
                    csi.volume.kubernetes.io/nodeid: {"ebs.csi.aws.com":"i-061369b27ea9661fc"}
```
2. Label it as egress node
3. Configure multiple EIPs , should have EIPs assigned successfully
4. Restart CNCC pod by killing it
5. Check capacity is not changed 
6. Check'oc get cloudprivateipconfigs -o yaml', no errors.


