### PR TITLE
CNTRLPLANE-2185: register the OTE binary cluster-kube-descheduler-operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -248,6 +248,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-etcd-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-kube-descheduler-operator",
+		binaryPath: "/usr/bin/cluster-kube-descheduler-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-kube-scheduler-operator",
 		binaryPath: "/usr/bin/cluster-kube-scheduler-operator-tests-ext.gz",
 	},


### PR DESCRIPTION
Register the OTE binary cluster-kube-descheduler-operator as part of JIRA [ticket](https://issues.redhat.com/browse/CNTRLPLANE-2185)  (first [PR](https://github.com/openshift/cluster-kube-descheduler-operator/pull/1071) already merged).