### PR TITLE
Enable OTE for Cluster CAPI Operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -222,6 +222,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/machine-api-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-capi-operator",
+		binaryPath: "/cluster-capi-operator-ext.gz",
+	},
+	{
 		imageTag:   "cluster-control-plane-machine-set-operator",
 		binaryPath: "/cluster-control-plane-machine-set-operator-ext.gz",
 	},


### PR DESCRIPTION
/hold

The bin is added here: https://github.com/openshift/cluster-capi-operator/pull/413 