### PR TITLE
OCPBUGS-66225: Add more exceptions for CO/image-registry's Degraded=True

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -432,7 +432,12 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-23744"
 			}
 		case "image-registry":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && (condition.Reason == "NodeCADaemonControllerError" || condition.Reason == "ProgressDeadlineExceeded") {
+			if condition.Type == configv1.OperatorDegraded &&
+				condition.Status == configv1.ConditionTrue &&
+				(condition.Reason == "NodeCADaemonControllerError" ||
+					condition.Reason == "ProgressDeadlineExceeded" ||
+					condition.Reason == "ImageConfigControllerError" ||
+					condition.Reason == "Unavailable") {
 				return "https://issues.redhat.com/browse/OCPBUGS-38667"
 			}
 			// this won't handle the replicaCount==2 serial test where both pods are on nodes that get tainted.


### PR DESCRIPTION
https://github.com/openshift/origin/pull/30549 makes the vsphere excpetion only for Available=False and thus more Degraded=True failures popped up.

The new reasons are ImageConfigControllerError and Unavailable. It would help jobs such as [1, 2].

[1]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.21-e2e-vsphere-ovn-upgrade/1997799449451040768 [2]. https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.21-e2e-aws-ovn-upgrade-fips/1997883437565874176