### PR TITLE
add system-reserved-compressible test

### DIFF
--- a/test/extended/node/perfscale/auto-sizing-reserved/dynamic-system-reserved-cpu.sh
+++ b/test/extended/node/perfscale/auto-sizing-reserved/dynamic-system-reserved-cpu.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+function dynamic_cpu_sizing {
+    total_cpu=$1
+    # Base allocation for 1 CPU in fractions of a core (60 millicores = 0.06 CPU core)
+    base_allocation_fraction=0.06
+    # Increment per additional CPU in fractions of a core (12 millicores = 0.012 CPU core)
+    increment_per_cpu_fraction=0.012
+    if ((total_cpu > 1)); then
+        # Calculate the total system-reserved CPU in fractions, starting with the base allocation
+        # and adding the incremental fraction for each additional CPU
+        recommended_systemreserved_cpu=$(awk -v base="$base_allocation_fraction" -v increment="$increment_per_cpu_fraction" -v cpus="$total_cpu" 'BEGIN {printf "%.2f\n", base + increment * (cpus - 1)}')
+    else
+        # For a single CPU, use the base allocation
+        recommended_systemreserved_cpu=$base_allocation_fraction
+    fi
+
+    # Enforce minimum threshold of 0.5 CPU
+    recommended_systemreserved_cpu=$(awk -v val="$recommended_systemreserved_cpu" 'BEGIN {if (val < 0.5) print 0.5; else print val}')
+
+    echo "SYSTEM_RESERVED_CPU=${recommended_systemreserved_cpu}"
+}
+
+dynamic_cpu_sizing $1

--- a/test/extended/node/perfscale/system-reserved-compressible/stress-slice-single-node.sh
+++ b/test/extended/node/perfscale/system-reserved-compressible/stress-slice-single-node.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+# Systemd Slice CPU Stress Test - Stresses multiple slices on the host
+# This uses 'oc debug node' to run systemd-run commands directly on the node
+
+set -e
+
+# Configuration
+TARGET_NODE="${1:-}"
+STRESS_DURATION="${2:-300}"  # 5 minutes default
+SLICE_SPECS="${3:-system.slice:4}"  # Comma-separated list of slice:cores pairs
+MONITOR_INTERVAL=5
+
+# Parse slice specifications into arrays
+IFS=',' read -ra SLICE_ARRAY <<< "$SLICE_SPECS"
+SLICE_NAMES=()
+SLICE_CORES=()
+
+for spec in "${SLICE_ARRAY[@]}"; do
+    IFS=':' read -r slice cores <<< "$spec"
+    slice=$(echo "$slice" | xargs)  # Trim whitespace
+    cores=$(echo "$cores" | xargs)
+
+    if [ -z "$slice" ] || [ -z "$cores" ]; then
+        echo "Error: Invalid slice specification: '$spec'. Expected format: 'slice:cores'"
+        exit 1
+    fi
+
+    SLICE_NAMES+=("$slice")
+    SLICE_CORES+=("$cores")
+done
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Function to cleanup on exit
+cleanup() {
+    log_info "Cleaning up stress processes..."
+
+    # Stop all stress test units on the node
+    i=0
+    while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+        slice="${SLICE_NAMES[$i]}"
+        cores="${SLICE_CORES[$i]}"
+        slice_safe=$(echo "$slice" | sed 's/[.\/]/-/g')
+
+        log_info "Stopping processes for $slice..."
+        for j in $(seq 1 $cores); do
+            oc debug node/${TARGET_NODE} -- chroot /host systemctl stop stress-test-${slice_safe}-${j} 2>/dev/null || true
+        done
+        i=$((i+1))
+    done
+
+    if [ ! -z "$MONITOR_PID" ]; then
+        kill $MONITOR_PID 2>/dev/null || true
+    fi
+    log_info "Cleanup complete"
+}
+
+trap cleanup INT TERM
+
+# Validate node name provided
+if [ -z "$TARGET_NODE" ]; then
+    log_error "Usage: $0 <node-name> [duration-seconds] [slice-specs]"
+    echo ""
+    echo "Arguments:"
+    echo "  node-name       : Name of the node to stress (required)"
+    echo "  duration-seconds: Duration of stress test in seconds (default: 300)"
+    echo "  slice-specs     : Comma-separated list of 'slice:cores' pairs (default: system.slice:4)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 worker-1 300 system.slice:4"
+    echo "  $0 worker-1 300 'system.slice:4,user.slice:2'"
+    echo "  $0 worker-1 600 'system.slice:4,user.slice:2,kubepods.slice:8'"
+    echo ""
+    echo "Available nodes:"
+    kubectl get nodes -o custom-columns=NAME:.metadata.name,STATUS:.status.conditions[-1].type,CPU:.status.capacity.cpu
+    exit 1
+fi
+
+# Validate node exists
+if ! kubectl get node "$TARGET_NODE" &>/dev/null; then
+    log_error "Node '$TARGET_NODE' not found"
+    exit 1
+fi
+
+log_info "========================================="
+log_info "Systemd Slice CPU Stress Test (Host-level)"
+log_info "========================================="
+log_info "Target Node: $TARGET_NODE"
+log_info "Duration: ${STRESS_DURATION}s"
+log_info "Target Slices:"
+i=0
+while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+    slice="${SLICE_NAMES[$i]}"
+    cores="${SLICE_CORES[$i]}"
+    log_info "  - $slice: $cores cores"
+    i=$((i+1))
+done
+log_info "========================================="
+
+# Get node information
+log_info "Gathering node information..."
+NODE_INFO=$(kubectl get node "$TARGET_NODE" -o json)
+CAPACITY_CPU=$(echo "$NODE_INFO" | jq -r '.status.capacity.cpu')
+ALLOCATABLE_CPU=$(echo "$NODE_INFO" | jq -r '.status.allocatable.cpu')
+
+# Convert to millicores for calculation if they contain 'm'
+if [[ "$CAPACITY_CPU" == *m ]]; then
+    CAPACITY_MILLI=${CAPACITY_CPU%m}
+else
+    CAPACITY_MILLI=$((CAPACITY_CPU * 1000))
+fi
+
+if [[ "$ALLOCATABLE_CPU" == *m ]]; then
+    ALLOCATABLE_MILLI=${ALLOCATABLE_CPU%m}
+else
+    ALLOCATABLE_MILLI=$((ALLOCATABLE_CPU * 1000))
+fi
+
+SYSTEM_RESERVED_MILLI=$((CAPACITY_MILLI - ALLOCATABLE_MILLI))
+SYSTEM_RESERVED=$(awk "BEGIN {printf \"%.2f\", $SYSTEM_RESERVED_MILLI/1000}")
+
+log_info "Node CPU Info:"
+echo "  Total Capacity: ${CAPACITY_CPU} cores"
+echo "  Allocatable: ${ALLOCATABLE_CPU} cores"
+echo "  System Reserved: ${SYSTEM_RESERVED} cores (${SYSTEM_RESERVED_MILLI}m)"
+
+# Check if node has any taints
+TAINTS=$(kubectl get node "$TARGET_NODE" -o jsonpath='{.spec.taints}')
+if [ ! -z "$TAINTS" ] && [ "$TAINTS" != "null" ]; then
+    log_warn "Node has taints: $TAINTS"
+fi
+
+# Function to monitor node and pod status
+monitor_status() {
+    local output_file="stress_test_log_${TARGET_NODE}_$(date +%Y%m%d_%H%M%S).log"
+    log_info "Monitoring output will be saved to: $output_file"
+
+    echo "=== Systemd Slice Stress Test Monitor Log ===" > "$output_file"
+    echo "Start Time: $(date)" >> "$output_file"
+    echo "Target Node: $TARGET_NODE" >> "$output_file"
+    echo "Target Slices:" >> "$output_file"
+    i=0
+    while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+        slice="${SLICE_NAMES[$i]}"
+        cores="${SLICE_CORES[$i]}"
+        echo "  - $slice: $cores cores" >> "$output_file"
+        i=$((i+1))
+    done
+    echo "" >> "$output_file"
+    
+    while true; do
+        {
+            echo "==================== $(date) ===================="
+            
+#             # Node status
+#             echo ""
+#             echo "--- Node Status ---"
+#             kubectl get node "$TARGET_NODE" -o custom-columns=\
+# NAME:.metadata.name,\
+# STATUS:.status.conditions[-1].type,\
+# READY:.status.conditions[-1].status,\
+# CPU:.status.capacity.cpu,\
+# MEMORY:.status.capacity.memory
+            
+            # # Node conditions
+            # echo ""
+            # echo "--- Node Conditions ---"
+            # kubectl get node "$TARGET_NODE" -o json | jq -r '.status.conditions[] | "\(.type): \(.status) - \(.message // "N/A")"'
+            
+            # Check if metrics-server is available
+            if kubectl top node "$TARGET_NODE" &>/dev/null; then
+                echo ""
+                echo "--- Node Resource Usage ---"
+                kubectl top node "$TARGET_NODE"
+            fi
+            
+            # Pods on the node
+            echo ""
+            echo "--- Pods on Node (Non-Running, excluding Completed) ---"
+            kubectl get pods -A --field-selector spec.nodeName="$TARGET_NODE" 2>/dev/null | \
+                grep -v -E "(Running|Completed|STATUS|installer-)" || echo "All pods running or none found"
+            
+            # # Recent events
+            # echo ""
+            # echo "--- Recent Node Events (last 2 minutes) ---"
+            # kubectl get events -A --field-selector involvedObject.name="$TARGET_NODE" \
+            #     --sort-by='.lastTimestamp' 2>/dev/null | tail -10 || echo "No recent events"
+
+            echo ""
+            echo "--- Stress test processes are running ---"
+            oc debug node/${TARGET_NODE} -- bash -c "chroot /host systemctl --type=service --state=running | grep stress-test" || echo "No stress test processes are running"
+            
+        } | tee -a "$output_file"
+        
+        sleep $MONITOR_INTERVAL
+    done
+}
+
+# Start stress processes directly on the node using oc debug
+log_info "Starting stress test on node: $TARGET_NODE"
+log_warn "Using 'oc debug node' to run systemd-run commands directly on the host"
+
+echo "========================================="
+echo "Starting multi-slice stress test"
+
+# Create stress processes in each specified slice using systemd-run
+echo ""
+echo "Launching stress processes..."
+i=0
+while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+    slice="${SLICE_NAMES[$i]}"
+    cores="${SLICE_CORES[$i]}"
+    # Sanitize slice name for unit naming (replace dots and slashes)
+    slice_safe=$(echo "$slice" | sed 's/[.\/]/-/g')
+
+    echo ""
+    echo "Starting $cores processes in $slice..."
+    for j in $(seq 1 $cores); do
+        oc debug node/${TARGET_NODE} -- chroot /host systemd-run \
+          --unit=stress-test-${slice_safe}-${j} \
+          --slice=$slice \
+          --description="CPU Stress Test for $slice Process $j" \
+          bash -c 'while true; do :; done' &
+        echo "  Started process $j in $slice"
+    done
+    i=$((i+1))
+done
+
+sleep 5
+
+# Show that processes are running in the specified slices
+echo ""
+echo "Verifying processes are running:"
+oc debug node/${TARGET_NODE} -- bash -c "chroot /host systemctl --type=service --state=running | grep stress-test" || echo "No stress test processes are running"
+
+echo ""
+echo "CPU-intensive processes running. Will run for $STRESS_DURATION seconds..."
+echo ""
+
+log_info ""
+log_info "========================================="
+log_info "Stress test running for ${STRESS_DURATION} seconds"
+log_info "Monitor the output above for node behavior"
+log_info "Stress processes are running in the following slices on the HOST:"
+i=0
+while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+    slice="${SLICE_NAMES[$i]}"
+    cores="${SLICE_CORES[$i]}"
+    log_info "  - $slice: $cores cores"
+    i=$((i+1))
+done
+log_info "========================================="
+log_info ""
+
+# Start monitoring in background
+log_info "Starting background monitoring..."
+monitor_status &
+MONITOR_PID=$!
+
+# Monitor for the duration
+START_TIME=$(date +%s)
+END_TIME=$((START_TIME + STRESS_DURATION))
+while [ $(date +%s) -lt $END_TIME ]; do
+    CURRENT_TIME=$(date +%s)
+    REMAINING=$((END_TIME - CURRENT_TIME))
+    echo "[Time remaining]: ${REMAINING}s"
+    echo ""
+    sleep 10
+done
+
+# Cleanup 
+cleanup
+
+# Wait a bit and show final status
+sleep 5
+echo ""
+echo "Slice status AFTER stress:"
+oc debug node/${TARGET_NODE} -- bash -c "chroot /host systemctl --type=service --state=running | grep stress-test" || echo "No stress test processes are running"
+
+echo ""
+echo "========================================="
+echo "Stress test completed!"
+echo "========================================="
+
+log_info ""
+log_info "========================================="
+log_info "Stress test completed!"
+log_info "========================================="
+
+# Final status check
+log_info "Checking final node status..."
+sleep 5
+
+kubectl get node "$TARGET_NODE" -o wide
+
+log_info ""
+log_info "Checking for any evicted or failed pods..."
+kubectl get pods -A --field-selector spec.nodeName="$TARGET_NODE" | grep -E "(Evicted|Failed|Error)" || log_info "No evicted/failed pods found"
+
+log_info ""
+log_info "Recent events on node:"
+kubectl get events -A --field-selector involvedObject.name="$TARGET_NODE" --sort-by='.lastTimestamp' | tail -20
+
+log_info ""
+log_info "========================================="
+log_info "Test Summary"
+log_info "========================================="
+log_info "Node: $TARGET_NODE"
+log_info "Stress Duration: ${STRESS_DURATION}s"
+log_info "Slices stressed:"
+total_cores=0
+i=0
+while [ $i -lt ${#SLICE_NAMES[@]} ]; do
+    slice="${SLICE_NAMES[$i]}"
+    cores="${SLICE_CORES[$i]}"
+    log_info "  - $slice: $cores cores"
+    total_cores=$((total_cores + cores))
+    i=$((i+1))
+done
+log_info "Total CPU cores stressed: $total_cores"
+log_info "Log file: stress_test_log_${TARGET_NODE}_*.log"
+log_info ""
+log_info "  chroot /host journalctl -u stress-test-* --since '10 minutes ago'"
+log_info ""
+log_info "Prometheus queries to check (example for first slice):"
+if [ ${#SLICE_NAMES[@]} -gt 0 ]; then
+    first_slice="${SLICE_NAMES[0]}"
+    log_info "  rate(container_cpu_usage_seconds_total{id=\"/$first_slice\", node=\"$TARGET_NODE\"}[1m])* 1000"
+ #   log_info "  rate(container_cpu_cfs_throttled_seconds_total{id=\"/$first_slice\"}[1m])"
+fi
+log_info "========================================="

--- a/test/extended/node/perfscale/system-reserved-compressible/stress-slice-single-node.sh
+++ b/test/extended/node/perfscale/system-reserved-compressible/stress-slice-single-node.sh
@@ -5,10 +5,59 @@
 set -e
 
 # Configuration
-TARGET_NODE="${1:-}"
-STRESS_DURATION="${2:-300}"  # 5 minutes default
-SLICE_SPECS="${3:-system.slice:4}"  # Comma-separated list of slice:cores pairs
+NON_PROMETHEUS_NODE=$(oc get nodes --no-headers | grep worker | awk '{print $1}' | grep -v -f <(oc get po -n openshift-monitoring -o wide --no-headers | grep prometheus-k8s | awk '{print $7}') | head -n 1)
+TARGET_NODE="${NON_PROMETHEUS_NODE}"
+STRESS_DURATION="300"  # 5 minutes default
+SLICE_SPECS="system.slice:4,kubepods.slice:7"  # Comma-separated list of slice:cores pairs
+SYSTEM_SLICE_COMPRESSIBLE="517.5" # Default value for system slice compressible
 MONITOR_INTERVAL=5
+
+usage() {
+    echo "Usage: $0 [-n <node-name>] [-d <duration-seconds>] [-s <slice-specs>] [-c <compressible-value>]"
+    echo "  -n, --node          : Name of the node to stress (default: a non-prometheus worker node)"
+    echo "  -d, --duration      : Duration of stress test in seconds (default: 300)"
+    echo "  -s, --slices        : Comma-separated list of 'slice:cores' pairs (default: system.slice:4,kubepods.slice:7)"
+    echo "  -c, --compressible  : The compressible value for the system slice (default: 500)"
+    exit 1
+}
+
+if [[ "$#" -eq 0 ]]; then
+    usage
+fi
+
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -n|--node)
+        TARGET_NODE="$2"
+        shift # past argument
+        shift # past value
+        ;;
+        -d|--duration)
+        STRESS_DURATION="$2"
+        shift # past argument
+        shift # past value
+        ;;
+        -s|--slices)
+        SLICE_SPECS="$2"
+        shift # past argument
+        shift # past value
+        ;;
+        -c|--compressible)
+        SYSTEM_SLICE_COMPRESSIBLE="$2"
+        shift # past argument
+        shift # past value
+        ;;
+        -h|--help)
+        usage
+        ;;
+        *)    # unknown option
+        echo "Unknown option: $1"
+        usage
+        ;;
+    esac
+done
+
 
 # Parse slice specifications into arrays
 IFS=',' read -ra SLICE_ARRAY <<< "$SLICE_SPECS"
@@ -53,6 +102,8 @@ cleanup() {
 
         log_info "Stopping processes for $slice..."
         for j in $(seq 1 $cores); do
+            # sleep 1s to reduce pod creation burst
+            sleep 1
             oc debug node/${TARGET_NODE} -- chroot /host systemctl stop stress-test-${slice_safe}-${j} 2>/dev/null || true
         done
         i=$((i+1))
@@ -66,24 +117,94 @@ cleanup() {
 
 trap cleanup INT TERM
 
-# Validate node name provided
-if [ -z "$TARGET_NODE" ]; then
-    log_error "Usage: $0 <node-name> [duration-seconds] [slice-specs]"
-    echo ""
-    echo "Arguments:"
-    echo "  node-name       : Name of the node to stress (required)"
-    echo "  duration-seconds: Duration of stress test in seconds (default: 300)"
-    echo "  slice-specs     : Comma-separated list of 'slice:cores' pairs (default: system.slice:4)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 worker-1 300 system.slice:4"
-    echo "  $0 worker-1 300 'system.slice:4,user.slice:2'"
-    echo "  $0 worker-1 600 'system.slice:4,user.slice:2,kubepods.slice:8'"
-    echo ""
-    echo "Available nodes:"
-    kubectl get nodes -o custom-columns=NAME:.metadata.name,STATUS:.status.conditions[-1].type,CPU:.status.capacity.cpu
-    exit 1
-fi
+parse_results() {
+    echo "Parsing results directly from JSON output and storing into variables:"
+
+    # MID_TIME
+    MID_KUBEPODS_SLICE=$(printf "%.2f" "$(echo "$1" | jq -r '.data.result[] | select(.metric.id == "/kubepods.slice") | .value[1]')")
+    MID_SYSTEM_SLICE=$(printf "%.2f" "$(echo "$1" | jq -r '.data.result[] | select(.metric.id == "/system.slice") | .value[1]')")
+
+    # AVG_OVER_TIME
+    AVG_KUBEPODS_SLICE=$(printf "%.2f" "$(echo "$2" | jq -r '.data.result[] | select(.metric.id == "/kubepods.slice") | .value[1]')")
+    AVG_SYSTEM_SLICE=$(printf "%.2f" "$(echo "$2" | jq -r '.data.result[] | select(.metric.id == "/system.slice") | .value[1]')")
+
+    # MAX_OVER_TIME
+    MAX_KUBEPODS_SLICE=$(printf "%.2f" "$(echo "$3" | jq -r '.data.result[] | select(.metric.id == "/kubepods.slice") | .value[1]')")
+    MAX_SYSTEM_SLICE=$(printf "%.2f" "$(echo "$3" | jq -r '.data.result[] | select(.metric.id == "/system.slice") | .value[1]')")
+
+    # Optionally print them to confirm (for debugging/user feedback)
+    echo "--- Parsed Values ---"
+    echo "MID_KUBEPODS_SLICE: $MID_KUBEPODS_SLICE"
+    echo "MID_SYSTEM_SLICE: $MID_SYSTEM_SLICE"
+    echo "AVG_KUBEPODS_SLICE: $AVG_KUBEPODS_SLICE"
+    echo "AVG_SYSTEM_SLICE: $AVG_SYSTEM_SLICE"
+    echo "MAX_KUBEPODS_SLICE: $MAX_KUBEPODS_SLICE"
+    echo "MAX_SYSTEM_SLICE: $MAX_SYSTEM_SLICE"
+}
+
+verify_results() {
+    log_info "========================================="                                                                                                                                                                          │
+    log_info "Checking for Throttling"                                                                                                                                                                                            │
+    log_info "=========================================" 
+    oc debug node/${TARGET_NODE} -- bash -c "chroot /host cat /sys/fs/cgroup/system.slice/cpu.stat" | grep -E "nr_throttled|throttled_usec"
+
+    echo "--- Verifying System Slice Compressible ---"
+    echo "SYSTEM_SLICE_COMPRESSIBLE threshold: $SYSTEM_SLICE_COMPRESSIBLE"
+
+    # Using awk for floating point comparison
+    local mid_check=$(awk -v val="$MID_SYSTEM_SLICE" -v threshold="$SYSTEM_SLICE_COMPRESSIBLE" 'BEGIN { print (val <= threshold) }')
+    local avg_check=$(awk -v val="$AVG_SYSTEM_SLICE" -v threshold="$SYSTEM_SLICE_COMPRESSIBLE" 'BEGIN { print (val <= threshold) }')
+    local max_check=$(awk -v val="$MAX_SYSTEM_SLICE" -v threshold="$SYSTEM_SLICE_COMPRESSIBLE" 'BEGIN { print (val <= threshold) }')
+
+    log_info "========================================="
+    log_info "Test Result - System Slice Compressible"
+    log_info "========================================="
+
+    if [ "$mid_check" -eq 1 ]; then
+        echo "Test Case PASSED: MID_SYSTEM_SLICE value is within the compressible limit."
+        echo "  - MID_SYSTEM_SLICE ($MID_SYSTEM_SLICE) <= $SYSTEM_SLICE_COMPRESSIBLE"
+        echo "  - AVG_SYSTEM_SLICE ($AVG_SYSTEM_SLICE)"
+        echo "  - MAX_SYSTEM_SLICE ($MAX_SYSTEM_SLICE)"
+        exit 0
+    else
+        echo "Test Case FAILED: MID_SYSTEM_SLICE value exceeded the compressible limit."
+        echo "  - MID_SYSTEM_SLICE ($MID_SYSTEM_SLICE) > $SYSTEM_SLICE_COMPRESSIBLE"
+        if [ "$avg_check" -ne 1 ]; then echo "  - AVG_SYSTEM_SLICE ($AVG_SYSTEM_SLICE) > $SYSTEM_SLICE_COMPRESSIBLE"; fi
+        if [ "$max_check" -ne 1 ]; then echo "  - MAX_SYSTEM_SLICE ($MAX_SYSTEM_SLICE) > $SYSTEM_SLICE_COMPRESSIBLE"; fi
+        exit 1
+    fi
+}
+
+run_queries() {
+    query_duration=$((STRESS_DURATION/2))
+    token=`oc create token prometheus-k8s -n openshift-monitoring`
+
+    query="sum by (id)(irate(container_cpu_usage_seconds_total{id=~'/system.slice|/kubepods.slice', node='$TARGET_NODE'}[1m])) * 1000"
+    query_avg='avg_over_time(sum by (id)(irate(container_cpu_usage_seconds_total{id=~"/system.slice|/kubepods.slice", node="'"$TARGET_NODE"'"}[1m]))['"${query_duration}s"':1m]) * 1000'
+    query_max='max_over_time(sum by (id)(irate(container_cpu_usage_seconds_total{id=~"/system.slice|/kubepods.slice", node="'"$TARGET_NODE"'"}[1m]))['"${query_duration}s"':1m]) * 1000'
+
+    echo "=== system.slice & kubepods.slice (millicores) metrics on the middle of the test ===" | tee -a "$output_file"
+    MID_TIME_JSON=$(oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -sk -H "Authorization: Bearer $token" 'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query' --data-urlencode "query=$query" --data-urlencode "time=$MID_TIME" | jq | tee -a "$output_file")
+    echo $MID_TIME_JSON
+
+    echo "=== avg_over_time from middle of the test to the end ===" | tee -a "$output_file"
+    AVG_OVER_TIME_JSON=$(oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+      curl -sk -H "Authorization: Bearer $token" \
+      'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query' \
+      --data-urlencode "query=$query_avg" \
+      --data-urlencode "time=$END_TIME" | jq | tee -a "$output_file")
+    echo $AVG_OVER_TIME_JSON
+
+    echo "=== max_over_time from middle of the test to the end ===" | tee -a "$output_file"
+    MAX_OVER_TIME_JSON=$(oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- \
+      curl -sk -H "Authorization: Bearer $token" \
+      'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query' \
+      --data-urlencode "query=$query_max" \
+      --data-urlencode "time=$END_TIME" | jq | tee -a "$output_file")
+    echo $MAX_OVER_TIME_JSON
+}
+
+
 
 # Validate node exists
 if ! kubectl get node "$TARGET_NODE" &>/dev/null; then
@@ -141,11 +262,11 @@ fi
 
 # Function to monitor node and pod status
 monitor_status() {
-    local output_file="stress_test_log_${TARGET_NODE}_$(date +%Y%m%d_%H%M%S).log"
     log_info "Monitoring output will be saved to: $output_file"
 
     echo "=== Systemd Slice Stress Test Monitor Log ===" > "$output_file"
     echo "Start Time: $(date)" >> "$output_file"
+    echo "Stress Duration: ${STRESS_DURATION}s" >> "$output_file"
     echo "Target Node: $TARGET_NODE" >> "$output_file"
     echo "Target Slices:" >> "$output_file"
     i=0
@@ -187,7 +308,7 @@ monitor_status() {
             echo ""
             echo "--- Pods on Node (Non-Running, excluding Completed) ---"
             kubectl get pods -A --field-selector spec.nodeName="$TARGET_NODE" 2>/dev/null | \
-                grep -v -E "(Running|Completed|STATUS|installer-)" || echo "All pods running or none found"
+                grep -v -E "(Running|Completed|STATUS|installer-)" || echo "All pods running or no pod found"
             
             # # Recent events
             # echo ""
@@ -197,7 +318,7 @@ monitor_status() {
 
             echo ""
             echo "--- Stress test processes are running ---"
-            oc debug node/${TARGET_NODE} -- bash -c "chroot /host systemctl --type=service --state=running | grep stress-test" || echo "No stress test processes are running"
+            oc debug node/${TARGET_NODE} -- bash -c "chroot /host cat systemctl --type=service --state=running | grep stress-test" || echo "No stress test processes are running"
             
         } | tee -a "$output_file"
         
@@ -231,6 +352,8 @@ while [ $i -lt ${#SLICE_NAMES[@]} ]; do
           --description="CPU Stress Test for $slice Process $j" \
           bash -c 'while true; do :; done' &
         echo "  Started process $j in $slice"
+        # sleep 1s to reduce pod creation burst
+        sleep 1
     done
     i=$((i+1))
 done
@@ -261,6 +384,9 @@ done
 log_info "========================================="
 log_info ""
 
+# Define the output file name
+output_file="stress_test_log_${TARGET_NODE}_$(date +%Y%m%d_%H%M%S).log"
+
 # Start monitoring in background
 log_info "Starting background monitoring..."
 monitor_status &
@@ -280,7 +406,7 @@ done
 # Cleanup 
 cleanup
 
-# Wait a bit and show final status
+# Wait a 5s and show final status
 sleep 5
 echo ""
 echo "Slice status AFTER stress:"
@@ -327,14 +453,17 @@ while [ $i -lt ${#SLICE_NAMES[@]} ]; do
     i=$((i+1))
 done
 log_info "Total CPU cores stressed: $total_cores"
-log_info "Log file: stress_test_log_${TARGET_NODE}_*.log"
+log_info "Log file: $output_file"
 log_info ""
-log_info "  chroot /host journalctl -u stress-test-* --since '10 minutes ago'"
+log_info "chroot /host journalctl -u stress-test-* --since '10 minutes ago'"
 log_info ""
-log_info "Prometheus queries to check (example for first slice):"
-if [ ${#SLICE_NAMES[@]} -gt 0 ]; then
-    first_slice="${SLICE_NAMES[0]}"
-    log_info "  rate(container_cpu_usage_seconds_total{id=\"/$first_slice\", node=\"$TARGET_NODE\"}[1m])* 1000"
- #   log_info "  rate(container_cpu_cfs_throttled_seconds_total{id=\"/$first_slice\"}[1m])"
-fi
 log_info "========================================="
+
+echo "Start timestamp: $START_TIME. Start time: "$(date -r $START_TIME)
+echo "End timestamp: $END_TIME. End time: "$(date -r $END_TIME)
+MID_TIME=$((START_TIME + STRESS_DURATION/2))
+echo "Mid timestamp: $MID_TIME. Mid time: "$(date -r $MID_TIME)
+
+run_queries
+parse_results "$MID_TIME_JSON" "$AVG_OVER_TIME_JSON" "$MAX_OVER_TIME_JSON"
+verify_results

--- a/test/extended/node/perfscale/system-reserved-compressible/system-reserved-compressible.yaml
+++ b/test/extended/node/perfscale/system-reserved-compressible/system-reserved-compressible.yaml
@@ -1,0 +1,13 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved-compressible
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  kubeletConfig:
+    systemReservedCgroup: "/system.slice" 
+    enforceNodeAllocatable:
+      - pods
+      - system-reserved-compressible 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPNODE-3939

dynamic-system-reserved-cpu.sh is used to calculate the SYSTEM_RESERVED_CPU for AutoSizingReserved
Test
```
./dynamic-system-reserved-cpu.sh 96
SYSTEM_RESERVED_CPU=1.20
```

stress-slice-single-node.sh is to stress a given node's given slice with specified cpu cores for a period of time
Test
```
./stress-slice-single-node.sh ip-xx-xx-xx-xx.us-east-2.compute.internal 600 system.slice:4,kubepods.slice:7                                    
[INFO] =========================================
[INFO] Systemd Slice CPU Stress Test (Host-level)
[INFO] =========================================
[INFO] Target Node: ip-xx-xx-xx-xx.us-east-2.compute.internal
[INFO] Duration: 600s
[INFO] Target Slices:
[INFO]   - system.slice: 4 cores
[INFO]   - kubepods.slice: 7 cores
[INFO] =========================================
[INFO] Gathering node information...
[INFO] Node CPU Info:
  Total Capacity: 4 cores
  Allocatable: 3500m cores
  System Reserved: 0.50 cores (500m)
[INFO] Starting stress test on node: ip-xx-xx-xx-xx.us-east-2.compute.internal
[WARN] Using 'oc debug node' to run systemd-run commands directly on the host
=========================================
Starting multi-slice stress test

Launching stress processes...

Starting 4 processes in system.slice...
  Started process 1 in system.slice
  Started process 2 in system.slice
  Started process 3 in system.slice
  Started process 4 in system.slice

Starting 7 processes in kubepods.slice...
  Started process 1 in kubepods.slice
  Started process 2 in kubepods.slice
  Started process 3 in kubepods.slice
  Started process 4 in kubepods.slice
  Started process 5 in kubepods.slice
  Started process 6 in kubepods.slice
  Started process 7 in kubepods.slice

Removing debug pod ...
Running as unit: stress-test-kubepods-slice-1.service
  stress-test-kubepods-slice-1.service loaded active running CPU Stress Test for kubepods.slice Process 1
  stress-test-kubepods-slice-2.service loaded active running CPU Stress Test for kubepods.slice Process 2
  stress-test-kubepods-slice-3.service loaded active running CPU Stress Test for kubepods.slice Process 3
  stress-test-kubepods-slice-4.service loaded active running CPU Stress Test for kubepods.slice Process 4
  stress-test-kubepods-slice-5.service loaded active running CPU Stress Test for kubepods.slice Process 5
  stress-test-kubepods-slice-6.service loaded active running CPU Stress Test for kubepods.slice Process 6
  stress-test-kubepods-slice-7.service loaded active running CPU Stress Test for kubepods.slice Process 7
  stress-test-system-slice-1.service   loaded active running CPU Stress Test for system.slice Process 1
  stress-test-system-slice-2.service   loaded active running CPU Stress Test for system.slice Process 2
  stress-test-system-slice-3.service   loaded active running CPU Stress Test for system.slice Process 3
  stress-test-system-slice-4.service   loaded active running CPU Stress Test for system.slice Process 4

CPU-intensive processes running. Will run for 600 seconds...

[INFO] 
[INFO] =========================================
[INFO] Stress test running for 600 seconds
[INFO] Monitor the output above for node behavior
[INFO] Stress processes are running in the following slices on the HOST:
[INFO]   - system.slice: 4 cores
[INFO]   - kubepods.slice: 7 cores
[INFO] =========================================
[INFO] 
[INFO] Starting background monitoring...
[INFO] Monitoring output will be saved to: stress_test_log_iip-xx-xx-xx-xx.us-east-2.compute.internal_20251209_140745.log
[Time remaining]: 600s

==================== Tue Dec  9 14:07:45 CST 2025 ====================

--- Node Resource Usage ---
NAME                                        CPU(cores)   CPU(%)   MEMORY(bytes)   MEMORY(%)   
ip-xx-xx-xx-xx.us-east-2.compute.internal   3993m        114%     1948Mi          15%         

--- Pods on Node (Non-Running, excluding Completed) ---
All pods running or none found

--- Stress test processes are running ---
[Time remaining]: 590s

  stress-test-kubepods-slice-1.service loaded active running CPU Stress Test for kubepods.slice Process 1
  stress-test-kubepods-slice-2.service loaded active running CPU Stress Test for kubepods.slice Process 2
  stress-test-kubepods-slice-3.service loaded active running CPU Stress Test for kubepods.slice Process 3
  stress-test-kubepods-slice-4.service loaded active running CPU Stress Test for kubepods.slice Process 4
  stress-test-kubepods-slice-5.service loaded active running CPU Stress Test for kubepods.slice Process 5
  stress-test-kubepods-slice-6.service loaded active running CPU Stress Test for kubepods.slice Process 6
  stress-test-kubepods-slice-7.service loaded active running CPU Stress Test for kubepods.slice Process 7
  stress-test-system-slice-1.service   loaded active running CPU Stress Test for system.slice Process 1
  stress-test-system-slice-2.service   loaded active running CPU Stress Test for system.slice Process 2
  stress-test-system-slice-3.service   loaded active running CPU Stress Test for system.slice Process 3
  stress-test-system-slice-4.service   loaded active running CPU Stress Test for system.slice Process 4

[Time remaining]: 580s

==================== Tue Dec  9 14:08:09 CST 2025 ====================
....
=========================================
Stress test completed!
=========================================
[INFO] 
[INFO] =========================================
[INFO] Stress test completed!
[INFO] =========================================
[INFO] Checking final node status...
NAME                                        STATUS   ROLES    AGE     VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                                KERNEL-VERSION                 CONTAINER-RUNTIME
ip-xx-xx-xx-xx.us-east-2.compute.internal  Ready    worker   4h45m   v1.34.2   10.0.64.194   <none>        Red Hat Enterprise Linux CoreOS 9.6.20251205-0 (Plow)   5.14.0-570.73.1.el9_6.x86_64   cri-o://1.34.2-2.rhaos4.21.gitc8e8b46.el9
[INFO] 
[INFO] Checking for any evicted or failed pods...
[INFO] No evicted/failed pods found
[INFO] 
[INFO] Recent events on node:
....
[INFO] 
[INFO] =========================================
[INFO] Test Summary
[INFO] =========================================
[INFO] Node: ip-xx-xx-xx-xx.us-east-2.compute.internal
[INFO] Stress Duration: 600s
[INFO] Slices stressed:
[INFO]   - system.slice: 4 cores
[INFO]   - kubepods.slice: 7 cores
[INFO] Total CPU cores stressed: 11
[INFO] Log file: stress_test_log_ip-xx-xx-xx-xx.us-east-2.compute.internal_*.log
[INFO] 
[INFO]   chroot /host journalctl -u stress-test-* --since '10 minutes ago'
[INFO] 
[INFO] Prometheus queries to check (example for first slice):
[INFO]   rate(container_cpu_usage_seconds_total{id="/system.slice", node="ip-xx-xx-xx-xx.us-east-2.compute.internal"}[1m])* 1000
[INFO] =========================================
```