### PR TITLE
OCPBUGS-60853: cert tests: mark TLS registry test as informing

### DIFF
--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -105,6 +105,9 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		if ok, _ := exutil.IsHypershift(ctx, configClient); ok {
 			g.Skip("hypershift does not auto-collect TLS.")
 		}
+		if ok, _ := exutil.IsRosaCluster(oc); ok {
+			g.Skip("ROSA does not auto-collect TLS.")
+		}
 		var err error
 		onDiskPKIContent := &certgraphapi.PKIList{}
 

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2337,6 +2337,16 @@ func IsMicroShiftCluster(kubeClient k8sclient.Interface) (bool, error) {
 	return true, nil
 }
 
+// IsRosaCluster returns "true" if a cluster is ROSA,
+// "false" otherwise.
+func IsRosaCluster(oc *CLI) (bool, error) {
+	product, err := oc.WithoutNamespace().AsAdmin().Run("get").Args("clusterclaims/product.open-cluster-management.io", "-o=jsonpath={.spec.value}").Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.Compare(product, "ROSA") == 0, nil
+}
+
 func IsTwoNodeFencing(ctx context.Context, configClient clientconfigv1.Interface) bool {
 	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
Reapply the changes from PR #29074 that were previously reverted, mark both certificate tests as informing so failures don't block CI jobs, and skip the tests on ROSA clusters.

### **Current Skip Pattern:**

  The TLS certificate test currently skips on:
  1. MicroShift - doesn't auto-collect TLS (line 101-102)
  2. HyperShift - doesn't auto-collect TLS (line 105-106)
  3. ROSA - doesn't auto-collect TLS (line 108-109, your recent commit f7b77f2df4)

  **Other Managed Platforms - Analysis:**

  1. ARO (Azure Red Hat OpenShift)
  - Regular ARO: Not hosted control plane, runs like standard OCP → should NOT skip
  - ARO HCP (Hosted Control Plane): This is a HyperShift variant
    - Already covered by the HyperShift skip check (line 105-106)
    - Detection: IsAroHCP() checks for MANAGED_SERVICE=ARO-HCP env var in control-plane-operator

  2. OSD (OpenShift Dedicated)
  - Runs on AWS or GCP with standard control plane architecture
  - Should NOT skip - uses regular TLS auto-collection like standard OCP
  - Note: Only ROSA (managed service on AWS) has the special behavior requiring a skip

  3. General Managed Service Detection
  - The codebase has IsManagedServiceCluster() (framework.go:2279) that checks for openshift-backplane namespace
  - This broadly detects OSD, ROSA, and other managed services but is not used for cert tests
  - This is intentional - not all managed services lack TLS auto-collection

  **Key Insight:**

  The distinction is based on control plane architecture, not managed service status:
  - Hosted/External Control Plane (HyperShift, ROSA, ARO HCP) → Skip
  - Self-hosted Control Plane (standard OCP, OSD, regular ARO) → Don't skip

----

## Changes

### Commit 1: Reapply PR #29074 (was reverted in #30358)
- Changes `testresult.Flakef()` to `g.Fail()` for certificate tests
- Removes TODO comments about making tests required
- Original PR: #29074
- This commit brings back the proper failure reporting mechanism

### Commit 2: Mark TLS certificate tests as informing
- Added import for `github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo`
- Added `ote.Informing()` to both certificate tests:
  - "all tls artifacts must be registered"
  - "all registered tls artifacts must have no metadata violation regressions"

### Commit 3: Skip TLS certificate tests on ROSA clusters
- Added `IsRosaCluster()` function to `test/extended/util/framework.go`
- Skip certificate tests on ROSA clusters (similar to MicroShift and Hypershift)
- ROSA clusters do not auto-collect TLS certificates the same way as standard OpenShift clusters

## Behavior

After these changes:

**On standard OpenShift clusters:**
- Both certificate tests will continue to run in blocking CI jobs
- Tests use `g.Fail()` for proper failure reporting
- Tests have `ote.Informing()` label → **Non-blocking** (failures won't fail CI)
- Gather data about TLS artifacts and metadata violations without blocking PRs

**On ROSA, MicroShift, and Hypershift clusters:**
- Tests are skipped (these platforms don't auto-collect TLS the same way)

## Benefits
- Tests provide proper failure reports with `g.Fail()`
- Tests are marked as informing, so failures are recorded but don't block development
- We can gather data and stabilize the tests while work continues on certificate registration and metadata compliance
- Avoid running tests on platforms that don't support TLS auto-collection
- Once tests are stable, the `ote.Informing()` label can be removed to make them blocking again