### PR TITLE
NO-JIRA: register cluster-node-tuning-operator-test-ext the binary to origin for OTE migration

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -255,6 +255,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-version-operator",
 		binaryPath: "/usr/bin/cluster-version-operator-tests.gz",
 	},
+	{
+		imageTag:   "cluster-node-tuning-operator",
+		binaryPath: "/usr/bin/cluster-node-tuning-operator-test-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
register cluster-node-tuning-operator-test-ext the binary to origin for OTE migration