### PR TITLE
CNTRLPLANE-1309: register the OTE binary of cluster-kube-scheduler-operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -248,6 +248,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-etcd-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-kube-scheduler-operator",
+		binaryPath: "/usr/bin/cluster-kube-scheduler-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-version-operator",
 		binaryPath: "/usr/bin/cluster-version-operator-tests.gz",
 	},


### PR DESCRIPTION
Register the OTE binary cluster-kube-scheduler-operator as part of JIRA [CNTRLPLANE-1309](https://issues.redhat.com/browse/CNTRLPLANE-1309) (first [PR](https://github.com/openshift/cluster-kube-scheduler-operator/pull/585) for OTE infra changes and the relevant dependencies already merged).