### PR TITLE
NO-JIRA: Replace OCPBUGS-20062 with OCPBUGS-65984

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -379,7 +379,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			}
 		case "kube-storage-version-migrator":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
-				return "https://issues.redhat.com/browse/OCPBUGS-20062"
+				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
 		case "machine-api":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {


### PR DESCRIPTION
OCPBUGS-20062 has been "fixed" and shipped in 4.19.
But the symptom is still there in 4.21 and we use
OCPBUGS-65984 to track the issue.