### PR TITLE
NO-JIRA: Remove exception for co/monitoring's Available=False

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -396,15 +396,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/MCO-1447"
 			}
 		case "monitoring":
-			if condition.Type == configv1.OperatorAvailable &&
-				(condition.Status == configv1.ConditionFalse &&
-					(condition.Reason == "PlatformTasksFailed" ||
-						condition.Reason == "UpdatingAlertmanagerFailed" ||
-						condition.Reason == "UpdatingConsolePluginComponentsFailed" ||
-						condition.Reason == "UpdatingPrometheusK8SFailed" ||
-						condition.Reason == "UpdatingPrometheusOperatorFailed")) {
-				return "https://issues.redhat.com/browse/OCPBUGS-66230"
-			}
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 				return "https://issues.redhat.com/browse/OCPBUGS-39026"
 			}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -402,9 +402,8 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 						condition.Reason == "UpdatingAlertmanagerFailed" ||
 						condition.Reason == "UpdatingConsolePluginComponentsFailed" ||
 						condition.Reason == "UpdatingPrometheusK8SFailed" ||
-						condition.Reason == "UpdatingPrometheusOperatorFailed")) ||
-				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
-				return "https://issues.redhat.com/browse/OCPBUGS-23745"
+						condition.Reason == "UpdatingPrometheusOperatorFailed")) {
+				return "https://issues.redhat.com/browse/OCPBUGS-66230"
 			}
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 				return "https://issues.redhat.com/browse/OCPBUGS-39026"


### PR DESCRIPTION
OCPBUGS-23745 has been fixed and shipped with 4.15. However, the symptom is still there in 4.21 and we create OCPBUGS-66230 to track the issue.

---

[Remove OCPBUGS-66230](https://github.com/openshift/origin/pull/30552/commits/1c8033ed140ae67f255908ccf4ac1672abdd97a0)
OCPBUGS-66230 is closed as the fix is included in 4.21.0-0.nightly-2025-11-30-094855.