### PR TITLE
monitortest: fix empty value for machine phase

### DIFF
--- a/pkg/monitortests/machines/watchmachines/machines.go
+++ b/pkg/monitortests/machines/watchmachines/machines.go
@@ -41,10 +41,10 @@ func startMachineMonitoring(ctx context.Context, m monitorapi.RecorderWriter, cl
 			newHasPhase := machine != nil && machine.Status.Phase != nil
 			oldPhase := "<missing>"
 			newPhase := "<missing>"
-			if oldHasPhase {
+			if oldHasPhase && *oldMachine.Status.Phase != "" {
 				oldPhase = *oldMachine.Status.Phase
 			}
-			if newHasPhase {
+			if newHasPhase && *machine.Status.Phase != "" {
 				newPhase = *machine.Status.Phase
 			}
 

--- a/pkg/monitortests/machines/watchmachines/monitortest.go
+++ b/pkg/monitortests/machines/watchmachines/monitortest.go
@@ -3,8 +3,9 @@ package watchmachines
 import (
 	"context"
 	"fmt"
-	machineClient "github.com/openshift/client-go/machine/clientset/versioned"
 	"time"
+
+	machineClient "github.com/openshift/client-go/machine/clientset/versioned"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
@@ -72,16 +73,16 @@ func (*machineWatcher) ConstructComputedIntervals(ctx context.Context, startingI
 			return eventInterval.Message.Reason == monitorapi.MachinePhaseChanged
 		})
 		for _, phaseChange := range phaseChanges {
-			previousPhase := phaseChange.Message.Annotations[monitorapi.AnnotationPreviousPhase]
+			newPhase := phaseChange.Message.Annotations[monitorapi.AnnotationPhase]
 			nodeName := phaseChange.Message.Annotations[monitorapi.AnnotationNode]
 			constructedIntervals = append(constructedIntervals,
 				monitorapi.NewInterval(monitorapi.SourceMachine, monitorapi.Info).
 					Locator(phaseChange.Locator).
 					Message(monitorapi.NewMessage().Reason(monitorapi.MachinePhase).
 						Constructed(monitorapi.ConstructionOwnerMachineLifecycle).
-						WithAnnotation(monitorapi.AnnotationPhase, previousPhase).
+						WithAnnotation(monitorapi.AnnotationPhase, newPhase).
 						WithAnnotation(monitorapi.AnnotationNode, nodeName).
-						HumanMessage(fmt.Sprintf("Machine is in %q", previousPhase))).
+						HumanMessage(fmt.Sprintf("Machine is in %q", newPhase))).
 					Display().
 					Build(previousChangeTime, phaseChange.From),
 			)


### PR DESCRIPTION
I have discovered that at times it happens that I see `Machine is in ""` in the reported intervals. This is not correct and may be caused by the fact that phase is defined as an optional `Phase *string json:"phase,omitempty"` field so technically an empty value is correct one there.

In any case, for constructing interval I would prefer to explicitly see "missing" message instead of empty value.