### PR TITLE
OCPSTRAT-2728: Remove pod label length check in oc debug test

### DIFF
--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -313,7 +313,6 @@ spec:
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(pods.Items).To(o.HaveLen(1))
 		o.Expect(pods.Items[0].Labels).To(o.HaveKeyWithValue("debug.openshift.io/managed-by", "oc-debug"))
-		o.Expect(pods.Items[0].Labels).To(o.HaveLen(1))
 
 		oc.AsAdmin().Run("delete").Args("pod", pods.Items[0].Name, "-n", ns).Output()
 
@@ -336,6 +335,5 @@ spec:
 		pods, err = oc.AdminKubeClient().CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: "debug.openshift.io/managed-by=oc-debug"})
 		o.Expect(pods.Items).To(o.HaveLen(1))
 		o.Expect(pods.Items[0].Labels).To(o.HaveKeyWithValue("debug.openshift.io/managed-by", "oc-debug"))
-		o.Expect(pods.Items[0].Labels).To(o.HaveLen(1))
 	})
 })


### PR DESCRIPTION
The `PodTopologyLabelsAdmission` feature has [graduated to Beta and is enabled by default](https://github.com/kubernetes/kubernetes/pull/135158) starting in 1.35-rc.0, adding extra labels to pods.

```
{  fail [github.com/openshift/origin/test/extended/cli/debug.go:316]: Expected
    <map[string]string | len:3>: {
        "debug.openshift.io/managed-by": "oc-debug",
        "topology.kubernetes.io/region": "us-east-2",
        "topology.kubernetes.io/zone": "us-east-2b",
    }
to have length 1}
```

Do we gain a benefit from ensuring that no extra labels are applied here? The number of labels will now differ between < 1.35 and >= 1.35 based versions of OCP, so extra logic will be necessary if so.

This is currently causing failures impacting the 1.35 rebase.