### PR TITLE
NO-JIRA: Remove the exception for CO/console's Available=False

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -363,11 +363,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "console":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
-			} else if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
-				(condition.Reason == "RouteHealth_FailedGet" ||
-					condition.Reason == "RouteHealth_RouteNotAdmitted" ||
-					condition.Reason == "RouteHealth_StatusError") {
-				return "https://issues.redhat.com/browse/OCPBUGS-24041"
 			}
 		case "control-plane-machine-set":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UnavailableReplicas" {


### PR DESCRIPTION
OCPBUGS-24041 has been fixed and shipped in 4.16.

Sippy shows very high success rate: over 99%

<img width="1583" height="487" alt="Screenshot 2025-12-01 at 20 15 53" src="https://github.com/user-attachments/assets/b0be7ede-b098-43a5-8709-5dc61d96d743" />

I can still find example flaky on this test. But I will let Sippy to judge the regression in the future.