### PR TITLE
NO-JIRA: Remove the exception for CO/control-plane-machine-set's Available=False

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -369,10 +369,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					condition.Reason == "RouteHealth_StatusError") {
 				return "https://issues.redhat.com/browse/OCPBUGS-24041"
 			}
-		case "control-plane-machine-set":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "UnavailableReplicas" {
-				return "https://issues.redhat.com/browse/OCPBUGS-20061"
-			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
 				return "https://issues.redhat.com/browse/OCPBUGS-25739"


### PR DESCRIPTION
OCPBUGS-20061 has been fixed and shipped in 4.17.

Sippy shows very high success rate: 100%.
<img width="1580" height="484" alt="Screenshot 2025-12-01 at 21 01 31" src="https://github.com/user-attachments/assets/36b9dfaa-3401-4792-b63f-c2e7625f584d" />
