### PR TITLE
OCPNODE-3932: Add automated tests for non-CNV swap configuration

### DIFF
--- a/test/extended/node/node_swap.go
+++ b/test/extended/node/node_swap.go
@@ -1,0 +1,195 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	workerGeneratedKubeletMC = "99-worker-generated-kubelet"
+)
+
+var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("node-swap")
+
+	g.BeforeEach(func(ctx context.Context) {
+		// Skip all tests on MicroShift clusters
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Skipping test on MicroShift cluster")
+		}
+	})
+
+	// This test validates that:
+	// - Worker nodes have failSwapOn=false to allow kubelet to start even if swap is present at OS level
+	// - Control plane nodes have failSwapOn=true to prevent kubelet from starting if swap is enabled
+	// - All nodes have swapBehavior=NoSwap to ensure kubelet does not utilize swap even if available at OS level
+	// The swapBehavior=NoSwap configuration ensures that even if swap is manually enabled on a worker node,
+	// the kubelet will not use it for memory management, maintaining consistent behavior across the cluster.
+	g.It("should have correct default kubelet swap settings with worker nodes failSwapOn=false, control plane nodes failSwapOn=true, and both swapBehavior=NoSwap [OCP-86394]", func(ctx context.Context) {
+		g.By("Getting worker nodes")
+		workerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(workerNodes)).Should(o.BeNumerically(">", 0), "Expected at least one worker node")
+
+		g.By("Validating kubelet configuration on each worker node")
+		for _, node := range workerNodes {
+			config, err := getKubeletConfigFromNode(ctx, oc, node.Name)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get kubelet config for worker node %s", node.Name)
+
+			g.By(fmt.Sprintf("Checking failSwapOn=false on worker node %s", node.Name))
+			o.Expect(config.FailSwapOn).NotTo(o.BeNil(), "failSwapOn should be set on worker node %s", node.Name)
+			o.Expect(*config.FailSwapOn).To(o.BeFalse(), "failSwapOn should be false on worker node %s", node.Name)
+			framework.Logf("Worker node %s: failSwapOn=%v ✓", node.Name, *config.FailSwapOn)
+
+			g.By(fmt.Sprintf("Checking swapBehavior=NoSwap on worker node %s", node.Name))
+			o.Expect(config.MemorySwap).NotTo(o.BeNil(), "memorySwap should be set on worker node %s", node.Name)
+			o.Expect(config.MemorySwap.SwapBehavior).To(o.Equal("NoSwap"), "swapBehavior should be NoSwap on worker node %s", node.Name)
+			framework.Logf("Worker node %s: swapBehavior=%s ✓", node.Name, config.MemorySwap.SwapBehavior)
+		}
+
+		g.By("Getting control plane nodes")
+		controlPlaneNodes, err := getControlPlaneNodes(ctx, oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(controlPlaneNodes)).Should(o.BeNumerically(">", 0), "Expected at least one control plane node")
+
+		g.By("Validating kubelet configuration on each control plane node")
+		for _, node := range controlPlaneNodes {
+			config, err := getKubeletConfigFromNode(ctx, oc, node.Name)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get kubelet config for control plane node %s", node.Name)
+
+			g.By(fmt.Sprintf("Checking failSwapOn=true on control plane node %s", node.Name))
+			o.Expect(config.FailSwapOn).NotTo(o.BeNil(), "failSwapOn should be set on control plane node %s", node.Name)
+			o.Expect(*config.FailSwapOn).To(o.BeTrue(), "failSwapOn should be true on control plane node %s", node.Name)
+			framework.Logf("Control plane node %s: failSwapOn=%v ✓", node.Name, *config.FailSwapOn)
+
+			g.By(fmt.Sprintf("Checking swapBehavior=NoSwap on control plane node %s", node.Name))
+			o.Expect(config.MemorySwap).NotTo(o.BeNil(), "memorySwap should be set on control plane node %s", node.Name)
+			o.Expect(config.MemorySwap.SwapBehavior).To(o.Equal("NoSwap"), "swapBehavior should be NoSwap on control plane node %s", node.Name)
+			framework.Logf("Control plane node %s: swapBehavior=%s ✓", node.Name, config.MemorySwap.SwapBehavior)
+		}
+		framework.Logf("Test PASSED: All nodes have correct default swap settings")
+	})
+
+	g.It("should reject user override of swap settings via KubeletConfig API [OCP-86395]", func(ctx context.Context) {
+		g.By("Creating machine config client")
+		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create machine config client")
+
+		g.By("Getting initial machine config resourceVersion")
+		// Get the initial resourceVersion of the worker machine config before creating KubeletConfig
+		workerMC, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(ctx, workerGeneratedKubeletMC, metav1.GetOptions{})
+		initialResourceVersion := ""
+		if err == nil {
+			initialResourceVersion = workerMC.ResourceVersion
+			framework.Logf("Initial %s resourceVersion: %s", workerGeneratedKubeletMC, initialResourceVersion)
+		}
+
+		g.By("Creating a KubeletConfig with swap settings")
+		kubeletConfig := &machineconfigv1.KubeletConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-swap-override",
+			},
+			Spec: machineconfigv1.KubeletConfigSpec{
+				KubeletConfig: &runtime.RawExtension{
+					Raw: []byte(`{
+						"failSwapOn": true,
+						"memorySwap": {
+							"swapBehavior": "LimitedSwap"
+						}
+					}`),
+				},
+			},
+		}
+
+		g.By("Attempting to apply the KubeletConfig")
+		defer func() {
+			_ = mcClient.MachineconfigurationV1().KubeletConfigs().Delete(ctx, "test-swap-override", metav1.DeleteOptions{})
+		}()
+		framework.Logf("Creating KubeletConfig with failSwapOn=true and swapBehavior=LimitedSwap")
+		_, err = mcClient.MachineconfigurationV1().KubeletConfigs().Create(ctx, kubeletConfig, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create KubeletConfig")
+
+		g.By("Checking KubeletConfig status for expected error message")
+		err = wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
+			kc, err := mcClient.MachineconfigurationV1().KubeletConfigs().Get(ctx, "test-swap-override", metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if kc.Status.ObservedGeneration != kc.Generation {
+				framework.Logf("Waiting for controller to process generation %d (current: %d)", kc.Generation, kc.Status.ObservedGeneration)
+				return false, nil
+			}
+
+			// Fail fast if KubeletConfig was unexpectedly accepted
+			for _, condition := range kc.Status.Conditions {
+				if condition.Type == machineconfigv1.KubeletConfigSuccess && condition.Status == corev1.ConditionTrue {
+					return false, fmt.Errorf("KubeletConfig was unexpectedly accepted")
+				}
+			}
+
+			// Check for Failure condition with the expected error message
+			for _, condition := range kc.Status.Conditions {
+				if condition.Type == machineconfigv1.KubeletConfigFailure && condition.Status == corev1.ConditionTrue {
+					framework.Logf("Found Failure condition: %s", condition.Message)
+					if condition.Message == "Error: KubeletConfiguration: failSwapOn is not allowed to be set, but contains: true" {
+						return true, nil
+					}
+				}
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Expected to find error message about failSwapOn not being allowed in KubeletConfig status")
+
+		g.By("Verifying machine config was not created or updated")
+		// Wait a bit to ensure no update happens
+		time.Sleep(5 * time.Second)
+
+		// Check if the machine config was created or updated (compare to initial resourceVersion captured earlier)
+		workerMC, err = mcClient.MachineconfigurationV1().MachineConfigs().Get(ctx, workerGeneratedKubeletMC, metav1.GetOptions{})
+		if err == nil {
+			o.Expect(workerMC.ResourceVersion).To(o.Equal(initialResourceVersion), "Machine config %s should not be updated when failSwapOn is rejected", workerGeneratedKubeletMC)
+			framework.Logf("Verified: %s was not updated (resourceVersion: %s)", workerGeneratedKubeletMC, workerMC.ResourceVersion)
+		}
+
+		g.By("Verifying worker nodes still have correct swap settings")
+		workerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(len(workerNodes)).Should(o.BeNumerically(">", 0), "Expected at least one worker node")
+
+		for _, node := range workerNodes {
+			config, err := getKubeletConfigFromNode(ctx, oc, node.Name)
+			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get kubelet config for worker node %s", node.Name)
+
+			g.By(fmt.Sprintf("Verifying failSwapOn=false remains unchanged on worker node %s", node.Name))
+			o.Expect(config.FailSwapOn).NotTo(o.BeNil(), "failSwapOn should be set on worker node %s", node.Name)
+			o.Expect(*config.FailSwapOn).To(o.BeFalse(), "failSwapOn should still be false on worker node %s after rejection", node.Name)
+			framework.Logf("Worker node %s: failSwapOn=%v (unchanged) ✓", node.Name, *config.FailSwapOn)
+
+			g.By(fmt.Sprintf("Verifying swapBehavior=NoSwap remains unchanged on worker node %s", node.Name))
+			o.Expect(config.MemorySwap).NotTo(o.BeNil(), "memorySwap should be set on worker node %s", node.Name)
+			o.Expect(config.MemorySwap.SwapBehavior).To(o.Equal("NoSwap"), "swapBehavior should still be NoSwap on worker node %s after rejection", node.Name)
+			framework.Logf("Worker node %s: swapBehavior=%s (unchanged) ✓", node.Name, config.MemorySwap.SwapBehavior)
+		}
+
+		framework.Logf("Test PASSED: KubeletConfig with failSwapOn was properly rejected")
+	})
+})

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -1,0 +1,65 @@
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// getNodesByLabel returns nodes matching the specified label selector
+func getNodesByLabel(ctx context.Context, oc *exutil.CLI, labelSelector string) ([]v1.Node, error) {
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return nodes.Items, nil
+}
+
+// getControlPlaneNodes returns all control plane nodes in the cluster
+func getControlPlaneNodes(ctx context.Context, oc *exutil.CLI) ([]v1.Node, error) {
+	// Try master label first (OpenShift uses this)
+	nodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/master")
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) > 0 {
+		return nodes, nil
+	}
+
+	// Fallback to control-plane label (upstream Kubernetes uses this)
+	return getNodesByLabel(ctx, oc, "node-role.kubernetes.io/control-plane")
+}
+
+// getKubeletConfigFromNode retrieves the kubelet configuration from a specific node
+func getKubeletConfigFromNode(ctx context.Context, oc *exutil.CLI, nodeName string) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
+	// Use the node proxy API to get configz
+	configzPath := fmt.Sprintf("/api/v1/nodes/%s/proxy/configz", nodeName)
+
+	data, err := oc.AdminKubeClient().CoreV1().RESTClient().Get().AbsPath(configzPath).DoRaw(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get configz from node %s: %w", nodeName, err)
+	}
+
+	// Parse the JSON response
+	var configzResponse struct {
+		KubeletConfig *kubeletconfigv1beta1.KubeletConfiguration `json:"kubeletconfig"`
+	}
+
+	if err := json.Unmarshal(data, &configzResponse); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal configz response: %w", err)
+	}
+
+	if configzResponse.KubeletConfig == nil {
+		return nil, fmt.Errorf("kubeletconfig is nil in response")
+	}
+
+	return configzResponse.KubeletConfig, nil
+}


### PR DESCRIPTION
Summary
Adds automated tests for non-CNV swap configuration on OpenShift nodes.

Jira story: https://issues.redhat.com/browse/OCPNODE-3932 

Validates:
  - Default kubelet swap settings on worker and control plane nodes
  - Rejection of user-defined swap overrides via KubeletConfig API
 
Files Added
  - `test/extended/node/node_swap.go` - Test cases
  - `test/extended/node/node_utils.go` - Helper functions for node and kubelet config operations

Test cases:
[OCP-86394 ](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-86394)
[OCP-86395](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-86395)

<pre>
    [Jira:Node][sig-node] Node non-cnv swap configuration should have correct default kubelet swap settings with worker nodes failSwapOn=false, control plane nodes failSwapOn=true, and both swapBehavior=NoSwap [Jira:Node] [OCP-86394]
  github.com/openshift/origin/test/extended/node/node_swap.go:46
    STEP: Creating a kubernetes client @ 01/12/26 13:53:15.953
  I0112 13:53:15.954150   54173 discovery.go:214] Invalidating discovery information
  I0112 13:53:19.087172 54173 client.go:293] configPath is now "/tmp/configfile1332138601"
  I0112 13:53:19.087205 54173 client.go:368] The user is now "e2e-test-node-swap-btg8f-user"
  I0112 13:53:19.087220 54173 client.go:370] Creating project "e2e-test-node-swap-btg8f"
  I0112 13:53:19.509151 54173 client.go:378] Waiting on permissions in project "e2e-test-node-swap-btg8f" ...
  I0112 13:53:20.757654 54173 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0112 13:53:21.030854 54173 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0112 13:53:21.780319 54173 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0112 13:53:22.497353 54173 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0112 13:53:23.214772 54173 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0112 13:53:23.828307 54173 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0112 13:53:24.362820 54173 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0112 13:53:25.572055 54173 client.go:465] Project "e2e-test-node-swap-btg8f" has been fully provisioned.
  I0112 13:53:25.876964 54173 framework.go:2334] microshift-version configmap not found
    STEP: Getting worker nodes @ 01/12/26 13:53:25.877
    STEP: Validating kubelet configuration on each worker node @ 01/12/26 13:53:26.184
    STEP: Checking failSwapOn=false on worker node bgudi-j12-kgf87-worker-a-ks7zw @ 01/12/26 13:53:26.491
  I0112 13:53:26.491051 54173 node_swap.go:60] Worker node bgudi-j12-kgf87-worker-a-ks7zw: failSwapOn=false ✓
    STEP: Checking swapBehavior=NoSwap on worker node bgudi-j12-kgf87-worker-a-ks7zw @ 01/12/26 13:53:26.491
  I0112 13:53:26.491076 54173 node_swap.go:65] Worker node bgudi-j12-kgf87-worker-a-ks7zw: swapBehavior=NoSwap ✓
    STEP: Checking failSwapOn=false on worker node bgudi-j12-kgf87-worker-b-hnkhq @ 01/12/26 13:53:26.799
  I0112 13:53:26.799069 54173 node_swap.go:60] Worker node bgudi-j12-kgf87-worker-b-hnkhq: failSwapOn=false ✓
    STEP: Checking swapBehavior=NoSwap on worker node bgudi-j12-kgf87-worker-b-hnkhq @ 01/12/26 13:53:26.799
  I0112 13:53:26.799116 54173 node_swap.go:65] Worker node bgudi-j12-kgf87-worker-b-hnkhq: swapBehavior=NoSwap ✓
    STEP: Checking failSwapOn=false on worker node bgudi-j12-kgf87-worker-c-xbbkd @ 01/12/26 13:53:27.105
  I0112 13:53:27.105627 54173 node_swap.go:60] Worker node bgudi-j12-kgf87-worker-c-xbbkd: failSwapOn=false ✓
    STEP: Checking swapBehavior=NoSwap on worker node bgudi-j12-kgf87-worker-c-xbbkd @ 01/12/26 13:53:27.105
  I0112 13:53:27.105664 54173 node_swap.go:65] Worker node bgudi-j12-kgf87-worker-c-xbbkd: swapBehavior=NoSwap ✓
    STEP: Getting control plane nodes @ 01/12/26 13:53:27.105
    STEP: Validating kubelet configuration on each control plane node @ 01/12/26 13:53:27.404
    STEP: Checking failSwapOn=true on control plane node bgudi-j12-kgf87-master-0.us-central1-a.c.openshift-qe.internal @ 01/12/26 13:53:27.695
  I0112 13:53:27.695585 54173 node_swap.go:81] Control plane node bgudi-j12-kgf87-master-0.us-central1-a.c.openshift-qe.internal: failSwapOn=true ✓
    STEP: Checking swapBehavior=NoSwap on control plane node bgudi-j12-kgf87-master-0.us-central1-a.c.openshift-qe.internal @ 01/12/26 13:53:27.695
  I0112 13:53:27.695623 54173 node_swap.go:86] Control plane node bgudi-j12-kgf87-master-0.us-central1-a.c.openshift-qe.internal: swapBehavior=NoSwap ✓
    STEP: Checking failSwapOn=true on control plane node bgudi-j12-kgf87-master-1.us-central1-b.c.openshift-qe.internal @ 01/12/26 13:53:28.006
  I0112 13:53:28.007013 54173 node_swap.go:81] Control plane node bgudi-j12-kgf87-master-1.us-central1-b.c.openshift-qe.internal: failSwapOn=true ✓
    STEP: Checking swapBehavior=NoSwap on control plane node bgudi-j12-kgf87-master-1.us-central1-b.c.openshift-qe.internal @ 01/12/26 13:53:28.007
  I0112 13:53:28.007073 54173 node_swap.go:86] Control plane node bgudi-j12-kgf87-master-1.us-central1-b.c.openshift-qe.internal: swapBehavior=NoSwap ✓
    STEP: Checking failSwapOn=true on control plane node bgudi-j12-kgf87-master-2.us-central1-c.c.openshift-qe.internal @ 01/12/26 13:53:28.295
  I0112 13:53:28.295523 54173 node_swap.go:81] Control plane node bgudi-j12-kgf87-master-2.us-central1-c.c.openshift-qe.internal: failSwapOn=true ✓
    STEP: Checking swapBehavior=NoSwap on control plane node bgudi-j12-kgf87-master-2.us-central1-c.c.openshift-qe.internal @ 01/12/26 13:53:28.295
  I0112 13:53:28.295549 54173 node_swap.go:86] Control plane node bgudi-j12-kgf87-master-2.us-central1-c.c.openshift-qe.internal: swapBehavior=NoSwap ✓
  I0112 13:53:28.295564 54173 node_swap.go:88] Test PASSED: All nodes have correct default swap settings
  I0112 13:53:28.641012 54173 client.go:681] Deleted {user.openshift.io/v1, Resource=users  e2e-test-node-swap-btg8f-user}, err: <nil>
  I0112 13:53:28.920122 54173 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-node-swap-btg8f}, err: <nil>
  I0112 13:53:29.205068 54173 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~B0he02YdA3rQmivC_6pxgH1W-Fq8OxWRhXi4bkQlJnk}, err: <nil>
    STEP: Destroying namespace "e2e-test-node-swap-btg8f" for this suite. @ 01/12/26 13:53:29.205
  • [13.618 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 13.618 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
</pre>

<pre>
  Will run 1 of 1 specs
  ------------------------------
  [Jira:Node][sig-node] Node non-cnv swap configuration should reject user override of swap settings via KubeletConfig API [OCP-86395]
  github.com/openshift/origin/test/extended/node/node_swap.go:91
    STEP: Creating a kubernetes client @ 01/12/26 15:25:28.344
  I0112 15:25:28.345790   88048 discovery.go:214] Invalidating discovery information
  I0112 15:25:33.846094 88048 client.go:293] configPath is now "/tmp/configfile1714018848"
  I0112 15:25:33.846149 88048 client.go:368] The user is now "e2e-test-node-swap-9tzrc-user"
  I0112 15:25:33.846161 88048 client.go:370] Creating project "e2e-test-node-swap-9tzrc"
  I0112 15:25:34.199847 88048 client.go:378] Waiting on permissions in project "e2e-test-node-swap-9tzrc" ...
  I0112 15:25:35.381516 88048 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0112 15:25:35.640898 88048 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0112 15:25:36.300768 88048 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0112 15:25:37.016542 88048 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0112 15:25:37.731628 88048 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0112 15:25:38.398078 88048 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0112 15:25:39.013079 88048 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0112 15:25:40.139612 88048 client.go:465] Project "e2e-test-node-swap-9tzrc" has been fully provisioned.
  I0112 15:25:40.446533 88048 framework.go:2334] microshift-version configmap not found
    STEP: Creating machine config client @ 01/12/26 15:25:40.446
    STEP: Getting initial machine config resourceVersion @ 01/12/26 15:25:40.446
    STEP: Creating a KubeletConfig with swap settings @ 01/12/26 15:25:40.704
    STEP: Attempting to apply the KubeletConfig @ 01/12/26 15:25:40.704
  I0112 15:25:40.704259 88048 node_swap.go:126] Creating KubeletConfig with failSwapOn=true and swapBehavior=LimitedSwap
    STEP: Checking KubeletConfig status for expected error message @ 01/12/26 15:25:40.963
  I0112 15:25:43.234048 88048 node_swap.go:152] Found Failure condition: Error: KubeletConfiguration: failSwapOn is not allowed to be set, but contains: true
    STEP: Verifying machine config was not created or updated @ 01/12/26 15:25:43.234
    STEP: Verifying worker nodes still have correct swap settings @ 01/12/26 15:25:48.508
    STEP: Verifying failSwapOn=false remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus1-9dz4n @ 01/12/26 15:25:49.458
  I0112 15:25:49.458183 88048 node_swap.go:185] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus1-9dz4n: failSwapOn=false (unchanged) ✓
    STEP: Verifying swapBehavior=NoSwap remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus1-9dz4n @ 01/12/26 15:25:49.458
  I0112 15:25:49.458219 88048 node_swap.go:190] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus1-9dz4n: swapBehavior=NoSwap (unchanged) ✓
    STEP: Verifying failSwapOn=false remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus2-75l7t @ 01/12/26 15:25:49.754
  I0112 15:25:49.754444 88048 node_swap.go:185] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus2-75l7t: failSwapOn=false (unchanged) ✓
    STEP: Verifying swapBehavior=NoSwap remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus2-75l7t @ 01/12/26 15:25:49.754
  I0112 15:25:49.754525 88048 node_swap.go:190] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus2-75l7t: swapBehavior=NoSwap (unchanged) ✓
    STEP: Verifying failSwapOn=false remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus3-9lnrz @ 01/12/26 15:25:50.073
  I0112 15:25:50.073677 88048 node_swap.go:185] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus3-9lnrz: failSwapOn=false (unchanged) ✓
    STEP: Verifying swapBehavior=NoSwap remains unchanged on worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus3-9lnrz @ 01/12/26 15:25:50.073
  I0112 15:25:50.073813 88048 node_swap.go:190] Worker node ci-op-5v1xq5wl-10999-jrj4s-worker-centralus3-9lnrz: swapBehavior=NoSwap (unchanged) ✓
  I0112 15:25:50.073838 88048 node_swap.go:193] Test PASSED: KubeletConfig with failSwapOn was properly rejected
  I0112 15:25:50.687721 88048 client.go:681] Deleted {user.openshift.io/v1, Resource=users  e2e-test-node-swap-9tzrc-user}, err: <nil>
  I0112 15:25:50.993412 88048 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-node-swap-9tzrc}, err: <nil>
  I0112 15:25:51.258458 88048 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~urJPAAwYTdNinFhNqG-lZ1UzWd8-qHq8FcVca9OcY-s}, err: <nil>
    STEP: Destroying namespace "e2e-test-node-swap-9tzrc" for this suite. @ 01/12/26 15:25:51.258
  • [23.184 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 23.185 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
</pre>
