### PR TITLE
NO-JIRA: Replace OCPBUGS-38667 with OCPBUGS-66225

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -444,7 +444,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					condition.Reason == "ProgressDeadlineExceeded" ||
 					condition.Reason == "ImageConfigControllerError" ||
 					condition.Reason == "Unavailable") {
-				return "https://issues.redhat.com/browse/OCPBUGS-38667"
+				return "https://issues.redhat.com/browse/OCPBUGS-66225"
 			}
 			// this won't handle the replicaCount==2 serial test where both pods are on nodes that get tainted.
 			// need to consider how we detect that or modify the job to set replicaCount==3


### PR DESCRIPTION
OCPBUGS-38667 is shipped with 4.18 but the symptom is still there in 4.21. OCPBUGS-66225 is created to track the issue.

This pull is to reflect that in the test code.