### PR TITLE
NO-JIRA: Increase tolerance of CO's not reporting Progressing

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -685,9 +685,9 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 			return fmt.Sprintf("%s completing its update so fast that CVO did not recogize any waiting", co)
 		}
 		from, to := fromAndTo(intervals)
-		if d := to.Sub(from); d < 2*time.Minute {
-			// CO showed up in CVO Progressing message but the total duration is less than two minutes
-			return fmt.Sprintf("%s completing its update within less than two minutes: %s", co, d.String())
+		if d := to.Sub(from); d < 3*time.Minute {
+			// CO showed up in CVO Progressing message but the total duration is less than three minutes
+			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, d.String())
 		}
 		switch co {
 		case "baremetal":
@@ -734,7 +734,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 				output = fmt.Sprintf("%s which is expected up to %s", output, exception)
 			} else {
 				from, to := fromAndTo(COWaiting[operatorName])
-				output = fmt.Sprintf("%s and CVO waited for it over 2 minutes from %s to %s", output, from.Format(time.RFC3339), to.Format(time.RFC3339))
+				output = fmt.Sprintf("%s and CVO waited for it over 3 minutes from %s to %s", output, from.Format(time.RFC3339), to.Format(time.RFC3339))
 			}
 			mcTestCase.FailureOutput = &junitapi.FailureOutput{
 				Output: output,


### PR DESCRIPTION
We found sometimes in CI that the CVO's waiting is timed out because Kubelet is slow, e.g. `45s`, to get a running pod for the target version of the component's deployment.

CVO should not include the time there because it is out of the control of component. However, it is challenging to exclude it in the current CVO's implementation.

The original timeout `2m` was there up to CVO's batching strategy (only once in `1m`) to update CVO's status for which the component should not be responsible. This pull adjusts it to `3m` for the slow Kubelet actions.

The adjustment is only a temporary measure as we do not know how slow it could be for Kubelet such as pulling an image for the deployment. Thus, the ideal solution for the issue here is that CVO figures out how to measure the timing precisely. For now, the compromise is this pull.