### PR TITLE
OCPBUGS-61855: Revert "Temporarily disable InstallPlanStepAppliedWithWarnings alert for k8s 1.34 rebase"

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -44,8 +44,7 @@ var AllowedAlertNames = []string{
 
 	// indicates a problem in the external Telemeter service, presently very common, does not impact our ability to e2e test:
 	"TelemeterClientFailures",
-	"CDIDefaultStorageClassDegraded",     // Installing openshift virt with RWX storage fire an alarm, that is not relevant for most of the tests.
-	"VirtHandlerRESTErrorsHigh",          // https://issues.redhat.com/browse/CNV-50418
-	"VirtControllerRESTErrorsHigh",       // https://issues.redhat.com/browse/CNV-50418
-	"InstallPlanStepAppliedWithWarnings", // https://issues.redhat.com/browse/OCPBUGS-61855
+	"CDIDefaultStorageClassDegraded", // Installing openshift virt with RWX storage fire an alarm, that is not relevant for most of the tests.
+	"VirtHandlerRESTErrorsHigh",      // https://issues.redhat.com/browse/CNV-50418
+	"VirtControllerRESTErrorsHigh",   // https://issues.redhat.com/browse/CNV-50418
 }


### PR DESCRIPTION
Per @dgoodwin 's comment in the associated bug this will light up the component readiness tests, but it needs to be removed anyway and the particular CRD that was causing the alert is [being fixed](https://github.com/istio/api/pull/3606).