### PR TITLE
OCPBUGS-65674: VsphereConfigurationTestsRollOutTooOften event matcher should match also dep and ds events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1024,8 +1024,8 @@ func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals moni
 			locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
 				monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
 			},
-			messageReasonRegex: regexp.MustCompile(`(^SuccessfulCreate$|^SuccessfulDelete$)`),
-			messageHumanRegex:  regexp.MustCompile(`(Created pod.*vmware-vsphere-csi-driver.*|Deleted pod.*vmware-vsphere-csi-driver.*)`),
+			messageReasonRegex: regexp.MustCompile(`(^SuccessfulCreate$|^SuccessfulDelete$|^DeploymentUpdated$|^DaemonSetUpdated$)`),
+			messageHumanRegex:  regexp.MustCompile(`(Created pod.*vmware-vsphere-csi-driver.*|Deleted pod.*vmware-vsphere-csi-driver.*|Updated (Deployment|DaemonSet)\.apps/vmware-vsphere-csi-driver.*)`),
 			jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
 		},
 		allowIfWithinIntervals: configurationTestIntervals,


### PR DESCRIPTION
We've observed more pathological events related to vsphere snapshot tests, this time related to Deployment and DaemonSet updates. Both are using secret hash annotation hooks, so the updates are expected when changing snapshot options, and we should filter out the related events in the event matcher.


```
event happened 29 times, something is wrong: namespace/openshift-cluster-csi-drivers deployment/vmware-vsphere-csi-driver-operator hmsg/f08cbd1e38 - reason/DaemonSetUpdated Updated DaemonSet.apps/vmware-vsphere-csi-driver-node -n openshift-cluster-csi-drivers because it changed (06:48:16Z) result=reject 
event happened 21 times, something is wrong: namespace/openshift-cluster-csi-drivers deployment/vmware-vsphere-csi-driver-operator hmsg/5fc8006e70 - reason/DeploymentUpdated Updated Deployment.apps/vmware-vsphere-csi-driver-controller -n openshift-cluster-csi-drivers because it changed (06:47:32Z) result=reject } 
```


cc @openshift/storage 