### PR TITLE
OCPBUGS-66060: update watch request limits for marketplace-operator

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
@@ -311,7 +311,7 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 			"kube-controller-manager-operator":       175.0,
 			"kube-storage-version-migrator-operator": 70.0,
 			"machine-api-operator":                   50.0,
-			"marketplace-operator":                   17.0,
+			"marketplace-operator":                   43.0,
 			"openshift-apiserver-operator":           244.0,
 			"openshift-config-operator":              52.0,
 			"openshift-controller-manager-operator":  200.0,


### PR DESCRIPTION
With https://github.com/operator-framework/operator-marketplace/pull/684, operator-marketplace now watches the configMap for the client side root CA, increasing the number of expected watch requests. This PR bumps the expected watch requests to match the expected bump.