### PR TITLE
CNTRLPLANE-1310: register the OTE binary for secondary scheduler operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -252,6 +252,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-kube-scheduler-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "secondary-scheduler-operator",
+		binaryPath: "/usr/bin/secondary-scheduler-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-version-operator",
 		binaryPath: "/usr/bin/cluster-version-operator-tests.gz",
 	},


### PR DESCRIPTION
Register the OTE binary secondary-scheduler-operator as part of JIRA [CNTRLPLANE-1310](https://issues.redhat.com/browse/CNTRLPLANE-1310) (first [PR](https://github.com/openshift/secondary-scheduler-operator/pull/695) for OTE infra changes and the relevant dependencies already merged).