### PR TITLE
[wip] test: experiment with size labels for resource-aware parallelism

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -184,6 +184,15 @@
       return eventInterval.source === "CPUMonitor" && eventInterval.message.reason === "HighCPUUsage"
     }
 
+    function isTestBucket(eventInterval) {
+        return eventInterval.source === "TestBucket"
+    }
+
+    function testBucketValue(item) {
+        const bucketName = item.locator.keys['test-bucket'] || 'Unknown'
+        return [bucketName, "", "TestBucket"]
+    }
+
     function pathologicalEvents(item) {
         if (item.message.annotations["pathological"] === "true") {
             if (item.message.annotations["interesting"] === "true") {
@@ -479,6 +488,9 @@
         var loc = window.location.href;
 
         var timelineGroups = []
+        timelineGroups.push({group: "test-buckets", data: []})
+        createTimelineData(testBucketValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isTestBucket, regex)
+
         timelineGroups.push({group: "operator-unavailable", data: []})
         createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable, regex)
 
@@ -573,6 +585,7 @@
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'TestBucket', // test bucket intervals
                 'InterestingEvent', 'PathologicalKnown', "PathologicalNew", "PodSandbox", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
@@ -584,6 +597,7 @@
                 'PodLogInfo', 'PodLogWarning', 'PodLogError',
                 'EtcdOther', 'EtcdLeaderFound', 'EtcdLeaderLost', 'EtcdLeaderElected', 'EtcdLeaderMissing'])
             .range([
+                '#9370DB', // test bucket intervals - medium purple
                 '#6E6E6E', '#0000ff', '#d0312d', '#ffa500', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -528,6 +528,12 @@ func (b *LocatorBuilder) ClusterOperator(name string) Locator {
 	return b.Build()
 }
 
+func (b *LocatorBuilder) TestBucket(bucketName string) Locator {
+	b.targetType = LocatorTypeTestBucket
+	b.annotations[LocatorTestBucketKey] = bucketName
+	return b.Build()
+}
+
 func (b *LocatorBuilder) Build() Locator {
 	ret := Locator{
 		Type: b.targetType,

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -118,6 +118,7 @@ const (
 	LocatorTypeKubeletSyncLoopProbe LocatorType = "KubeletSyncLoopProbe"
 	LocatorTypeKubeletSyncLoopPLEG  LocatorType = "KubeletSyncLoopPLEG"
 	LocatorTypeStaticPodInstall     LocatorType = "StaticPodInstall"
+	LocatorTypeTestBucket           LocatorType = "TestBucket"
 )
 
 type LocatorKey string
@@ -164,6 +165,7 @@ const (
 	LocatorTypeKubeletSyncLoopProbeType LocatorKey = "probe"
 	LocatorTypeKubeletSyncLoopPLEGType  LocatorKey = "plegType"
 	LocatorStaticPodInstallType         LocatorKey = "podType"
+	LocatorTestBucketKey                LocatorKey = "test-bucket"
 )
 
 type Locator struct {
@@ -390,6 +392,7 @@ const (
 	SourceCPUMonitor               IntervalSource = "CPUMonitor"
 	SourceEtcdDiskCommitDuration   IntervalSource = "EtcdDiskCommitDuration"
 	SourceEtcdDiskWalFsyncDuration IntervalSource = "EtcdDiskWalFsyncDuration"
+	SourceTestBucket               IntervalSource = "TestBucket"
 )
 
 type Interval struct {

--- a/pkg/test/ginkgo/SCHEDULER.md
+++ b/pkg/test/ginkgo/SCHEDULER.md
@@ -1,0 +1,286 @@
+# Test Scheduler Design
+
+## Overview
+
+The OpenShift test suite uses a sophisticated scheduler to execute thousands of tests efficiently while managing resource constraints. This document describes the scheduling philosophy and implementation.
+
+## Core Principles
+
+### 1. Resource-Aware Parallelism
+
+Tests have different resource requirements. Running too many resource-intensive tests concurrently can:
+- Exhaust CPU on test nodes
+- Cause cloud provider quota issues (storage, networking)
+- Lead to test failures due to resource contention rather than actual bugs
+
+**Solution**: Tests are organized into buckets with different parallelism levels based on their resource intensity.
+
+### 2. Avoiding Long-Tail Problems
+
+Traditional sequential bucket execution has a "long tail" problem:
+```
+Bucket A: [============================] (30 parallel)
+          [============================]
+          [============================]
+          [========]                     <- Last test runs alone!
+
+Bucket B:           Waiting...
+```
+
+When Bucket A has only one slow test remaining, we're stuck at parallelism=1, wasting cluster capacity.
+
+**Solution**: Chained bucket execution - activate the next bucket when the current bucket's active tests drop below the next bucket's max parallelism.
+
+### 3. Gradual Parallelism Transitions
+
+When transitioning from high-parallelism to low-parallelism buckets, we must respect the lower limit:
+
+**WRONG**:
+```
+Bucket A (max=30): 14 active tests
+Bucket B (max=15): Activated
+Total: 14 + 15 = 29 tests running  ❌ Violates B's limit!
+```
+
+**CORRECT**:
+```
+Bucket A (max=30): 14 active tests
+Bucket B (max=15): Activated
+Global max: min(30, 15) = 15
+Total: 14 from A + 1 from B = 15  ✅
+```
+
+As A's tests complete, they're replaced by B's tests until B fully takes over at parallelism=15.
+
+## Test Organization
+
+### Size-Based Buckets
+
+Tests are labeled with size tags indicating resource intensity:
+
+- **Size:S** - Small/Simple
+  - No pod creation
+  - Simple API calls, CLI commands
+  - Quick execution (seconds to low minutes)
+  - Examples: `oc explain`, basic CRUD operations, status checks
+  - **Parallelism**: 2x base (e.g., 60 if base is 30)
+
+- **Size:M** - Medium (DEFAULT for unlabeled tests)
+  - 1-2 pods
+  - Basic services, simple deployments
+  - Moderate complexity
+  - Examples: Single pod apps, basic networking, simple builds
+  - **Parallelism**: 1x base (e.g., 30)
+
+- **Size:L** - Large/Complex
+  - Many pods, image builds, stress tests
+  - Complex workflows, multi-replica deployments
+  - High resource usage
+  - Examples: must-gather, complex builds, stress tests
+  - **Parallelism**: 0.5x base (e.g., 15)
+
+### Bucket Execution Order
+
+Tests execute in this order:
+
+1. **Early** - Setup/invariant tests (parallelism=base)
+2. **KubernetesTests** - Upstream k8s tests including network (parallelism=base)
+3. **StorageTests** - Storage-intensive tests (parallelism=base/2)
+4. **NetworkTests** - OpenShift networking tests (parallelism=base/2)
+5. **OpenShiftTests-S** - Small OpenShift tests (parallelism=base*2)
+6. **OpenShiftTests-M** - Medium OpenShift tests (parallelism=base)
+7. **OpenShiftTests-L** - Large OpenShift tests (parallelism=base/2)
+8. **MustGatherTests** - Resource collection tests (parallelism=base)
+9. **Late** - Cleanup/invariant tests (parallelism=base)
+
+Early and Late buckets run standalone (not chained). Buckets 2-8 use chained execution.
+
+## Chained Bucket Scheduler
+
+### Algorithm
+
+The `chainedBucketScheduler` implements the `TestScheduler` interface and manages multiple test buckets with progressive activation.
+
+#### Key Components
+
+1. **Test Queues**: One queue per bucket containing tests to execute
+2. **Active Test Counts**: Tracks how many tests from each bucket are currently running
+3. **Current Bucket Index**: The primary bucket we're executing from
+4. **Global Max Parallelism**: Calculated as the minimum of all active buckets' max parallelism
+
+#### Activation Logic
+
+```go
+func shouldActivateNextBucket() bool {
+    currentActive := activeTestCounts[currentBucketIdx]
+    nextBucketMax := buckets[currentBucketIdx + 1].MaxParallelism
+
+    return currentActive < nextBucketMax
+}
+```
+
+When bucket A has fewer active tests than bucket B's max parallelism, bucket B is activated.
+
+#### Scheduling Logic
+
+On each `GetNextTestToRun()` call:
+
+1. **Calculate global max parallelism**
+   ```go
+   globalMax = currentBucket.MaxParallelism
+   for each active bucket:
+       globalMax = min(globalMax, bucket.MaxParallelism)
+   ```
+
+2. **Check global limit**
+   ```go
+   totalActive = sum of all activeTestCounts
+   if totalActive >= globalMax:
+       wait for a test to complete
+   ```
+
+3. **Try to get a test from any active bucket**
+   - Iterate through active buckets (currentBucketIdx onwards)
+   - Skip buckets that are empty or at their individual max
+   - Find a runnable test (respecting conflicts/taints)
+   - If found, increment that bucket's active count
+   - Check if we should activate the next bucket
+
+4. **Handle bucket transitions**
+   - When current bucket is exhausted (empty queue + zero active):
+     - End monitoring interval for that bucket
+     - Advance to next bucket
+     - Start monitoring interval for new current bucket
+
+### Example Execution
+
+Base parallelism = 30
+
+**Phase 1: KubernetesTests (max=30)**
+```
+Active: 30 tests from Kube
+Global max: 30
+```
+
+**Phase 2: Kube Tail (14 active tests)**
+```
+Kube active: 14
+14 < 15 (Storage max) → Activate StorageTests
+Global max: min(30, 15) = 15
+Active: 14 from Kube, can add 1 from Storage
+```
+
+**Phase 3: Transition**
+```
+Kube active: 13 → 12 → 11... (completing)
+Storage active: 2 → 3 → 4... (ramping up)
+Total: Always ≤ 15
+```
+
+**Phase 4: Storage Dominates (max=15)**
+```
+Kube active: 0 (exhausted)
+Storage active: 15
+Global max: 15
+```
+
+**Phase 5: Storage Tail (7 active tests)**
+```
+Storage active: 7
+7 < 15 (Network max) → Activate NetworkTests
+Global max: min(15, 15) = 15
+Active: 7 from Storage, can add 8 from Network
+```
+
+And so on through all buckets...
+
+## Conflict and Taint Management
+
+### Conflicts
+
+Some tests cannot run concurrently because they:
+- Modify the same cluster resource
+- Depend on exclusive access to a feature
+- Would interfere with each other's validation
+
+Tests declare conflicts in their spec:
+```go
+Isolation.Conflict: ["egressip", "network-policy"]
+```
+
+The scheduler ensures no two tests with overlapping conflicts run simultaneously within the same conflict group.
+
+### Taints and Tolerations
+
+**Taints** allow tests to declare they modify cluster state in specific ways:
+```go
+Isolation.Taint: ["cluster-network-config"]
+```
+
+**Tolerations** allow tests to declare they can run despite certain cluster modifications:
+```go
+Isolation.Toleration: ["cluster-network-config"]
+```
+
+Only tests that tolerate all active taints can run. Tests without tolerations can only run when no taints are active.
+
+### Serial Tests
+
+Tests marked with `[Serial]` in their name run sequentially after all parallel tests complete. This is for tests that:
+- Modify global cluster state
+- Cannot tolerate any other tests running
+- Need exclusive cluster access
+
+## Worker Pool
+
+Workers are goroutines that continuously:
+1. Call `GetNextTestToRun()` (blocks until a test is available)
+2. Execute the test
+3. Call `MarkTestComplete()` (signals other workers)
+4. Repeat until all tests are done
+
+The number of workers equals the maximum parallelism (typically base parallelism, e.g., 30).
+
+Workers don't need to know about buckets - the scheduler handles all bucket logic internally.
+
+## Benefits
+
+1. **Eliminates long-tail waste**: No bucket sits idle while another has one slow test
+2. **Respects resource limits**: Each bucket's max parallelism is enforced globally
+3. **Smooth transitions**: Gradual ramp-down/ramp-up between buckets
+4. **Flexible**: Easy to add new buckets or adjust parallelism levels
+5. **Observable**: Monitoring intervals track each bucket's execution time
+6. **Conflict-aware**: Tests with conflicts are safely serialized
+7. **Taint-aware**: Cluster state changes are properly managed
+
+## Monitoring
+
+Each bucket records a monitoring interval:
+```
+StartInterval("OpenShiftTests-S")
+... tests execute ...
+EndInterval()
+Log: "Completed OpenShiftTests-S bucket in 15m32s"
+```
+
+This provides visibility into:
+- How long each bucket takes
+- When buckets overlap (chaining periods)
+- Whether parallelism adjustments are working
+
+## Future Improvements
+
+Potential enhancements:
+
+1. **Dynamic parallelism**: Adjust based on actual cluster resource usage
+2. **Priority scheduling**: Run flaky/important tests first
+3. **Smart bucket ordering**: Reorder based on historical runtimes
+4. **Adaptive chaining threshold**: Trigger next bucket at different thresholds (e.g., 50% remaining)
+5. **Cross-bucket conflict detection**: Allow conflicts to span buckets
+
+## Implementation Files
+
+- `pkg/test/ginkgo/chained_scheduler.go` - Chained bucket scheduler
+- `pkg/test/ginkgo/queue.go` - Test queue and execution logic
+- `pkg/test/ginkgo/cmd_runsuite.go` - Bucket definition and suite execution
+- `test/extended/**/*.go` - Individual test files with Size labels

--- a/pkg/test/ginkgo/chained_scheduler.go
+++ b/pkg/test/ginkgo/chained_scheduler.go
@@ -1,0 +1,356 @@
+package ginkgo
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// TestBucket represents a group of tests with a specific max parallelism level
+type TestBucket struct {
+	Name           string
+	Tests          []*testCase
+	MaxParallelism int
+}
+
+// chainedBucketScheduler manages multiple test buckets with progressive chaining.
+// It activates buckets progressively: when bucket A's active count drops below
+// bucket B's max parallelism, bucket B starts feeding tests.
+type chainedBucketScheduler struct {
+	mu                   sync.Mutex
+	cond                 *sync.Cond
+	buckets              []TestBucket
+	testQueues           [][]*testCase        // one queue per bucket
+	testToBucket         map[*testCase]int    // maps test to bucket index
+	activeTestCounts     map[int]int          // bucket index -> active test count
+	runningConflicts     map[string]sets.Set[string] // tracks conflicts per group
+	activeTaints         map[string]int       // tracks active taints
+	currentBucketIdx     int                  // primary active bucket
+	monitorEventRecorder monitorapi.Recorder
+	intervalIDs          map[int]int       // bucket index -> interval ID
+	startTimes           map[int]time.Time // bucket index -> start time
+}
+
+// newChainedBucketScheduler creates a scheduler that chains multiple test buckets
+func newChainedBucketScheduler(buckets []TestBucket, monitorEventRecorder monitorapi.Recorder) *chainedBucketScheduler {
+	testQueues := make([][]*testCase, len(buckets))
+	testToBucket := make(map[*testCase]int)
+
+	for i, bucket := range buckets {
+		testQueues[i] = make([]*testCase, len(bucket.Tests))
+		copy(testQueues[i], bucket.Tests)
+		for _, test := range bucket.Tests {
+			testToBucket[test] = i
+		}
+	}
+
+	cbs := &chainedBucketScheduler{
+		buckets:              buckets,
+		testQueues:           testQueues,
+		testToBucket:         testToBucket,
+		currentBucketIdx:     0,
+		activeTestCounts:     make(map[int]int),
+		runningConflicts:     make(map[string]sets.Set[string]),
+		activeTaints:         make(map[string]int),
+		monitorEventRecorder: monitorEventRecorder,
+		intervalIDs:          make(map[int]int),
+		startTimes:           make(map[int]time.Time),
+	}
+	cbs.cond = sync.NewCond(&cbs.mu)
+
+	// Start the first bucket
+	if len(buckets) > 0 {
+		cbs.startBucket(0)
+	}
+
+	return cbs
+}
+
+// startBucket activates a bucket by starting its monitoring interval
+func (cbs *chainedBucketScheduler) startBucket(idx int) {
+	if idx >= len(cbs.buckets) {
+		return
+	}
+
+	bucket := cbs.buckets[idx]
+	intervalID, startTime := recordTestBucketInterval(cbs.monitorEventRecorder, bucket.Name)
+	cbs.intervalIDs[idx] = intervalID
+	cbs.startTimes[idx] = startTime
+	logrus.Infof("Started bucket %s (index %d) with max parallelism %d", bucket.Name, idx, bucket.MaxParallelism)
+}
+
+// endBucket finishes a bucket's monitoring interval
+func (cbs *chainedBucketScheduler) endBucket(idx int) {
+	if intervalID, ok := cbs.intervalIDs[idx]; ok {
+		cbs.monitorEventRecorder.EndInterval(intervalID, time.Now())
+		if startTime, ok := cbs.startTimes[idx]; ok {
+			logrus.Infof("Completed %s bucket in %v", cbs.buckets[idx].Name, time.Since(startTime))
+		}
+		delete(cbs.intervalIDs, idx)
+		delete(cbs.startTimes, idx)
+	}
+}
+
+// shouldActivateNextBucket determines if we should start pulling from the next bucket
+func (cbs *chainedBucketScheduler) shouldActivateNextBucket() bool {
+	if cbs.currentBucketIdx >= len(cbs.buckets)-1 {
+		return false
+	}
+
+	currentActive := cbs.activeTestCounts[cbs.currentBucketIdx]
+	nextBucket := cbs.buckets[cbs.currentBucketIdx+1]
+
+	return currentActive < nextBucket.MaxParallelism
+}
+
+// canTolerateTaints checks if a test can tolerate all currently active taints
+func (cbs *chainedBucketScheduler) canTolerateTaints(test *testCase) bool {
+	if test.spec == nil {
+		return len(cbs.activeTaints) == 0
+	}
+
+	for taint, count := range cbs.activeTaints {
+		if count <= 0 {
+			continue
+		}
+
+		tolerated := false
+		for _, toleration := range test.spec.Resources.Isolation.Toleration {
+			if toleration == taint {
+				tolerated = true
+				break
+			}
+		}
+		if !tolerated {
+			return false
+		}
+	}
+	return true
+}
+
+// findRunnableTest scans a bucket's queue for a runnable test
+func (cbs *chainedBucketScheduler) findRunnableTest(bucketIdx int) *testCase {
+	queue := cbs.testQueues[bucketIdx]
+
+	for i, test := range queue {
+		conflictGroup := getTestConflictGroup(test)
+
+		if cbs.runningConflicts[conflictGroup] == nil {
+			cbs.runningConflicts[conflictGroup] = sets.New[string]()
+		}
+
+		// Check conflicts
+		hasConflict := false
+		if test.spec != nil {
+			for _, conflict := range test.spec.Resources.Isolation.Conflict {
+				if cbs.runningConflicts[conflictGroup].Has(conflict) {
+					hasConflict = true
+					break
+				}
+			}
+		}
+
+		// Check taints
+		canTolerate := cbs.canTolerateTaints(test)
+
+		if !hasConflict && canTolerate {
+			// Found a runnable test - mark it as running
+			if test.spec != nil {
+				for _, conflict := range test.spec.Resources.Isolation.Conflict {
+					cbs.runningConflicts[conflictGroup].Insert(conflict)
+				}
+				for _, taint := range test.spec.Resources.Isolation.Taint {
+					cbs.activeTaints[taint]++
+				}
+			}
+
+			// Remove from queue
+			cbs.testQueues[bucketIdx] = append(queue[:i], queue[i+1:]...)
+			return test
+		}
+	}
+
+	return nil
+}
+
+// GetNextTestToRun implements TestScheduler interface
+func (cbs *chainedBucketScheduler) GetNextTestToRun(ctx context.Context) *testCase {
+	cbs.mu.Lock()
+	defer cbs.mu.Unlock()
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		// Calculate global max parallelism - it's the minimum of all active buckets' max parallelism
+		globalMaxParallelism := cbs.buckets[cbs.currentBucketIdx].MaxParallelism
+		for i := cbs.currentBucketIdx + 1; i < len(cbs.buckets); i++ {
+			if _, started := cbs.startTimes[i]; started {
+				// This bucket is active, so global limit is constrained by it
+				if cbs.buckets[i].MaxParallelism < globalMaxParallelism {
+					globalMaxParallelism = cbs.buckets[i].MaxParallelism
+				}
+			}
+		}
+
+		// Calculate total active tests across all buckets
+		totalActive := 0
+		for _, count := range cbs.activeTestCounts {
+			totalActive += count
+		}
+
+		// If we've hit the global parallelism cap, wait for tests to complete
+		if totalActive >= globalMaxParallelism {
+			// Check if all buckets are done first
+			allDone := cbs.currentBucketIdx >= len(cbs.buckets)
+			if !allDone {
+				hasActiveTests := false
+				hasRemainingTests := false
+				for i := cbs.currentBucketIdx; i < len(cbs.buckets); i++ {
+					if cbs.activeTestCounts[i] > 0 {
+						hasActiveTests = true
+					}
+					if len(cbs.testQueues[i]) > 0 {
+						hasRemainingTests = true
+					}
+				}
+				if !hasActiveTests && !hasRemainingTests {
+					allDone = true
+				}
+			}
+
+			if allDone {
+				return nil
+			}
+
+			// Wait for a test to complete to free up a slot
+			cbs.cond.Wait()
+			continue
+		}
+
+		// Try to get a test from any active bucket
+		for bucketIdx := cbs.currentBucketIdx; bucketIdx < len(cbs.buckets); bucketIdx++ {
+			// Only consider buckets that:
+			// 1. Have tests remaining
+			// 2. Haven't exceeded their individual max parallelism
+			if len(cbs.testQueues[bucketIdx]) == 0 {
+				continue
+			}
+
+			bucket := cbs.buckets[bucketIdx]
+			if cbs.activeTestCounts[bucketIdx] >= bucket.MaxParallelism {
+				continue
+			}
+
+			// Try to find a runnable test in this bucket
+			test := cbs.findRunnableTest(bucketIdx)
+			if test != nil {
+				cbs.activeTestCounts[bucketIdx]++
+
+				// Check if we should activate the next bucket
+				if bucketIdx == cbs.currentBucketIdx && cbs.shouldActivateNextBucket() {
+					nextIdx := cbs.currentBucketIdx + 1
+					if _, started := cbs.startTimes[nextIdx]; !started {
+						cbs.startBucket(nextIdx)
+					}
+				}
+
+				return test
+			}
+		}
+
+		// Check if current bucket is exhausted and has no active tests
+		if cbs.currentBucketIdx < len(cbs.buckets) {
+			if len(cbs.testQueues[cbs.currentBucketIdx]) == 0 && cbs.activeTestCounts[cbs.currentBucketIdx] == 0 {
+				cbs.endBucket(cbs.currentBucketIdx)
+				delete(cbs.activeTestCounts, cbs.currentBucketIdx)
+				cbs.currentBucketIdx++
+
+				// Start the new current bucket
+				if cbs.currentBucketIdx < len(cbs.buckets) {
+					cbs.startBucket(cbs.currentBucketIdx)
+					continue // Try again with new bucket
+				}
+			}
+		}
+
+		// Check if all buckets are done
+		allDone := cbs.currentBucketIdx >= len(cbs.buckets)
+		if !allDone {
+			// Check if we have any active tests or remaining tests
+			hasActiveTests := false
+			hasRemainingTests := false
+			for i := cbs.currentBucketIdx; i < len(cbs.buckets); i++ {
+				if cbs.activeTestCounts[i] > 0 {
+					hasActiveTests = true
+				}
+				if len(cbs.testQueues[i]) > 0 {
+					hasRemainingTests = true
+				}
+			}
+			if !hasActiveTests && !hasRemainingTests {
+				allDone = true
+			}
+		}
+
+		if allDone {
+			return nil
+		}
+
+		// Wait for a test to complete
+		cbs.cond.Wait()
+	}
+}
+
+// MarkTestComplete implements TestScheduler interface
+func (cbs *chainedBucketScheduler) MarkTestComplete(test *testCase) {
+	cbs.mu.Lock()
+	defer cbs.mu.Unlock()
+
+	// Find which bucket this test belongs to
+	bucketIdx, ok := cbs.testToBucket[test]
+	if !ok {
+		cbs.cond.Broadcast()
+		return
+	}
+
+	// Clean up conflicts and taints
+	if test.spec != nil {
+		conflictGroup := getTestConflictGroup(test)
+		if groupConflicts, exists := cbs.runningConflicts[conflictGroup]; exists {
+			for _, conflict := range test.spec.Resources.Isolation.Conflict {
+				groupConflicts.Delete(conflict)
+			}
+		}
+
+		for _, taint := range test.spec.Resources.Isolation.Taint {
+			cbs.activeTaints[taint]--
+			if cbs.activeTaints[taint] <= 0 {
+				delete(cbs.activeTaints, taint)
+			}
+		}
+	}
+
+	// Decrement active count
+	if cbs.activeTestCounts[bucketIdx] > 0 {
+		cbs.activeTestCounts[bucketIdx]--
+
+		// Check if we should activate the next bucket
+		if bucketIdx == cbs.currentBucketIdx && cbs.shouldActivateNextBucket() {
+			nextIdx := cbs.currentBucketIdx + 1
+			if nextIdx < len(cbs.buckets) {
+				if _, started := cbs.startTimes[nextIdx]; !started {
+					cbs.startBucket(nextIdx)
+				}
+			}
+		}
+	}
+
+	// Signal waiting workers
+	cbs.cond.Broadcast()
+}

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -1104,6 +1104,7 @@ func recordTestBucketInterval(monitorEventRecorder monitorapi.Recorder, bucketNa
 	startTime := time.Now()
 	interval := monitorapi.NewInterval(monitorapi.SourceTestBucket, monitorapi.Info).
 		Locator(monitorapi.NewLocator().TestBucket(bucketName)).
+		Display().
 		Message(monitorapi.NewMessage().
 			HumanMessage(fmt.Sprintf("Executing test bucket: %s", bucketName))).
 		Build(startTime, time.Time{})

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -535,6 +535,15 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 			{Name: "MustGatherTests", Tests: mustGatherTestsCopy, MaxParallelism: parallelism},
 		}
 
+		// Log bucket sizes for debugging
+		logrus.Infof("Test bucket distribution:")
+		totalTests := 0
+		for _, bucket := range buckets {
+			logrus.Infof("  %s: %d tests (max parallelism: %d)", bucket.Name, len(bucket.Tests), bucket.MaxParallelism)
+			totalTests += len(bucket.Tests)
+		}
+		logrus.Infof("  Total: %d tests", totalTests)
+
 		// Execute all buckets with chaining
 		completedTests := q.ExecuteChained(testCtx, buckets, parallelism, testOutputConfig, abortFn, monitorEventRecorder)
 		tests = append(tests, completedTests...)

--- a/pkg/test/ginkgo/queue.go
+++ b/pkg/test/ginkgo/queue.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 

--- a/pkg/test/ginkgo/queue.go
+++ b/pkg/test/ginkgo/queue.go
@@ -263,6 +263,90 @@ func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase
 	execute(ctx, testSuiteRunner, tests, parallelism)
 }
 
+// ExecuteChained runs multiple test buckets with chained execution to avoid long-tail problems.
+// When the active test count from the current bucket drops below the next bucket's max parallelism,
+// it starts pulling tests from the next bucket. This keeps parallelism high throughout the run.
+func (q *parallelByFileTestQueue) ExecuteChained(ctx context.Context, buckets []TestBucket, maxParallelism int, testOutput testOutputConfig, maybeAbortOnFailureFn testAbortFunc, monitorEventRecorder interface{}) []*testCase {
+	// Count total tests for progress tracking
+	totalTests := 0
+	for _, bucket := range buckets {
+		totalTests += len(bucket.Tests)
+	}
+
+	testSuiteProgress := newTestSuiteProgress(totalTests)
+	testSuiteRunner := &testSuiteRunnerImpl{
+		commandContext:        q.commandContext,
+		testOutput:            testOutput,
+		testSuiteProgress:     testSuiteProgress,
+		maybeAbortOnFailureFn: maybeAbortOnFailureFn,
+	}
+
+	return executeChained(ctx, testSuiteRunner, buckets, maxParallelism, monitorEventRecorder)
+}
+
+// executeChained is the core implementation for chained bucket execution
+func executeChained(ctx context.Context, testSuiteRunner testSuiteRunner, buckets []TestBucket, maxParallelism int, monitorEventRecorder interface{}) []*testCase {
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	// Separate serial tests from all buckets
+	var allTests []*testCase
+	var parallelBuckets []TestBucket
+
+	for _, bucket := range buckets {
+		serial, parallel := splitTests(bucket.Tests, isSerialTest)
+
+		// Add serial tests to be run at the end
+		allTests = append(allTests, serial...)
+
+		// Keep parallel tests in buckets
+		if len(parallel) > 0 {
+			parallelBuckets = append(parallelBuckets, TestBucket{
+				Name:           bucket.Name,
+				Tests:          parallel,
+				MaxParallelism: bucket.MaxParallelism,
+			})
+		}
+	}
+
+	if len(parallelBuckets) > 0 {
+		// Create chained bucket scheduler
+		recorder, _ := monitorEventRecorder.(monitorapi.Recorder)
+		scheduler := newChainedBucketScheduler(parallelBuckets, recorder)
+
+		var wg sync.WaitGroup
+
+		// Launch workers up to max parallelism
+		// They'll pull from whichever buckets are active
+		for i := 0; i < maxParallelism; i++ {
+			wg.Add(1)
+			go func(ctx context.Context) {
+				defer wg.Done()
+				runTestsUntilDone(ctx, scheduler, testSuiteRunner)
+			}(ctx)
+		}
+
+		wg.Wait()
+
+		// Collect all tests from buckets for return value
+		for _, bucket := range parallelBuckets {
+			allTests = append(allTests, bucket.Tests...)
+		}
+	}
+
+	// Run serial tests sequentially at the end
+	serialTests, _ := splitTests(allTests, isSerialTest)
+	for _, test := range serialTests {
+		if ctx.Err() != nil {
+			return allTests
+		}
+		testSuiteRunner.RunOneTest(ctx, test)
+	}
+
+	return allTests
+}
+
 // execute is a convenience for unit testing
 func execute(ctx context.Context, testSuiteRunner testSuiteRunner, tests []*testCase, parallelism int) {
 	if ctx.Err() != nil {

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -137,7 +137,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 	f := framework.NewDefaultFramework("cluster-upgrade")
 	f.SkipNamespaceCreation = true
 
-	g.It("Cluster should be upgradeable before beginning upgrade [Early][Suite:upgrade]", func() {
+	g.It("Cluster should be upgradeable before beginning upgrade [Early][Suite:upgrade]", g.Label("Size:S"), func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		client := configv1client.NewForConfigOrDie(config)
@@ -145,7 +145,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 		framework.ExpectNoError(err)
 	})
 
-	g.It("All nodes should be in ready state [Early][Suite:upgrade]", func() {
+	g.It("All nodes should be in ready state [Early][Suite:upgrade]", g.Label("Size:S"), func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		client := kubernetes.NewForConfigOrDie(config)
@@ -169,7 +169,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 		}
 	})
 
-	g.It("Cluster should remain functional during upgrade [Disruptive]", func() {
+	g.It("Cluster should remain functional during upgrade [Disruptive]", g.Label("Size:L"), func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		client := configv1client.NewForConfigOrDie(config)
@@ -197,7 +197,7 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 		)
 	})
 
-	g.It("Cluster should be upgradeable after finishing upgrade [Late][Suite:upgrade]", func() {
+	g.It("Cluster should be upgradeable after finishing upgrade [Late][Suite:upgrade]", g.Label("Size:S"), func() {
 		config, err := framework.LoadConfig()
 		framework.ExpectNoError(err)
 		client := configv1client.NewForConfigOrDie(config)

--- a/test/extended/adminack/adminack.go
+++ b/test/extended/adminack/adminack.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 	oc := exutil.NewCLI("cli-deployment")
 
 	g.Describe("TestAdminAck", func() {
-		g.It("should succeed [apigroup:config.openshift.io]", func() {
+		g.It("should succeed [apigroup:config.openshift.io]", g.Label("Size:M"), func() {
 			config, err := framework.LoadConfig()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			ctx := context.Background()

--- a/test/extended/apiserver/access.go
+++ b/test/extended/apiserver/access.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] kube-api
 		"api-int":         "api-int",
 		"api-ext":         "api-ext",
 	} {
-		g.It(fmt.Sprintf("%s endpoint", description), func() {
+		g.It(fmt.Sprintf("%s endpoint", description), g.Label("Size:M"), func() {
 			// skip on microshift
 			isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/api_requests.go
+++ b/test/extended/apiserver/api_requests.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-arch][Late]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("api-requests")
 
-	g.It("clients should not use APIs that are removed in upcoming releases [apigroup:apiserver.openshift.io]", func() {
+	g.It("clients should not use APIs that are removed in upcoming releases [apigroup:apiserver.openshift.io]", g.Label("Size:S"), func() {
 		ctx := context.Background()
 		adminConfig := oc.AdminConfig()
 

--- a/test/extended/apiserver/apply.go
+++ b/test/extended/apiserver/apply.go
@@ -66,7 +66,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ServerSideApply] Server-Side App
 			continue
 		}
 
-		g.It(fmt.Sprintf("should work for %s [apigroup:%s]", gvr, gvr.Group), func() {
+		g.It(fmt.Sprintf("should work for %s [apigroup:%s]", gvr, gvr.Group), g.Label("Size:M"), func() {
 			// create the testing namespace
 			testNamespace := oc.SetupProject()
 

--- a/test/extended/apiserver/config_admission_test.go
+++ b/test/extended/apiserver/config_admission_test.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 
 	oc := exutil.NewCLI("apiserver")
 
-	g.It("validates APIServer in config.openshift.io/v1", func() {
+	g.It("validates APIServer in config.openshift.io/v1", g.Label("Size:S"), func() {
 		client, err := dynamic.NewForConfig(oc.AdminConfig())
 		if err != nil {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))

--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 	// This test checks whether the apiserver reports any events that may indicate a problem at any time,
 	// not just when the suite is running. We already have invariant tests that fail if these are violated
 	// during suite execution, but we want to know if there are fingerprints of these failures outside of tests.
-	g.It("kubelet terminates kube-apiserver gracefully", func() {
+	g.It("kubelet terminates kube-apiserver gracefully", g.Label("Size:S"), func() {
 		client, err := kubernetes.NewForConfig(oc.AdminConfig())
 		if err != nil {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 	// This test extends the previous test by checking the content of the termination files for kube-apiservers.
 	// It should catch cases where the event is not persisted in the database. It should also catch
 	// cases where the KAS is immediately restarted or shut down after an ungraceful termination.
-	g.It("kubelet terminates kube-apiserver gracefully extended", func() {
+	g.It("kubelet terminates kube-apiserver gracefully extended", g.Label("Size:M"), func() {
 		var finalMessageBuilder strings.Builder
 		terminationRegexp := regexp.MustCompile(`Previous pod .* did not terminate gracefully`)
 
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 	// This test checks whether the apiserver reports any events that may indicate a problem at any time,
 	// not just when the suite is running. We already have invariant tests that fail if these are violated
 	// during suite execution, but we want to know if there are fingerprints of these failures outside of tests.
-	g.It("kube-apiserver terminates within graceful termination period", func() {
+	g.It("kube-apiserver terminates within graceful termination period", g.Label("Size:S"), func() {
 		client, err := kubernetes.NewForConfig(oc.AdminConfig())
 		if err != nil {
 			g.Fail(fmt.Sprintf("Unexpected error: %v", err))
@@ -121,7 +121,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 		}
 	})
 
-	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests", func() {
+	g.It("API LBs follow /readyz of kube-apiserver and stop sending requests", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		client, err := kubernetes.NewForConfig(oc.AdminConfig())
@@ -147,7 +147,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 		}
 	})
 
-	g.It("API LBs follow /readyz of kube-apiserver and don't send request early", func() {
+	g.It("API LBs follow /readyz of kube-apiserver and don't send request early", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		client, err := kubernetes.NewForConfig(oc.AdminConfig())

--- a/test/extended/apiserver/health_endpoints.go
+++ b/test/extended/apiserver/health_endpoints.go
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] API health endpoints", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("api-health-endpoints").AsAdmin()
 
-	ginkgo.It("should contain the required checks for the openshift-apiserver APIs", func() {
+	ginkgo.It("should contain the required checks for the openshift-apiserver APIs", ginkgo.Label("Size:S"), func() {
 		ctx := context.Background()
 		supported, msg := isSupportedPlatform(ctx, "openshift-apiserver", oc)
 		if !supported {
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] API health endpoints", func() {
 		return
 	})
 
-	ginkgo.It("should contain the required checks for the oauth-apiserver APIs", func() {
+	ginkgo.It("should contain the required checks for the oauth-apiserver APIs", ginkgo.Label("Size:S"), func() {
 		ctx := context.Background()
 		supported, msg := isSupportedPlatform(ctx, "oauth-apiserver", oc)
 		if !supported {

--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -36,13 +36,13 @@ var _ = g.Describe("[Conformance][sig-api-machinery][Feature:APIServer] local ku
 	oc := exutil.NewCLIWithPodSecurityLevel("apiserver", admissionapi.LevelPrivileged)
 
 	for kubeconfig := range kcLocations {
-		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), func() {
+		g.It(fmt.Sprintf("%q should be present on all masters and work", kubeconfig), g.Label("Size:M"), func() {
 			testKubeConfig(oc, kubeconfig, testNode)
 		})
 	}
 
 	for kubeconfig := range kubeApiserverLocations {
-		g.It(fmt.Sprintf("%q should be present in all kube-apiserver containers", kubeconfig), func() {
+		g.It(fmt.Sprintf("%q should be present in all kube-apiserver containers", kubeconfig), g.Label("Size:M"), func() {
 			// skip on microshift
 			isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/openapiv3.go
+++ b/test/extended/apiserver/openapiv3.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("apiserver-openapi")
 
-	g.It("should serve openapi v3 discovery", func() {
+	g.It("should serve openapi v3 discovery", g.Label("Size:S"), func() {
 		transport, err := rest.TransportFor(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 		}
 	})
 
-	g.It("should serve openapi v3", func() {
+	g.It("should serve openapi v3", g.Label("Size:M"), func() {
 		transport, err := rest.TransportFor(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/apiserver/patch.go
+++ b/test/extended/apiserver/patch.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-api-machinery] JSON Patch [apigroup:operator.openshift.
 		}
 	})
 
-	g.It("should delete an entry from an array with a test precondition provided", func() {
+	g.It("should delete an entry from an array with a test precondition provided", g.Label("Size:S"), func() {
 		g.By("Creating KubeAPIServerOperator CR for the test")
 		resourceClient := createResourceClient(oc.AdminConfig(), gvr)
 		kasOperator := createWellKnownKubeAPIServerOperatorResource(ctx, resourceClient)
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-api-machinery] JSON Patch [apigroup:operator.openshift.
 			{NodeName: "master-1"},
 		}))
 	})
-	g.It("should delete multiple entries from an array when multiple test precondition provided", func() {
+	g.It("should delete multiple entries from an array when multiple test precondition provided", g.Label("Size:S"), func() {
 		g.By("Creating KubeAPIServerOperator CR for the test")
 		resourceClient := createResourceClient(oc.AdminConfig(), gvr)
 		kasOperator := createWellKnownKubeAPIServerOperatorResource(ctx, resourceClient)
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-api-machinery] JSON Patch [apigroup:operator.openshift.
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(kasOperator.Status.NodeStatuses).To(o.HaveLen(0))
 	})
-	g.It("should error when the test precondition provided doesn't match", func() {
+	g.It("should error when the test precondition provided doesn't match", g.Label("Size:S"), func() {
 		g.By("Creating KubeAPIServerOperator CR for the test")
 		resourceClient := createResourceClient(oc.AdminConfig(), gvr)
 		kasOperator := createWellKnownKubeAPIServerOperatorResource(ctx, resourceClient)
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-api-machinery] JSON Patch [apigroup:operator.openshift.
 		o.Expect(k8serrors.IsInvalid(err)).To(o.BeTrue(), fmt.Sprintf("unexpected error received = %v", err))
 	})
 
-	g.It("should delete an entry from an array with multiple field owners", func() {
+	g.It("should delete an entry from an array with multiple field owners", g.Label("Size:S"), func() {
 		g.By("Creating KubeAPIServerOperator CR for the test")
 		resourceClient := createResourceClient(oc.AdminConfig(), gvr)
 		kasOperator := createWellKnownKubeAPIServerOperatorResource(ctx, resourceClient)

--- a/test/extended/apiserver/resiliency.go
+++ b/test/extended/apiserver/resiliency.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("[Conformance][sig-sno][Serial] Cluster", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("cluster-resiliency")
 
-	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", func() {
+	ginkgo.It("should allow a fast rollout of kube-apiserver with no pods restarts during API disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", ginkgo.Label("Size:L"), func() {
 		ctx := context.Background()
 
 		controlPlaneTopology, _ := single_node.GetTopologies(f)

--- a/test/extended/apiserver/rollout.go
+++ b/test/extended/apiserver/rollout.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe("[Conformance][Suite:openshift/kube-apiserver/rollout][J
 
 	oc := exutil.NewCLIWithoutNamespace("rollout-resiliency")
 
-	ginkgo.It("should roll out new revisions without disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", func() {
+	ginkgo.It("should roll out new revisions without disruption [apigroup:config.openshift.io][apigroup:operator.openshift.io]", ginkgo.Label("Size:L"), func() {
 		ctx := context.Background()
 
 		// separate context so we exit our loop, but it is still possible to use the main context for client calls

--- a/test/extended/apiserver/root_403.go
+++ b/test/extended/apiserver/root_403.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("apiserver")
 
-	g.It("anonymous browsers should get a 403 from /", func() {
+	g.It("anonymous browsers should get a 403 from /", g.Label("Size:S"), func() {
 		transport, err := anonymousHttpTransport(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 		o.Expect(resp.StatusCode).Should(o.Equal(http.StatusForbidden))
 	})
 
-	g.It("authenticated browser should get a 200 from /", func() {
+	g.It("authenticated browser should get a 200 from /", g.Label("Size:S"), func() {
 		transport, err := rest.TransportFor(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/apiserver/security_context.go
+++ b/test/extended/apiserver/security_context.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-auth][Feature:ControlPlaneSecurity]", func() {
 	// Related issues:
 	// OCP-32383: Control plane security context verification
 	//bug 1793694: Init container security context
-	g.It("should have privileged securityContext for control plane init and main containers", func() {
+	g.It("should have privileged securityContext for control plane init and main containers", g.Label("Size:S"), func() {
 		// Skip on MicroShift clusters
 		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/apiserver/tls.go
+++ b/test/extended/apiserver/tls.go
@@ -14,7 +14,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 
 	oc := exutil.NewCLI("apiserver")
 
-	g.It("TestTLSDefaults", func() {
+	g.It("TestTLSDefaults", g.Label("Size:S"), func() {
 		g.Skip("skipping because it was broken in master")
 
 		t := g.GinkgoT()

--- a/test/extended/authentication/front_proxy.go
+++ b/test/extended/authentication/front_proxy.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-auth][Feature:Authentication] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestFrontProxy", func() {
-		g.It(fmt.Sprintf("should succeed"), func() {
+		g.It(fmt.Sprintf("should succeed"), g.Label("Size:S"), func() {
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -121,7 +121,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 		})
 
 		g.Describe("external IdP is configured", g.Ordered, func() {
-			g.It("should configure kube-apiserver", func() {
+			g.It("should configure kube-apiserver", g.Label("Size:L"), func() {
 				kas, err := oc.AdminOperatorClient().OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting the kubeapiservers.operator.openshift.io/cluster")
 
@@ -140,7 +140,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				o.Expect(apiServerArgs["authentication-config"].([]interface{})[0].(string)).To(o.Equal("/etc/kubernetes/static-pod-resources/configmaps/auth-config/auth-config.json"))
 			})
 
-			g.It("should remove the OpenShift OAuth stack", func() {
+			g.It("should remove the OpenShift OAuth stack", g.Label("Size:L"), func() {
 				o.Eventually(func(gomega o.Gomega) {
 					_, err := oc.AdminKubeClient().AppsV1().Deployments("openshift-authentication").Get(ctx, "oauth-openshift", metav1.GetOptions{})
 					gomega.Expect(err).NotTo(o.BeNil(), "should not be able to get the integrated oauth stack")
@@ -148,7 +148,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 			})
 
-			g.It("should not accept tokens provided by the OAuth server", func() {
+			g.It("should not accept tokens provided by the OAuth server", g.Label("Size:L"), func() {
 				o.Eventually(func(gomega o.Gomega) {
 					clientset, err := kubernetes.NewForConfig(oauthUserConfig)
 					gomega.Expect(err).NotTo(o.HaveOccurred())
@@ -163,12 +163,12 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 			})
 
-			g.It("should accept authentication via a certificate-based kubeconfig (break-glass)", func() {
+			g.It("should accept authentication via a certificate-based kubeconfig (break-glass)", g.Label("Size:L"), func() {
 				_, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).List(ctx, metav1.ListOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred(), "should be able to list pods using certificate-based authentication")
 			})
 
-			g.It("should map cluster identities correctly", func() {
+			g.It("should map cluster identities correctly", g.Label("Size:L"), func() {
 				// should always be able to create an SSR for yourself
 				o.Eventually(func(gomega o.Gomega) {
 					err := keycloakCli.Authenticate("admin-cli", username, password)
@@ -217,7 +217,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				}
 			})
 
-			g.It("should rollout configuration on the kube-apiserver successfully", func() {
+			g.It("should rollout configuration on the kube-apiserver successfully", g.Label("Size:L"), func() {
 				kas, err := oc.AdminOperatorClient().OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting the kubeapiservers.operator.openshift.io/cluster")
 
@@ -235,14 +235,14 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				o.Expect(apiServerArgs["authentication-config"]).To(o.BeNil(), "authentication-config argument should not be specified when OIDC authentication is not configured")
 			})
 
-			g.It("should rollout the OpenShift OAuth stack", func() {
+			g.It("should rollout the OpenShift OAuth stack", g.Label("Size:L"), func() {
 				o.Eventually(func(gomega o.Gomega) {
 					_, err := oc.AdminKubeClient().AppsV1().Deployments("openshift-authentication").Get(ctx, "oauth-openshift", metav1.GetOptions{})
 					gomega.Expect(err).Should(o.BeNil(), "should be able to get the integrated oauth stack")
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 			})
 
-			g.It("should not accept tokens provided by an external IdP", func() {
+			g.It("should not accept tokens provided by an external IdP", g.Label("Size:L"), func() {
 				o.Eventually(func(gomega o.Gomega) {
 					// always re-authenticate to get a new token
 					err := keycloakCli.Authenticate("admin-cli", username, password)
@@ -261,7 +261,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 			})
 
-			g.It("should accept tokens provided by the OpenShift OAuth server", func() {
+			g.It("should accept tokens provided by the OpenShift OAuth server", g.Label("Size:L"), func() {
 				o.Eventually(func(gomega o.Gomega) {
 					clientset, err := kubernetes.NewForConfig(oauthUserConfig)
 					gomega.Expect(err).NotTo(o.HaveOccurred())
@@ -288,7 +288,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 					waitForHealthyOIDCClients(ctx, oc)
 				})
 
-				g.It("should default UID to the 'sub' claim in the access token from the IdP", func() {
+				g.It("should default UID to the 'sub' claim in the access token from the IdP", g.Label("Size:L"), func() {
 					// should always be able to create an SSR for yourself
 					o.Eventually(func(gomega o.Gomega) {
 						err := keycloakCli.Authenticate("admin-cli", username, password)
@@ -346,11 +346,11 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 						}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 					})
 
-					g.It("should map UID correctly", func() {
+					g.It("should map UID correctly", g.Label("Size:L"), func() {
 						o.Expect(ssr.UID).NotTo(o.Equal(strings.ToUpper(username)))
 					})
 
-					g.It("should map Extra correctly", func() {
+					g.It("should map Extra correctly", g.Label("Size:L"), func() {
 						o.Expect(ssr.Status.UserInfo.Extra).To(o.HaveKey("payload/test"))
 						o.Expect(ssr.Status.UserInfo.Extra["payload/test"]).To(o.HaveLen(1))
 						o.Expect(ssr.Status.UserInfo.Extra["payload/test"][0]).To(o.Equal(fmt.Sprintf("%s@payload.openshift.ioextra", username)))
@@ -359,7 +359,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 			})
 
 			g.Describe("with invalid specified UID or Extra claim mappings", func() {
-				g.It("should reject admission when UID claim expression is not compilable CEL", func() {
+				g.It("should reject admission when UID claim expression is not compilable CEL", g.Label("Size:L"), func() {
 					_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(o *configv1.OIDCProvider) {
 						o.ClaimMappings.UID = &configv1.TokenClaimOrExpressionMapping{
 							Expression: "!@&*#^",
@@ -368,7 +368,7 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 					o.Expect(err).To(o.HaveOccurred(), "should encounter an error configuring OIDC authentication")
 				})
 
-				g.It("should reject admission when Extra claim expression is not compilable CEL", func() {
+				g.It("should reject admission when Extra claim expression is not compilable CEL", g.Label("Size:L"), func() {
 					_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(o *configv1.OIDCProvider) {
 						o.ClaimMappings.Extra = []configv1.ExtraMapping{
 							{

--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestClusterReaderCoverage", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed"), g.Label("Size:S"), func() {
 				g.Skip("this test was in integration and didn't cover a real configuration, so it's horribly, horribly wrong now")
 
 				t := g.GinkgoT()
@@ -400,7 +400,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization][Serial] authoriza
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationResourceAccessReview", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				clusterAdminAuthorizationClient := oc.AdminAuthorizationClient().AuthorizationV1()
 
 				hammerProjectName := createProject(oc, "hammer")
@@ -512,7 +512,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationSubjectAccessReview", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:M"), func() {
 				t := g.GinkgoT()
 
 				clusterAdminLocalSARGetter := oc.AdminKubeClient().AuthorizationV1()
@@ -1042,7 +1042,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestAuthorizationSubjectAccessReviewAPIGroup", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				t := g.GinkgoT()
 
 				clusterAdminKubeClient := oc.AdminKubeClient()
@@ -1178,7 +1178,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 
 	g.Context("", func() {
 		g.Describe("TestBrowserSafeAuthorizer", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io]"), g.Label("Size:S"), func() {
 				t := g.GinkgoT()
 
 				// this client has an API token so it is safe

--- a/test/extended/authorization/authorization_rbac_proxy.go
+++ b/test/extended/authorization/authorization_rbac_proxy.go
@@ -31,31 +31,31 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] RBAC proxy for op
 	oc := exutil.NewCLI("rbac-proxy")
 	g.Context("", func() {
 		g.Describe("RunLegacyLocalRoleBindingEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				RunLegacyLocalRoleBindingEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyEndpointConfirmNoEscalation [apigroup:authorization.openshift.io]", func() {
-			g.It(fmt.Sprintf("should succeed"), func() {
+			g.It(fmt.Sprintf("should succeed"), g.Label("Size:S"), func() {
 				RunLegacyEndpointConfirmNoEscalation(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Username(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyClusterRoleBindingEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				RunLegacyClusterRoleBindingEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyClusterRoleEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				RunLegacyClusterRoleEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 
 		g.Describe("RunLegacyLocalRoleEndpoint", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				RunLegacyLocalRoleEndpoint(g.GinkgoT(), oc.AdminAuthorizationClient().AuthorizationV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})

--- a/test/extended/authorization/podsecurity_admission.go
+++ b/test/extended/authorization/podsecurity_admission.go
@@ -35,7 +35,7 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity]", func() {
 
 	oc := exutil.NewCLIWithPodSecurityLevel("pod-security", psapi.LevelRestricted)
 
-	g.It("restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile", func() {
+	g.It("restricted-v2 SCC should mutate empty securityContext to match restricted PSa profile", g.Label("Size:M"), func() {
 		pod, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(context.Background(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "psa-testpod",
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 
 	oc := exutil.NewCLIWithPodSecurityLevel("pod-security-scc-mutation", psapi.LevelRestricted)
 
-	g.It("creating pod controllers", func() {
+	g.It("creating pod controllers", g.Label("Size:M"), func() {
 		ns, err := oc.AdminKubeClient().CoreV1().Namespaces().Get(context.Background(), oc.Namespace(), metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/authorization/rbac/groups_default_rules.go
+++ b/test/extended/authorization/rbac/groups_default_rules.go
@@ -177,7 +177,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] The default clust
 
 	oc := exutil.NewCLI("default-rbac-policy")
 
-	g.It("should have correct RBAC rules", func() {
+	g.It("should have correct RBAC rules", g.Label("Size:S"), func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 

--- a/test/extended/authorization/rolebinding_restrictions.go
+++ b/test/extended/authorization/rolebinding_restrictions.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 	oc := exutil.NewCLI("rolebinding-restrictions")
 	g.Context("", func() {
 		g.Describe("Create a rolebinding when there are no restrictions", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				user := "alice"
 				roleBindingCreate(oc, false, false, ns, user, "rb1")
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is permitted by RBR", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				users := []string{"bob"}
 				_, err := oc.AdminAuthorizationClient().AuthorizationV1().RoleBindingRestrictions(ns).Create(context.Background(), generateAllowUserRolebindingRestriction(ns, users), metav1.CreateOptions{})
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is already bound", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				users := []string{"cindy"}
 				ns := oc.Namespace()
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding when subject is not already bound and is not permitted by any RBR", func() {
-			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				users := []string{"dave", "eve"}
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a RBAC rolebinding when subject is not already bound and is not permitted by any RBR", func() {
-			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should fail [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				users := []string{"frank", "george"}
 				roleBindingCreate(oc, false, false, ns, users[0], "rb1")
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Create a rolebinding that also contains system:non-existing users", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				users := []string{"harry", "system:non-existing"}
 				_, err := oc.AdminAuthorizationClient().AuthorizationV1().RoleBindingRestrictions(ns).Create(context.Background(), generateAllowUserRolebindingRestriction(ns, users), metav1.CreateOptions{})
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-auth][Feature:RoleBindingRestrictions] RoleBindingRestr
 		})
 
 		g.Describe("Rolebinding restrictions tests single project", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				ns := oc.Namespace()
 				users := []string{"zed", "yvette"}
 				users2 := []string{"xavier", "system:non-existing"}

--- a/test/extended/authorization/scc.go
+++ b/test/extended/authorization/scc.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-auth][Feature:SCC][Early]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("working-scc-during-install")
 
-	g.It("should not have pod creation failures during install", func() {
+	g.It("should not have pod creation failures during install", g.Label("Size:S"), func() {
 		kubeClient := oc.AdminKubeClient()
 
 		events, err := kubeClient.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 
 	oc := exutil.NewCLIWithPodSecurityLevel("required-scc", psapi.LevelPrivileged)
 
-	g.It("required-scc annotation is being applied to workloads", func() {
+	g.It("required-scc annotation is being applied to workloads", g.Label("Size:M"), func() {
 		sccRole, err := oc.AdminKubeClient().RbacV1().ClusterRoles().Create(context.Background(),
 			&rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
@@ -164,7 +164,7 @@ var _ = g.Describe("[sig-auth][Feature:PodSecurity][Feature:SCC]", func() {
 		o.Expect(pod.Annotations[securityv1.ValidatedSCCAnnotation]).To(o.Equal("restricted-v2"))
 	})
 
-	g.It("SCC admission fails for incorrect/non-existent required-scc annotation", func() {
+	g.It("SCC admission fails for incorrect/non-existent required-scc annotation", g.Label("Size:M"), func() {
 		sccPod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "required-scc-testpod",

--- a/test/extended/authorization/scopes.go
+++ b/test/extended/authorization/scopes.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopedTokens", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:oauth.openshift.io][apigroup:build.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:oauth.openshift.io][apigroup:build.openshift.io]"), g.Label("Size:S"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -104,7 +104,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopedImpersonation", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io]"), g.Label("Size:S"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -139,7 +139,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestScopeEscalations", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:oauth.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:oauth.openshift.io]"), g.Label("Size:S"), func() {
 			t := g.GinkgoT()
 
 			projectName := oc.Namespace()
@@ -216,7 +216,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestTokensWithIllegalScopes", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:oauth.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:oauth.openshift.io]"), g.Label("Size:S"), func() {
 			t := g.GinkgoT()
 
 			clusterAdminClientConfig := oc.AdminConfig()
@@ -447,7 +447,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] scopes", func() {
 	oc := exutil.NewCLI("scopes")
 
 	g.Describe("TestUnknownScopes", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]"), g.Label("Size:S"), func() {
 			t := g.GinkgoT()
 
 			clusterAdminClientConfig := oc.AdminConfig()

--- a/test/extended/authorization/self_sar.go
+++ b/test/extended/authorization/self_sar.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatib
 
 	g.Context("", func() {
 		g.Describe("TestBootstrapPolicySelfSubjectAccessReviews", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				t := g.GinkgoT()
 
 				valerieName := oc.CreateUser("valerie-").Name
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] self-SAR compatib
 		})
 
 		g.Describe("TestSelfSubjectAccessReviewsNonExistingNamespace", func() {
-			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:authorization.openshift.io]"), g.Label("Size:S"), func() {
 				t := g.GinkgoT()
 
 				valerieName := oc.CreateUser("valerie-").Name

--- a/test/extended/baremetal/high_availability.go
+++ b/test/extended/baremetal/high_availability.go
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 		helper.DeleteAllExtraWorkers()
 	})
 
-	g.It("cluster baremetal operator and metal3 deployment return back healthy after they are deleted", func() {
+	g.It("cluster baremetal operator and metal3 deployment return back healthy after they are deleted", g.Label("Size:L"), func() {
 		c, err := e2e.LoadClientset()
 		o.Expect(err).ToNot(o.HaveOccurred())
 

--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -21,7 +21,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal/OpenStack/vSphe
 		oc = exutil.NewCLI("baremetal")
 	)
 
-	g.It("have a metal3 deployment", func() {
+	g.It("have a metal3 deployment", g.Label("Size:S"), func() {
 		dc := oc.AdminDynamicClient()
 		skipIfUnsupportedPlatformOrConfig(oc, dc)
 
@@ -48,7 +48,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 		isTNFDeployment = exutil.IsTwoNodeFencing(context.TODO(), oc.AdminConfigClient())
 	})
 
-	g.It("have baremetalhost resources", func() {
+	g.It("have baremetalhost resources", g.Label("Size:S"), func() {
 		dc := oc.AdminDynamicClient()
 		bmc := baremetalClient(dc)
 
@@ -70,7 +70,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 		}
 	})
 
-	g.It("have preprovisioning images for workers", func() {
+	g.It("have preprovisioning images for workers", g.Label("Size:S"), func() {
 		dc := oc.AdminDynamicClient()
 		bmc := baremetalClient(dc)
 		ppiClient := preprovisioningImagesClient(dc)
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 		}
 	})
 
-	g.It("have hostfirmwaresetting resources", func() {
+	g.It("have hostfirmwaresetting resources", g.Label("Size:M"), func() {
 		dc := oc.AdminDynamicClient()
 
 		bmc := baremetalClient(dc)
@@ -124,7 +124,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal] Baremetal platform should
 		}
 	})
 
-	g.It("not allow updating BootMacAddress", func() {
+	g.It("not allow updating BootMacAddress", g.Label("Size:S"), func() {
 		dc := oc.AdminDynamicClient()
 		bmc := baremetalClient(dc)
 
@@ -173,7 +173,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 		helper.DeleteAllExtraWorkers()
 	})
 
-	g.It("skip inspection when disabled by annotation", func() {
+	g.It("skip inspection when disabled by annotation", g.Label("Size:L"), func() {
 
 		// Get extra worker info
 		hostData, secretData := helper.GetExtraWorkerData(0)

--- a/test/extended/bootstrap_user/bootstrap_user_login.go
+++ b/test/extended/bootstrap_user/bootstrap_user_login.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-auth][Feature:BootstrapUser] The bootstrap user", func(
 	// as that will give each one of our test runs a new config via SetupProject
 	oc := exutil.NewCLI("bootstrap-login")
 
-	g.It("should successfully login with password decoded from kubeadmin secret [Disruptive]", func() {
+	g.It("should successfully login with password decoded from kubeadmin secret [Disruptive]", g.Label("Size:M"), func() {
 		var originalPasswordHash []byte
 		secretExists := true
 		recorder := events.NewInMemoryRecorder("", clocktesting.NewFakePassiveClock(time.Now()))

--- a/test/extended/builds/build_pruning.go
+++ b/test/extended/builds/build_pruning.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 			}
 		})
 
-		g.It("should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
+		g.It("should prune completed builds based on the successfulBuildsHistoryLimit setting [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulBuildConfig).Execute()
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune failed builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
+		g.It("should prune failed builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test failed build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune canceled builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
+		g.It("should prune canceled builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -189,7 +189,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune errored builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", func() {
+		g.It("should prune errored builds based on the failedBuildsHistoryLimit setting [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("creating test failed build config")
 			err := oc.Run("create").Args("-f", erroredBuildConfig).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -233,7 +233,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("should prune builds after a buildConfig change [apigroup:build.openshift.io]", func() {
+		g.It("should prune builds after a buildConfig change [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test failed build config")
 			err := oc.Run("create").Args("-f", failedBuildConfig).Execute()
@@ -284,7 +284,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] prune builds based on settings 
 
 		})
 
-		g.It("buildconfigs should have a default history limit set when created via the group api [apigroup:build.openshift.io]", func() {
+		g.It("buildconfigs should have a default history limit set when created via the group api [apigroup:build.openshift.io]", g.Label("Size:S"), func() {
 
 			g.By("creating a build config with the group api")
 			err := oc.Run("create").Args("-f", groupBuildConfig).Execute()

--- a/test/extended/builds/build_timing.go
+++ b/test/extended/builds/build_timing.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 			}
 		})
 
-		g.It("should record build stages and durations for s2i [apigroup:build.openshift.io]", func() {
+		g.It("should record build stages and durations for s2i [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			expectedBuildStages := make(map[string][]string)
 			expectedBuildStages["PullImages"] = []string{"", "1000s"}
 			expectedBuildStages["Build"] = []string{"10ms", "1000s"}
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][timing] capture build stages an
 			verifyStages(br.Build.Status.Stages, expectedBuildStages)
 		})
 
-		g.It("should record build stages and durations for docker [apigroup:build.openshift.io]", func() {
+		g.It("should record build stages and durations for docker [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			expectedBuildStages := make(map[string][]string)
 			expectedBuildStages["PullImages"] = []string{"", "1000s"}
 			expectedBuildStages["Build"] = []string{"10ms", "1000s"}

--- a/test/extended/builds/buildconfigsecretinjector.go
+++ b/test/extended/builds/buildconfigsecretinjector.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] buildconfig secret injector", f
 			}
 		})
 
-		g.It("should inject secrets to the appropriate buildconfigs [apigroup:build.openshift.io]", func() {
+		g.It("should inject secrets to the appropriate buildconfigs [apigroup:build.openshift.io]", g.Label("Size:S"), func() {
 			out, err := oc.Run("get").Args("bc/test1", "-o", "template", "--template", "{{.spec.source.sourceSecret.name}}").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).To(o.Equal("secret1"))

--- a/test/extended/builds/cluster_config.go
+++ b/test/extended/builds/cluster_config.go
@@ -186,7 +186,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
 			})
 
-			g.It("should default registry search to docker.io for image pulls", func() {
+			g.It("should default registry search to docker.io for image pulls", g.Label("Size:L"), func() {
 				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply default cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", defaultConfigFixture).Execute()
@@ -204,7 +204,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				o.Expect(buildLog).To(o.ContainSubstring("defaulting registry to docker.io"))
 			})
 
-			g.It("should allow registries to be blacklisted", func() {
+			g.It("should allow registries to be blacklisted", g.Label("Size:L"), func() {
 				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply blacklist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", blacklistConfigFixture).Execute()
@@ -221,7 +221,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				o.Expect(buildLog).To(o.ContainSubstring("Source image rejected"))
 			})
 
-			g.It("should allow registries to be whitelisted", func() {
+			g.It("should allow registries to be whitelisted", g.Label("Size:L"), func() {
 				g.Skip("TODO: disabled due to https://bugzilla.redhat.com/show_bug.cgi?id=1685185")
 				g.By("apply whitelist cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", whitelistConfigFixture).Execute()
@@ -251,7 +251,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("Apply default proxy configuration to source build pod through env vars [apigroup:build.openshift.io]", func() {
+			g.It("Apply default proxy configuration to source build pod through env vars [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("apply proxy cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", invalidproxyConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -276,7 +276,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				checkPodProxyEnvs(pod.Spec.InitContainers, buildConfig.Spec.BuildDefaults.DefaultProxy)
 			})
 
-			g.It("Apply default proxy configuration to docker build pod through env vars [apigroup:build.openshift.io]", func() {
+			g.It("Apply default proxy configuration to docker build pod through env vars [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("apply proxy cluster configuration")
 				err := oc.AsAdmin().Run("apply").Args("-f", invalidproxyConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -302,7 +302,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildDefaultGitHTTPProxy and TestBuildDefaultGitHTTPSProxy integration test
-			g.It("Apply git proxy configuration to build pod [apigroup:build.openshift.io]", func() {
+			g.It("Apply git proxy configuration to build pod [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("apply proxy cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -356,7 +356,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildDefaultEnvironment integration test
-			g.It("Apply env configuration to build pod", func() {
+			g.It("Apply env configuration to build pod", g.Label("Size:L"), func() {
 				g.By("apply env cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -409,7 +409,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildDefaultLabels integration test
-			g.It("Apply default image label configuration to build pod", func() {
+			g.It("Apply default image label configuration to build pod", g.Label("Size:L"), func() {
 				g.By("apply label cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -463,7 +463,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildOverrideLabels integration test
-			g.It("Apply override image label configuration to build pod [apigroup:build.openshift.io]", func() {
+			g.It("Apply override image label configuration to build pod [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("apply label cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -518,7 +518,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildDefaultNodeSelectors integration test
-			g.It("Apply node selector configuration to build pod", func() {
+			g.It("Apply node selector configuration to build pod", g.Label("Size:L"), func() {
 				g.By("apply node selector cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -552,7 +552,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 			})
 
 			// this replaces coverage from the TestBuildOverrideTolerations integration test
-			g.It("Apply toleration override configuration to build pod", func() {
+			g.It("Apply toleration override configuration to build pod", g.Label("Size:L"), func() {
 				g.By("apply toleration cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -605,7 +605,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Serial][Slow][Disruptive] alter
 				o.Expect(foundTwo).To(o.BeTrue())
 			})
 
-			g.It("Apply resource configuration to build pod", func() {
+			g.It("Apply resource configuration to build pod", g.Label("Size:L"), func() {
 				g.By("apply resource cluster configuration")
 				buildConfig, err := oc.AdminConfigClient().ConfigV1().Builds().Get(context.Background(), "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/completiondeadlineseconds.go
+++ b/test/extended/builds/completiondeadlineseconds.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should have deadli
 		})
 
 		g.Describe("oc start-build source-build --wait", func() {
-			g.It("Source: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", func() {
+			g.It("Source: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 				g.By("calling oc create source-build")
 				err := oc.Run("create").Args("-f", sourceFixture).Execute()
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should have deadli
 		})
 
 		g.Describe("oc start-build docker-build --wait", func() {
-			g.It("Docker: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", func() {
+			g.It("Docker: should start a build and wait for the build failed and build pod being killed by kubelet [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 				g.By("calling oc create docker-build")
 				err := oc.Run("create").Args("-f", dockerFixture).Execute()

--- a/test/extended/builds/contextdir.go
+++ b/test/extended/builds/contextdir.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context dir
 		})
 
 		g.Describe("s2i context directory build", func() {
-			g.It(fmt.Sprintf("should s2i build an application using a context directory [apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should s2i build an application using a context directory [apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 
 				exutil.WaitForImageStreamImport(oc)
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds with a context dir
 		})
 
 		g.Describe("docker context directory build", func() {
-			g.It(fmt.Sprintf("should docker build an application using a context directory [apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should docker build an application using a context directory [apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 				g.By("initializing local repo")
 				repo, err := exutil.NewGitRepo("contextdir")
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/controller_compat.go
+++ b/test/extended/builds/controller_compat.go
@@ -26,17 +26,17 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build controller", func()
 		})
 
 		g.Describe("RunBuildCompletePodDeleteTest", func() {
-			g.It("should succeed [apigroup:build.openshift.io]", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				RunBuildCompletePodDeleteTest(g.GinkgoT(), oc.BuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 		g.Describe("RunBuildDeleteTest", func() {
-			g.It("should succeed [apigroup:build.openshift.io]", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				RunBuildDeleteTest(g.GinkgoT(), oc.AdminBuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})
 		})
 		g.Describe("RunBuildRunningPodDeleteTest", func() {
-			g.It("should succeed [apigroup:build.openshift.io]", func() {
+			g.It("should succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.Skip("skipping until devex team figures this out in the new split API setup, see https://bugzilla.redhat.com/show_bug.cgi?id=164118")
 				RunBuildRunningPodDeleteTest(g.GinkgoT(), oc.AdminBuildClient().BuildV1(), oc.AdminKubeClient(), oc.Namespace())
 			})

--- a/test/extended/builds/custom_build.go
+++ b/test/extended/builds/custom_build.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] custom build with buildah", fun
 		})
 
 		g.Describe("being created from new-build", func() {
-			g.It("should complete build with custom builder image [apigroup:build.openshift.io]", func() {
+			g.It("should complete build with custom builder image [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("create custom builder image")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=custom-builder-image").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/digest.go
+++ b/test/extended/builds/digest.go
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] completed builds should h
 })
 
 func testBuildDigest(oc *exutil.CLI, buildFixture string, buildLogLevel uint) {
-	g.It(fmt.Sprintf("should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]"), func() {
+	g.It(fmt.Sprintf("should save the image digest when finished [apigroup:build.openshift.io][apigroup:image.openshift.io]"), g.Label("Size:L"), func() {
 		g.By("creating test build")
 		err := oc.Run("create").Args("-f", buildFixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/docker_pullsearch.go
+++ b/test/extended/builds/docker_pullsearch.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsearch] docker build where 
 		})
 
 		g.Describe("Building from a Dockerfile whose FROM image ref does not specify the image registry", func() {
-			g.It("should create a docker build that has buildah search from our predefined list of image registries and succeed [apigroup:build.openshift.io]", func() {
+			g.It("should create a docker build that has buildah search from our predefined list of image registries and succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 				g.By("creating a BuildConfig whose base image does not have a fully qualified registry name")
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/docker_pullsecret.go
+++ b/test/extended/builds/docker_pullsecret.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][pullsecret] docker build using 
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It("should create a docker build that pulls using a secret run it [apigroup:build.openshift.io]", func() {
+			g.It("should create a docker build that pulls using a secret run it [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()

--- a/test/extended/builds/dockerfile.go
+++ b/test/extended/builds/dockerfile.go
@@ -51,7 +51,7 @@ USER 1001
 		})
 
 		g.Describe("being created from new-build", func() {
-			g.It("should create a image via new-build [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+			g.It("should create a image via new-build [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 				g.By("calling oc new-build with Dockerfile")
 				err := oc.Run("new-build").Args("-D", "-", "--to", "busybox:custom").InputString(testDockerfile).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -80,7 +80,7 @@ USER 1001
 				o.Expect(image.Image.DockerImageMetadata.Object.(*docker10.DockerImage).Config.User).To(o.Equal("1001"))
 			})
 
-			g.It("should create a image via new-build and infer the origin tag [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+			g.It("should create a image via new-build and infer the origin tag [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 				g.By("calling oc new-build with Dockerfile that uses the same tag as the output")
 				err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile2).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -114,7 +114,7 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to start a build from Dockerfile with FROM reference to scratch [apigroup:build.openshift.io]", func() {
+			g.It("should be able to start a build from Dockerfile with FROM reference to scratch [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("calling oc new-build with Dockerfile that uses scratch")
 				err := oc.Run("new-build").Args("-D", "-").InputString(testDockerfile3).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -134,7 +134,7 @@ USER 1001
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("testing build image with invalid dockerfile content [apigroup:build.openshift.io]", func() {
+			g.It("testing build image with invalid dockerfile content [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				// https://bugzilla.redhat.com/show_bug.cgi?id=1694867
 				g.By("creating a build")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=centos").Execute()
@@ -147,7 +147,7 @@ USER 1001
 				o.Expect(logs).To(o.ContainSubstring("no such file or directory"))
 			})
 
-			g.It("testing build image with dockerfile contains a file path uses a variable in its name [apigroup:build.openshift.io]", func() {
+			g.It("testing build image with dockerfile contains a file path uses a variable in its name [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				// https://bugzilla.redhat.com/show_bug.cgi?id=1810174
 				g.By("creating a build")
 				err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=buildah-env").Execute()

--- a/test/extended/builds/failure_status.go
+++ b/test/extended/builds/failure_status.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status postcommit hook failure", func() {
-			g.It("should contain the post commit hook failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the post commit hook failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", postCommitHookFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status Docker fetch image content failure", func() {
-			g.It("should contain the Docker build fetch image content reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the Docker build fetch image content reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", fetchDockerImg).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -108,7 +108,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status Docker fetch source failure", func() {
-			g.It("should contain the Docker build fetch source failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the Docker build fetch source failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", fetchDockerSrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -143,7 +143,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status S2I fetch source failure", func() {
-			g.It("should contain the S2I fetch source failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the S2I fetch source failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", fetchS2ISrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -162,7 +162,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status OutOfMemoryKilled", func() {
-			g.It("should contain OutOfMemoryKilled failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain OutOfMemoryKilled failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", oomkilled).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -208,7 +208,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status S2I bad context dir failure", func() {
-			g.It("should contain the S2I bad context dir failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the S2I bad context dir failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", badContextDirS2ISrc).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -227,7 +227,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status fetch builder image failure", func() {
-			g.It("should contain the fetch builder image failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the fetch builder image failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", builderImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -246,7 +246,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status push image to registry failure", func() {
-			g.It("should contain the image push to registry failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the image push to registry failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", pushToRegistryFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -270,7 +270,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status failed assemble container", func() {
-			g.It("should contain the failure reason related to an assemble script failing in s2i [apigroup:build.openshift.io]", func() {
+			g.It("should contain the failure reason related to an assemble script failing in s2i [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", failedAssembleFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -289,7 +289,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] update failure status", f
 		})
 
 		g.Describe("Build status failed https proxy invalid url", func() {
-			g.It("should contain the generic failure reason and message [apigroup:build.openshift.io]", func() {
+			g.It("should contain the generic failure reason and message [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", failedGenericReason).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/gitauth.go
+++ b/test/extended/builds/gitauth.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use private repositor
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to clone source code via an HTTP token [apigroup:build.openshift.io]", func() {
+			g.It("should be able to clone source code via an HTTP token [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				testGitAuth("https://github.com/openshift-github-testing/nodejs-ex-private.git", "github-http-token")
 			})
 
@@ -110,11 +110,11 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use private repositor
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should be able to clone source code via ssh [apigroup:build.openshift.io]", func() {
+			g.It("should be able to clone source code via ssh [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				testGitAuth("ssh://git@github.com/openshift-github-testing/nodejs-ex-private.git", "github-ssh-privatekey")
 			})
 
-			g.It("should be able to clone source code via ssh using SCP-style URIs [apigroup:build.openshift.io]", func() {
+			g.It("should be able to clone source code via ssh using SCP-style URIs [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				testGitAuth("git@github.com:openshift-github-testing/nodejs-ex-private.git", "github-ssh-privatekey")
 			})
 		})

--- a/test/extended/builds/hooks.go
+++ b/test/extended/builds/hooks.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 
 		g.Describe("testing postCommit hook", func() {
 
-			g.It("should run s2i postCommit hooks [apigroup:build.openshift.io]", func() {
+			g.It("should run s2i postCommit hooks [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				oc.Run("create").Args("-f", imagestreamFixture).Execute()
 				oc.Run("create").Args("-f", s2iBuildFixture).Execute()
 
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] testing build configurati
 
 			})
 
-			g.It("should run docker postCommit hooks [apigroup:build.openshift.io]", func() {
+			g.It("should run docker postCommit hooks [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				oc.Run("create").Args("-f", imagestreamFixture).Execute()
 				oc.Run("create").Args("-f", dockerBuildFixture).Execute()
 

--- a/test/extended/builds/image_source.go
+++ b/test/extended/builds/image_source.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 		})
 
 		g.Describe("buildconfig with input source image and s2i strategy", func() {
-			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", func() {
+			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("Creating build configs for source build")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("buildconfig with input source image and docker strategy", func() {
-			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", func() {
+			g.It("should complete successfully and contain the expected file [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("Creating build configs for docker build")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -129,7 +129,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and s2i strategy", func() {
-			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -174,7 +174,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and docker strategy", func() {
-			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -219,7 +219,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] build can have container 
 			})
 		})
 		g.Describe("creating a build with an input source image and custom strategy", func() {
-			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", func() {
+			g.It("should resolve the imagestream references and secrets [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("Creating build configs for input image")
 				err := oc.Run("create").Args("-f", buildConfigFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/imagechangetriggers.go
+++ b/test/extended/builds/imagechangetriggers.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] imagechangetriggers", func() {
 			}
 		})
 
-		g.It("imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io]", func() {
+		g.It("imagechangetriggers should trigger builds of all types [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			err := oc.AsAdmin().Run("create").Args("-f", buildFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/labels.go
+++ b/test/extended/builds/labels.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		})
 
 		g.Describe("S2I build from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiBuildFixture)), g.Label("Size:L"), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()
@@ -65,7 +65,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] result image should have proper
 		})
 
 		g.Describe("Docker build from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(dockerBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template with proper Docker labels [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(dockerBuildFixture)), g.Label("Size:L"), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/multistage.go
+++ b/test/extended/builds/multistage.go
@@ -43,7 +43,7 @@ COPY --from=%[2]s /bin/wget /test/
 		}
 	})
 
-	g.It("should succeed [apigroup:build.openshift.io]", func() {
+	g.It("should succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		g.By("creating a build directly")
 		registryURL, err := eximages.GetDockerRegistryURL(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/new_app.go
+++ b/test/extended/builds/new_app.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 			deployutil.DeploymentConfigFailureTrap(oc, a59, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should succeed with a --name of 58 characters [apigroup:build.openshift.io]", func() {
+		g.It("should succeed with a --name of 58 characters [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("calling oc new-app")
 			err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a58, "--build-env=BUILD_LOGLEVEL=5").Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -79,14 +79,14 @@ var _ = g.Describe("[sig-builds][Feature:Builds] oc new-app", func() {
 			}
 		})
 
-		g.It("should fail with a --name longer than 58 characters [apigroup:build.openshift.io]", func() {
+		g.It("should fail with a --name longer than 58 characters [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("calling oc new-app")
 			out, err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex", "--name", a59).Output()
 			o.Expect(err).To(o.HaveOccurred())
 			o.Expect(out).To(o.ContainSubstring("error: invalid name: "))
 		})
 
-		g.It("should succeed with an imagestream [apigroup:build.openshift.io]", func() {
+		g.It("should succeed with an imagestream [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			// Bug 1767163 - oc new-app with --image-stream produced invalid labels
 			g.By("calling oc new-app with imagestream")
 			// Note: the imagestream used here does not matter (does not have to a valid builder) since we are not checking

--- a/test/extended/builds/no_outputname.go
+++ b/test/extended/builds/no_outputname.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 		})
 
 		g.Describe("building from templates", func() {
-			g.It(fmt.Sprintf("should create an image from a docker template without an output image reference defined [apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should create an image from a docker template without an output image reference defined [apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", dockerImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build without output image", fu
 				o.Expect(buildLog).Should(o.ContainSubstring(`Build complete, no image push requested`))
 			})
 
-			g.It(fmt.Sprintf("should create an image from a S2i template without an output image reference defined [apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should create an image from a S2i template without an output image reference defined [apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 				err := oc.Run("create").Args("-f", s2iImageFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/builds/nosrc.go
+++ b/test/extended/builds/nosrc.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build with empty source", func(
 		})
 
 		g.Describe("started build", func() {
-			g.It("should build even with an empty source in build config [apigroup:build.openshift.io]", func() {
+			g.It("should build even with an empty source in build config [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting the empty source build")
 				br, err := exutil.StartBuildAndWait(oc, "nosrc-build", fmt.Sprintf("--from-dir=%s", exampleBuild))
 				br.AssertSuccess()

--- a/test/extended/builds/optimized.go
+++ b/test/extended/builds/optimized.go
@@ -45,7 +45,7 @@ USER 1001
 			}
 		})
 
-		g.It("should succeed [apigroup:build.openshift.io]", func() {
+		g.It("should succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("creating a build directly")
 			build, err := oc.AdminBuildClient().BuildV1().Builds(oc.Namespace()).Create(context.Background(), &buildv1.Build{
 				ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/builds/pipeline_origin_bld.go
+++ b/test/extended/builds/pipeline_origin_bld.go
@@ -119,7 +119,7 @@ var _ = g.Describe("[sig-builds][Feature:JenkinsRHELImagesOnly][Feature:Jenkins]
 				o.Expect(err).NotTo(o.HaveOccurred(), "error creating the imagestream for Jenkins")
 			})
 
-			g.It("using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]", func() {
+			g.It("using a jenkins instance launched with the ephemeral template [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				defer cleanup()
 				setupJenkins()
 

--- a/test/extended/builds/proxy.go
+++ b/test/extended/builds/proxy.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 		})
 
 		g.Describe("start build with broken proxy", func() {
-			g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", func() {
+			g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting the build")
 
 				br, _ := exutil.StartBuildAndWait(oc, "sample-build", "--build-loglevel=5")
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 		})
 
 		g.Describe("start build with broken proxy and a no_proxy override", func() {
-			g.It("should start an s2i build and wait for the build to succeed [apigroup:build.openshift.io]", func() {
+			g.It("should start an s2i build and wait for the build to succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-s2i-build-noproxy", "--build-loglevel=5")
 				br.AssertSuccess()
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 				o.Expect(buildLog).To(o.ContainSubstring("proxy3"), "build log should include proxy host")
 				o.Expect(buildLog).To(o.ContainSubstring("proxy4"), "build log should include proxy host")
 			})
-			g.It("should start a docker build and wait for the build to succeed [apigroup:build.openshift.io]", func() {
+			g.It("should start a docker build and wait for the build to succeed [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-docker-build-noproxy", "--build-loglevel=5")
 				br.AssertSuccess()
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] builds should support pro
 
 		g.Describe("start build with cluster-wide custom PKI", func() {
 
-			g.It("should mount the custom PKI into the build if specified [apigroup:config.openshift.io][apigroup:build.openshift.io]", func() {
+			g.It("should mount the custom PKI into the build if specified [apigroup:config.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				ctx := context.TODO()
 				proxy, err := oc.AdminConfigClient().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/pullsecret.go
+++ b/test/extended/builds/pullsecret.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 			})
 
 			g.Describe("binary builds", func() {
-				g.It("should be able to run a build that is implicitly pulling from the internal registry [apigroup:build.openshift.io]", func() {
+				g.It("should be able to run a build that is implicitly pulling from the internal registry [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("creating a build")
 					err := oc.Run("new-build").Args("--binary", "--strategy=docker", "--name=docker").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 					oc.Run("delete").Args("secret", "local-ps").Execute()
 				})
 
-				g.It("should be able to use a pull secret in a build [apigroup:build.openshift.io]", func() {
+				g.It("should be able to use a pull secret in a build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("creating build config")
 					err := oc.Run("create").Args("-f", pullSecretBuild).Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using pull secrets in a b
 					br.AssertSuccess()
 				})
 
-				g.It("should be able to use a pull secret linked to the builder service account [apigroup:build.openshift.io]", func() {
+				g.It("should be able to use a pull secret linked to the builder service account [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("linking pull secret with the builder service account")
 					err := oc.Run("secrets").Args("link", "builder", "local-ps").Execute()
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/remove_buildconfig.go
+++ b/test/extended/builds/remove_buildconfig.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] remove all builds when build co
 		})
 
 		g.Describe("oc delete buildconfig", func() {
-			g.It("should start builds and delete the buildconfig [apigroup:build.openshift.io]", func() {
+			g.It("should start builds and delete the buildconfig [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				var (
 					err    error
 					builds [4]string

--- a/test/extended/builds/revision.go
+++ b/test/extended/builds/revision.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] build have source revision meta
 		})
 
 		g.Describe("started build", func() {
-			g.It("should contain source revision information [apigroup:build.openshift.io]", func() {
+			g.It("should contain source revision information [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting the build")
 				br, _ := exutil.StartBuildAndWait(oc, "sample-build")
 				br.AssertSuccess()

--- a/test/extended/builds/run_fs_verification.go
+++ b/test/extended/builds/run_fs_verification.go
@@ -109,7 +109,7 @@ valid_fields.json
 		})
 
 		g.Describe("do not have unexpected content", func() {
-			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", func() {
+			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerifyRunFSContentsBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -135,7 +135,7 @@ valid_fields.json
 		})
 
 		g.Describe("are writeable", func() {
-			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", func() {
+			g.It("using a simple Docker Strategy Build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("calling oc create with yaml")
 				err := oc.Run("create").Args("-f", "-").InputString(testVerityRunFSWriteableBuildConfigYaml).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/run_policy.go
+++ b/test/extended/builds/run_policy.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Parallel build run policy", func() {
-			g.It("runs the builds in parallel [apigroup:build.openshift.io]", func() {
+			g.It("runs the builds in parallel [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds []string
@@ -138,7 +138,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy", func() {
-			g.It("runs the builds in serial order [apigroup:build.openshift.io]", func() {
+			g.It("runs the builds in serial order [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds []string
@@ -217,7 +217,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling cancellation", func() {
-			g.It("starts the next build immediately after one is canceled [apigroup:build.openshift.io]", func() {
+			g.It("starts the next build immediately after one is canceled [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 				bcName := "sample-serial-build"
 
@@ -266,7 +266,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling failure", func() {
-			g.It("starts the next build immediately after one fails [apigroup:build.openshift.io]", func() {
+			g.It("starts the next build immediately after one fails [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 				bcName := "sample-serial-build-fail"
 
@@ -346,7 +346,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with Serial build run policy handling deletion", func() {
-			g.It("starts the next build immediately after running one is deleted [apigroup:build.openshift.io]", func() {
+			g.It("starts the next build immediately after running one is deleted [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 
 				bcName := "sample-serial-build"
@@ -404,7 +404,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] using build configuration
 		})
 
 		g.Describe("build configuration with SerialLatestOnly build run policy", func() {
-			g.It("runs the builds in serial order but cancel previous builds [apigroup:build.openshift.io]", func() {
+			g.It("runs the builds in serial order but cancel previous builds [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("starting multiple builds")
 				var (
 					startedBuilds        []string

--- a/test/extended/builds/s2i_dropcaps.go
+++ b/test/extended/builds/s2i_dropcaps.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] Capabilities should be dr
 		})
 
 		g.Describe("s2i build with a rootable builder", func() {
-			g.It("should not be able to switch to root with an assemble script [apigroup:build.openshift.io]", func() {
+			g.It("should not be able to switch to root with an assemble script [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 				g.By("calling oc new-build for rootable-builder")
 				err := oc.Run("new-build").Args("--binary", "--name=rootable-ruby").Execute()

--- a/test/extended/builds/s2i_env.go
+++ b/test/extended/builds/s2i_env.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] s2i build with environmen
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It(fmt.Sprintf("should create a image from %q template and run it in a pod [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiEnvBuildFixture)), func() {
+			g.It(fmt.Sprintf("should create a image from %q template and run it in a pod [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(stiEnvBuildFixture)), g.Label("Size:L"), func() {
 
 				g.By(fmt.Sprintf("calling oc create -f %q", imageStreamFixture))
 				err := oc.Run("create").Args("-f", imageStreamFixture).Execute()

--- a/test/extended/builds/s2i_incremental.go
+++ b/test/extended/builds/s2i_incremental.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] incremental s2i build", f
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It(fmt.Sprintf("should create a build from %q template and run it [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(templateFixture)), func() {
+			g.It(fmt.Sprintf("should create a build from %q template and run it [apigroup:build.openshift.io][apigroup:image.openshift.io]", filepath.Base(templateFixture)), g.Label("Size:L"), func() {
 
 				g.By(fmt.Sprintf("calling oc new-app -f %q", templateFixture))
 				err := oc.Run("new-app").Args("-f", templateFixture).Execute()

--- a/test/extended/builds/s2i_quota.go
+++ b/test/extended/builds/s2i_quota.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a quota", func()
 		})
 
 		g.Describe("Building from a template", func() {
-			g.It("should create an s2i build with a quota and run it [apigroup:build.openshift.io]", func() {
+			g.It("should create an s2i build with a quota and run it [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By(fmt.Sprintf("calling oc create -f %q", buildFixture))
 				err := oc.Run("create").Args("-f", buildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/s2i_root.go
+++ b/test/extended/builds/s2i_root.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("s2i-build-root", admissionapi.LevelBaseline)
 
-	g.It("should create a root build and fail without a privileged SCC [apigroup:build.openshift.io]", func() {
+	g.It("should create a root build and fail without a privileged SCC [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		g.Skip("TODO: figure out why we aren't properly denying this, also consider whether we still need to deny it")
 		Before(oc)
 		defer After(oc)
@@ -70,7 +70,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds] s2i build with a root user imag
 		}
 	})
 
-	g.It("should create a root build and pass with a privileged SCC [apigroup:build.openshift.io]", func() {
+	g.It("should create a root build and pass with a privileged SCC [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		Before(oc)
 		defer After(oc)
 		g.By("adding builder account to privileged SCC")

--- a/test/extended/builds/secrets.go
+++ b/test/extended/builds/secrets.go
@@ -61,7 +61,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use build secrets", f
 				o.Expect(err).NotTo(o.HaveOccurred())
 			})
 
-			g.It("should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+			g.It("should contain secrets during the source strategy build [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 				g.By("creating test build config")
 				err := oc.Run("create").Args("-f", sourceBuildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] can use build secrets", f
 				})
 			})
 
-			g.It("should contain secrets during the docker strategy build", func() {
+			g.It("should contain secrets during the docker strategy build", g.Label("Size:L"), func() {
 				g.By("creating test build config")
 				err := oc.Run("create").Args("-f", dockerBuildFixture).Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/service.go
+++ b/test/extended/builds/service.go
@@ -42,7 +42,7 @@ RUN curl -vvv hello-nodejs:8080
 		})
 
 		g.Describe("with a build being created from new-build", func() {
-			g.It("should be able to run a build that references a cluster service [apigroup:build.openshift.io]", func() {
+			g.It("should be able to run a build that references a cluster service [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				g.By("standing up a new hello world nodejs service via oc new-app")
 				err := oc.Run("new-app").Args("registry.redhat.io/ubi8/nodejs-16:latest~https://github.com/sclorg/nodejs-ex.git", "--name", "hello-nodejs").Execute()
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/start.go
+++ b/test/extended/builds/start.go
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("oc start-build --wait", func() {
-				g.It("should start a build and wait for the build to complete [apigroup:build.openshift.io]", func() {
+				g.It("should start a build and wait for the build to complete [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with --wait flag")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "--wait")
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -100,7 +100,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					verifyBuildPod(oc, br.BuildName)
 				})
 
-				g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", func() {
+				g.It("should start a build and wait for the build to fail [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with --wait flag but wrong --commit")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build", "--wait", "--commit=fffffff")
 					br.AssertFailure()
@@ -111,7 +111,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("oc start-build with pr ref", func() {
-				g.It("should start a build from a PR ref, wait for the build to complete, and confirm the right level was used [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+				g.It("should start a build from a PR ref, wait for the build to complete, and confirm the right level was used [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 					g.By("make sure python imagestream has latest tag")
 					err := exutil.WaitForAnImageStreamTag(oc.AsAdmin(), "openshift", "python", "latest")
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -156,7 +156,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("override environment", func() {
-				g.It("should accept environment variables [apigroup:build.openshift.io]", func() {
+				g.It("should accept environment variables [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with -e FOO=bar,-e VAR=test")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", "-e", "FOO=bar", "-e", "VAR=test")
 					br.AssertSuccess()
@@ -173,7 +173,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("BAR=test"))
 				})
 
-				g.It("BUILD_LOGLEVEL in buildconfig should create verbose output [apigroup:build.openshift.io]", func() {
+				g.It("BUILD_LOGLEVEL in buildconfig should create verbose output [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build")
 					br.AssertSuccess()
@@ -188,7 +188,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).NotTo(o.ContainSubstring("ERROR: logging before flag.Parse"))
 				})
 
-				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel [apigroup:build.openshift.io]", func() {
+				g.It("BUILD_LOGLEVEL in buildconfig can be overridden by build-loglevel [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with buildconfig strategy env BUILD_LOGLEVEL=5 but build-loglevel=1")
 					br, err := exutil.StartBuildAndWait(oc, "sample-verbose-build", "--build-loglevel=1")
 					br.AssertSuccess()
@@ -211,7 +211,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					fmt.Fprintf(g.GinkgoWriter, "Tried to init git repo: %v\n%s\n", err, string(out))
 				}
 
-				g.It("should accept --from-file as input [apigroup:build.openshift.io]", func() {
+				g.It("should accept --from-file as input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with a Dockerfile")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfile))
 					br.AssertSuccess()
@@ -225,7 +225,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-dir as input [apigroup:build.openshift.io]", func() {
+				g.It("should accept --from-dir as input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-dir=%s", exampleBuild))
 					br.AssertSuccess()
@@ -238,7 +238,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-repo as input [apigroup:build.openshift.io]", func() {
+				g.It("should accept --from-repo as input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with a Git repository")
 					tryRepoInit(exampleBuild)
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-repo=%s", exampleBuild))
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("should accept --from-repo with --commit as input [apigroup:build.openshift.io]", func() {
+				g.It("should accept --from-repo with --commit as input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with a Git repository")
 					tryRepoInit(exampleBuild)
 					gitCmd := exec.Command("git", "rev-parse", "HEAD~1")
@@ -275,7 +275,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 				})
 
 				// run one valid binary build so we can do --from-build later
-				g.It("should reject binary build requests without a --from-xxxx value [apigroup:build.openshift.io]", func() {
+				g.It("should reject binary build requests without a --from-xxxx value [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.Skip("TODO: refactor such that we don't rely on external package managers (i.e. Rubygems)")
 					g.By("starting a valid build with a directory")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-binary", "--follow", fmt.Sprintf("--from-dir=%s", exampleBuild))
@@ -298,7 +298,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(br.StartBuildStdErr).To(o.ContainSubstring("has no valid source inputs"))
 				})
 
-				g.It("shoud accept --from-file with https URL as an input [apigroup:build.openshift.io]", func() {
+				g.It("shoud accept --from-file with https URL as an input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting a valid build with input file served by https")
 					br, err := exutil.StartBuildAndWait(oc, "sample-build", fmt.Sprintf("--from-file=%s", exampleGemfileURL))
 					br.AssertSuccess()
@@ -309,7 +309,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(buildLog).To(o.ContainSubstring("Build complete"))
 				})
 
-				g.It("shoud accept --from-archive with https URL as an input [apigroup:build.openshift.io]", func() {
+				g.It("shoud accept --from-archive with https URL as an input [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting a valid build with input archive served by https")
 					// can't use sample-build-binary because we need contextDir due to github archives containing the top-level directory
 					br, err := exutil.StartBuildAndWait(oc, "sample-build-github-archive", fmt.Sprintf("--from-archive=%s", exampleArchiveURL))
@@ -323,7 +323,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("cancel a binary build that doesn't start running in 5 minutes", func() {
-				g.It("should start a build and wait for the build to be cancelled [apigroup:build.openshift.io]", func() {
+				g.It("should start a build and wait for the build to be cancelled [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting a build with a nodeselector that can't be matched")
 					go func() {
 						exutil.StartBuild(oc, "sample-build-binary-invalidnodeselector", fmt.Sprintf("--from-file=%s", exampleGemfile))
@@ -342,7 +342,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("cancel a build started by oc start-build --wait", func() {
-				g.It("should start a build and wait for the build to cancel [apigroup:build.openshift.io]", func() {
+				g.It("should start a build and wait for the build to cancel [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with --wait flag")
 					var wg sync.WaitGroup
 					wg.Add(1)
@@ -385,7 +385,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("Setting build-args on Docker builds", func() {
-				g.It("Should copy build args from BuildConfig to Build [apigroup:build.openshift.io]", func() {
+				g.It("Should copy build args from BuildConfig to Build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build without --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args-preset")
 					br.AssertSuccess()
@@ -395,7 +395,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("verifying the build output contains the build args from the BuildConfig.")
 					o.Expect(buildLog).To(o.ContainSubstring("default"))
 				})
-				g.It("Should accept build args that are specified in the Dockerfile [apigroup:build.openshift.io]", func() {
+				g.It("Should accept build args that are specified in the Dockerfile [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=foofoo=bar")
 					br.AssertSuccess()
@@ -405,7 +405,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					g.By("verifying the build output contains the changes.")
 					o.Expect(buildLog).To(o.ContainSubstring("bar"))
 				})
-				g.It("Should complete with a warning on non-existent build-arg [apigroup:build.openshift.io]", func() {
+				g.It("Should complete with a warning on non-existent build-arg [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("starting the build with --build-arg flag")
 					br, _ := exutil.StartBuildAndWait(oc, "sample-build-docker-args", "--build-arg=bar=foo")
 					br.AssertSuccess()
@@ -418,7 +418,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("Trigger builds with branch refs matching directories on master branch", func() {
-				g.It("Should checkout the config branch, not config directory [apigroup:build.openshift.io]", func() {
+				g.It("Should checkout the config branch, not config directory [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("calling oc new-app")
 					_, err := oc.Run("new-app").Args("https://github.com/openshift/ruby-hello-world#config").Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -474,7 +474,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 					o.Expect(err).NotTo(o.HaveOccurred(), "checking if webhook role binding exists")
 				})
 
-				g.It("should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]", func() {
+				g.It("should be able to start builds via the webhook with valid secrets and fail with invalid secrets [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 					g.By("clearing existing builds")
 					_, err := oc.Run("delete").Args("builds", "--all").Output()
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -553,7 +553,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][Slow] starting a build using CL
 			})
 
 			g.Describe("s2i build maintaining symlinks", func() {
-				g.It(fmt.Sprintf("should s2i build image and maintain symlinks [apigroup:build.openshift.io][apigroup:image.openshift.io]"), func() {
+				g.It(fmt.Sprintf("should s2i build image and maintain symlinks [apigroup:build.openshift.io][apigroup:image.openshift.io]"), g.Label("Size:L"), func() {
 					g.By("initializing a local git repo")
 					repo, err := exutil.NewGitRepo("symlinks")
 					o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/subscription_content.go
+++ b/test/extended/builds/subscription_content.go
@@ -67,21 +67,21 @@ var _ = g.Describe("[sig-builds][Feature:Builds][subscription-content] builds in
 			}
 		})
 
-		g.It("should succeed for RHEL 7 base images", func() {
+		g.It("should succeed for RHEL 7 base images", g.Label("Size:L"), func() {
 			err := oc.Run("apply").Args("-f", rhel7BuildConfig).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
 			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel7")
 			br.AssertSuccess()
 		})
 
-		g.It("should succeed for RHEL 8 base images", func() {
+		g.It("should succeed for RHEL 8 base images", g.Label("Size:L"), func() {
 			err := oc.Run("apply").Args("-f", rhel8BuildConfig).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
 			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel8")
 			br.AssertSuccess()
 		})
 
-		g.It("should succeed for RHEL 9 base images", func() {
+		g.It("should succeed for RHEL 9 base images", g.Label("Size:L"), func() {
 			err := oc.Run("apply").Args("-f", rhel9BuildConfig).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred(), "creating BuildConfig")
 			br, _ := exutil.StartBuildAndWait(oc, "subscription-content-rhel9")

--- a/test/extended/builds/valuefrom.go
+++ b/test/extended/builds/valuefrom.go
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should successfully resolve valueFrom in s2i build environment variables [apigroup:build.openshift.io]", func() {
+		g.It("should successfully resolve valueFrom in s2i build environment variables [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulSTIBuildValueFrom).Execute()
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should successfully resolve valueFrom in docker build environment variables [apigroup:build.openshift.io]", func() {
+		g.It("should successfully resolve valueFrom in docker build environment variables [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test successful build config")
 			err := oc.Run("create").Args("-f", successfulDockerBuildValueFrom).Execute()
@@ -97,7 +97,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should fail resolving unresolvable valueFrom in sti build environment variable references [apigroup:build.openshift.io]", func() {
+		g.It("should fail resolving unresolvable valueFrom in sti build environment variable references [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test build config")
 			err := oc.Run("create").Args("-f", failedSTIBuildValueFrom).Execute()
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][valueFrom] process valueFrom in
 
 		})
 
-		g.It("should fail resolving unresolvable valueFrom in docker build environment variable references [apigroup:build.openshift.io]", func() {
+		g.It("should fail resolving unresolvable valueFrom in docker build environment variable references [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 
 			g.By("creating test build config")
 			err := oc.Run("create").Args("-f", failedDockerBuildValueFrom).Execute()

--- a/test/extended/builds/volumes.go
+++ b/test/extended/builds/volumes.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 			}
 		})
 
-		g.It("should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should mount given secrets and configmaps into the build pod for source strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", s2iImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -90,7 +90,7 @@ var _ = g.Describe("[sig-builds][Feature:Builds][volumes] build volumes", func()
 			o.Expect(out).To(o.ContainSubstring("cat: /var/run/configmaps/some-configmap/key: No such file or directory"))
 		})
 
-		g.It("should mount given secrets and configmaps into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should mount given secrets and configmaps into the build pod for docker strategy builds [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("creating an imagestream")
 			err := oc.Run("create").Args("-f", dockerImageStream).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/builds/webhook.go
+++ b/test/extended/builds/webhook.go
@@ -34,16 +34,16 @@ var _ = g.Describe("[sig-builds][Feature:Builds][webhook]", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("build-webhooks", admissionapi.LevelBaseline)
 	)
 
-	g.It("TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("TestWebhook [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		TestWebhook(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPushWithImage [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestWebhookGitHubPushWithImage [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestWebhookGitHubPushWithImage(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPushWithImageStream [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestWebhookGitHubPushWithImageStream [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestWebhookGitHubPushWithImageStream(g.GinkgoT(), oc)
 	})
-	g.It("TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestWebhookGitHubPing [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestWebhookGitHubPing(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/ci/dummy_retry.go
+++ b/test/extended/ci/dummy_retry.go
@@ -20,7 +20,7 @@ Example usage:
 var _ = g.Describe("[sig-ci] [Suite:none] Test should fail", func() {
 	defer g.GinkgoRecover()
 
-	g.It("at a configurable rate", func() {
+	g.It("at a configurable rate", g.Label("Size:S"), func() {
 		failureRateStr := os.Getenv("DUMMY_FAILURE_RATE")
 		if failureRateStr == "" {
 			// Default is always passes just in case this test is accidentally run in CI...

--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	}
 	isPeriodic := strings.HasPrefix(jobName, "periodic-")
 
-	g.It("should match feature set", func() {
+	g.It("should match feature set", g.Label("Size:S"), func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	g.It("should match security mode", func() {
+	g.It("should match security mode", g.Label("Size:S"), func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}
@@ -62,7 +62,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	g.It("should match platform type", func() {
+	g.It("should match platform type", g.Label("Size:S"), func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		} else if strings.Contains(jobName, "agnostic") {
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 
 	})
 
-	g.It("should match network type", func() {
+	g.It("should match network type", g.Label("Size:S"), func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}
@@ -131,7 +131,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	g.It("should match cluster version [apigroup:config.openshift.io]", func() {
+	g.It("should match cluster version [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}

--- a/test/extended/cli/adm_upgrade/recommend.go
+++ b/test/extended/cli/adm_upgrade/recommend.go
@@ -59,12 +59,12 @@ var _ = g.Describe("[Serial][sig-cli] oc adm upgrade recommend", g.Ordered, func
 		}
 	})
 
-	g.It("runs successfully, even without upstream OpenShift Update Service customization", func() {
+	g.It("runs successfully, even without upstream OpenShift Update Service customization", g.Label("Size:S"), func() {
 		_, err := oc.Run("adm", "upgrade", "recommend").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND", "true").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND_PRECHECK", "true").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND_ACCEPT", "true").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("runs successfully with an empty channel", func() {
+	g.It("runs successfully with an empty channel", g.Label("Size:S"), func() {
 		err := oc.Run("adm", "upgrade", "channel").Execute()
 		if err != nil {
 			g.Skip(fmt.Sprintf("failed to update the ClusterVersion channel (perhaps we are on a HyperShift cluster): %s", err))
@@ -104,7 +104,7 @@ var _ = g.Describe("[Serial][sig-cli] oc adm upgrade recommend", g.Ordered, func
 			time.Sleep(16 * time.Second) // Give the CVO time to retrieve recommendations and push to status
 		})
 
-		g.It("runs successfully", func() {
+		g.It("runs successfully", g.Label("Size:M"), func() {
 			out, err := oc.Run("adm", "upgrade", "recommend").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND", "true").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND_PRECHECK", "true").EnvVar("OC_ENABLE_CMD_UPGRADE_RECOMMEND_ACCEPT", "true").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = matchRegexp(out, `.*Upstream update service: http://.*
@@ -208,7 +208,7 @@ No updates available. You may still upgrade to a specific release image.*`)
 			oc.Run("delete").Args("clusterrolebinding", fmt.Sprintf("%s-test", oc.Namespace())).Execute()
 		})
 
-		g.It("runs successfully when listing all updates", func() {
+		g.It("runs successfully when listing all updates", g.Label("Size:M"), func() {
 			oc.WithKubeConfigCopy(func(oc *exutil.CLI) {
 				o.Expect(oc.Run("config", "set-credentials").Args("test", "--token", token).Execute()).To(o.Succeed())
 				o.Expect(oc.Run("config", "set-context").Args("--current", "--user", "test").Execute()).To(o.Succeed())
@@ -235,7 +235,7 @@ Updates to 4[.][0-9]*:
 			})
 		})
 
-		g.It("runs successfully with conditional recommendations to the --version target", func() {
+		g.It("runs successfully with conditional recommendations to the --version target", g.Label("Size:M"), func() {
 			oc.WithKubeConfigCopy(func(oc *exutil.CLI) {
 				o.Expect(oc.Run("config", "set-credentials").Args("test", "--token", token).Execute()).To(o.Succeed())
 				o.Expect(oc.Run("config", "set-context").Args("--current", "--user", "test").Execute()).To(o.Succeed())

--- a/test/extended/cli/adm_upgrade/status.go
+++ b/test/extended/cli/adm_upgrade/status.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli][OCPFeatureGate:UpgradeStatus] oc adm upgrade statu
 
 	oc := exutil.NewCLIWithoutNamespace("oc-adm-upgrade-status").AsAdmin()
 
-	g.It("reports correctly when the cluster is not updating", func() {
+	g.It("reports correctly when the cluster is not updating", g.Label("Size:S"), func() {
 
 		// CLI-side oc adm upgrade status does not support HyperShift (assumes MCPs, ignores NodePools, has no knowledge of
 		// management / hosted cluster separation)

--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	policyClusterRolesPath := exutil.FixturePath("testdata", "roles", "policy-clusterroles.yaml")
 	gen := names.SimpleNameGenerator
 
-	g.It("node-logs", func() {
+	g.It("node-logs", g.Label("Size:S"), func() {
 		masters, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 			LabelSelector: "node-role.kubernetes.io/master",
 		})
@@ -69,7 +69,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(oc.Run("adm", "node-logs").Args(randomNode(oc), "--tail=5").Execute()).To(o.Succeed())
 	})
 
-	g.It("groups [apigroup:user.openshift.io]", func() {
+	g.It("groups [apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		shortoutputgroup := gen.GenerateName("shortoutputgroup-")
 		out, err := oc.Run("adm", "groups", "new").Args(shortoutputgroup, "--output=name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -127,7 +127,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete", fmt.Sprintf("groups/%s", group1)).Execute()
 	})
 
-	g.It("who-can [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("who-can [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods", "-n", "default").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "who-can").Args("get", "pods", "--all-namespaces").Execute()).To(o.Succeed())
@@ -154,7 +154,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring("Resource:  horizontalpodautoscalers.autoscaling"))
 	})
 
-	g.It("policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("policy [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 		o.Expect(ocns.Run("adm", "policy", "add-role-to-group").Args("--rolebinding-name=cluster-admin", "cluster-admin", "system:unauthenticated").Execute()).To(o.Succeed())
 		o.Expect(ocns.Run("adm", "policy", "add-role-to-user").Args("--rolebinding-name=cluster-admin", "cluster-admin", "system:no-user").Execute()).To(o.Succeed())
 
@@ -248,7 +248,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring("clusterrolebinding.rbac.authorization.k8s.io/system:openshift:scc:privileged updated"))
 	})
 
-	g.It("storage-admin [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("storage-admin [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 		g.By("Test storage-admin role and impersonation")
 		o.Expect(oc.Run("adm", "policy", "add-cluster-role-to-user").Args("storage-admin", "storage-adm").Execute()).To(o.Succeed())
 		o.Expect(oc.Run("adm", "policy", "add-cluster-role-to-user").Args("storage-admin", "storage-adm2").Execute()).To(o.Succeed())
@@ -319,7 +319,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.HaveSuffix("yes"))
 	})
 
-	g.It("role-reapers [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("role-reapers [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		policyRoles, _, err := ocns.Run("process").Args("-f", policyRolesPath, "-p", fmt.Sprintf("NAMESPACE=%s", ocns.Namespace())).Outputs()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(ocns.Run("create").Args("-f", "-").InputString(policyRoles).Execute()).To(o.Succeed())
@@ -339,7 +339,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	})
 
 	// "oc adm prune auth clusterrole/edit" is a disruptive command and needs to be run in a Serial test
-	g.It("cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("cluster-role-reapers [Serial][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		clusterRole := gen.GenerateName("basic-user2-")
 		clusterBinding := gen.GenerateName("basic-users2-")
 		policyClusterRoles, _, err := ocns.Run("process").Args("-f", policyClusterRolesPath, "-p", fmt.Sprintf("ROLE_NAME=%s", clusterRole), "-p", fmt.Sprintf("BINDING_NAME=%s", clusterBinding)).Outputs()
@@ -369,7 +369,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("-f", "-").InputString(policyClusterRoles).Execute()
 	})
 
-	g.It("role-selectors [apigroup:template.openshift.io]", func() {
+	g.It("role-selectors [apigroup:template.openshift.io]", g.Label("Size:S"), func() {
 		clusterRole := gen.GenerateName("basic-user2-")
 		clusterBinding := gen.GenerateName("basic-users2-")
 		// template processing requires a namespaced client
@@ -400,7 +400,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("-f", "-").InputString(policyClusterRoles).Execute()
 	})
 
-	g.It("ui-project-commands [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("ui-project-commands [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 		// Test the commands the UI projects page tells users to run
 		// These should match what is described in projects.html
 		o.Expect(oc.Run("adm", "new-project").Args("ui-test-project", "--admin=createuser").Execute()).To(o.Succeed())
@@ -422,7 +422,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		ocns.Run("delete").Args("project/ui-test-project").Execute()
 	})
 
-	g.It("new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("new-project [apigroup:project.openshift.io][apigroup:authorization.openshift.io]", g.Label("Size:M"), func() {
 		projectName := gen.GenerateName("recreated-project-")
 		// Test deleting and recreating a project
 		o.Expect(oc.Run("adm", "new-project").Args(projectName, "--admin=createuser1").Execute()).To(o.Succeed())
@@ -449,7 +449,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring("createuser2"))
 	})
 
-	g.It("build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("build-chain [apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io]", g.Label("Size:S"), func() {
 		// Test building a dependency tree
 		s2iBuildPath := exutil.FixturePath("..", "..", "examples", "sample-app", "application-template-stibuild.json")
 		out, _, err := ocns.Run("process").Args("-f", s2iBuildPath, "-l", "build=sti").Outputs()
@@ -467,7 +467,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring(`digraph "ruby-27:latest"`))
 	})
 
-	g.It("serviceaccounts", func() {
+	g.It("serviceaccounts", g.Label("Size:M"), func() {
 		// create a new service account
 		out, err := ocns.Run("create", "serviceaccount").Args("my-sa-name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -513,7 +513,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		ocns.Run("delete").Args("sa/my-sa-name").Execute()
 	})
 
-	g.It("user-creation [apigroup:user.openshift.io]", func() {
+	g.It("user-creation [apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		user := gen.GenerateName("test-cmd-user-")
 		identity := gen.GenerateName("test-idp:test-uid-")
 		o.Expect(oc.Run("create", "user").Args(user).Execute()).To(o.Succeed())
@@ -532,7 +532,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args(fmt.Sprintf("useridentitymapping/%s", identity)).Execute()
 	})
 
-	g.It("images [apigroup:image.openshift.io]", func() {
+	g.It("images [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		stableBusyboxPath := exutil.FixturePath("testdata", "stable-busybox.yaml")
 		o.Expect(oc.Run("create").Args("-f", stableBusyboxPath).Execute()).To(o.Succeed())
 
@@ -546,7 +546,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		oc.Run("delete").Args("-f", stableBusyboxPath).Execute()
 	})
 
-	g.It("release extract image-references", func() {
+	g.It("release extract image-references", g.Label("Size:S"), func() {
 		expected := string(testdata.MustAsset("test/extended/testdata/cli/test-release-image-references.json"))
 		out, err := oc.Run("adm", "release", "extract").Args("--file", "image-references", "quay.io/openshift-release-dev/ocp-release:4.13.0-rc.0-x86_64").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/annotation.go
+++ b/test/extended/cli/annotation.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-cli] oc annotate", func() {
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("oc-annotation", admissionapi.LevelBaseline)
 
-	g.It("pod", func() {
+	g.It("pod", g.Label("Size:S"), func() {
 		g.By("creating hello-openshift pod")
 		helloPodFile, err := writeObjectToFile(newHelloPod())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/apiresources.go
+++ b/test/extended/cli/apiresources.go
@@ -12,7 +12,7 @@ var _ = g.Describe("[sig-cli] oc api-resources", func() {
 
 	var oc = exutil.NewCLI("oc-api-resources")
 
-	g.It("can output expected information about api-resources", func() {
+	g.It("can output expected information about api-resources", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("configmaps"))
@@ -42,33 +42,33 @@ var _ = g.Describe("[sig-cli] oc api-resources", func() {
 		o.Expect(out).To(o.ContainSubstring("storage.k8s.io/v1"))
 	})
 
-	g.It("can output expected information about build.openshift.io api-resources [apigroup:build.openshift.io]", func() {
+	g.It("can output expected information about build.openshift.io api-resources [apigroup:build.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Args("--api-group=build.openshift.io").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("builds"))
 		o.Expect(out).To(o.ContainSubstring("buildconfigs"))
 	})
 
-	g.It("can output expected information about image.openshift.io api-resources [apigroup:image.openshift.io]", func() {
+	g.It("can output expected information about image.openshift.io api-resources [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("images"))
 		o.Expect(out).To(o.ContainSubstring("imagestreamtags"))
 	})
 
-	g.It("can output expected information about operator.openshift.io api-resources [apigroup:operator.openshift.io]", func() {
+	g.It("can output expected information about operator.openshift.io api-resources [apigroup:operator.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Args("--verbs=get").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("configs"))
 	})
 
-	g.It("can output expected information about project.openshift.io api-resources [apigroup:project.openshift.io]", func() {
+	g.It("can output expected information about project.openshift.io api-resources [apigroup:project.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-versions").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("project.openshift.io/v1"))
 	})
 
-	g.It("can output expected information about route.openshift.io api-resources and api-version [apigroup:route.openshift.io]", func() {
+	g.It("can output expected information about route.openshift.io api-resources and api-version [apigroup:route.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Args("--verbs=get").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("routes"))
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-cli] oc api-resources", func() {
 		o.Expect(out).To(o.ContainSubstring("route.openshift.io/v1"))
 	})
 
-	g.It("can output expected information about snapshot.storage.k8s.io api-resources [apigroup:snapshot.storage.k8s.io]", func() {
+	g.It("can output expected information about snapshot.storage.k8s.io api-resources [apigroup:snapshot.storage.k8s.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("api-resources").Args("--verbs=get").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("volumesnapshots"))

--- a/test/extended/cli/basics.go
+++ b/test/extended/cli/basics.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		templateFile         = filepath.Join(cmdTestData, "application-template-mix.json")
 	)
 
-	g.It("can create and interact with a list of resources", func() {
+	g.It("can create and interact with a list of resources", g.Label("Size:S"), func() {
 		file, err := replaceImageInFile(mixedAPIVersionsFile, "openshift/hello-openshift", k8simage.GetE2EImage(k8simage.HttpdNew))
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer os.Remove(file)
@@ -66,7 +66,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("can create deploymentconfig and clusterquota [apigroup:apps.openshift.io]", func() {
+	g.It("can create deploymentconfig and clusterquota [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 		nginx := k8simage.GetE2EImage(k8simage.Nginx)
 		tools := exutilimage.ShellImage()
 
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("can patch resources [apigroup:user.openshift.io]", func() {
+	g.It("can patch resources [apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		// need admin here
 		ocAdmin := oc.AsAdmin()
 
@@ -137,7 +137,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("can describe an OAuth access token [apigroup:oauth.openshift.io]", func() {
+	g.It("can describe an OAuth access token [apigroup:oauth.openshift.io]", g.Label("Size:S"), func() {
 		// need admin here
 		ocAdmin := oc.AsAdmin()
 
@@ -152,7 +152,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("can output expected --dry-run text", func() {
+	g.It("can output expected --dry-run text", g.Label("Size:S"), func() {
 		out, err := oc.Run("create").Args("deploymentconfig", "--dry-run", "foo", "--image=bar", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/foo"))
@@ -166,7 +166,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(out).To(o.ContainSubstring("job.batch/foo"))
 	})
 
-	g.It("can process templates [apigroup:template.openshift.io]", func() {
+	g.It("can process templates [apigroup:template.openshift.io]", g.Label("Size:S"), func() {
 		name := filepath.Join(os.TempDir(), "template.json")
 
 		out, err := oc.Run("process").Args("-f", templateFile, "-l", "name=mytemplate").Output()
@@ -183,7 +183,7 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("can get version information from API", func() {
+	g.It("can get version information from API", g.Label("Size:S"), func() {
 		kubeCA := oc.UserConfig().CAData
 		transport := http.DefaultTransport
 
@@ -236,21 +236,21 @@ var _ = g.Describe("[sig-cli] oc basics", func() {
 		o.Expect(version["platform"]).NotTo(o.BeEmpty())
 	})
 
-	g.It("can get version information from CLI", func() {
+	g.It("can get version information from CLI", g.Label("Size:S"), func() {
 		out, err := oc.Run("version").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("Client Version: "))
 		o.Expect(out).To(o.ContainSubstring("Kubernetes Version: "))
 	})
 
-	g.It("can show correct whoami result", func() {
+	g.It("can show correct whoami result", g.Label("Size:S"), func() {
 		out, err := oc.Run("whoami").Args("--show-server").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		found := serverPattern.MatchString(out)
 		o.Expect(found).To(o.BeTrue())
 	})
 
-	g.It("can show correct whoami result with console", func() {
+	g.It("can show correct whoami result with console", g.Label("Size:S"), func() {
 		out, err := oc.Run("whoami").Args("--show-console").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		found := consolePattern.MatchString(out)

--- a/test/extended/cli/builds.go
+++ b/test/extended/cli/builds.go
@@ -69,7 +69,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		testDockerfileContent = fmt.Sprintf("FROM %s", image.ShellImage())
 	)
 
-	g.It("new-build [apigroup:build.openshift.io]", func() {
+	g.It("new-build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		g.By("build from a binary with no inputs requires name")
 		out, err := oc.Run("new-build").Args("--binary").Output()
 		o.Expect(err).To(o.HaveOccurred())
@@ -153,7 +153,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(json.Valid([]byte(out))).To(o.BeTrue())
 	})
 
-	g.It("get buildconfig [apigroup:build.openshift.io]", func() {
+	g.It("get buildconfig [apigroup:build.openshift.io]", g.Label("Size:M"), func() {
 		err := oc.Run("new-build").Args("-D", testDockerfileContent, "--name", "get-test").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -175,7 +175,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 		o.Expect(strings.Fields(lines[1])[1]).To(o.MatchRegexp(fmt.Sprintf("%v/get-test$", oc.Namespace())))
 	})
 
-	g.It("patch buildconfig [apigroup:build.openshift.io]", func() {
+	g.It("patch buildconfig [apigroup:build.openshift.io]", g.Label("Size:M"), func() {
 		err := oc.Run("new-build").Args("-D", testDockerfileContent, "--name", "patch-test").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		realOutputTo, err := oc.Run("get").Args("bc/patch-test", "--template", bcOutputToNameTemplate).Output()
@@ -226,7 +226,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("webhooks CRUD [apigroup:build.openshift.io]", func() {
+		g.It("webhooks CRUD [apigroup:build.openshift.io]", g.Label("Size:M"), func() {
 			g.By("check bc webhooks")
 			out, err := oc.Run("describe").Args("buildConfigs", "ruby-sample-build").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -284,7 +284,7 @@ var _ = g.Describe("[sig-cli] oc builds", func() {
 			))
 		})
 
-		g.It("start-build [apigroup:build.openshift.io]", func() {
+		g.It("start-build [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			g.By("valid build")
 			out, err := oc.Run("start-build").Args("--from-webhook", getTriggerURL("secret101", "generic")).Output()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/compat.go
+++ b/test/extended/cli/compat.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 
 	oc = exutil.NewCLIWithPodSecurityLevel("cli", admissionapi.LevelBaseline)
 
-	g.It("can run inside of a busybox container [apigroup:image.openshift.io]", func() {
+	g.It("can run inside of a busybox container [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		ns := oc.Namespace()
 		cli := e2epod.PodClientNS(oc.KubeFramework(), ns)
 
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 		cli.WaitForSuccess(context.TODO(), pod.Name, 5*time.Minute)
 	})
 
-	g.It("can get list of nodes", func() {
+	g.It("can get list of nodes", g.Label("Size:S"), func() {
 		oc := oc.AsAdmin()
 		err := oc.Run("get").Args("nodes").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/completions.go
+++ b/test/extended/cli/completions.go
@@ -12,7 +12,7 @@ var _ = g.Describe("[sig-cli] oc completion", func() {
 
 	var oc = exutil.NewCLI("oc-completion")
 
-	g.It("returns expected help messages", func() {
+	g.It("returns expected help messages", g.Label("Size:S"), func() {
 		out, err := oc.Run("completion").Args("-h").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("interactive completion of oc commands"))

--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -35,7 +35,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 	helloPod := exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
 	imageStreamsCentos := exutil.FixturePath("..", "..", "examples", "image-streams", "image-streams-centos7.json")
 
-	g.It("deployment from a build [apigroup:image.openshift.io]", func() {
+	g.It("deployment from a build [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		projectName, err := oc.Run("project").Args("-q").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -90,7 +90,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 		o.Expect(out).To(o.MatchRegexp("Starting pod/busybox2-debug.*, command was: foo bar baz qux\n"))
 	})
 
-	g.It("dissect deployment config debug [apigroup:apps.openshift.io]", func() {
+	g.It("dissect deployment config debug [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		err := oc.Run("create").Args("-f", testDeploymentConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -135,7 +135,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 		o.Expect(out).To(o.ContainSubstring(`on node "invalid"`))
 	})
 
-	g.It("dissect deployment debug", func() {
+	g.It("dissect deployment debug", g.Label("Size:M"), func() {
 		err := oc.Run("create").Args("-f", testDeployment).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -180,7 +180,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 		o.Expect(out).To(o.ContainSubstring(`on node "invalid"`))
 	})
 
-	g.It("does not require a real resource on the server", func() {
+	g.It("does not require a real resource on the server", g.Label("Size:S"), func() {
 		out, err := oc.Run("debug").Args("-T", "-f", helloPod, "-oyaml").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).NotTo(o.ContainSubstring("tty"))
@@ -197,7 +197,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 
 	// TODO: write a test that emulates a TTY to verify the correct defaulting of what the pod is created
 
-	g.It("ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io]", func() {
+	g.It("ensure debug does not depend on a container actually existing for the selected resource [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		err := oc.Run("create").Args("-f", testReplicationController).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("create").Args("-f", testDeploymentConfig).Execute()
@@ -220,7 +220,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 		o.Expect(out).To(o.ContainSubstring("test-deployment-config"))
 	})
 
-	g.It("ensure debug does not depend on a container actually existing for the selected resource for deployment", func() {
+	g.It("ensure debug does not depend on a container actually existing for the selected resource for deployment", g.Label("Size:M"), func() {
 		err := oc.Run("create").Args("-f", "-").InputString(`
 apiVersion: apps/v1
 kind: Deployment
@@ -251,7 +251,7 @@ spec:
 		o.Expect(out).To(o.ContainSubstring("test-deployment-debug"))
 	})
 
-	g.It("ensure it works with image streams [apigroup:image.openshift.io]", func() {
+	g.It("ensure it works with image streams [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -281,7 +281,7 @@ spec:
 		o.Expect(out).To(o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7"))
 	})
 
-	g.It("ensure that the label is set for node debug", func() {
+	g.It("ensure that the label is set for node debug", g.Label("Size:M"), func() {
 		var err error
 
 		ns := oc.Namespace()

--- a/test/extended/cli/env.go
+++ b/test/extended/cli/env.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli] oc env", func() {
 		oc              = exutil.NewCLI("oc-env")
 	)
 
-	g.It("can set environment variables [apigroup:apps.openshift.io][apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("can set environment variables [apigroup:apps.openshift.io][apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:M"), func() {
 		g.By("creating a test-deployment-config deploymentconfig")
 		err := oc.Run("create").Args("-f", file).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-cli] oc env", func() {
 		o.Expect(out).To(o.ContainSubstring("updated"))
 	})
 
-	g.It("can set environment variables for deployment [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("can set environment variables for deployment [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:M"), func() {
 		g.By("creating a test-deployment deployment")
 		err := oc.Run("create").Args("-f", fileDeployment).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/explain.go
+++ b/test/extended/cli/explain.go
@@ -517,7 +517,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 
 	oc := exutil.NewCLI("oc-explain")
 
-	g.It("list uncovered GroupVersionResources", func() {
+	g.It("list uncovered GroupVersionResources", g.Label("Size:S"), func() {
 		crdTypes := getCrdTypes(oc)
 		resourceMap := make(map[schema.GroupVersionResource]bool)
 		kubeClient := kclientset.NewForConfigOrDie(oc.AdminConfig())
@@ -568,7 +568,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 	for group, bts := range builtinTypes {
 		groupName := group
 		types := bts
-		g.It(fmt.Sprintf("should contain spec+status for %s [apigroup:%s]", groupName, groupName), func() {
+		g.It(fmt.Sprintf("should contain spec+status for %s [apigroup:%s]", groupName, groupName), g.Label("Size:S"), func() {
 			for _, bt := range types {
 				e2e.Logf("Checking %v...", bt)
 				o.Expect(verifySpecStatusExplain(oc, nil, bt.gvr, bt.fieldTypeNameOverride)).NotTo(o.HaveOccurred())
@@ -581,7 +581,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 		types := bets
 		for _, bet := range types {
 			resourceName := bet.gvr.Resource
-			g.It(fmt.Sprintf("should contain spec+status for %s of %s, if the resource is present [apigroup:%s]", resourceName, groupName, groupName), func() {
+			g.It(fmt.Sprintf("should contain spec+status for %s of %s, if the resource is present [apigroup:%s]", resourceName, groupName, groupName), g.Label("Size:S"), func() {
 				e2e.Logf("Checking %s of %s...", resourceName, groupName)
 				exist, err := exutil.DoesApiResourceExist(oc.AdminConfig(), resourceName, groupName)
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -593,7 +593,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 		}
 	}
 
-	g.It("should contain proper spec+status for CRDs", func() {
+	g.It("should contain proper spec+status for CRDs", g.Label("Size:S"), func() {
 		crdClient := apiextensionsclientset.NewForConfigOrDie(oc.AdminConfig())
 		crdTypesTest := getCrdTypes(oc)
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
@@ -612,7 +612,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 	for group, sts := range specialTypes {
 		groupName := group
 		types := sts
-		g.It(fmt.Sprintf("should contain proper fields description for %s [apigroup:%s]", groupName, groupName), func() {
+		g.It(fmt.Sprintf("should contain proper fields description for %s [apigroup:%s]", groupName, groupName), g.Label("Size:S"), func() {
 			for _, st := range types {
 				e2e.Logf("Checking %s, Field=%s...", st.gv, st.field)
 				resource := strings.Split(st.field, ".")
@@ -628,7 +628,7 @@ var _ = g.Describe("[sig-cli] oc explain", func() {
 		types := sets
 		for _, set := range types {
 			resourceName := strings.Split(set.field, ".")[0]
-			g.It(fmt.Sprintf("should contain proper fields description for %s of %s, if the resource is present [apigroup:%s]", resourceName, groupName, groupName), func() {
+			g.It(fmt.Sprintf("should contain proper fields description for %s of %s, if the resource is present [apigroup:%s]", resourceName, groupName, groupName), g.Label("Size:S"), func() {
 				e2e.Logf("Checking %s, Field=%s...", set.gv, set.field)
 				gvr := set.gv.WithResource(resourceName)
 				exist, err := exutil.DoesApiResourceExist(oc.AdminConfig(), resourceName, groupName)

--- a/test/extended/cli/expose.go
+++ b/test/extended/cli/expose.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc expose", func() {
 		multiportSvcFile    = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "multiport-service.yaml")
 	)
 
-	g.It("can ensure the expose command is functioning as expected [apigroup:route.openshift.io]", func() {
+	g.It("can ensure the expose command is functioning as expected [apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 		frontendServiceFile, err := writeObjectToFile(newFrontendService())
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer os.Remove(frontendServiceFile)

--- a/test/extended/cli/help.go
+++ b/test/extended/cli/help.go
@@ -14,7 +14,7 @@ var _ = g.Describe("[sig-cli] oc help", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("oc-help")
 
-	g.It("works as expected", func() {
+	g.It("works as expected", g.Label("Size:S"), func() {
 		err := exec.Command("kubectl").Run()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/idle.go
+++ b/test/extended/cli/idle.go
@@ -110,7 +110,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("by name", func() {
+	g.It("by name", g.Label("Size:M"), func() {
 		err := oc.Run("idle").Args(fmt.Sprintf("dc/%s", deploymentConfigName)).Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
@@ -123,7 +123,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
 
-	g.It("by label", func() {
+	g.It("by label", g.Label("Size:M"), func() {
 		out, err := oc.Run("idle").Args("-l", "app=idling-echo").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
@@ -133,7 +133,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
 
-	g.It("by all", func() {
+	g.It("by all", g.Label("Size:M"), func() {
 		out, err := oc.Run("idle").Args("--all").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
@@ -143,7 +143,7 @@ var _ = g.Describe("[sig-cli] oc idle [apigroup:apps.openshift.io][apigroup:rout
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
 
-	g.It("by checking previous scale", func() {
+	g.It("by checking previous scale", g.Label("Size:M"), func() {
 		out, err := oc.Run("idle").Args("idling-echo").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-cli] oc idle Deployments [apigroup:route.openshift.io][
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("by name", func() {
+	g.It("by name", g.Label("Size:M"), func() {
 		err := oc.Run("idle").Args(fmt.Sprintf("deployment/%s", deploymentName)).Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
@@ -266,7 +266,7 @@ var _ = g.Describe("[sig-cli] oc idle Deployments [apigroup:route.openshift.io][
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
 
-	g.It("by label", func() {
+	g.It("by label", g.Label("Size:M"), func() {
 		out, err := oc.Run("idle").Args("-l", "app=idling-echo").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))
@@ -276,7 +276,7 @@ var _ = g.Describe("[sig-cli] oc idle Deployments [apigroup:route.openshift.io][
 		o.Expect(out).NotTo(o.BeEmpty())
 	})
 
-	g.It("by all", func() {
+	g.It("by all", g.Label("Size:M"), func() {
 		out, err := oc.Run("idle").Args("--all").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring(expectedOutput))

--- a/test/extended/cli/label.go
+++ b/test/extended/cli/label.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-cli] oc label", func() {
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("oc-label", admissionapi.LevelBaseline)
 
-	g.It("pod", func() {
+	g.It("pod", g.Label("Size:S"), func() {
 		g.By("creating hello-openshift pod")
 		helloPodFile, err := writeObjectToFile(newHelloPod())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("runs successfully [apigroup:config.openshift.io]", func() {
+	g.It("runs successfully [apigroup:config.openshift.io]", g.Label("Size:L"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		}
 	})
 
-	g.It("runs successfully with options [apigroup:config.openshift.io]", func() {
+	g.It("runs successfully with options [apigroup:config.openshift.io]", g.Label("Size:L"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
@@ -127,7 +127,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		o.Expect(stat.Size()).To(o.BeNumerically(">", 0))
 	})
 
-	g.It("runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io]", func() {
+	g.It("runs successfully for audit logs [apigroup:config.openshift.io][apigroup:oauth.openshift.io]", g.Label("Size:L"), func() {
 		// On External clusters, events will not be part of the output, since audit logs do not include control plane logs.
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -286,7 +286,7 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 	g.When("looking at the audit logs [apigroup:config.openshift.io]", func() {
 		g.Describe("[sig-node] kubelet", func() {
-			g.It("runs apiserver processes strictly sequentially in order to not risk audit log corruption", func() {
+			g.It("runs apiserver processes strictly sequentially in order to not risk audit log corruption", g.Label("Size:L"), func() {
 				controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 				o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/observe.go
+++ b/test/extended/cli/observe.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-cli] oc observe", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("oc-observe").AsAdmin()
 
-	g.It("works as expected", func() {
+	g.It("works as expected", g.Label("Size:S"), func() {
 		g.By("Find out the clusterIP of the kubernetes.default service")
 		kubernetesSVC, err := oc.AdminKubeClient().CoreV1().Services("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -104,7 +104,7 @@ var _ = g.Describe("[sig-cli] oc observe", func() {
 		o.Expect(os.Unsetenv("MYENV")).NotTo(o.HaveOccurred())
 	})
 
-	g.It("works as expected with cluster operators [apigroup:config.openshift.io]", func() {
+	g.It("works as expected with cluster operators [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("observe").Args("clusteroperators", "--once", "--listen-addr=:11252").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("kube-apiserver"))

--- a/test/extended/cli/policy.go
+++ b/test/extended/cli/policy.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli] policy", func() {
 		simpleDeployment = exutil.FixturePath("testdata", "deployments", "deployment-simple-sleep.yaml")
 	)
 
-	g.It("scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("scc-subject-review, scc-review [apigroup:authorization.openshift.io][apigroup:user.openshift.io]", g.Label("Size:S"), func() {
 		err := oc.Run("policy", "scc-subject-review").Execute()
 		o.Expect(err).To(o.HaveOccurred())
 		err = oc.Run("policy", "scc-review").Execute()

--- a/test/extended/cli/probe.go
+++ b/test/extended/cli/probe.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-cli] oc probe", func() {
 		oc               = exutil.NewCLIWithPodSecurityLevel("oc-probe", admissionapi.LevelBaseline)
 	)
 
-	g.It("can ensure the probe command is functioning as expected on pods", func() {
+	g.It("can ensure the probe command is functioning as expected on pods", g.Label("Size:M"), func() {
 		g.By("creating a hello-openshift pod")
 		file, err := writeObjectToFile(newHelloPod())
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-cli] oc probe", func() {
 		oc.Run("delete").Args("-f", file).Execute()
 	})
 
-	g.It("can ensure the probe command is functioning as expected on deploymentconfigs [apigroup:apps.openshift.io]", func() {
+	g.It("can ensure the probe command is functioning as expected on deploymentconfigs [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		g.By("creating a test-deployment-config deploymentconfig")
 		err := oc.Run("create").Args("-f", deploymentConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/project.go
+++ b/test/extended/cli/project.go
@@ -18,7 +18,7 @@ var _ = g.Describe("[sig-cli] oc project", func() {
 
 	var oc = exutil.NewCLI("oc-project").AsAdmin()
 
-	g.It("--show-labels works for projects [apigroup:project.openshift.io]", func() {
+	g.It("--show-labels works for projects [apigroup:project.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("label").Args("namespace", oc.Namespace(), "foo=bar").Output()
 		o.Expect(out).To(o.ContainSubstring("labeled"))
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-cli] oc project", func() {
 		o.Expect(out).To(o.ContainSubstring("foo=bar"))
 	})
 
-	g.It("can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io][Serial]", func() {
+	g.It("can switch between different projects [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io][Serial]", g.Label("Size:M"), func() {
 		g.By("check auth usage is correct")
 		_, err := oc.Run("policy", "who-can").Args("get", "pods", "-n", "missing-ns").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/routes.go
+++ b/test/extended/cli/routes.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-cli] oc", func() {
 		testService = filepath.Join(cmdTestData, "test-service.json")
 	)
 
-	g.It("can route traffic to services [apigroup:route.openshift.io]", func() {
+	g.It("can route traffic to services [apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 		err := oc.Run("get").Args("routes").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/rsh.go
+++ b/test/extended/cli/rsh.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-cli] oc rsh", func() {
 	)
 
 	g.Describe("specific flags", func() {
-		g.It("should work well when access to a remote shell", func() {
+		g.It("should work well when access to a remote shell", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 			g.By("Creating pods with multi containers")
 

--- a/test/extended/cli/rsync.go
+++ b/test/extended/cli/rsync.go
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 	})
 
 	g.Describe("using a watch", func() {
-		g.It("should watch for changes and rsync them", func() {
+		g.It("should watch for changes and rsync them", g.Label("Size:M"), func() {
 			g.By("Creating a local temporary directory")
 			tempDir, err := ioutil.TempDir("", "rsync")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -283,13 +283,13 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 		}
 
 		for _, strategy := range strategies {
-			g.It(fmt.Sprintf("should copy files with the %s strategy", strategy), testRsyncFn(strategy))
+			g.It(fmt.Sprintf("should copy files with the %s strategy", strategy), g.Label("Size:M"), testRsyncFn(strategy))
 		}
 	})
 
 	g.Describe("rsync specific flags", func() {
 
-		g.It("should honor the --exclude flag", func() {
+		g.It("should honor the --exclude flag", g.Label("Size:M"), func() {
 			g.By(fmt.Sprintf("Calling oc rsync %s %s:/tmp --exclude=image-streams-rhel7.json", sourcePath1, podName))
 			err := oc.Run("rsync").Args(
 				sourcePath1,
@@ -304,7 +304,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 			o.Expect(result).NotTo(o.ContainSubstring("image-streams-rhel7.json"))
 		})
 
-		g.It("should honor multiple --exclude flags", func() {
+		g.It("should honor multiple --exclude flags", g.Label("Size:M"), func() {
 			g.By(fmt.Sprintf("Calling oc rsync %s %s:/tmp --exclude=application-template-pullspecbuild.json --exclude=application-template-dockerbuild.json", sourcePath2, podName))
 			err := oc.Run("rsync").Args(
 				sourcePath2,
@@ -321,7 +321,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 			o.Expect(result).To(o.ContainSubstring("application-template-stibuild.json"))
 		})
 
-		g.It("should honor the --include flag", func() {
+		g.It("should honor the --include flag", g.Label("Size:M"), func() {
 			g.By(fmt.Sprintf("Calling oc rsync %s %s:/tmp --exclude=*.json --include=image-streams-rhel7.json", sourcePath1, podName))
 			err := oc.Run("rsync").Args(
 				sourcePath1,
@@ -337,7 +337,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 			o.Expect(result).NotTo(o.ContainSubstring("image-streams-centos7.json"))
 		})
 
-		g.It("should honor multiple --include flags", func() {
+		g.It("should honor multiple --include flags", g.Label("Size:M"), func() {
 			g.By(fmt.Sprintf("Calling oc rsync %s %s:/tmp --exclude=*.json --include=application-template-stibuild.json --include=application-template-dockerbuild.json", sourcePath2, podName))
 			err := oc.Run("rsync").Args(
 				sourcePath2,
@@ -355,7 +355,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 			o.Expect(result).NotTo(o.ContainSubstring("application-template-pullspecbuild.json"))
 		})
 
-		g.It("should honor the --progress flag", func() {
+		g.It("should honor the --progress flag", g.Label("Size:M"), func() {
 			g.By(fmt.Sprintf("Calling oc rsync %s %s:/tmp --progress", sourcePath1, podName))
 			result, err := oc.Run("rsync").Args(
 				sourcePath1,
@@ -365,7 +365,7 @@ var _ = g.Describe("[sig-cli][Slow] can use rsync to upload files to pods [apigr
 			o.Expect(result).To(o.ContainSubstring("100%"))
 		})
 
-		g.It("should honor the --no-perms flag", func() {
+		g.It("should honor the --no-perms flag", g.Label("Size:M"), func() {
 			g.By("Creating a temporary destination directory")
 			tempDir, err := ioutil.TempDir("", "rsync")
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/run.go
+++ b/test/extended/cli/run.go
@@ -14,7 +14,7 @@ var _ = g.Describe("[sig-cli] oc run", func() {
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("oc-run", admissionapi.LevelBaseline)
 
-	g.It("can use --image flag correctly [apigroup:apps.openshift.io]", func() {
+	g.It("can use --image flag correctly [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 		_, err := oc.Run("create").Args("deploymentconfig", "newdcforimage", "--image=validimagevalue").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-cli] oc run", func() {
 		o.Expect(err.Error()).To(o.ContainSubstring("error: Invalid image name \"\\\"InvalidImageValue0192\\\"\": invalid reference format"))
 	})
 
-	g.It("can use --image flag correctly for deployment", func() {
+	g.It("can use --image flag correctly for deployment", g.Label("Size:S"), func() {
 		_, err := oc.Run("create").Args("deployment", "newdcforimage", "--image=validimagevalue").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/secret.go
+++ b/test/extended/cli/secret.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli] oc secret", func() {
 		testData = exutil.FixturePath("testdata", "cmd", "test", "cmd", "testdata", "resource-builder")
 	)
 
-	g.It("creates and retrieves expected", func() {
+	g.It("creates and retrieves expected", g.Label("Size:S"), func() {
 		g.By("creating secrets from a directory of files with proper extensions, as well as explicit filenames without extensions")
 		err := oc.Run("create").Args(
 			"-f", filepath.Join(testData, "directory"),

--- a/test/extended/cli/service.go
+++ b/test/extended/cli/service.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli] oc service", func() {
 
 	var oc = exutil.NewCLI("oc-service")
 
-	g.It("creates and deletes services", func() {
+	g.It("creates and deletes services", g.Label("Size:M"), func() {
 		err := oc.Run("get").Args("services").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		oc               = exutil.NewCLIWithPodSecurityLevel("oc-set-image", admissionapi.LevelBaseline)
 	)
 
-	g.It("can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io][Skipped:Disconnected]", func() {
+	g.It("can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io][Skipped:Disconnected]", g.Label("Size:M"), func() {
 		g.By("creating test deployment, pod, and image stream")
 		err := oc.Run("create").Args("-f", deploymentConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -130,7 +130,7 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
 	})
 
-	g.It("can set images for pods and deployments [apigroup:image.openshift.io][Skipped:Disconnected]", func() {
+	g.It("can set images for pods and deployments [apigroup:image.openshift.io][Skipped:Disconnected]", g.Label("Size:M"), func() {
 		g.By("creating test deployment, pod, and image stream")
 		err := oc.Run("create").Args("-f", deployment).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cli/statefulset.go
+++ b/test/extended/cli/statefulset.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cli] oc statefulset", func() {
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("oc-statefulset", admissionapi.LevelBaseline)
 
-	g.It("creates and deletes statefulsets", func() {
+	g.It("creates and deletes statefulsets", g.Label("Size:M"), func() {
 		g.By("creating a new service for the statefulset")
 
 		frontendFile, err := writeObjectToFile(newFrontendService())

--- a/test/extended/cli/status.go
+++ b/test/extended/cli/status.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-cli] oc status", func() {
 
 	var oc = exutil.NewCLI("oc-status")
 
-	g.It("returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("returns expected help messages [apigroup:project.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:route.openshift.io]", g.Label("Size:S"), func() {
 		out, err := oc.Run("status").Args("-h").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("oc describe buildconfig"))
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-cli] oc status", func() {
 		o.Expect(out).To(o.ContainSubstring("oc new-app"))
 	})
 
-	g.It("can show correct status after switching between projects [apigroup:project.openshift.io][apigroup:image.openshift.io][Serial]", func() {
+	g.It("can show correct status after switching between projects [apigroup:project.openshift.io][apigroup:image.openshift.io][Serial]", g.Label("Size:M"), func() {
 		projectBar := oc.Namespace() + "-project-bar"
 		projectBar2 := oc.Namespace() + "-project-bar-2"
 		projectStatus := oc.Namespace() + "-project-status"

--- a/test/extended/cli/template.go
+++ b/test/extended/cli/template.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-cli] templates", func() {
 		multilinePath                = filepath.Join(testDataPath, "templates", "multiline.txt")
 	)
 
-	g.It("process [apigroup:template.openshift.io][Skipped:Disconnected]", func() {
+	g.It("process [apigroup:template.openshift.io][Skipped:Disconnected]", g.Label("Size:M"), func() {
 		err := oc.Run("get").Args("templates").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("create").Args("-f", appTemplatePath).Execute()
@@ -342,7 +342,7 @@ var _ = g.Describe("[sig-cli] templates", func() {
 		o.Expect(out).To(o.ContainSubstring("also,with=commas"))
 	})
 
-	g.It("different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Skipped:Disconnected]", func() {
+	g.It("different namespaces [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:template.openshift.io][apigroup:authorization.openshift.io][Skipped:Disconnected]", g.Label("Size:M"), func() {
 		bob := oc.CreateUser("bob-")
 
 		err := oc.Run("create").Args("-f", appTemplatePath).Execute()

--- a/test/extended/cli/timeout.go
+++ b/test/extended/cli/timeout.go
@@ -13,7 +13,7 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 
 	oc := exutil.NewCLI("oc-request-timeout")
 
-	g.It("works as expected [apigroup:apps.openshift.io]", func() {
+	g.It("works as expected [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		busyBoxImage := k8simage.GetE2EImage(k8simage.BusyBox)
 		err := oc.Run("create").Args("deploymentconfig", "testdc", "--image="+busyBoxImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -41,7 +41,7 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 			o.ContainSubstring("Client.Timeout exceeded while awaiting headers")))
 	})
 
-	g.It("works as expected for deployment", func() {
+	g.It("works as expected for deployment", g.Label("Size:M"), func() {
 		busyBoxImage := k8simage.GetE2EImage(k8simage.BusyBox)
 		err := oc.Run("create").Args("deployment", "testdc", "--image="+busyBoxImage).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cloud_controller_manager/ccm.go
+++ b/test/extended/cloud_controller_manager/ccm.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("ccm")
 
-	g.It("Deploy an external cloud provider [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Deploy an external cloud provider [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-cloud-provider][Feature:OpenShiftCloudControllerManager
 			)))
 	})
 
-	g.It("Cluster scoped load balancer healthcheck port and path should be 10256/healthz", func() {
+	g.It("Cluster scoped load balancer healthcheck port and path should be 10256/healthz", g.Label("Size:M"), func() {
 		exutil.SkipIfNotPlatform(oc, "AWS")
 		if strings.HasPrefix(exutil.GetClusterRegion(oc), "us-iso") {
 			g.Skip("Skipped: There is no public subnet on AWS C2S/SC2S disconnected clusters!")

--- a/test/extended/cluster/audit.go
+++ b/test/extended/cluster/audit.go
@@ -21,7 +21,7 @@ import (
 var _ = g.Describe("[sig-api-machinery][Feature:Audit] Basic audit", func() {
 	f := framework.NewDefaultFramework("audit")
 
-	g.It("should audit API calls", func() {
+	g.It("should audit API calls", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 
 		// Create & Delete pod

--- a/test/extended/cluster/cl.go
+++ b/test/extended/cluster/cl.go
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance] Load cluster", func()
 		}
 	})
 
-	g.It("should populate the cluster [Slow][Serial][apigroup:template.openshift.io][apigroup:apps.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("should populate the cluster [Slow][Serial][apigroup:template.openshift.io][apigroup:apps.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		project := ConfigContext.ClusterLoader.Projects
 		tuningSets := ConfigContext.ClusterLoader.TuningSets
 		sync := ConfigContext.ClusterLoader.Sync

--- a/test/extended/cluster/clt.go
+++ b/test/extended/cluster/clt.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance][Serial][Slow] Load cl
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLIWithoutNamespace("cl")
 
-	g.It("concurrently with templates", func() {
+	g.It("concurrently with templates", g.Label("Size:L"), func() {
 		var namespaces []string
 
 		project := ConfigContext.ClusterLoader.Projects

--- a/test/extended/cluster/cm.go
+++ b/test/extended/cluster/cm.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance][Serial][Slow] Mirror 
 		c = oc.AdminKubeClient()
 	})
 
-	g.It("it should read the node info", func() {
+	g.It("it should read the node info", g.Label("Size:S"), func() {
 		nodeinfo := map[string]map[string]int{}
 
 		nodes, err := c.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-scalability][Feature:Performance][Serial][Slow] Mirror 
 		e2e.Logf("We have %v\n", nodeinfo)
 	})
 
-	g.It("it should read the cluster apps [apigroup:apps.openshift.io]", func() {
+	g.It("it should read the cluster apps [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 		var pods *v1.PodList
 		config := ContextType{}
 		config.ClusterLoader.Cleanup = true

--- a/test/extended/clusterversion/clusterversion.go
+++ b/test/extended/clusterversion/clusterversion.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][OCPFeatureGate:ImageStreamImportMode
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("")
 
-	g.It("desired architecture should be valid when architecture is set in release payload metadata [apigroup:config.openshift.io]", func() {
+	g.It("desired architecture should be valid when architecture is set in release payload metadata [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		TestClusterVersionDesiredArchitecture(g.GinkgoT(), oc)
 	})
 

--- a/test/extended/cmd/cmd.go
+++ b/test/extended/cmd/cmd.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-cli][Feature:LegacyCommandTests][Disruptive][Serial] te
 			continue
 		}
 
-		g.It("test/cmd/"+currFilename+" [apigroup:image.openshift.io]", func() {
+		g.It("test/cmd/"+currFilename+" [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 			testsDir := exutil.FixturePath("testdata", "cmd", "test", "cmd")
 			oc.AddExplicitResourceToDelete(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}, "", "cmd-"+currFilename[0:len(currFilename)-3])
 

--- a/test/extended/controller_manager/deploy_defaults.go
+++ b/test/extended/controller_manager/deploy_defaults.go
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-defaults")
 
-	g.It("TestDeploymentConfigDefaults [apigroup:apps.openshift.io]", func() {
+	g.It("TestDeploymentConfigDefaults [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		namespace := oc.Namespace()

--- a/test/extended/controller_manager/deploy_scale.go
+++ b/test/extended/controller_manager/deploy_scale.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-scale")
 
-	g.It("TestDeployScale [apigroup:apps.openshift.io]", func() {
+	g.It("TestDeployScale [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		namespace := oc.Namespace()

--- a/test/extended/controller_manager/deploy_trigger.go
+++ b/test/extended/controller_manager/deploy_trigger.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("deployment-trigger")
 
-	g.It("TestTriggers_manual [apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_manual [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_imageChange ensures that a deployment config with an ImageChange trigger
 	// will start a new deployment when an image change happens.
-	g.It("TestTriggers_imageChange [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("TestTriggers_imageChange [apigroup:apps.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		const registryHostname = "registry:8080"
@@ -195,7 +195,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_imageChange_nonAutomatic ensures that a deployment config with a non-automatic
 	// trigger will have its image updated when a deployment is started manually.
-	g.It("TestTriggers_imageChange_nonAutomatic [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_imageChange_nonAutomatic [apigroup:image.openshift.io][apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10
@@ -379,7 +379,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_MultipleICTs ensures that a deployment config with more than one ImageChange trigger
 	// will start a new deployment iff all images are resolved.
-	g.It("TestTriggers_MultipleICTs [apigroup:apps.openshift.io][apigroup:images.openshift.io]", func() {
+	g.It("TestTriggers_MultipleICTs [apigroup:apps.openshift.io][apigroup:images.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		const registryHostname = "registry:8080"
@@ -535,7 +535,7 @@ var _ = g.Describe("[sig-apps][Feature:OpenShiftControllerManager]", func() {
 
 	// TestTriggers_configChange ensures that a change in the template of a deployment config with
 	// a config change trigger will start a new deployment.
-	g.It("TestTriggers_configChange [apigroup:apps.openshift.io]", func() {
+	g.It("TestTriggers_configChange [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		const maxUpdateRetries = 10

--- a/test/extended/controller_manager/pull_secret.go
+++ b/test/extended/controller_manager/pull_secret.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-devex][Feature:OpenShiftControllerManager]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("pull-secrets")
 
-	g.It("TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("TestAutomaticCreationOfPullSecrets [apigroup:config.openshift.io][apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClient := oc.AdminKubeClient()
@@ -98,7 +98,7 @@ var _ = g.Describe("[sig-devex][Feature:OpenShiftControllerManager]", func() {
 		}
 	})
 
-	g.It("TestDockercfgTokenDeletedController [apigroup:image.openshift.io]", func() {
+	g.It("TestDockercfgTokenDeletedController [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/coreos/coreos.go
+++ b/test/extended/coreos/coreos.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-coreos] [Conformance] CoreOS bootimages", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("coreos")
 
-	g.It("TestBootimagesPresent [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("TestBootimagesPresent [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		client := oc.AdminKubeClient()
 		cm, err := client.CoreV1().ConfigMaps(mcoNamespace).Get(context.Background(), cmName, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cpu_partitioning/crio.go
+++ b/test/extended/cpu_partitioning/crio.go
@@ -140,7 +140,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning no
 		o.Expect(cleanup(managedNamespace, managedNamespace.Namespace())).To(o.Succeed())
 	})
 
-	g.It("should have correct cpuset and cpushare set in crio containers", func() {
+	g.It("should have correct cpuset and cpushare set in crio containers", g.Label("Size:L"), func() {
 
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/cpu_partitioning/managed.go
+++ b/test/extended/cpu_partitioning/managed.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 			o.Expect(cleanup(oc, namespace)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should be modified if CPUPartitioningMode = AllNodes", func() {
+		g.It("should be modified if CPUPartitioningMode = AllNodes", g.Label("Size:M"), func() {
 
 			e := createNamespace(oc, namespace, namespaceAnnotation)
 			o.Expect(e).ToNot(o.HaveOccurred(), "error creating namespace %s", namespace)
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 			o.Expect(cleanup(oc, namespace)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should be allowed if CPUPartitioningMode = AllNodes with a warning annotation", func() {
+		g.It("should be allowed if CPUPartitioningMode = AllNodes with a warning annotation", g.Label("Size:M"), func() {
 
 			e := createNamespace(oc, namespace, nil)
 			o.Expect(e).ToNot(o.HaveOccurred(), "error creating namespace %s", namespace)
@@ -143,7 +143,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 			o.Expect(cleanup(managedOC, managedOC.Namespace())).To(o.Succeed())
 		})
 
-		g.It("should have resources modified if CPUPartitioningMode = AllNodes", func() {
+		g.It("should have resources modified if CPUPartitioningMode = AllNodes", g.Label("Size:M"), func() {
 
 			requests := corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("20m"),

--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 		isClusterCPUPartitioned = getCpuPartitionedStatus(oc) == ocpv1.CPUPartitioningAllNodes
 	})
 
-	g.It("should be configured correctly", func() {
+	g.It("should be configured correctly", g.Label("Size:M"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/cpu_partitioning/pods.go
+++ b/test/extended/cpu_partitioning/pods.go
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 		matcher, messageFormat = adjustMatcherAndMessageForCluster(isClusterCPUPartitioned, matcher)
 	})
 
-	g.It("should be annotated correctly for Deployments", func() {
+	g.It("should be annotated correctly for Deployments", g.Label("Size:L"), func() {
 
 		var (
 			deploymentErr []error
@@ -150,7 +150,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 		o.Expect(deploymentErr).To(o.BeEmpty())
 	})
 
-	g.It("should be annotated correctly for DaemonSets", func() {
+	g.It("should be annotated correctly for DaemonSets", g.Label("Size:L"), func() {
 
 		var (
 			daemonsetErr []error

--- a/test/extended/crdvalidation/apiserver.go
+++ b/test/extended/crdvalidation/apiserver.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-api-machinery] APIServer CR fields validation", func() 
 	)
 	defer g.GinkgoRecover()
 
-	g.It("additionalCORSAllowedOrigins [apigroup:config.openshift.io]", func() {
+	g.It("additionalCORSAllowedOrigins [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		apiServerClient := oc.AdminConfigClient().ConfigV1().APIServers()
 
 		apiServer, err := apiServerClient.Get(context.Background(), "cluster", metav1.GetOptions{})

--- a/test/extended/csrapprover/csrapprover.go
+++ b/test/extended/csrapprover/csrapprover.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("cluster-client-cert", admissionapi.LevelBaseline)
 	defer g.GinkgoRecover()
 
-	g.It("Pods cannot access the /config/master API endpoint", func() {
+	g.It("Pods cannot access the /config/master API endpoint", g.Label("Size:M"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -73,7 +73,7 @@ var _ = g.Describe("[sig-cluster-lifecycle]", func() {
 		o.Expect(curlOutput).To(o.Or(o.ContainSubstring("Connection refused"), o.ContainSubstring("Connection timed out")))
 	})
 
-	g.It("CSRs from machines that are not recognized by the cloud provider are not approved", func() {
+	g.It("CSRs from machines that are not recognized by the cloud provider are not approved", g.Label("Size:S"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/deployments/deployments.go
+++ b/test/extended/deployments/deployments.go
@@ -114,7 +114,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should only deploy the last deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should only deploy the last deployment [apigroup:apps.openshift.io]", g.Label("Size:L"), func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -203,7 +203,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForLatestCondition(oc, "deployment-simple", deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should immediately start a new deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should immediately start a new deployment [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -289,7 +289,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("resolve the image pull spec [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("resolve the image pull spec [apigroup:apps.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 			// FIXME: Wrap the IS creation into utility helper
 			err := oc.Run("create").Args("-f", resolutionIsFixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -337,7 +337,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should run a deployment to completion and then scale to zero [apigroup:apps.openshift.io]", func() {
+		g.It("should run a deployment to completion and then scale to zero [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 
 			dc := ReadFixtureOrFail(deploymentFixture).(*appsv1.DeploymentConfig)
@@ -421,7 +421,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should successfully trigger from an updated image [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should successfully trigger from an updated image [apigroup:apps.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, imageChangeTriggerFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -473,7 +473,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should successfully tag the deployed image [apigroup:apps.openshift.io][apigroup:authorization.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 			g.By("creating the deployment config fixture")
 			dc, err := createDeploymentConfig(oc, tagImagesFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -518,7 +518,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should expand the config map key to a value [apigroup:apps.openshift.io]", func() {
+		g.It("should expand the config map key to a value [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			_, err := oc.Run("create").Args("configmap", "test", "--from-literal=foo=bar").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -545,7 +545,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should run a successful deployment with multiple triggers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 			g.By("creating DC")
 
 			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
@@ -561,7 +561,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(waitForLatestCondition(oc, dcName, deploymentRunTimeout, deploymentReachedCompletion)).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", func() {
+		g.It("should run a successful deployment with a trigger used by different containers [apigroup:apps.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 
 			_, err := oc.Run("import-image").Args("registry.redhat.io/ubi8/ruby-30:latest", "--confirm", "--reference-policy=local").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -582,7 +582,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should include various info in status [apigroup:apps.openshift.io]", func() {
+		g.It("should include various info in status [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -615,7 +615,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should run the custom deployment steps [apigroup:apps.openshift.io]", func() {
+		g.It("should run the custom deployment steps [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 
 			dc := ReadFixtureOrFail(customDeploymentFixture).(*appsv1.DeploymentConfig)
@@ -652,7 +652,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should print the rollout history [apigroup:apps.openshift.io]", func() {
+		g.It("should print the rollout history [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -703,7 +703,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, "generation-test", g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should deploy based on a status version bump [apigroup:apps.openshift.io]", func() {
+		g.It("should deploy based on a status version bump [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, generationFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -792,7 +792,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should disable actions on deployments [apigroup:apps.openshift.io]", func() {
+		g.It("should disable actions on deployments [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 			dc, err := createDeploymentConfig(oc, pausedDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -856,7 +856,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should get all logs from retried hooks [apigroup:apps.openshift.io]", func() {
+		g.It("should get all logs from retried hooks [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, failedHookFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -879,7 +879,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should rollback to an older deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should rollback to an older deployment [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, simpleDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -926,7 +926,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should delete all failed deployer pods and hook pods [apigroup:apps.openshift.io]", func() {
+		g.It("should delete all failed deployer pods and hook pods [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, brokenDeploymentFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -967,7 +967,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should not deploy if pods never transition to ready [apigroup:apps.openshift.io]", func() {
+		g.It("should not deploy if pods never transition to ready [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc, err := createDeploymentConfig(oc, readinessFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -984,7 +984,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should never persist more old deployments than acceptable after being observed by the controller [apigroup:apps.openshift.io]", func() {
+		g.It("should never persist more old deployments than acceptable after being observed by the controller [apigroup:apps.openshift.io]", g.Label("Size:L"), func() {
 			revisionHistoryLimit := 3 // as specified in the fixture
 
 			dc, err := createDeploymentConfig(oc, historyLimitedDeploymentFixture)
@@ -1045,7 +1045,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should not transition the deployment to Complete before satisfied [apigroup:apps.openshift.io]", func() {
+		g.It("should not transition the deployment to Complete before satisfied [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			dc := ReadFixtureOrFail(minReadySecondsFixture).(*appsv1.DeploymentConfig)
 			o.Expect(dc.Name).To(o.Equal(dcName))
 			o.Expect(dc.Spec.Triggers).To(o.BeNil())
@@ -1118,7 +1118,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should let the deployment config with a NewReplicationControllerCreated reason [apigroup:apps.openshift.io]", func() {
+		g.It("should let the deployment config with a NewReplicationControllerCreated reason [apigroup:apps.openshift.io]", g.Label("Size:S"), func() {
 			dc, err := createDeploymentConfig(oc, ignoresDeployersFixture)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(dc.Name).To(o.Equal(dcName))
@@ -1161,7 +1161,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrapForDetachedRCs(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should adhere to Three Laws of Controllers [apigroup:apps.openshift.io]", func() {
+		g.It("should adhere to Three Laws of Controllers [apigroup:apps.openshift.io]", g.Label("Size:L"), func() {
 			namespace := oc.Namespace()
 			rcName := func(i int) string { return fmt.Sprintf("%s-%d", dcName, i) }
 
@@ -1268,7 +1268,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("should deal with cancellation of running deployment [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with cancellation of running deployment [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1342,7 +1342,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should deal with config change in case the deployment is still running [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with config change in case the deployment is still running [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1405,7 +1405,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should deal with cancellation after deployer pod succeeded [apigroup:apps.openshift.io]", func() {
+		g.It("should deal with cancellation after deployer pod succeeded [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 			const (
 				deploymentCancelledAnnotation    = "openshift.io/deployment.cancelled"
@@ -1520,7 +1520,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("when patched with empty image [apigroup:apps.openshift.io]", func() {
+		g.It("when patched with empty image [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")
@@ -1599,7 +1599,7 @@ var _ = g.Describe("[sig-apps][Feature:DeploymentConfig] deploymentconfigs", fun
 			failureTrap(oc, dcName, g.CurrentSpecReport().Failed())
 		})
 
-		g.It("will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io]", func() {
+		g.It("will orphan all RCs and adopt them back when recreated [apigroup:apps.openshift.io]", g.Label("Size:L"), func() {
 			namespace := oc.Namespace()
 
 			g.By("creating DC")

--- a/test/extended/dns/dns.go
+++ b/test/extended/dns/dns.go
@@ -421,7 +421,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 		}
 	})
 
-	It("should answer endpoint and wildcard queries for the cluster", func() {
+	It("should answer endpoint and wildcard queries for the cluster", Label("Size:L"), func() {
 		ctx := context.Background()
 		createOpts := metav1.CreateOptions{}
 		if _, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, createServiceSpec("headless", true, "", nil), createOpts); err != nil {
@@ -505,7 +505,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 		validateDNSResults(f, pod, expect, times)
 	})
 
-	It("should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]", func() {
+	It("should answer A and AAAA queries for a dual-stack service [apigroup:config.openshift.io]", Label("Size:M"), func() {
 		// Only run this test on dual-stack enabled clusters.
 		networkConfig, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 		if err != nil {
@@ -593,7 +593,7 @@ var _ = Describe("[sig-network-edge] DNS", func() {
 		validateDNSResults(f, pod, expect, times)
 	})
 
-	It("should answer queries using the local DNS endpoint", func() {
+	It("should answer queries using the local DNS endpoint", Label("Size:M"), func() {
 		ctx := context.Background()
 
 		By("starting an exec pod for running queries")

--- a/test/extended/dr/cert_rotation.go
+++ b/test/extended/dr/cert_rotation.go
@@ -35,7 +35,7 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certro
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("can manually rotate signer certificates [Timeout:30m]", func() {
+	g.It("can manually rotate signer certificates [Timeout:30m]", g.Label("Size:L"), func() {
 		kasSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-kube-apiserver")
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
 
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certro
 		o.Expect(rotatedEtcdLeafCerts.Data).ToNot(o.Equal(currentEtcdLeafCerts.Data))
 	})
 
-	g.It("can manually rotate metrics signer certificates [Timeout:45m]", func() {
+	g.It("can manually rotate metrics signer certificates [Timeout:45m]", g.Label("Size:L"), func() {
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
 		prometheus, err := client.NewE2EPrometheusRouterClient(ctx, oc)
 		o.Expect(err).ToNot(o.HaveOccurred())
@@ -116,7 +116,7 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certro
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("can recreate dynamic certificates [Timeout:30m]", func() {
+	g.It("can recreate dynamic certificates [Timeout:30m]", g.Label("Size:L"), func() {
 		nodes := masterNodes(oc)
 		etcdSecretsClient := oc.AdminKubeClient().CoreV1().Secrets("openshift-etcd")
 
@@ -152,7 +152,7 @@ var _ = g.Describe("[sig-etcd][Feature:CertRotation][Suite:openshift/etcd/certro
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("can recreate trust bundle [Timeout:15m]", func() {
+	g.It("can recreate trust bundle [Timeout:15m]", g.Label("Size:L"), func() {
 		etcdConfigMapClient := oc.AdminKubeClient().CoreV1().ConfigMaps("openshift-etcd")
 		bundleName := "etcd-ca-bundle"
 

--- a/test/extended/dr/recovery.go
+++ b/test/extended/dr/recovery.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("[Feature:EtcdRecovery][Disruptive] Restore snapshot from node on another single unhealthy node", func() {
+	g.It("[Feature:EtcdRecovery][Disruptive] Restore snapshot from node on another single unhealthy node", g.Label("Size:L"), func() {
 		// ensure the CEO can still act without quorum, doing it first so the CEO can cycle while we install ssh keys
 		data := fmt.Sprintf(`{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`)
 		_, err := oc.AdminOperatorClient().OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, []byte(data), metav1.PatchOptions{})
@@ -103,7 +103,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("[Feature:EtcdRecovery][Disruptive] Recover with snapshot with two unhealthy nodes and lost quorum", func() {
+	g.It("[Feature:EtcdRecovery][Disruptive] Recover with snapshot with two unhealthy nodes and lost quorum", g.Label("Size:L"), func() {
 		// ensure the CEO can still act without quorum, doing it first so the CEO can cycle while we install ssh keys
 		data := fmt.Sprintf(`{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`)
 		_, err := oc.AdminOperatorClient().OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, []byte(data), metav1.PatchOptions{})
@@ -186,7 +186,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 		o.Expect(err).ToNot(o.HaveOccurred())
 	})
 
-	g.It("[Feature:EtcdRecovery][Disruptive] Recover with quorum restore", func() {
+	g.It("[Feature:EtcdRecovery][Disruptive] Recover with quorum restore", g.Label("Size:L"), func() {
 		// ensure the CEO can still act without quorum, doing it first so the CEO can cycle while we install ssh keys
 		data := fmt.Sprintf(`{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}`)
 		_, err := oc.AdminOperatorClient().OperatorV1().Etcds().Patch(context.Background(), "cluster", types.MergePatchType, []byte(data), metav1.PatchOptions{})

--- a/test/extended/dr/static_pod_rollouts.go
+++ b/test/extended/dr/static_pod_rollouts.go
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/re
 
 	})
 
-	g.It("is able to block the rollout of a revision when the quorum is not safe", func(ctx context.Context) {
+	g.It("is able to block the rollout of a revision when the quorum is not safe", g.Label("Size:L"), func(ctx context.Context) {
 		var err error
 
 		g.GinkgoT().Logf("debugging into node %s to remove the etcd static pod manifest", etcdTargetNodeName)

--- a/test/extended/etcd/etcd_test_runner.go
+++ b/test/extended/etcd/etcd_test_runner.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-api-machinery] API data in etcd", func() {
 	cli := exutil.NewCLIWithPodSecurityLevel("etcd-storage-path", psapi.LevelBaseline)
 	adminCLI := cli.AsAdmin()
 
-	g.It("should be stored at the correct location and version for all resources [Serial]", func() {
+	g.It("should be stored at the correct location and version for all resources [Serial]", g.Label("Size:L"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(adminCLI)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/etcd/hardware_speed.go
+++ b/test/extended/etcd/hardware_speed.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 	// It starts by changing the hardware speed to Standard.
 	// next it ensures that the etcd servers come back up and are healthy.
 	// next it validates that the etcd servers were started with the expected environment variables.
-	g.It("is able to set the hardware speed to Standard [Timeout:30m][apigroup:machine.openshift.io]", func(ctx context.Context) {
+	g.It("is able to set the hardware speed to Standard [Timeout:30m][apigroup:machine.openshift.io]", g.Label("Size:L"), func(ctx context.Context) {
 		// Set the hardware speed to Standard from default ""
 		g.GinkgoT().Log("setting hardware speed to Standard")
 		data := fmt.Sprintf(`{"spec": {"controlPlaneHardwareSpeed": "Standard"}}`)
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 	// It starts by changing the hardware speed to Profile.
 	// next it ensures that the etcd servers come back up and are healthy.
 	// next it validates that the etcd servers were started with the expected environment variables.
-	g.It("is able to set the hardware speed to Slower [Timeout:30m][apigroup:machine.openshift.io]", func(ctx context.Context) {
+	g.It("is able to set the hardware speed to Slower [Timeout:30m][apigroup:machine.openshift.io]", g.Label("Size:L"), func(ctx context.Context) {
 		g.GinkgoT().Log("setting hardware speed to Slower")
 		data := fmt.Sprintf(`{"spec": {"controlPlaneHardwareSpeed": "Slower"}}`)
 		_, err := oc.AdminOperatorClient().OperatorV1().Etcds().Patch(ctx, "cluster", types.MergePatchType, []byte(data), metav1.PatchOptions{})
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-etcd][OCPFeatureGate:HardwareSpeed][Serial] etcd", func
 	// It starts by changing the hardware speed to "".
 	// next it ensures that the etcd servers come back up and are healthy.
 	// next it validates that the etcd servers were started with the expected environment variables.
-	g.It("is able to set the hardware speed to \"\" [Timeout:30m][apigroup:machine.openshift.io]", func(ctx context.Context) {
+	g.It("is able to set the hardware speed to \"\" [Timeout:30m][apigroup:machine.openshift.io]", g.Label("Size:L"), func(ctx context.Context) {
 		g.GinkgoT().Log("setting hardware speed to \"\"")
 		data := fmt.Sprintf(`{"spec": {"controlPlaneHardwareSpeed": ""}}`)
 		_, err := oc.AdminOperatorClient().OperatorV1().Etcds().Patch(ctx, "cluster", types.MergePatchType, []byte(data), metav1.PatchOptions{})

--- a/test/extended/etcd/invariants.go
+++ b/test/extended/etcd/invariants.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("etcd-invariants").AsAdmin()
 
-	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]", func() {
+	g.It("cluster has the same number of master nodes and voting members from the endpoints configmap [Early][apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		exutil.SkipIfExternalControlplaneTopology(oc, "clusters with external controlplane topology don't have master nodes")
 		masterNodeLabelSelectorString := "node-role.kubernetes.io/master"
 		controlPlaneNodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: masterNodeLabelSelectorString})

--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -21,11 +21,11 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	oc := exutil.NewCLIWithoutNamespace("etcd-leader-change").AsAdmin()
 
 	var earlyTimeStamp time.Time
-	g.It("record the start revision of the etcd-operator [Early]", func() {
+	g.It("record the start revision of the etcd-operator [Early]", g.Label("Size:S"), func() {
 		earlyTimeStamp = time.Now()
 	})
 
-	g.It("leader changes are not excessive [Late]", func(ctx g.SpecContext) {
+	g.It("leader changes are not excessive [Late]", g.Label("Size:S"), func(ctx g.SpecContext) {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {

--- a/test/extended/etcd/vertical_scaling.go
+++ b/test/extended/etcd/vertical_scaling.go
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 	// 4) Then scale-down the machine that is pending deletion by removing its member and deletion hook
 	// The test will validate the size of the etcd cluster and make sure the cluster membership
 	// changes with the new member added and the old one removed.
-	g.It("is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]", func() {
+	g.It("is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]", g.Label("Size:L"), func() {
 		if cpmsActive {
 			// TODO: Add cleanup step to recover back to 3 running machines and members if the test fails
 
@@ -210,7 +210,7 @@ var _ = g.Describe("[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd
 	// 	  to verify that scale-down hasn't occurred before scale up when cluster membership is healthy
 	// 4) Create a new master machine and ensure it is running (scale-up)
 	// 5) Scale-down is validated by confirming the member removal and changes in the cluster membership
-	g.It("is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]", func() {
+	g.It("is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]", g.Label("Size:L"), func() {
 		if cpmsActive {
 			// step 0: disable the CPMS
 			framework.Logf("Disable the CPMS")

--- a/test/extended/extension/extension.go
+++ b/test/extended/extension/extension.go
@@ -9,9 +9,9 @@ import (
 var _ = g.Describe("[sig-ci] [OTE] OpenShift Tests Extension [Suite:openshift/ote]", func() {
 	defer g.GinkgoRecover()
 
-	_ = g.It("should support tests that succeed", func() {})
+	_ = g.It("should support tests that succeed", g.Label("Size:S"), func() {})
 
-	_ = g.It("should support tests with an informing lifecycle", ote.Informing(), func() {
+	_ = g.It("should support tests with an informing lifecycle", g.Label("Size:S"), ote.Informing(), func() {
 		e2e.Fail("This test is intended to fail.")
 	})
 })

--- a/test/extended/idling/idling.go
+++ b/test/extended/idling/idling.go
@@ -222,7 +222,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 				fixture = echoServerFixture
 			})
 
-			g.It("should idle the service and DeploymentConfig properly [apigroup:apps.openshift.io]", func() {
+			g.It("should idle the service and DeploymentConfig properly [apigroup:apps.openshift.io]", g.Label("Size:M"), func() {
 				checkSingleIdle(oc, idlingFile, resources, "deploymentconfig.apps.openshift.io", "DeploymentConfig", "apps.openshift.io")
 			})
 		})
@@ -232,7 +232,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 				fixture = echoServerRcFixture
 			})
 
-			g.It("should idle the service and ReplicationController properly", func() {
+			g.It("should idle the service and ReplicationController properly", g.Label("Size:M"), func() {
 				checkSingleIdle(oc, idlingFile, resources, "replicationcontroller", "ReplicationController", "")
 			})
 		})
@@ -243,7 +243,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			fixture = echoServerFixture
 		})
 
-		g.It("should work with TCP (when fully idled)", func() {
+		g.It("should work with TCP (when fully idled)", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -273,7 +273,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 		})
 
-		g.It("should work with TCP (while idling)", func() {
+		g.It("should work with TCP (while idling)", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -300,7 +300,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 
 		// This is [Serial] because we really want to spam the service, and that
 		// seems to disrupt the cluster if we do it in the parallel suite.
-		g.It("should handle many TCP connections by possibly dropping those over a certain bound [Serial]", func() {
+		g.It("should handle many TCP connections by possibly dropping those over a certain bound [Serial]", g.Label("Size:L"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -355,7 +355,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 		})
 
-		g.It("should work with UDP", func() {
+		g.It("should work with UDP", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -387,7 +387,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 
 		// This is [Serial] because we really want to spam the service, and that
 		// seems to disrupt the cluster if we do it in the parallel suite.
-		g.It("should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]", func() {
+		g.It("should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]", g.Label("Size:L"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -449,7 +449,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			fixture = echoServerFixtureDeployment
 		})
 
-		g.It("should work with TCP (when fully idled)", func() {
+		g.It("should work with TCP (when fully idled)", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -479,7 +479,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 		})
 
-		g.It("should work with TCP (while idling)", func() {
+		g.It("should work with TCP (while idling)", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -506,7 +506,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 
 		// This is [Serial] because we really want to spam the service, and that
 		// seems to disrupt the cluster if we do it in the parallel suite.
-		g.It("should handle many TCP connections by possibly dropping those over a certain bound [Serial]", func() {
+		g.It("should handle many TCP connections by possibly dropping those over a certain bound [Serial]", g.Label("Size:L"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -561,7 +561,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 			o.Expect(endpoints.Annotations).NotTo(o.HaveKey(unidlingapi.UnidleTargetAnnotation))
 		})
 
-		g.It("should work with UDP", func() {
+		g.It("should work with UDP", g.Label("Size:M"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())
@@ -593,7 +593,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Idling]", func() {
 
 		// This is [Serial] because we really want to spam the service, and that
 		// seems to disrupt the cluster if we do it in the parallel suite.
-		g.It("should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]", func() {
+		g.It("should handle many UDP senders (by continuing to drop all packets on the floor) [Serial]", g.Label("Size:L"), func() {
 			g.By("Idling the service")
 			_, err := oc.Run("idle").Args("--resource-names-file", idlingFile).Output()
 			o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/image_ecosystem/mariadb_ephemeral.go
+++ b/test/extended/image_ecosystem/mariadb_ephemeral.go
@@ -30,7 +30,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][mariadb][Slow] openshift
 		})
 
 		g.Describe("Creating from a template", func() {
-			g.It(fmt.Sprintf("should instantiate the template [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:apps.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should instantiate the template [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:apps.openshift.io]"), g.Label("Size:M"), func() {
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 
 				g.By(fmt.Sprintf("calling oc process %q", templatePath))

--- a/test/extended/image_ecosystem/mysql_ephemeral.go
+++ b/test/extended/image_ecosystem/mysql_ephemeral.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][mysql][Slow] openshift m
 		})
 
 		g.Describe("Creating from a template", func() {
-			g.It(fmt.Sprintf("should instantiate the template [apigroup:apps.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should instantiate the template [apigroup:apps.openshift.io]"), g.Label("Size:M"), func() {
 
 				g.By(fmt.Sprintf("calling oc process %q", templatePath))
 				configFile, err := oc.Run("process").Args("openshift//" + templatePath).OutputToFile("config.json")

--- a/test/extended/image_ecosystem/s2i_perl.go
+++ b/test/extended/image_ecosystem/s2i_perl.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][perl][Slow] hot deploy f
 		})
 
 		g.Describe("hot deploy test", func() {
-			g.It("should work [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]", func() {
+			g.It("should work [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 				// This image-ecosystem test fails on ARM because it depends on behaviour specific to mod_perl,
 				// which is only included in the RHSCL (RHEL 7) perl images which are not available on ARM.
 				if !archHasModPerl(oc) {

--- a/test/extended/image_ecosystem/s2i_php.go
+++ b/test/extended/image_ecosystem/s2i_php.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][php][Slow] hot deploy fo
 		})
 
 		g.Describe("CakePHP example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app %q -p %q", cakephpTemplate, hotDeployParam))

--- a/test/extended/image_ecosystem/s2i_python.go
+++ b/test/extended/image_ecosystem/s2i_python.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][python][Slow] hot deploy
 		})
 
 		g.Describe("Django example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 
 				// skipping this test for now until we figure out why is not
 				// passing on CI bz: 2023238

--- a/test/extended/image_ecosystem/s2i_ruby.go
+++ b/test/extended/image_ecosystem/s2i_ruby.go
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-devex][Feature:ImageEcosystem][ruby][Slow] hot deploy f
 		})
 
 		g.Describe("Rails example", func() {
-			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), func() {
+			g.It(fmt.Sprintf("should work with hot deploy [apigroup:image.openshift.io][apigroup:operator.openshift.io][apigroup:config.openshift.io][apigroup:build.openshift.io]"), g.Label("Size:L"), func() {
 				exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 				g.By(fmt.Sprintf("calling oc new-app %q", railsTemplate))
 				err := oc.Run("new-app").Args(railsTemplate).Execute()

--- a/test/extended/image_ecosystem/sample_repos.go
+++ b/test/extended/image_ecosystem/sample_repos.go
@@ -53,7 +53,7 @@ func NewSampleRepoTest(c sampleRepoConfig) func() {
 			})
 
 			g.Describe("Building "+c.repoName+" app from new-app", func() {
-				g.It(fmt.Sprintf("should build a %s image and run it in a pod [apigroup:build.openshift.io]", c.repoName), func() {
+				g.It(fmt.Sprintf("should build a %s image and run it in a pod [apigroup:build.openshift.io]", c.repoName), g.Label("Size:L"), func() {
 					err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 					o.Expect(err).NotTo(o.HaveOccurred())
 					g.By(fmt.Sprintf("calling oc new-app with the %s example template", c.repoName))

--- a/test/extended/image_ecosystem/scl.go
+++ b/test/extended/image_ecosystem/scl.go
@@ -47,7 +47,7 @@ func skipArch(oc *exutil.CLI, arches []string) bool {
 // is ok for these tests).
 func defineTest(name string, t tc, oc *exutil.CLI) {
 	g.Describe("returning s2i usage when running the image", func() {
-		g.It(fmt.Sprintf("%q should print the usage", t.DockerImageReference), func() {
+		g.It(fmt.Sprintf("%q should print the usage", t.DockerImageReference), g.Label("Size:S"), func() {
 			e2e.Logf("checking %s:%s for architecture compatibility", name, t.Tag)
 			if skipArch(oc, t.Arches) {
 				e2eskipper.Skipf("skipping %s:%s because not available on cluster architecture", name, t.Tag)
@@ -109,7 +109,7 @@ func defineTest(name string, t tc, oc *exutil.CLI) {
 		})
 	})
 	g.Describe("using the SCL in s2i images", func() {
-		g.It(fmt.Sprintf("%q should be SCL enabled", t.DockerImageReference), func() {
+		g.It(fmt.Sprintf("%q should be SCL enabled", t.DockerImageReference), g.Label("Size:M"), func() {
 			e2e.Logf("checking %s:%s for architecture compatibility", name, t.Tag)
 			if skipArch(oc, t.Arches) {
 				e2eskipper.Skipf("skipping %s:%s because not available on cluster architecture", name, t.Tag)

--- a/test/extended/imageapis/imagesigning.go
+++ b/test/extended/imageapis/imagesigning.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] signature", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("image")
 
-	g.It("TestImageAddSignature [apigroup:image.openshift.io]", func() {
+	g.It("TestImageAddSignature [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		adminClient := oc.AdminImageClient()
@@ -123,7 +123,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] signature", func() {
 	oc := exutil.NewCLI("image").AsAdmin()
 	ctx := context.Background()
 
-	g.It("TestImageRemoveSignature [apigroup:image.openshift.io]", func() {
+	g.It("TestImageRemoveSignature [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		adminClient := oc.AdminImageClient()

--- a/test/extended/imageapis/limitrange_admission.go
+++ b/test/extended/imageapis/limitrange_admission.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding %s limit [apigroup:build.openshift.io]", imagev1.LimitTypeImage), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding %s limit [apigroup:build.openshift.io]", imagev1.LimitTypeImage), g.Label("Size:L"), func() {
 		_, err := createLimitRangeOfType(oc, imagev1.LimitTypeImage, corev1.ResourceList{
 			corev1.ResourceStorage: resource.MustParse("10Ki"),
 		})
@@ -59,7 +59,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamImages), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamImages), g.Label("Size:L"), func() {
 		limits := corev1.ResourceList{
 			imagev1.ResourceImageStreamTags:   resource.MustParse("0"),
 			imagev1.ResourceImageStreamImages: resource.MustParse("0"),
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny a container image reference exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), func() {
+	g.It(fmt.Sprintf("should deny a container image reference exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), g.Label("Size:L"), func() {
 		tag2Image, err := buildAndPushTestImagesTo(oc, "src", "tag", 2)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -163,7 +163,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota][Serial][Suite:opensh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It(fmt.Sprintf("should deny an import of a repository exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), func() {
+	g.It(fmt.Sprintf("should deny an import of a repository exceeding limit on %s resource [apigroup:build.openshift.io]", imagev1.ResourceImageStreamTags), g.Label("Size:L"), func() {
 		maxBulkImport, err := getMaxImagesBulkImportedPerRepository()
 		if err != nil {
 			g.Skip(err.Error())

--- a/test/extended/imageapis/quota_admission.go
+++ b/test/extended/imageapis/quota_admission.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageQuota] Image resource quota
 	defer g.GinkgoRecover()
 	var oc = exutil.NewCLI("resourcequota-admission")
 
-	g.It(fmt.Sprintf("should deny a push of built image exceeding %s quota [apigroup:image.openshift.io]", imagev1.ResourceImageStreams), func() {
+	g.It(fmt.Sprintf("should deny a push of built image exceeding %s quota [apigroup:image.openshift.io]", imagev1.ResourceImageStreams), g.Label("Size:M"), func() {
 		g.Skip("TODO: determine why this test is not skipped/fails on 4.0 clusters")
 		quota := corev1.ResourceList{
 			imagev1.ResourceImageStreams: resource.MustParse("0"),

--- a/test/extended/imagepolicy/imagepolicy.go
+++ b/test/extended/imagepolicy/imagepolicy.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 		}
 	})
 
-	g.It("Should fail clusterimagepolicy signature validation root of trust does not match the identity in the signature", func() {
+	g.It("Should fail clusterimagepolicy signature validation root of trust does not match the identity in the signature", g.Label("Size:M"), func() {
 		createClusterImagePolicy(oc, testClusterImagePolicies[invalidPublicKeyClusterImagePolicyName])
 		g.DeferCleanup(deleteClusterImagePolicy, oc, invalidPublicKeyClusterImagePolicyName)
 
@@ -94,7 +94,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("Should fail clusterimagepolicy signature validation when scope in allowedRegistries list does not skip signature verification", func() {
+	g.It("Should fail clusterimagepolicy signature validation when scope in allowedRegistries list does not skip signature verification", g.Label("Size:L"), func() {
 		// Ensure allowedRegistries do not skip signature verification by adding testSignedPolicyScope to the list.
 		allowedRegistries := []string{"quay.io", "registry.redhat.io", "image-registry.openshift-image-registry.svc:5000", testSignedPolicyScope}
 		updateImageConfig(oc, allowedRegistries)
@@ -111,7 +111,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("Should pass clusterimagepolicy signature validation with signed image", func() {
+	g.It("Should pass clusterimagepolicy signature validation with signed image", g.Label("Size:M"), func() {
 		createClusterImagePolicy(oc, testClusterImagePolicies[publiKeyRekorClusterImagePolicyName])
 		g.DeferCleanup(deleteClusterImagePolicy, oc, publiKeyRekorClusterImagePolicyName)
 
@@ -123,7 +123,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("Should fail imagepolicy signature validation in different namespaces root of trust does not match the identity in the signature", func() {
+	g.It("Should fail imagepolicy signature validation in different namespaces root of trust does not match the identity in the signature", g.Label("Size:M"), func() {
 		createImagePolicy(oc, testImagePolicies[invalidPublicKeyImagePolicyName], imgpolicyClif.Namespace.Name)
 		g.DeferCleanup(deleteImagePolicy, oc, invalidPublicKeyImagePolicyName, imgpolicyClif.Namespace.Name)
 
@@ -136,7 +136,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 
 	})
 
-	g.It("Should pass imagepolicy signature validation with signed image in namespaces", func() {
+	g.It("Should pass imagepolicy signature validation with signed image in namespaces", g.Label("Size:M"), func() {
 
 		createImagePolicy(oc, testImagePolicies[publiKeyRekorImagePolicyName], imgpolicyClif.Namespace.Name)
 		g.DeferCleanup(deleteImagePolicy, oc, publiKeyRekorImagePolicyName, imgpolicyClif.Namespace.Name)
@@ -177,9 +177,9 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerificationPK
 			err := verifyFunc(tctx, clif, expectPass, testPodName, imageSpec)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		},
-		g.Entry("fail with PKI root of trust does not match the identity in the signature", invalidPKIClusterImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
-		g.Entry("fail with PKI email does not match", invalidEmailPKIClusterImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
-		g.Entry("pass with valid PKI", pkiClusterImagePolicyName, true, testPKISignedPolicyScope, verifyPodSignature),
+		g.Entry("fail with PKI root of trust does not match the identity in the signature", g.Label("Size:M"), invalidPKIClusterImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
+		g.Entry("fail with PKI email does not match", g.Label("Size:M"), invalidEmailPKIClusterImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
+		g.Entry("pass with valid PKI", g.Label("Size:M"), pkiClusterImagePolicyName, true, testPKISignedPolicyScope, verifyPodSignature),
 	)
 
 	g.DescribeTable("imagepolicy signature validation tests",
@@ -190,8 +190,8 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerificationPK
 			err := verifyFunc(tctx, imgpolicyClif, expectPass, testPodName, imageSpec)
 			o.Expect(err).NotTo(o.HaveOccurred())
 		},
-		g.Entry("fail with PKI root of trust does not match the identity in the signature", invalidPKIImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
-		g.Entry("pass with valid PKI", pkiImagePolicyName, true, testPKISignedPolicyScope, verifyPodSignature),
+		g.Entry("fail with PKI root of trust does not match the identity in the signature", g.Label("Size:M"), invalidPKIImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
+		g.Entry("pass with valid PKI", g.Label("Size:M"), pkiImagePolicyName, true, testPKISignedPolicyScope, verifyPodSignature),
 	)
 
 })

--- a/test/extended/images/append.go
+++ b/test/extended/images/append.go
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageAppend] Image append", func
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-append", admissionapi.LevelBaseline)
 
-	g.It("should create images by appending them [apigroup:image.openshift.io]", func() {
+	g.It("should create images by appending them [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(is.Status.DockerImageRepository).NotTo(o.BeEmpty(), "registry not yet configured?")

--- a/test/extended/images/distruptiveimportmode.go
+++ b/test/extended/images/distruptiveimportmode.go
@@ -23,11 +23,11 @@ var _ = g.Describe("[sig-imageregistry][Suite:openshift/test-image-stream-import
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 
-	g.It("import mode should be Legacy if the import mode specified in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]", func() {
+	g.It("import mode should be Legacy if the import mode specified in image.config.openshift.io config is Legacy [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		TestImageConfigImageStreamImportModeLegacy(g.GinkgoT(), oc)
 	})
 
-	g.It("import mode should be PreserveOriginal if the import mode specified in image.config.openshift.io config is PreserveOriginal [apigroup:image.openshift.io]", func() {
+	g.It("import mode should be PreserveOriginal if the import mode specified in image.config.openshift.io config is PreserveOriginal [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		TestImageConfigImageStreamImportModePreserveOriginal(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/dryrun.go
+++ b/test/extended/images/dryrun.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-imageregistry] Image --dry-run", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("image-dry-run", admissionapi.LevelBaseline)
 	)
 
-	g.It("should not delete resources [apigroup:image.openshift.io]", func() {
+	g.It("should not delete resources [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		g.By("preparing the image stream where the test image will be pushed")
 		err := oc.Run("tag").Args("openshift/cli:latest", "test:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-imageregistry] Image --dry-run", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should not update resources [apigroup:image.openshift.io]", func() {
+	g.It("should not update resources [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 
 		g.By("actually creating imagestream for update dry-run test")
 		err := oc.Run("create").Args("imagestream", "dryrun-test").Execute()

--- a/test/extended/images/extract.go
+++ b/test/extended/images/extract.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageExtract] Image extract", fu
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-extract", admissionapi.LevelBaseline)
 
-	g.It("should extract content from an image [apigroup:image.openshift.io]", func() {
+	g.It("should extract content from an image [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		is, err := oc.ImageClient().ImageV1().ImageStreams("openshift").Get(context.Background(), "tools", metav1.GetOptions{})

--- a/test/extended/images/hardprune.go
+++ b/test/extended/images/hardprune.go
@@ -327,11 +327,11 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 		}
 	}
 
-	g.It("should show orphaned blob deletions in dry-run mode [apigroup:image.openshift.io]", func() {
+	g.It("should show orphaned blob deletions in dry-run mode [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		testHardPrune(true)
 	})
 
-	g.It("should delete orphaned blobs [apigroup:image.openshift.io]", func() {
+	g.It("should delete orphaned blobs [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		testHardPrune(false)
 	})
 })

--- a/test/extended/images/imagechange_buildtrigger.go
+++ b/test/extended/images/imagechange_buildtrigger.go
@@ -20,25 +20,25 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Image change buil
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("image-change-build-trigger")
 
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagSTI(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagSTIWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagDocker(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagDockerWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagCustom(g.GinkgoT(), oc)
 	})
-	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestSimpleImageChangeBuildTriggerFromImageStreamTagCustomWithConfigChange(g.GinkgoT(), oc)
 	})
-	g.It("TestMultipleImageChangeBuildTriggers [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("TestMultipleImageChangeBuildTriggers [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		TestMultipleImageChangeBuildTriggers(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestream.go
+++ b/test/extended/images/imagestream.go
@@ -25,13 +25,13 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers][Serial] ImageStre
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 
-	g.It("TestImageStreamMappingCreate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamMappingCreate [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImageStreamMappingCreate(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamWithoutDockerImageConfig [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamWithoutDockerImageConfig [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImageStreamWithoutDockerImageConfig(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamTagLifecycleHook [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamTagLifecycleHook [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		TestImageStreamTagLifecycleHook(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestream_admission.go
+++ b/test/extended/images/imagestream_admission.go
@@ -27,13 +27,13 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers][Serial] ImageStre
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-admission")
 
-	g.It("TestImageStreamTagsAdmission [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamTagsAdmission [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		TestImageStreamTagsAdmission(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamAdmitSpecUpdate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamAdmitSpecUpdate [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		TestImageStreamAdmitSpecUpdate(g.GinkgoT(), oc)
 	})
-	g.It("TestImageStreamAdmitStatusUpdate [apigroup:image.openshift.io]", func() {
+	g.It("TestImageStreamAdmitStatusUpdate [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		TestImageStreamAdmitStatusUpdate(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/imagestreamimport.go
+++ b/test/extended/images/imagestreamimport.go
@@ -74,16 +74,16 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageStreamImport][Serial][Slow]
 		}
 	})
 
-	g.It("TestImportImageFromInsecureRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportImageFromInsecureRegistry [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImportImageFromInsecureRegistry(oc)
 	})
-	g.It("TestImportImageFromBlockedRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportImageFromBlockedRegistry [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImportImageFromBlockedRegistry(oc)
 	})
-	g.It("TestImportRepositoryFromInsecureRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportRepositoryFromInsecureRegistry [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImportRepositoryFromInsecureRegistry(oc)
 	})
-	g.It("TestImportRepositoryFromBlockedRegistry [apigroup:image.openshift.io]", func() {
+	g.It("TestImportRepositoryFromBlockedRegistry [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		TestImportRepositoryFromBlockedRegistry(oc)
 	})
 })

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-info", admissionapi.LevelBaseline)
 
-	g.It("should display information about images [apigroup:image.openshift.io]", func() {
+	g.It("should display information about images [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		ns = oc.Namespace()
 		cli := e2epod.PodClientNS(oc.KubeFramework(), ns)
 		pod := cli.Create(context.TODO(), cliPodWithPullSecret(oc, heredoc.Docf(`

--- a/test/extended/images/layers.go
+++ b/test/extended/images/layers.go
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 
 	oc = exutil.NewCLIWithPodSecurityLevel("image-layers", admissionapi.LevelBaseline)
 
-	g.It("should identify a deleted image as missing [apigroup:image.openshift.io]", func() {
+	g.It("should identify a deleted image as missing [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		client := oc.AdminImageClient().ImageV1()
 		_, err := client.ImageStreams(oc.Namespace()).Create(ctx, &imagev1.ImageStream{
 			ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +97,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLayers] Image layer subreso
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should return layers from tagged images [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("should return layers from tagged images [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		ns = []string{oc.Namespace()}
 		client := oc.ImageClient().ImageV1()
 		isi, err := client.ImageStreamImports(oc.Namespace()).Create(ctx, &imagev1.ImageStreamImport{

--- a/test/extended/images/mirror.go
+++ b/test/extended/images/mirror.go
@@ -207,7 +207,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageMirror][Slow] Image mirror"
 
 	var oc = exutil.NewCLIWithPodSecurityLevel("image-mirror", admissionapi.LevelBaseline)
 
-	g.It("mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("mirror image from integrated registry to external registry [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		g.By("get user credentials")
 		user, token := getCreds(oc)
 
@@ -283,7 +283,7 @@ spec:
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("mirror image from integrated registry into few external registries [apigroup:image.openshift.io][apigroup:build.openshift.io]", func() {
+	g.It("mirror image from integrated registry into few external registries [apigroup:image.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 		g.By("get user credentials")
 		user, token := getCreds(oc)
 

--- a/test/extended/images/oc_tag.go
+++ b/test/extended/images/oc_tag.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("image-oc-tag", admissionapi.LevelBaseline)
 	ctx := context.Background()
 
-	g.It("should preserve image reference for external images [apigroup:image.openshift.io]", func() {
+	g.It("should preserve image reference for external images [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		var (
 			externalImage = k8simage.GetE2EImage(k8simage.BusyBox)
 			isName        = "busybox"
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:Image] oc tag", func() {
 		o.Expect(tag2.Items[0].DockerImageReference).To(o.Equal(tag1.Items[0].DockerImageReference))
 	})
 
-	g.It("should change image reference for internal images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("should change image reference for internal images [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		var (
 			isName     = "localimage"
 			isName2    = "localimage2"
@@ -125,7 +125,7 @@ RUN touch /test-image
 		o.Expect(tag.Items[0].DockerImageReference).To(o.Equal(fmt.Sprintf("%s/%s/%s@%s", registryHost, oc.Namespace(), isName2, digest)))
 	})
 
-	g.It("should work when only imagestreams api is available [apigroup:image.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("should work when only imagestreams api is available [apigroup:image.openshift.io][apigroup:authorization.openshift.io]", g.Label("Size:S"), func() {
 		err := oc.Run("tag").Args("--source=docker", image.ShellImage(), "testis:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/images/prune.go
+++ b/test/extended/images/prune.go
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneImages(oc, 1) })
+		g.It("should prune old image [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() { testPruneImages(oc, 1) })
 	})
 
 	g.Describe("of schema 2", func() {
@@ -106,7 +106,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image with config [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneImages(oc, 2) })
+		g.It("should prune old image with config [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() { testPruneImages(oc, 2) })
 	})
 
 	g.Describe("with --prune-registry==false", func() {
@@ -134,7 +134,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune old image but skip registry [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testSoftPruneImages(oc) })
+		g.It("should prune old image but skip registry [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() { testSoftPruneImages(oc) })
 	})
 
 	g.Describe("with default --all flag", func() {
@@ -162,7 +162,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune both internally managed and external images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneAllImages(oc, true, 2) })
+		g.It("should prune both internally managed and external images [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() { testPruneAllImages(oc, true, 2) })
 	})
 
 	g.Describe("with --all=false flag", func() {
@@ -190,7 +190,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImagePrune][Serial][Suite:opensh
 			}
 		})
 
-		g.It("should prune only internally managed images [apigroup:build.openshift.io][apigroup:image.openshift.io]", func() { testPruneAllImages(oc, false, 2) })
+		g.It("should prune only internally managed images [apigroup:build.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() { testPruneAllImages(oc, false, 2) })
 	})
 })
 

--- a/test/extended/images/redirect.go
+++ b/test/extended/images/redirect.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-imageregistry] Image registry [apigroup:route.openshift
 
 	oc = exutil.NewCLI("image-redirect")
 
-	g.It("should redirect on blob pull [apigroup:image.openshift.io]", func() {
+	g.It("should redirect on blob pull [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		ctx := context.TODO()
 		imageRegistryConfigClient, err := imageregistry.NewForConfig(oc.AdminConfig())
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/resolve.go
+++ b/test/extended/images/resolve.go
@@ -28,7 +28,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func
 	one := int64(0)
 	ctx := context.Background()
 
-	g.It("should update standard Kube object image fields when local names are on [apigroup:image.openshift.io]", func() {
+	g.It("should update standard Kube object image fields when local names are on [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -207,7 +207,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func
 		o.Expect(dc.Spec.Template.Spec.Containers[0].Image).To(o.Equal(internalImageReference))
 	})
 
-	g.It("should update OpenShift object image fields when local names are on [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+	g.It("should update OpenShift object image fields when local names are on [apigroup:image.openshift.io][apigroup:apps.openshift.io]", g.Label("Size:L"), func() {
 		err := oc.Run("tag").Args(k8simage.GetE2EImage(k8simage.BusyBox), "busybox:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		err = oc.Run("set", "image-lookup").Args("busybox").Execute()
@@ -259,7 +259,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func
 		o.Expect(dc.Spec.Template.Spec.Containers[0].Image).To(o.Equal(internalImageReference))
 	})
 
-	g.It("should perform lookup when the object has the resolve-names annotation [apigroup:image.openshift.io]", func() {
+	g.It("should perform lookup when the object has the resolve-names annotation [apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -614,7 +614,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageLookup] Image policy", func
 		o.Expect(cronjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image).To(o.Equal(internalImageReference))
 	})
 
-	g.It("should perform lookup when the Deployment gets the resolve-names annotation later [apigroup:image.openshift.io]", func() {
+	g.It("should perform lookup when the Deployment gets the resolve-names annotation later [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		imageReference := k8simage.GetE2EImage(k8simage.BusyBox)
 		err := oc.Run("tag").Args(imageReference, "busybox:latest").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/images/signatures.go
+++ b/test/extended/images/signatures.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-imageregistry][Serial] Image signature workflow", func(
 		}
 	})
 
-	g.It("can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("can push a signed image to openshift registry and verify it [apigroup:user.openshift.io][apigroup:image.openshift.io]", g.Label("Size:L"), func() {
 		g.By("building a signer image that knows how to sign images")
 		output, err := oc.Run("create").Args("-f", signerBuildFixture).Output()
 		if err != nil {

--- a/test/extended/images/tagimportmode.go
+++ b/test/extended/images/tagimportmode.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ImageStreamImportMode][Se
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("imagestream-api")
 
-	g.It("import mode should be PreserveOriginal or Legacy depending on desired.architecture field in the CV [apigroup:image.openshift.io]", func() {
+	g.It("import mode should be PreserveOriginal or Legacy depending on desired.architecture field in the CV [apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		TestImageStreamImportMode(g.GinkgoT(), oc)
 	})
 })

--- a/test/extended/images/trigger/annotation.go
+++ b/test/extended/images/trigger/annotation.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageTriggers] Annotation trigge
 		deploymentFixture = exutil.FixturePath("testdata", "image", "deployment-with-annotation-trigger.yaml")
 	)
 
-	g.It("reconciles after the image is overwritten [apigroup:image.openshift.io]", func() {
+	g.It("reconciles after the image is overwritten [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 		namespace := oc.Namespace()
 
 		g.By("creating a Deployment")

--- a/test/extended/kernel/kernel_rt_functional.go
+++ b/test/extended/kernel/kernel_rt_functional.go
@@ -21,17 +21,17 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real 
 		startRtTestPod(oc)
 	})
 
-	g.It("pi_stress to run successfully with the fifo algorithm", func() {
+	g.It("pi_stress to run successfully with the fifo algorithm", g.Label("Size:L"), func() {
 		err := runPiStressFifo(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the fifo algorithm")
 	})
 
-	g.It("pi_stress to run successfully with the round robin algorithm", func() {
+	g.It("pi_stress to run successfully with the round robin algorithm", g.Label("Size:L"), func() {
 		err := runPiStressRR(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the round robin algorithm")
 	})
 
-	g.It("deadline_test to run successfully", func() {
+	g.It("deadline_test to run successfully", g.Label("Size:M"), func() {
 		err := runDeadlineTest(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running deadline_test")
 	})

--- a/test/extended/kernel/kernel_rt_latency.go
+++ b/test/extended/kernel/kernel_rt_latency.go
@@ -21,12 +21,12 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		startRtTestPod(oc)
 	})
 
-	g.It("hwlatdetect", func() {
+	g.It("hwlatdetect", g.Label("Size:L"), func() {
 		err := runHwlatdetect(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running hwlatdetect")
 	})
 
-	g.It("oslat", func() {
+	g.It("oslat", g.Label("Size:L"), func() {
 		cpuCount, err := getProcessorCount(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "unable to get the number of processors online")
 
@@ -34,7 +34,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running oslat")
 	})
 
-	g.It("cyclictest", func() {
+	g.It("cyclictest", g.Label("Size:L"), func() {
 		cpuCount, err := getProcessorCount(oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "unable to get the number of processors online")
 

--- a/test/extended/kubevirt/migration.go
+++ b/test/extended/kubevirt/migration.go
@@ -58,7 +58,7 @@ var _ = Describe("[sig-kubevirt] migration", func() {
 				SetMgmtFramework(mgmtFramework)
 				expectNoError(migrateWorkers(mgmtFramework))
 			})
-			It("should maintain node readiness", func() {
+			It("should maintain node readiness", Label("Size:L"), func() {
 				By("Check node readiness is as expected")
 				isAWS, err := MgmtClusterIsType(mgmtFramework, configv1.AWSPlatformType)
 				Expect(err).ToNot(HaveOccurred())

--- a/test/extended/kubevirt/services.go
+++ b/test/extended/kubevirt/services.go
@@ -20,7 +20,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 		f1 := e2e.NewDefaultFramework("server-framework")
 		f1.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
-		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", func() {
+		It("should allow connections to pods from infra cluster pod via NodePort across different infra nodes", Label("Size:M"), func() {
 			oc = SetMgmtFramework(mgmtFramework)
 			// This tests connectivity from the infra cluster's pod network to a NodePort
 			// within a nested KubeVirt Hypershift guest cluster.
@@ -33,31 +33,31 @@ var _ = Describe("[sig-kubevirt] services", func() {
 			Expect(checkKubeVirtInfraClusterNodePortConnectivity(f1, mgmtFramework, oc)).To(Succeed())
 		})
 
-		It("should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes", func() {
+		It("should allow connections to pods from guest hostNetwork pod via NodePort across different guest nodes", Label("Size:M"), func() {
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// NodePort services to route from hostnet to pods across guest nodes.
 			Expect(checkKubeVirtGuestClusterHostNetworkNodePortConnectivity(f1, f1)).To(Succeed())
 		})
 
-		It("should allow connections to pods from guest podNetwork pod via NodePort across different guest nodes", func() {
+		It("should allow connections to pods from guest podNetwork pod via NodePort across different guest nodes", Label("Size:M"), func() {
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// NodePort services to route from pod network to pods across guest nodes.
 			Expect(checkKubeVirtGuestClusterPodNetworkNodePortConnectivity(f1, f1)).To(Succeed())
 		})
 
-		It("should allow direct connections to pods from guest cluster pod in pod network across different guest nodes", func() {
+		It("should allow direct connections to pods from guest cluster pod in pod network across different guest nodes", Label("Size:M"), func() {
 			// Within a nested KubeVirt guest cluster, this tests the ability for different pods within the
 			// guest cluster to communicate each other, across different guest cluster nodes, via PodNetwork.
 			Expect(checkKubeVirtGuestClusterPodNetworkConnectivity(f1, f1)).To(Succeed())
 		})
 
-		It("should allow direct connections to pods from guest cluster pod in host network across different guest nodes", func() {
+		It("should allow direct connections to pods from guest cluster pod in host network across different guest nodes", Label("Size:M"), func() {
 			// Within a nested KubeVirt guest cluster, this tests the ability for different pods within the
 			// guest cluster to communicate each other, across different guest cluster nodes, via HostNetwork.
 			Expect(checkKubeVirtGuestClusterHostNetworkConnectivity(f1, f1)).To(Succeed())
 		})
 
-		It("should allow connections to pods from infra cluster pod via LoadBalancer service across different guest nodes", func() {
+		It("should allow connections to pods from infra cluster pod via LoadBalancer service across different guest nodes", Label("Size:L"), func() {
 			oc = SetMgmtFramework(mgmtFramework)
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// LoadBalancer services to route from pod network to pods across infra nodes.
@@ -65,7 +65,7 @@ var _ = Describe("[sig-kubevirt] services", func() {
 			Expect(checkKubeVirtInfraClusterLoadBalancerConnectivity(f1, mgmtFramework, oc)).To(Succeed())
 		})
 
-		It("should allow connections to pods from guest cluster PodNetwork pod via LoadBalancer service across different guest nodes", func() {
+		It("should allow connections to pods from guest cluster PodNetwork pod via LoadBalancer service across different guest nodes", Label("Size:L"), func() {
 			// Within a nested KubeVirt guest cluster, this tests the ability for
 			// LoadBalancer services to route from pod network to pods across guest nodes.
 			Expect(checkKubeVirtGuestClusterLoadBalancerConnectivity(f1, f1)).To(Succeed())

--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -35,23 +35,23 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		ApplyMachineConfigurationFixture(oc, emptyMachineSetFixture)
 	})
 
-	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		PartialMachineSetTest(oc, partialMachineSetFixture)
 	})
 
-	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		AllMachineSetTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		NoneMachineSetTest(oc, noneMachineSetFixture)
 	})
 
-	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		EnsureConfigMapStampTest(oc, allMachineSetFixture)
 	})
 })

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -36,23 +36,23 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 		ApplyMachineConfigurationFixture(oc, emptyMachineSetFixture)
 	})
 
-	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		PartialMachineSetTest(oc, partialMachineSetFixture)
 	})
 
-	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		AllMachineSetTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		NoneMachineSetTest(oc, noneMachineSetFixture)
 	})
 
-	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		EnsureConfigMapStampTest(oc, allMachineSetFixture)
 	})
 })

--- a/test/extended/machine_config/boot_image_update_vsphere.go
+++ b/test/extended/machine_config/boot_image_update_vsphere.go
@@ -35,27 +35,27 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		ApplyMachineConfigurationFixture(oc, emptyMachineSetFixture)
 	})
 
-	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images only on MachineSets that are opted in [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		PartialMachineSetTest(oc, partialMachineSetFixture)
 	})
 
-	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should update boot images on all MachineSets when configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		AllMachineSetTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should not update boot images on any MachineSet when not configured [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		NoneMachineSetTest(oc, noneMachineSetFixture)
 	})
 
-	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should degrade on a MachineSet with an OwnerReference [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		DegradeOnOwnerRefTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should stamp coreos-bootimages configmap with current MCO hash and release version [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		EnsureConfigMapStampTest(oc, allMachineSetFixture)
 	})
 
-	g.It("Should upload the latest bootimage to the appropriate vCentre [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should upload the latest bootimage to the appropriate vCentre [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		UploadTovCentreTest(oc, partialMachineSetFixture)
 	})
 })

--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -54,26 +54,26 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	})
 
 	// The following 3 tests are `Parallel` because they do not make any changes to the cluster and run quickly (< 5 min).
-	g.It("Should have MCN properties matching associated node properties for nodes in default MCPs [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should have MCN properties matching associated node properties for nodes in default MCPs [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		ValidateMCNPropertiesByMCPs(oc)
 	})
 
-	g.It("Should properly block MCN updates from a MCD that is not the associated one [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should properly block MCN updates from a MCD that is not the associated one [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		ValidateMCNScopeSadPathTest(oc)
 	})
 
-	g.It("Should properly block MCN updates by impersonation of the MCD SA [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Should properly block MCN updates by impersonation of the MCD SA [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		ValidateMCNScopeImpersonationPathTest(oc)
 	})
 
 	// The following 3 tests are `Serial` because they makes changes to the cluster that can impact other tests, but still run quickly (< 5 min).
-	g.It("[Serial]Should have MCN properties matching associated node properties for nodes in custom MCPs [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Serial]Should have MCN properties matching associated node properties for nodes in custom MCPs [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		skipOnTwoNodeTopology(oc)    //skip this test for two-node openshift
 		ValidateMCNPropertiesCustomMCP(oc, infraMCPFixture)
 	})
 
-	g.It("[Serial]Should properly transition through MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Serial]Should properly transition through MCN conditions on rebootless node update [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		// Skip this test when the `ImageModeStatusReporting` FeatureGate is enabled, since its
 		// regression tests handle the different conditions list.
 		SkipWhenFeatureGateEnabled(oc.AdminConfigClient(), "ImageModeStatusReporting")
@@ -94,12 +94,12 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 		}
 	})
 
-	g.It("[Serial]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Serial]Should properly update the MCN from the associated MCD [apigroup:machineconfiguration.openshift.io]", g.Label("Size:S"), func() {
 		ValidateMCNScopeHappyPathTest(oc)
 	})
 
 	// This test is `Disruptive` because it degrades a node.
-	g.It("[Suite:openshift/machine-config-operator/disruptive][Disruptive]Should properly report MCN conditions on node degrade [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Suite:openshift/machine-config-operator/disruptive][Disruptive]Should properly report MCN conditions on node degrade [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		if IsSingleNode(oc) { //handle SNO clusters
 			ValidateMCNConditionOnNodeDegrade(oc, invalidMasterMCFixture, true)
 		} else { //handle standard, non-SNO, clusters
@@ -108,7 +108,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:MachineConfigNodes]", func() {
 	})
 
 	// This test is `Disruptive` because it creates and removes a node. It is also considered `Slow` because it takes longer than 5 min to run.
-	g.It("[Suite:openshift/machine-config-operator/disruptive][Disruptive][Slow]Should properly create and remove MCN on node creation and deletion [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Suite:openshift/machine-config-operator/disruptive][Disruptive][Slow]Should properly create and remove MCN on node creation and deletion [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		ValidateMCNOnNodeCreationAndDeletion(oc)
 	})

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -64,7 +64,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 	})
 
 	// This test is also considered `Slow` because it takes longer than 5 minutes to run.
-	g.It("[Slow]All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("[Slow]All Nodes in a custom Pool should have the PinnedImages even after Garbage Collection [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		// Skip this test on single node and two-node platforms since custom MCPs are not supported
 		// for clusters with only a master MCP
 		skipOnSingleNodeTopology(oc)
@@ -137,7 +137,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		GCPISTest(oc, kubeClient, clientSet, true, optedNodes[0], kcFixture, gcImage, pis.Name, isMetalDisconnected)
 	})
 
-	g.It("All Nodes in a Custom Pool should have the PinnedImages in PIS [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("All Nodes in a Custom Pool should have the PinnedImages in PIS [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		// Skip this test on single node and two-node platforms since custom MCPs are not supported
 		// for clusters with only a master MCP
 		skipOnSingleNodeTopology(oc)
@@ -200,7 +200,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		SimplePISTest(oc, kubeClient, clientSet, true, pis.Name, isMetalDisconnected)
 	})
 
-	g.It("All Nodes in a standard Pool should have the PinnedImages PIS [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("All Nodes in a standard Pool should have the PinnedImages PIS [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		// Create kube client and client set for test
 		kubeClient, err := kubernetes.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting kube client: %v", err))
@@ -258,7 +258,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		SimplePISTest(oc, kubeClient, clientSet, true, pis.Name, isMetalDisconnected)
 	})
 
-	g.It("Invalid PIS leads to degraded MCN in a standard Pool [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Invalid PIS leads to degraded MCN in a standard Pool [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		// Create kube client and client set for test
 		kubeClient, err := kubernetes.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting kube client: %v", err))
@@ -286,7 +286,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		SimplePISTest(oc, kubeClient, clientSet, false, pis.Name, false)
 	})
 
-	g.It("Invalid PIS leads to degraded MCN in a custom Pool [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("Invalid PIS leads to degraded MCN in a custom Pool [apigroup:machineconfiguration.openshift.io]", g.Label("Size:M"), func() {
 		// Skip this test on single node and two-node platforms since custom MCPs are not supported
 		// for clusters with only a master MCP
 		skipOnSingleNodeTopology(oc)

--- a/test/extended/machines/cluster.go
+++ b/test/extended/machines/cluster.go
@@ -29,7 +29,7 @@ import (
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Early] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have same number of Machines and Nodes [apigroup:machine.openshift.io]", func() {
+	g.It("have same number of Machines and Nodes [apigroup:machine.openshift.io]", g.Label("Size:S"), func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()
@@ -90,7 +90,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 	)
 
 	var staticNodeNames []string
-	g.It("record the number of nodes at the beginning of the tests [Early]", func() {
+	g.It("record the number of nodes at the beginning of the tests [Early]", g.Label("Size:S"), func() {
 		nodeList, err := oc.KubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -101,7 +101,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 
 	// This test makes use of Prometheus metrics, which are not present in the absence of cluster-monitoring-operator, the owner for
 	// the api groups tagged here.
-	g.It("should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]", func() {
+	g.It("should report ready nodes the entire duration of the test run [Late][apigroup:monitoring.coreos.com]", g.Label("Size:S"), func() {
 		// we only consider samples since the beginning of the test
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-node] Managed cluster", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should verify that nodes have no unexpected reboots [Late]", func() {
+	g.It("should verify that nodes have no unexpected reboots [Late]", g.Label("Size:M"), func() {
 		ctx := context.Background()
 
 		// List all nodes

--- a/test/extended/machines/machines.go
+++ b/test/extended/machines/machines.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("have machine resources [apigroup:machine.openshift.io]", func() {
+	g.It("have machine resources [apigroup:machine.openshift.io]", g.Label("Size:S"), func() {
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
 		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 		}
 	})
 
-	g.It("[sig-scheduling][Early] control plane machine set operator should not cause an early rollout", func() {
+	g.It("[sig-scheduling][Early] control plane machine set operator should not cause an early rollout", g.Label("Size:S"), func() {
 		machineClientSet, err := machineclient.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).ToNot(o.HaveOccurred())
 
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines] Managed cluster sh
 		}
 	})
 
-	g.It("[sig-scheduling][Early] control plane machine set operator should not have any events", func() {
+	g.It("[sig-scheduling][Early] control plane machine set operator should not have any events", g.Label("Size:S"), func() {
 		ctx := context.Background()
 
 		infrastructure, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -274,7 +274,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	// provisioning the new host, while it could take approx another 10 minutes for deprovisioning
 	// and deleting it. The extra timeout amount should be enough to cover future slower execution
 	// environments.
-	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", func() {
+	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", g.Label("Size:L"), func() {
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))

--- a/test/extended/machines/workers.go
+++ b/test/extended/machines/workers.go
@@ -130,7 +130,7 @@ func isNodeReady(node corev1.Node) bool {
 var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Disruptive] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("recover from deleted worker machines [apigroup:machine.openshift.io]", func() {
+	g.It("recover from deleted worker machines [apigroup:machine.openshift.io]", g.Label("Size:L"), func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()

--- a/test/extended/networking/acl_audit_log.go
+++ b/test/extended/networking/acl_audit_log.go
@@ -44,7 +44,7 @@ var _ = Describe("[sig-network][Feature:Network Policy Audit logging]", func() {
 	InOVNKubernetesContext(
 		func() {
 			f := oc.KubeFramework()
-			It("should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]", func() {
+			It("should ensure acl logs are created and correct [apigroup:project.openshift.io][apigroup:network.openshift.io]", Label("Size:M"), func() {
 				ns = append(ns, f.Namespace.Name)
 				makeNamespaceScheduleToAllNodes(f)
 				makeNamespaceACLLoggingEnabled(oc)

--- a/test/extended/networking/bonds.go
+++ b/test/extended/networking/bonds.go
@@ -22,7 +22,7 @@ var _ = g.Describe("[sig-network][Feature:bond]", func() {
 	oc := exutil.NewCLI("bond")
 	f := oc.KubeFramework()
 
-	g.It("should create a pod with bond interface [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("should create a pod with bond interface [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 		podName1, podName2 := "pod1", "pod2"
 		bondnad1, bondnad2 := "bondnad1", "bondnad2"

--- a/test/extended/networking/commatrix.go
+++ b/test/extended/networking/commatrix.go
@@ -103,7 +103,7 @@ var _ = Describe("[sig-network][Feature:commatrix][apigroup:config.openshift.io]
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("should validate the communication matrix ports match the node's listening ports", func() {
+	It("should validate the communication matrix ports match the node's listening ports", Label("Size:S"), func() {
 		listeningCheck, err := listeningsockets.NewCheck(cs, utilsHelpers, artifactsDir)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 
 	InOVNKubernetesContext(
 		func() {
-			g.It("should ensure egressfirewall is created", func() {
+			g.It("should ensure egressfirewall is created", g.Label("Size:M"), func() {
 				doEgressFwTest(egFwf, mgmtFw, egFwoc, oVNKManifest, true, false)
 			})
 		},
@@ -50,7 +50,7 @@ var _ = g.Describe("[sig-network][Feature:EgressFirewall]", func() {
 
 	noegFwoc := exutil.NewCLIWithPodSecurityLevel(noEgressFWE2E, admissionapi.LevelBaseline)
 	noegFwf := noegFwoc.KubeFramework()
-	g.It("egressFirewall should have no impact outside its namespace", func() {
+	g.It("egressFirewall should have no impact outside its namespace", g.Label("Size:M"), func() {
 		g.By("creating test pod")
 		pod := "dummy"
 		o.Expect(createTestEgressFw(noegFwf, pod)).To(o.Succeed())
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:DNSNameResolver][Feature:Egress
 	mgmtFramework.SkipNamespaceCreation = true
 	InOVNKubernetesContext(
 		func() {
-			g.It("should ensure egressfirewall with wildcard dns rules is created", func() {
+			g.It("should ensure egressfirewall with wildcard dns rules is created", g.Label("Size:M"), func() {
 				doEgressFwTest(wcEgFwF, mgmtFramework, wcEgFwOc, oVNKWCManifest, true, true)
 			})
 		},

--- a/test/extended/networking/egress_router_cni.go
+++ b/test/extended/networking/egress_router_cni.go
@@ -36,12 +36,12 @@ const (
 var _ = g.Describe("[sig-network][Feature:EgressRouterCNI]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel(egressRouterCNIE2E, admissionapi.LevelPrivileged).SetManagedNamespace()
 
-	g.It("should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
+	g.It("should ensure ipv4 egressrouter cni resources are created [apigroup:operator.openshift.io]", g.Label("Size:M"), func() {
 		doEgressRouterCNI(egressRouterCNIV4Manifest, oc, ipv4MatchPattern)
 	})
 	InOVNKubernetesContext(
 		func() {
-			g.It("should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]", func() {
+			g.It("should ensure ipv6 egressrouter cni resources are created [apigroup:operator.openshift.io]", g.Label("Size:M"), func() {
 				doEgressRouterCNI(egressRouterCNIV6Manifest, oc, ipv6MatchPattern)
 			})
 		},

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -195,7 +195,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("EgressIP pods should query hostNetwork pods with the local node's SNAT", func() {
+		g.It("EgressIP pods should query hostNetwork pods with the local node's SNAT", g.Label("Size:L"), func() {
 			var targetIP string
 			var targetPort int
 
@@ -346,7 +346,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 		})
 
 		// Skipped on Azure due to https://bugzilla.redhat.com/show_bug.cgi?id=2073045
-		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", func() {
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be deleted and recreated [Skipped:azure][apigroup:route.openshift.io]", g.Label("Size:L"), func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -404,7 +404,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			os.Remove(egressIPYamlPath)
 		})
 
-		g.It("pods should keep the assigned EgressIPs when being rescheduled to another node", func() {
+		g.It("pods should keep the assigned EgressIPs when being rescheduled to another node", g.Label("Size:L"), func() {
 			g.By("Selecting a single EgressIP node, and a single start node for the pod")
 			// requires a total of 3 worker nodes
 			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1))
@@ -462,7 +462,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
 		})
 
-		g.It("only pods matched by the pod selector should have the EgressIPs", func() {
+		g.It("only pods matched by the pod selector should have the EgressIPs", g.Label("Size:L"), func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			deployment0Name, route0Name, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "0", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -512,7 +512,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, route1Name, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, egressIPSet)
 		})
 
-		g.It("pods should have the assigned EgressIPs and EgressIPs can be updated", func() {
+		g.It("pods should have the assigned EgressIPs and EgressIPs can be updated", g.Label("Size:L"), func() {
 			g.By("Creating the EgressIP test source deployment with number of pods equals number of EgressIP nodes")
 			_, routeName, err := createAgnhostDeploymentAndIngressRoute(oc, egressIPNamespace, "", ingressDomain, len(egressIPNodesOrderedNames), egressIPNodesOrderedNames)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/networking/endpoint_admission.go
+++ b/test/extended/networking/endpoint_admission.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-network][endpoints] admission [apigroup:config.openshif
 		serviceIP = ip.String()
 	})
 
-	g.It("blocks manual creation of Endpoints pointing to the cluster or service network", func() {
+	g.It("blocks manual creation of Endpoints pointing to the cluster or service network", g.Label("Size:S"), func() {
 		serviceAccountClient, _, err := getClientForServiceAccount(clusterAdminKubeClient, rest.AnonymousClientConfig(oc.AdminConfig()), "kube-system", "endpoint-controller")
 		o.Expect(err).NotTo(o.HaveOccurred(), "error getting endpoint controller service account")
 
@@ -92,7 +92,7 @@ var _ = g.Describe("[sig-network][endpoints] admission [apigroup:config.openshif
 		// o.Expect(err).To(o.HaveOccurred(), "unexpected success modifying endpoint")
 	})
 
-	g.It("blocks manual creation of EndpointSlices pointing to the cluster or service network", func() {
+	g.It("blocks manual creation of EndpointSlices pointing to the cluster or service network", g.Label("Size:S"), func() {
 		serviceAccountClient, _, err := getClientForServiceAccount(clusterAdminKubeClient, rest.AnonymousClientConfig(oc.AdminConfig()), "kube-system", "endpointslice-controller")
 		o.Expect(err).NotTo(o.HaveOccurred(), "error getting endpoint controller service account")
 

--- a/test/extended/networking/external_gateway.go
+++ b/test/extended/networking/external_gateway.go
@@ -14,7 +14,7 @@ var _ = g.Describe("[sig-network] external gateway address", func() {
 	InOVNKubernetesContext(func() {
 		f := oc.KubeFramework()
 
-		g.It("should match the address family of the pod", func() {
+		g.It("should match the address family of the pod", g.Label("Size:M"), func() {
 			podIPFamily := GetIPFamilyForCluster(f)
 			o.Expect(podIPFamily).NotTo(o.Equal(Unknown))
 			// Set external gateway address into an IPv6 address and make sure

--- a/test/extended/networking/internal_ports.go
+++ b/test/extended/networking/internal_ports.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("[sig-network] Internal connectivity", func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	oc := exutil.NewCLIWithoutNamespace("nettest").AsAdmin()
 
-	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]", func() {
+	ginkgo.It("for TCP and UDP on ports 9000-9999 is allowed [Serial:Self]", ginkgo.Label("Size:L"), func() {
 		e2eskipper.SkipUnlessNodeCountIsAtLeast(2)
 
 		namespace := f.Namespace.Name

--- a/test/extended/networking/ipsec.go
+++ b/test/extended/networking/ipsec.go
@@ -611,7 +611,7 @@ var _ = g.Describe("[sig-network][Feature:IPsec]", g.Ordered, func() {
 			}).Should(o.Equal(true))
 		})
 
-		g.It("check traffic with IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", func() {
+		g.It("check traffic with IPsec [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", g.Label("Size:L"), func() {
 			o.Expect(config).NotTo(o.BeNil())
 			o.Expect(config.ipsecCfg).NotTo(o.BeNil())
 
@@ -670,14 +670,14 @@ var _ = g.Describe("[sig-network][Feature:IPsec] IPsec resilience", g.Ordered, f
 			ipsecMode = ipsecConfig.mode
 		})
 
-		g.It("check pod traffic is working across nodes [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", func() {
+		g.It("check pod traffic is working across nodes [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", g.Label("Size:L"), func() {
 			g.By("creating test pods")
 			pods := createWebServerPods(oc, f.Namespace.Name)
 			g.By("checking crossing connectivity over the pods")
 			checkPodCrossConnectivity(pods)
 		})
 
-		g.It("check pod traffic is working across nodes after ipsec daemonset restart [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", func() {
+		g.It("check pod traffic is working across nodes after ipsec daemonset restart [apigroup:config.openshift.io] [Suite:openshift/network/ipsec]", g.Label("Size:L"), func() {
 			// The IPsec daemonset manages IPsec connections between nodes for pod's east-west traffic.
 			// The IPsec daemonset exists only in IPsec full mode, so skip this test for other IPsec modes.
 			if ipsecMode != v1.IPsecModeFull {

--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -73,7 +73,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 			DescribeTableSubtree("created using",
 				func(createNetworkFn func(netConfig networkAttachmentConfigParams)) {
 
-					DescribeTable("[Suite:openshift/network/virtualization] should keep ip", func(netConfig networkAttachmentConfigParams, vmResource string, opCmd func(cli *kubevirt.Client, vmNamespace, vmName string), wlConfig ...workloadNetworkConfig) {
+					DescribeTable("[Suite:openshift/network/virtualization] should keep ip", Label("Size:L"), func(netConfig networkAttachmentConfigParams, vmResource string, opCmd func(cli *kubevirt.Client, vmNamespace, vmName string), wlConfig ...workloadNetworkConfig) {
 						var err error
 						var workloadConfig workloadNetworkConfig
 						if len(wlConfig) > 0 {
@@ -402,7 +402,7 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][OCPFeatureGate:Netw
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("assert the primary UDN feature works as expected", func() {
+		It("assert the primary UDN feature works as expected", Label("Size:L"), func() {
 			netConfig := networkAttachmentConfigParams{
 				name:               nadName,
 				topology:           "layer2",
@@ -435,7 +435,7 @@ var _ = Describe("[sig-network][Feature:Layer2LiveMigration][OCPFeatureGate:Netw
 })
 
 var _ = Describe("[sig-network][Feature:Layer2LiveMigration][Suite:openshift/network/virtualization] Kubevirt Virtual Machines", func() {
-	It("Placeholder test for GA", func() {
+	It("Placeholder test for GA", Label("Size:S"), func() {
 		Expect(1).To(Equal(1)) // we just need a test to run to ensure the platform comes up correctly
 	})
 })

--- a/test/extended/networking/load_balancer.go
+++ b/test/extended/networking/load_balancer.go
@@ -20,7 +20,7 @@ var _ = g.Describe("[sig-network] load balancer", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("load-balancer", admissionapi.LevelPrivileged)
 	)
 
-	g.It("should be managed by OpenShift", func() {
+	g.It("should be managed by OpenShift", g.Label("Size:S"), func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
 
@@ -43,7 +43,7 @@ var _ = g.Describe("[sig-network] load balancer", func() {
 		o.Expect(foundLBPods(infra, oc)).To(o.BeTrue(), "Keepalived and HAproxy pods are not deployed and should be")
 	})
 
-	g.It("should not be managed by OpenShift", func() {
+	g.It("should not be managed by OpenShift", g.Label("Size:S"), func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
 

--- a/test/extended/networking/multinetpolicy.go
+++ b/test/extended/networking/multinetpolicy.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-network][Feature:MultiNetworkPolicy][Serial][apigroup:o
 	oc := exutil.NewCLIWithPodSecurityLevel("multinetpol-e2e", admissionapi.LevelBaseline)
 	f := oc.KubeFramework()
 
-	g.DescribeTable("should enforce a network policies on secondary network", func(ctx context.Context, addrs podAddressSet) {
+	g.DescribeTable("should enforce a network policies on secondary network", g.Label("Size:M"), func(ctx context.Context, addrs podAddressSet) {
 		if !isMultinetNetworkPolicyEnabled(oc) {
 			skipper.Skipf("skipping because multinet network policy is not enabled on this cluster")
 		}

--- a/test/extended/networking/multus.go
+++ b/test/extended/networking/multus.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-network][Feature:Multus]", func() {
 
 	// Multus is already installed on origin. These tests aims to verify the integrity of the installation.
 
-	g.It("should use multus to create net1 device from network-attachment-definition [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("should use multus to create net1 device from network-attachment-definition [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		var err error
 		ns = f.Namespace.Name
 

--- a/test/extended/networking/network_diagnostics.go
+++ b/test/extended/networking/network_diagnostics.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("Should be enabled by default", func(ctx context.Context) {
+	g.It("Should be enabled by default", g.Label("Size:M"), func(ctx context.Context) {
 		o.Eventually(func() bool {
 			g.By("running one network-check-source pod")
 			srcPods, err := oc.AdminKubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		}, 3*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
-	g.It("Should remove all network diagnostics pods when disabled", func(ctx context.Context) {
+	g.It("Should remove all network diagnostics pods when disabled", g.Label("Size:M"), func(ctx context.Context) {
 		netConfigApply := applyconfigv1.Network(clusterConfig).WithSpec(
 			applyconfigv1.NetworkSpec().WithNetworkDiagnostics(
 				applyconfigv1.NetworkDiagnostics().WithMode(configv1.NetworkDiagnosticsDisabled),
@@ -124,7 +124,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		}, 3*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
-	g.It("Should move the source diagnostics pods based on the new selector and tolerations", func(ctx context.Context) {
+	g.It("Should move the source diagnostics pods based on the new selector and tolerations", g.Label("Size:M"), func(ctx context.Context) {
 		// Intentionally omit setting the mode to ensure that the diagnostics are enabled when it is unset
 		netConfigApply := applyconfigv1.Network(clusterConfig).WithSpec(
 			applyconfigv1.NetworkSpec().WithNetworkDiagnostics(
@@ -176,7 +176,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		}, 3*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
-	g.It("Should move the target diagnostics pods based on the new selector and tolerations", func(ctx context.Context) {
+	g.It("Should move the target diagnostics pods based on the new selector and tolerations", g.Label("Size:M"), func(ctx context.Context) {
 		netConfigApply := applyconfigv1.Network(clusterConfig).WithSpec(
 			applyconfigv1.NetworkSpec().WithNetworkDiagnostics(
 				applyconfigv1.NetworkDiagnostics().
@@ -230,7 +230,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		}, 3*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
-	g.It("Should function without any target pods", func(ctx context.Context) {
+	g.It("Should function without any target pods", g.Label("Size:M"), func(ctx context.Context) {
 		netConfigApply := applyconfigv1.Network(clusterConfig).WithSpec(
 			applyconfigv1.NetworkSpec().WithNetworkDiagnostics(
 				applyconfigv1.NetworkDiagnostics().
@@ -264,7 +264,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		}, 3*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
-	g.It("Should set the condition to false if there are no nodes able to host the source pods", func(ctx context.Context) {
+	g.It("Should set the condition to false if there are no nodes able to host the source pods", g.Label("Size:M"), func(ctx context.Context) {
 		netConfigApply := applyconfigv1.Network(clusterConfig).WithSpec(
 			applyconfigv1.NetworkSpec().WithNetworkDiagnostics(
 				applyconfigv1.NetworkDiagnostics().

--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -101,7 +101,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			func(createNetworkFn func(c *networkAttachmentConfigParams) error) {
 
 				DescribeTable(
-					"can perform east/west traffic between nodes",
+					"can perform east/west traffic between nodes", Label("Size:M"),
 					func(
 						netConfig *networkAttachmentConfigParams,
 						clientPodConfig podConfiguration,
@@ -194,7 +194,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				)
 
 				DescribeTable(
-					"is isolated from the default network",
+					"is isolated from the default network", Label("Size:M"),
 					func(
 						netConfigParams *networkAttachmentConfigParams,
 						udnPodConfig podConfiguration,
@@ -476,7 +476,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					),
 				)
 				DescribeTable(
-					"isolates overlapping CIDRs",
+					"isolates overlapping CIDRs", Label("Size:M"),
 					func(
 						topology string,
 						numberOfPods int,
@@ -692,7 +692,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				Eventually(userDefinedNetworkReadyFunc(oc.AdminDynamicClient(), f.Namespace.Name, testUdnName), udnCrReadyTimeout, time.Second).Should(Succeed())
 			})
 
-			It("should create NetworkAttachmentDefinition according to spec", func() {
+			It("should create NetworkAttachmentDefinition according to spec", Label("Size:S"), func() {
 				udnUidRaw, err := e2ekubectl.RunKubectl(f.Namespace.Name, "get", userDefinedNetworkResource, testUdnName, "-o", "jsonpath='{.metadata.uid}'")
 				Expect(err).NotTo(HaveOccurred(), "should get the UserDefinedNetwork UID")
 				testUdnUID := strings.Trim(udnUidRaw, "'")
@@ -701,7 +701,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				assertNetAttachDefManifest(nadClient, f.Namespace.Name, testUdnName, testUdnUID)
 			})
 
-			It("should delete NetworkAttachmentDefinition when UserDefinedNetwork is deleted", func() {
+			It("should delete NetworkAttachmentDefinition when UserDefinedNetwork is deleted", Label("Size:S"), func() {
 				By("delete UserDefinedNetwork")
 				_, err := e2ekubectl.RunKubectl(f.Namespace.Name, "delete", userDefinedNetworkResource, testUdnName)
 				Expect(err).NotTo(HaveOccurred())
@@ -733,7 +733,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					runUDNPod(cs, f.Namespace.Name, *cfg, nil)
 				})
 
-				It("cannot be deleted when being used", func() {
+				It("cannot be deleted when being used", Label("Size:M"), func() {
 					By("verify UserDefinedNetwork cannot be deleted")
 					cmd := e2ekubectl.NewKubectlCommand(f.Namespace.Name, "delete", userDefinedNetworkResource, testUdnName)
 					cmd.WithTimeout(time.NewTimer(deleteNetworkTimeout).C)
@@ -776,7 +776,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 		})
 
-		It("when primary network exist, UserDefinedNetwork status should report not-ready", func() {
+		It("when primary network exist, UserDefinedNetwork status should report not-ready", Label("Size:S"), func() {
 			const (
 				primaryNadName = "cluster-primary-net"
 				primaryUdnName = "primary-net"
@@ -895,7 +895,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				Eventually(clusterUserDefinedNetworkReadyFunc(oc.AdminDynamicClient(), testClusterUdnName), udnCrReadyTimeout, time.Second).Should(Succeed())
 			})
 
-			It("should create NAD according to spec in each target namespace and report active namespaces", func() {
+			It("should create NAD according to spec in each target namespace and report active namespaces", Label("Size:S"), func() {
 				Eventually(
 					validateClusterUDNStatusReportsActiveNamespacesFunc(oc.AdminDynamicClient(), testClusterUdnName, testTenantNamespaces...),
 					1*time.Minute, 3*time.Second).Should(Succeed())
@@ -910,7 +910,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				}
 			})
 
-			It("when CR is deleted, should delete all managed NAD in each target namespace", func() {
+			It("when CR is deleted, should delete all managed NAD in each target namespace", Label("Size:S"), func() {
 				By("delete test CR")
 				_, err := e2ekubectl.RunKubectl("", "delete", clusterUserDefinedNetworkResource, testClusterUdnName)
 				Expect(err).NotTo(HaveOccurred())
@@ -925,7 +925,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				}
 			})
 
-			It("should create NAD in new created namespaces that apply to namespace-selector", func() {
+			It("should create NAD in new created namespaces that apply to namespace-selector", Label("Size:S"), func() {
 				testNewNs := f.Namespace.Name + "green"
 
 				By("add new target namespace to CR namespace-selector")
@@ -963,7 +963,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 
 			When("namespace-selector is mutated", func() {
-				It("should create NAD in namespaces that apply to mutated namespace-selector", func() {
+				It("should create NAD in namespaces that apply to mutated namespace-selector", Label("Size:S"), func() {
 					testNewNs := f.Namespace.Name + "green"
 
 					By("create new namespace")
@@ -996,7 +996,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					assertClusterNADManifest(nadClient, testNewNs, testClusterUdnName, testUdnUID)
 				})
 
-				It("should delete managed NAD in namespaces that no longer apply to namespace-selector", func() {
+				It("should delete managed NAD in namespaces that no longer apply to namespace-selector", Label("Size:S"), func() {
 					By("remove one active namespace from CR namespace-selector")
 					activeTenantNs := testTenantNamespaces[1]
 					patch := fmt.Sprintf(`[{"op": "replace", "path": "./spec/namespaceSelector/matchExpressions/0/values", "value": [%q]}]`, activeTenantNs)
@@ -1042,7 +1042,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 					runUDNPod(cs, inUseNetTestTenantNamespace, *cfg, setRuntimeDefaultPSA)
 				})
 
-				It("CR & managed NADs cannot be deleted when being used", func() {
+				It("CR & managed NADs cannot be deleted when being used", Label("Size:M"), func() {
 					By("verify CR cannot be deleted")
 					cmd := e2ekubectl.NewKubectlCommand("", "delete", clusterUserDefinedNetworkResource, testClusterUdnName)
 					cmd.WithTimeout(time.NewTimer(deleteNetworkTimeout).C)
@@ -1086,7 +1086,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			})
 		})
 
-		It("when primary network exist, ClusterUserDefinedNetwork status should report not-ready", func() {
+		It("when primary network exist, ClusterUserDefinedNetwork status should report not-ready", Label("Size:S"), func() {
 			namespace, err := f.CreateNamespace(context.TODO(), f.BaseName, map[string]string{
 				"e2e-framework":           f.BaseName,
 				RequiredUDNNamespaceLabel: "",
@@ -1190,7 +1190,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 				udnPod = runUDNPod(cs, f.Namespace.Name, *cfg, nil)
 			})
 
-			It("should react to k8s.ovn.org/open-default-ports annotations changes", func() {
+			It("should react to k8s.ovn.org/open-default-ports annotations changes", Label("Size:M"), func() {
 				By("Creating second namespace for default network pod")
 				defaultNetNamespace := f.Namespace.Name + "-default"
 				_, err := cs.CoreV1().Namespaces().Create(context.Background(), &v1.Namespace{

--- a/test/extended/networking/network_segmentation_endpointslice_mirror.go
+++ b/test/extended/networking/network_segmentation_endpointslice_mirror.go
@@ -61,7 +61,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 			func(createNetworkFn func(c networkAttachmentConfigParams) error) {
 
 				DescribeTable(
-					"mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks",
+					"mirrors EndpointSlices managed by the default controller for namespaces with user defined primary networks", Label("Size:M"),
 					func(
 						netConfig networkAttachmentConfigParams,
 						isHostNetwork bool,
@@ -183,7 +183,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Feature:User
 		DescribeTableSubtree("created using",
 			func(createNetworkFn func(c networkAttachmentConfigParams) error) {
 				DescribeTable(
-					"does not mirror EndpointSlices in namespaces not using user defined primary networks",
+					"does not mirror EndpointSlices in namespaces not using user defined primary networks", Label("Size:M"),
 					func(
 						netConfig networkAttachmentConfigParams,
 					) {

--- a/test/extended/networking/network_segmentation_policy.go
+++ b/test/extended/networking/network_segmentation_policy.go
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 		})
 
 		ginkgo.DescribeTable(
-			"pods within namespace should be isolated when deny policy is present",
+			"pods within namespace should be isolated when deny policy is present", ginkgo.Label("Size:M"),
 			func(
 				topology string,
 				clientPodConfig podConfiguration,
@@ -175,7 +175,7 @@ var _ = ginkgo.Describe("[sig-network][OCPFeatureGate:NetworkSegmentation][Featu
 		)
 
 		ginkgo.DescribeTable(
-			"allow ingress traffic to one pod from a particular namespace",
+			"allow ingress traffic to one pod from a particular namespace", ginkgo.Label("Size:M"),
 			func(
 				topology string,
 				clientPodConfig podConfiguration,

--- a/test/extended/networking/route_advertisements.go
+++ b/test/extended/networking/route_advertisements.go
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 				v4PodIPSet, v6PodIPSet = extractPodIPs(podList)
 			})
 
-			g.It("Pods should communicate with external host without being SNATed", func() {
+			g.It("Pods should communicate with external host without being SNATed", g.Label("Size:L"), func() {
 				g.By("Checking that routes are advertised to each node")
 				for _, nodeName := range workerNodesOrderedNames {
 					verifyLearnedBgpRoutesForNode(oc, nodeName, "default")
@@ -272,7 +272,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 				}
 			})
 
-			g.It("External host should be able to query route advertised pods by the pod IP", func() {
+			g.It("External host should be able to query route advertised pods by the pod IP", g.Label("Size:L"), func() {
 				g.By("Launching an agent pod")
 				nodeSelection := e2epod.NodeSelection{}
 				e2epod.SetAffinity(&nodeSelection, externalNodeName)
@@ -473,8 +473,8 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 					g.AfterEach(func() {
 						o.Expect(afterEach()).To(o.Succeed())
 					})
-					g.It("Pods should communicate with external host without being SNATed", toExternalCheck)
-					g.It("External host should be able to query route advertised pods by the pod IP", fromExternalCheck)
+					g.It("Pods should communicate with external host without being SNATed", g.Label("Size:L"), toExternalCheck)
+					g.It("External host should be able to query route advertised pods by the pod IP", g.Label("Size:L"), fromExternalCheck)
 				},
 				g.Entry("When the network topology is Layer 3", "layer3"),
 				g.Entry("When the network topology is Layer 2", "layer2"),
@@ -556,7 +556,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 				// single test (or otherwise we should resort to a serial job)
 				// This test has a long timeout due to its serial nature, testing both
 				// Layer 3 and Layer 2 topologies serially, and also because of OCPBUGS-56488
-				g.It("Pods should be able to communicate on a secondary network [Timeout:30m]", func() {
+				g.It("Pods should be able to communicate on a secondary network [Timeout:30m]", g.Label("Size:L"), func() {
 					g.By("testing with a layer 3 CUDN", func() { test("layer3") })
 					g.By("testing with a layer 2 CUDN", func() { test("layer2") })
 				})
@@ -683,8 +683,8 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 							spawnProberSendEgressIPTrafficCheckLogs(oc, snifferNamespace, probePodName, svcUrl, targetProtocol, externalIP, serverPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, newEgressIPSet)
 						}
 					},
-					g.Entry("When the network is IPv4", IPv4, v4ExternalIP),
-					g.Entry("When the network is IPv6", IPv6, v6ExternalIP),
+					g.Entry("When the network is IPv4", g.Label("Size:M"), IPv4, v4ExternalIP),
+					g.Entry("When the network is IPv6", g.Label("Size:M"), IPv6, v6ExternalIP),
 				)
 			})
 
@@ -824,8 +824,8 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 								spawnProberSendEgressIPTrafficCheckLogs(oc, targetNamespace, probePodName, svcUrl, targetProtocol, externalIP, serverPort, numberOfRequestsToSend, 0, packetSnifferDaemonSet, newEgressIPSet)
 							}
 						},
-						g.Entry("When the network is IPv4", IPv4, v4ExternalIP),
-						g.Entry("When the network is IPv6", IPv6, v6ExternalIP),
+						g.Entry("When the network is IPv4", g.Label("Size:M"), IPv4, v4ExternalIP),
+						g.Entry("When the network is IPv6", g.Label("Size:M"), IPv6, v6ExternalIP),
 					)
 				},
 				g.Entry("When the network topology is Layer 3", "layer3"),

--- a/test/extended/networking/servicecidr.go
+++ b/test/extended/networking/servicecidr.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[sig-network] ServiceCIDR", func() {
 		}
 	})
 
-	g.It("should be blocked", func() {
+	g.It("should be blocked", g.Label("Size:S"), func() {
 		g.By("Trying to create a new ServiceCIDR")
 		yaml := exutil.FixturePath("testdata", "servicecidr.yaml")
 		err := oc.AsAdmin().Run("create").Args("-f", yaml).Execute()

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -23,7 +23,7 @@ var _ = Describe("[sig-network] services", func() {
 	var retryInterval = 1 * time.Minute
 
 	InIPv4ClusterContext(oc, func() {
-		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", func() {
+		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", Label("Size:M"), func() {
 			// Check if the test can write to cluster/network.config.openshift.io
 			hasAccess, err := hasNetworkConfigWriteAccess(oc)
 			Expect(err).NotTo(HaveOccurred())
@@ -107,7 +107,7 @@ var _ = Describe("[sig-network] services", func() {
 	})
 
 	InBareMetalIPv4ClusterContext(oc, func() {
-		It("ensures external auto assign cidr is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", func() {
+		It("ensures external auto assign cidr is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", Label("Size:M"), func() {
 			// Check if the test can write to cluster/network.config.openshift.io
 			hasAccess, err := hasNetworkConfigWriteAccess(oc)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/extended/networking/tap.go
+++ b/test/extended/networking/tap.go
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-network][Feature:tap]", func() {
 		}
 	})
 
-	g.It(fmt.Sprintf("should create a pod with a tap interface [apigroup:k8s.cni.cncf.io]"), func() {
+	g.It(fmt.Sprintf("should create a pod with a tap interface [apigroup:k8s.cni.cncf.io]"), g.Label("Size:M"), func() {
 		ns := f.Namespace.Name
 		podName := "pod1"
 		nadName := "nad-tap"

--- a/test/extended/networking/tuning.go
+++ b/test/extended/networking/tuning.go
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("tuning", admissionapi.LevelPrivileged)
 	f := oc.KubeFramework()
 
-	g.It("pod should start with all sysctl on whitelist [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("pod should start with all sysctl on whitelist [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 		sysctls := map[string]string{}
 		for _, sysctl := range whitelistedSysctls {
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 			o.Expect(result).To(o.Equal(sysctl.Value), "incorrect sysctl value")
 		}
 	})
-	g.DescribeTable("pod should not start for sysctls not on whitelist [apigroup:k8s.cni.cncf.io]", func(sysctl, value string) {
+	g.DescribeTable("pod should not start for sysctls not on whitelist [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func(sysctl, value string) {
 		namespace := f.Namespace.Name
 		tuningNADName := "tuningnadwithdisallowedsysctls"
 		err := createTuningNAD(oc.AdminConfig(), namespace, tuningNADName, map[string]string{sysctl: value})
@@ -104,7 +104,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 		g.Entry("net.ipv4.conf.IFNAME.arp_filter", "net.ipv4.conf.IFNAME.arp_filter", "1"),
 	)
 
-	g.It("pod sysctls should not affect node [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("pod sysctls should not affect node [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 		g.By("creating a preexisting pod to check host sysctl")
 		nodePod := e2epod.CreateExecPodOrFail(context.TODO(), f.ClientSet, f.Namespace.Name, "nodeaccess-pod-", func(pod *kapiv1.Pod) {
@@ -161,7 +161,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 		o.Expect(hostSysctlValue).Should(o.Equal(hostSysctlValue2))
 	})
 
-	g.It("pod sysctl should not affect existing pods [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("pod sysctl should not affect existing pods [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 		path := fmt.Sprintf(sysctlPath, "net1")
 		err := createNAD(oc.AdminConfig(), namespace, baseNAD)
@@ -190,7 +190,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 		o.Expect(podOutputBeforeSysctlAplied).Should(o.Equal(podOutputAfterSysctlAplied))
 	})
 
-	g.It("pod sysctl should not affect newly created pods [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("pod sysctl should not affect newly created pods [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		namespace := f.Namespace.Name
 		path := fmt.Sprintf(sysctlPath, "net1")
 
@@ -244,7 +244,7 @@ var _ = g.Describe("[sig-network][Feature:tuning]", func() {
 			updateAllowlistConfig(originalSysctls, f.ClientSet)
 		})
 
-		g.It("should start a pod with custom sysctl only when the sysctl is added to whitelist", func() {
+		g.It("should start a pod with custom sysctl only when the sysctl is added to whitelist", g.Label("Size:M"), func() {
 			updatedSysctls := originalSysctls + "\n" + "^net.ipv4.conf.IFNAME.accept_local$"
 			namespace := f.Namespace.Name
 

--- a/test/extended/networking/vlan.go
+++ b/test/extended/networking/vlan.go
@@ -88,7 +88,7 @@ var _ = g.Describe("[sig-network][Feature:vlan]", func() {
 	})
 
 	for _, pluginType := range []string{"vlan", "ipvlan", "macvlan"} {
-		g.It(fmt.Sprintf("should create pingable pods with %s interface on an in-container master [apigroup:k8s.cni.cncf.io]", pluginType), func() {
+		g.It(fmt.Sprintf("should create pingable pods with %s interface on an in-container master [apigroup:k8s.cni.cncf.io]", pluginType), g.Label("Size:M"), func() {
 			vlanId, otherVlanId := "73", "37"
 			ip1, ip2, otherIp = "10.10.0.2", "10.10.0.3", "10.10.0.4"
 			bridgeAnnotation := fmt.Sprintf("%s/%s@%s", namespace, bridge, bridge)

--- a/test/extended/networking/whereabouts.go
+++ b/test/extended/networking/whereabouts.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-network][Feature:Whereabouts]", func() {
 
 	// Whereabouts is already installed in Origin. These tests aims to verify the integrity of the installation.
 
-	g.It("should use whereabouts net-attach-def to limit IP ranges for newly created pods [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("should use whereabouts net-attach-def to limit IP ranges for newly created pods [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		var err error
 
 		f := oc.KubeFramework()
@@ -109,7 +109,7 @@ var _ = g.Describe("[sig-network][Feature:Whereabouts]", func() {
 
 	})
 
-	g.It("should assign unique IP addresses to each pod in the event of a race condition case [apigroup:k8s.cni.cncf.io]", func() {
+	g.It("should assign unique IP addresses to each pod in the event of a race condition case [apigroup:k8s.cni.cncf.io]", g.Label("Size:M"), func() {
 		// steps for the test
 		// 1. create sleepy pod
 		// 2. create awake pod

--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -38,20 +38,20 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 		}
 	})
 
-	g.It("should succeed with pod and pull policy of Always", func(ctx context.Context) {
+	g.It("should succeed with pod and pull policy of Always", g.Label("Size:M"), func(ctx context.Context) {
 		pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, image)
 		createPodAndWaitForRunning(ctx, oc, pod)
 		verifyVolumeMounted(f, pod, "ls", "/mnt/image/bin/oc")
 	})
 
-	g.It("should handle multiple image volumes", func(ctx context.Context) {
+	g.It("should handle multiple image volumes", g.Label("Size:M"), func(ctx context.Context) {
 		pod := buildPodWithMultipleImageVolumes(f.Namespace.Name, "", podName, image, image)
 		createPodAndWaitForRunning(ctx, oc, pod)
 		verifyVolumeMounted(f, pod, "ls", "/mnt/image/bin/oc")
 		verifyVolumeMounted(f, pod, "ls", "/mnt/image2/bin/oc")
 	})
 
-	g.It("should fail when image does not exist", func(ctx context.Context) {
+	g.It("should fail when image does not exist", g.Label("Size:M"), func(ctx context.Context) {
 		pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, "nonexistent:latest")
 
 		g.By("Creating a pod with non-existent image volume")
@@ -69,14 +69,14 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should succeed if image volume is not existing but unused", func(ctx context.Context) {
+	g.It("should succeed if image volume is not existing but unused", g.Label("Size:M"), func(ctx context.Context) {
 		pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, "nonexistent:latest")
 		pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{}
 		createPodAndWaitForRunning(ctx, oc, pod)
 		// The container has no image volume mount, so just checking running is enough
 	})
 
-	g.It("should succeed with multiple pods and same image on the same node", func(ctx context.Context) {
+	g.It("should succeed with multiple pods and same image on the same node", g.Label("Size:M"), func(ctx context.Context) {
 		pod1 := buildPodWithImageVolume(f.Namespace.Name, "", podName, image)
 		pod1 = createPodAndWaitForRunning(ctx, oc, pod1)
 
@@ -88,13 +88,13 @@ var _ = g.Describe("[sig-node] [FeatureGate:ImageVolume] ImageVolume", func() {
 	})
 
 	g.Context("when subPath is used", func() {
-		g.It("should handle image volume with subPath", func(ctx context.Context) {
+		g.It("should handle image volume with subPath", g.Label("Size:M"), func(ctx context.Context) {
 			pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, "", podName, image, "bin")
 			createPodAndWaitForRunning(ctx, oc, pod)
 			verifyVolumeMounted(f, pod, "ls", "/mnt/image/oc")
 		})
 
-		g.It("should fail to mount image volume with invalid subPath", func(ctx context.Context) {
+		g.It("should fail to mount image volume with invalid subPath", g.Label("Size:M"), func(ctx context.Context) {
 			pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, "", podName, image, "noexist")
 			g.By("Creating a pod with image volume and subPath")
 			_, err := oc.AdminKubeClient().CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})

--- a/test/extended/node/nested_container.go
+++ b/test/extended/node/nested_container.go
@@ -19,7 +19,7 @@ import (
 
 var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("nested-podman", admissionapi.LevelBaseline)
-	g.It("should pass podman localsystem test in baseline mode",
+	g.It("should pass podman localsystem test in baseline mode", g.Label("Size:L"),
 		func(ctx context.Context) {
 			runNestedPod(ctx, oc)
 		},

--- a/test/extended/node/zstd_chunked.go
+++ b/test/extended/node/zstd_chunked.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-builds][sig-node][Feature:Builds][apigroup:build.opensh
 		customBuildFixture = exutil.FixturePath("testdata", "node", "zstd-chunked", "test-custom-build.yaml")
 	)
 
-	g.It("should successfully run date command", func(ctx context.Context) {
+	g.It("should successfully run date command", g.Label("Size:L"), func(ctx context.Context) {
 		namespace := oc.Namespace()
 
 		g.By("creating custom builder image")

--- a/test/extended/node_tuning/node_tuning.go
+++ b/test/extended/node_tuning/node_tuning.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-node-tuning] NTO should", func() {
 	// author: liqcui@redhat.com
 	// OCP Bugs: https://issues.redhat.com/browse/OCPBUGS-11150
 
-	g.It("OCP-66086 NTO Prevent from stalld continually restarting [Slow]", func() {
+	g.It("OCP-66086 NTO Prevent from stalld continually restarting [Slow]", g.Label("Size:L"), func() {
 		e2e.Logf("get the first rhcos worker nodes as label node")
 		firstCoreOSWorkerNodes, err := exutil.GetFirstCoreOsWorkerNode(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/oauth/client_secret.go
+++ b/test/extended/oauth/client_secret.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer]", func() {
 	ctx := context.Background()
 
 	g.Describe("ClientSecretWithPlus", func() {
-		g.It(fmt.Sprintf("should create oauthclient [apigroup:oauth.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should create oauthclient [apigroup:oauth.openshift.io][apigroup:user.openshift.io]"), g.Label("Size:M"), func() {
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/expiration.go
+++ b/test/extended/oauth/expiration.go
@@ -64,11 +64,11 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 0
 			})
 
-			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
-			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 
@@ -79,10 +79,10 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Token Expiration]", func() 
 				accessTokenMaxAgeSeconds = 10
 			})
 
-			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a token authorization flow [apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 				testTokenFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
-			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", func() {
+			g.It("works as expected when using a code authorization flow [apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 				testCodeFlow(oc, newRequestTokenOptions, oAuthClientResource, accessTokenMaxAgeSeconds)
 			})
 		})

--- a/test/extended/oauth/groupsync.go
+++ b/test/extended/oauth/groupsync.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP][Serial] ldap group sync", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("ldap-group-sync", admissionapi.LevelPrivileged).AsAdmin()
 	)
 
-	g.It("can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
+	g.It("can sync groups from ldap [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", g.Label("Size:L"), func() {
 		g.By("starting an openldap server")
 		ldapNS, ldapName, _, ca, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/oauth/htpasswd.go
+++ b/test/extended/oauth/htpasswd.go
@@ -32,7 +32,7 @@ func init() {
 var _ = g.Describe("[sig-auth][Feature:HTPasswdAuth] HTPasswd IDP", func() {
 	var oc = exutil.NewCLIWithPodSecurityLevel("htpasswd-idp", admissionapi.LevelBaseline)
 
-	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should successfully configure htpasswd and be responsive [apigroup:user.openshift.io][apigroup:route.openshift.io]", g.Label("Size:L"), func() {
 		newTokenReqOpts, cleanup, err := deployOAuthServer(oc)
 		defer cleanup()
 		o.Expect(err).ToNot(o.HaveOccurred())

--- a/test/extended/oauth/http1.go
+++ b/test/extended/oauth/http1.go
@@ -17,7 +17,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth server [apigroup:auth.
 
 	oc := exutil.NewCLI("oauth")
 
-	g.It("should use http1.1 only to prevent http2 connection reuse", func() {
+	g.It("should use http1.1 only to prevent http2 connection reuse", g.Label("Size:S"), func() {
 		metadata := getOAuthWellKnownData(oc)
 
 		tlsClientConfig, err := rest.TLSConfigFor(oc.AdminConfig())

--- a/test/extended/oauth/ldap.go
+++ b/test/extended/oauth/ldap.go
@@ -15,7 +15,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP", func() {
 		oc = exutil.NewCLIWithPodSecurityLevel("oauth-ldap", admissionapi.LevelPrivileged)
 	)
 
-	g.It("should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("should start an OpenLDAP test server [apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:authorization.openshift.io]", g.Label("Size:L"), func() {
 		_, _, _, _, err := exutil.CreateLDAPTestServer(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})

--- a/test/extended/oauth/oauth_ldap.go
+++ b/test/extended/oauth/oauth_ldap.go
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-auth][Feature:LDAP] LDAP IDP", func() {
 		myEmail        = "person1smith@example.com"
 	)
 
-	g.It("should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should authenticate against an ldap server [apigroup:user.openshift.io][apigroup:route.openshift.io]", g.Label("Size:L"), func() {
 		adminConfig := oc.AdminConfig()
 
 		// Clean up mapped identity and user.

--- a/test/extended/oauth/oauthcertfallback.go
+++ b/test/extended/oauth/oauthcertfallback.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth server", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("oauth")
 
-	g.It("has the correct token and certificate fallback semantics [apigroup:user.openshift.io]", func() {
+	g.It("has the correct token and certificate fallback semantics [apigroup:user.openshift.io]", g.Label("Size:M"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/redirect_uris.go
+++ b/test/extended/oauth/redirect_uris.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [apigroup:oauth.openshift.io
 			},
 		}
 
-		g.It("must validate request URIs according to oauth-client definition", func() {
+		g.It("must validate request URIs according to oauth-client definition", g.Label("Size:M"), func() {
 			g.By("check oauth-openshift routes")
 			controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/oauth/requestheaders.go
+++ b/test/extended/oauth/requestheaders.go
@@ -61,7 +61,7 @@ type certAuthTest struct {
 var _ = g.Describe("[Serial] [sig-auth][Feature:OAuthServer] [RequestHeaders] [IdP]", func() {
 	var oc = exutil.NewCLI("request-headers")
 
-	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io]", func() {
+	g.It("test RequestHeaders IdP [apigroup:config.openshift.io][apigroup:user.openshift.io]", g.Label("Size:L"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/oauth/server_headers.go
+++ b/test/extended/oauth/server_headers.go
@@ -92,14 +92,14 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] [Headers][apigroup:route.ope
 
 			o.Expect(resp.Header).To(o.Equal(allHeaders))
 		},
-		g.Entry("root URL", "/"),
-		g.Entry("login URL for when there is only one IDP", "/login"),
-		g.Entry("login URL for the bootstrap IDP", "/login/kube:admin"),
-		g.Entry("login URL for the allow all IDP", "/login/anypassword"),
-		g.Entry("logout URL", "/logout"),
-		g.Entry("token URL", "/oauth/token"),
-		g.Entry("authorize URL", "/oauth/authorize"),
-		g.Entry("grant URL", "/oauth/authorize/approve"),
-		g.Entry("token request URL", "/oauth/token/request"),
+		g.Entry("root URL", g.Label("Size:S"), "/"),
+		g.Entry("login URL for when there is only one IDP", g.Label("Size:S"), "/login"),
+		g.Entry("login URL for the bootstrap IDP", g.Label("Size:S"), "/login/kube:admin"),
+		g.Entry("login URL for the allow all IDP", g.Label("Size:S"), "/login/anypassword"),
+		g.Entry("logout URL", g.Label("Size:S"), "/logout"),
+		g.Entry("token URL", g.Label("Size:S"), "/oauth/token"),
+		g.Entry("authorize URL", g.Label("Size:S"), "/oauth/authorize"),
+		g.Entry("grant URL", g.Label("Size:S"), "/oauth/authorize/approve"),
+		g.Entry("token request URL", g.Label("Size:S"), "/oauth/token/request"),
 	)
 })

--- a/test/extended/oauth/token.go
+++ b/test/extended/oauth/token.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] OAuth Authenticator", func()
 	oc := exutil.NewCLI("oauth-access-token-e2e-test")
 	ctx := context.Background()
 
-	g.It(fmt.Sprintf("accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]"), func() {
+	g.It(fmt.Sprintf("accepts sha256 access tokens [apigroup:user.openshift.io][apigroup:oauth.openshift.io]"), g.Label("Size:M"), func() {
 		user, err := oc.AdminUserClient().UserV1().Users().Create(ctx, &userv1.User{
 			TypeMeta: metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/extended/oauth/well_known.go
+++ b/test/extended/oauth/well_known.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-auth][Feature:OAuthServer] well-known endpoint", func()
 		oauthNamespace = "openshift-authentication"
 	)
 
-	g.It("should be reachable [apigroup:route.openshift.io] [apigroup:oauth.openshift.io]", func() {
+	g.It("should be reachable [apigroup:route.openshift.io] [apigroup:oauth.openshift.io]", g.Label("Size:S"), func() {
 		metadataJSON, err := oc.Run("get").Args("--raw", "/.well-known/oauth-authorization-server").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/olm/olm.go
+++ b/test/extended/olm/olm.go
@@ -68,7 +68,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 
 	for i := range providedAPIs {
 		api := providedAPIs[i]
-		g.It(fmt.Sprintf("be installed with %s at version %s [apigroup:%s]", api.plural, api.version, api.group), func() {
+		g.It(fmt.Sprintf("be installed with %s at version %s [apigroup:%s]", api.plural, api.version, api.group), g.Label("Size:S"), func() {
 			if api.fromAPIService {
 				// Ensure spec.version matches expected
 				raw, err := oc.AsAdmin().Run("get").Args("apiservices", fmt.Sprintf("%s.%s", api.version, api.group), "-o=jsonpath={.spec.version}").Output()
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 
 	// OCP-24061 - [bz 1685230] OLM operator should use imagePullPolicy: IfNotPresent
 	// author: bandrade@redhat.com
-	g.It("have imagePullPolicy:IfNotPresent on thier deployments", func() {
+	g.It("have imagePullPolicy:IfNotPresent on thier deployments", g.Label("Size:S"), func() {
 		oc := oc.AsAdmin().WithoutNamespace()
 		namespace := "openshift-operator-lifecycle-manager"
 
@@ -119,7 +119,7 @@ var _ = g.Describe("[sig-operator] OLM should", func() {
 
 	// OCP-21082 - Implement packages API server and list packagemanifest info with namespace not NULL
 	// author: bandrade@redhat.com
-	g.It("Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]", func() {
+	g.It("Implement packages API server and list packagemanifest info with namespace not NULL [apigroup:packages.operators.coreos.com]", g.Label("Size:S"), func() {
 		msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", "--all-namespaces", "--no-headers").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		packageserverLines := strings.Split(msg, "\n")
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-arch] ocp payload should be based on existing source", 
 	// TODO: This test should be more generic and across components
 	// OCP-20981, [BZ 1626434]The olm/catalog binary should output the exact version info
 	// author: jiazha@redhat.com
-	g.It("OLM version should contain the source commit id", func() {
+	g.It("OLM version should contain the source commit id", g.Label("Size:M"), func() {
 
 		oc := oc
 		namespace := "openshift-operator-lifecycle-manager"
@@ -269,7 +269,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 	)
 
 	files := []string{sub}
-	g.It("can subscribe to the operator [apigroup:config.openshift.io]", func() {
+	g.It("can subscribe to the operator [apigroup:config.openshift.io]", g.Label("Size:L"), func() {
 		g.By("Cluster-admin user subscribe the operator resource")
 
 		// skip test if marketplace-operator is not enabled
@@ -351,7 +351,7 @@ var _ = g.Describe("[sig-operator] an end user can use OLM", func() {
 
 	// OCP-24829 - Report `Upgradeable` in OLM ClusterOperators status
 	// author: bandrade@redhat.com
-	g.It("Report Upgradeable in OLM ClusterOperators status [apigroup:config.openshift.io]", func() {
+	g.It("Report Upgradeable in OLM ClusterOperators status [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		olmCOs := []string{"operator-lifecycle-manager", "operator-lifecycle-manager-catalog", "operator-lifecycle-manager-packageserver"}
 		for _, co := range olmCOs {
 			msg, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("co", co, "-o=jsonpath={range .status.conditions[*]}{.type}{' '}{.status}").Output()

--- a/test/extended/operators/certs.go
+++ b/test/extended/operators/certs.go
@@ -138,7 +138,7 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("collect certificate data", func() {
+	g.It("collect certificate data", g.Label("Size:M"), func() {
 		configClient := oc.AdminConfigClient()
 		featureGates, err := configClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -166,7 +166,7 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("all tls artifacts must be registered", func() {
+	g.It("all tls artifacts must be registered", g.Label("Size:M"), func() {
 
 		violationsPKIContent, err := certs.GetPKIInfoFromEmbeddedOwnership(ownership.PKIViolations)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -278,7 +278,7 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		}
 	})
 
-	g.It("all registered tls artifacts must have no metadata violation regressions", func() {
+	g.It("all registered tls artifacts must have no metadata violation regressions", g.Label("Size:M"), func() {
 		violationRegressionOptions := ensure_no_violation_regression.NewEnsureNoViolationRegressionOptions(ownership.AllViolations, genericclioptions.NewTestIOStreamsDiscard())
 		messages, _, err := violationRegressionOptions.HaveViolationsRegressed([]*certgraphapi.PKIList{actualPKIContent})
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -290,7 +290,7 @@ var _ = g.Describe(fmt.Sprintf("[sig-arch][Late][Jira:%q]", "kube-apiserver"), g
 		}
 	})
 
-	g.It("[OCPFeatureGate:ShortCertRotation] all certificates should expire in no more than 8 hours", func() {
+	g.It("[OCPFeatureGate:ShortCertRotation] all certificates should expire in no more than 8 hours", g.Label("Size:S"), func() {
 		var errs []error
 		// Skip router certificates (both certificate and signer)
 		// These are not being rotated automatically

--- a/test/extended/operators/check_crd_status.go
+++ b/test/extended/operators/check_crd_status.go
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-arch][Early]", func() {
 	})
 
 	g.Describe("CRDs for openshift.io", func() {
-		g.It("should have subresource.status", func() {
+		g.It("should have subresource.status", g.Label("Size:S"), func() {
 			failures := checkSubresourceStatus(crdItemList)
 			if len(failures) > 0 {
 				e2e.Fail(strings.Join(failures, "\n"))

--- a/test/extended/operators/cluster.go
+++ b/test/extended/operators/cluster.go
@@ -22,7 +22,7 @@ import (
 var _ = g.Describe("[sig-storage] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have no crashlooping recycler pods over four minutes", func() {
+	g.It("have no crashlooping recycler pods over four minutes", g.Label("Size:M"), func() {
 		crashloopingContainerCheck(InCoreNamespaces, recyclerPod)
 	})
 })

--- a/test/extended/operators/clusteroperators.go
+++ b/test/extended/operators/clusteroperators.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]",
 	})
 
 	g.Context("should define", func() {
-		g.Specify("at least one namespace in their lists of related objects", func() {
+		g.Specify("at least one namespace in their lists of related objects", g.Label("Size:S"), func() {
 			for _, clusterOperator := range clusterOperators {
 				if !whitelistNoNamespace.Has(clusterOperator.Name) {
 					o.Expect(clusterOperator.Status.RelatedObjects).To(o.ContainElement(isNamespace()), "ClusterOperator: %s", clusterOperator.Name)
@@ -62,7 +62,7 @@ var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]",
 		})
 
 		oc := exutil.NewCLI("clusteroperators")
-		g.Specify("at least one related object that is not a namespace", func() {
+		g.Specify("at least one related object that is not a namespace", g.Label("Size:S"), func() {
 			controlplaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -78,7 +78,7 @@ var _ = g.Describe("[sig-arch] ClusterOperators [apigroup:config.openshift.io]",
 			}
 		})
 
-		g.Specify("valid related objects", func() {
+		g.Specify("valid related objects", g.Label("Size:S"), func() {
 			controlplaneTopology, err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			if *controlplaneTopology == config.ExternalTopologyMode {

--- a/test/extended/operators/crd_must_be_stable.go
+++ b/test/extended/operators/crd_must_be_stable.go
@@ -61,7 +61,7 @@ var _ = g.Describe("[sig-arch][Early]", func() {
 	oc := exutil.NewCLI("crd-check")
 
 	g.Describe("APIs for openshift.io", func() {
-		g.It("must have stable versions", func() {
+		g.It("must have stable versions", g.Label("Size:S"), func() {
 			ctx := context.Background()
 
 			configClient := oc.AdminConfigClient()

--- a/test/extended/operators/daemon_set.go
+++ b/test/extended/operators/daemon_set.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 	// during an upgrade as new pods start and then establish connections.
 	//
 	// Currently only applies to daemonsets that don't explicitly target the control plane.
-	g.It("should only include cluster daemonsets that have maxUnavailable or maxSurge update of 10 percent or maxUnavailable of 33 percent", func() {
+	g.It("should only include cluster daemonsets that have maxUnavailable or maxSurge update of 10 percent or maxUnavailable of 33 percent", g.Label("Size:S"), func() {
 		// iterate over the references to find valid images
 		daemonSets, err := oc.KubeFramework().ClientSet.AppsV1().DaemonSets("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/operators/example.go
+++ b/test/extended/operators/example.go
@@ -7,7 +7,7 @@ import (
 var _ = g.Describe("[sig-arch][OCPFeatureGate:Example]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
-	g.It("should only run FeatureGated test when enabled", func() {
+	g.It("should only run FeatureGated test when enabled", g.Label("Size:S"), func() {
 	})
 
 })

--- a/test/extended/operators/images.go
+++ b/test/extended/operators/images.go
@@ -19,7 +19,7 @@ import (
 
 var _ = Describe("[sig-arch] Managed cluster", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
-	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy [apigroup:config.openshift.io]", func() {
+	It("should ensure pods use downstream images from our release image with proper ImagePullPolicy [apigroup:config.openshift.io]", Label("Size:M"), func() {
 		imagePullSecret, err := oc.KubeFramework().ClientSet.CoreV1().Secrets("openshift-config").Get(context.Background(), "pull-secret", metav1.GetOptions{})
 		if err != nil {
 			e2e.Failf("unable to get pull secret for cluster: %v", err)

--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -371,7 +371,7 @@ var _ = g.Describe("[sig-arch][Early] Operators", func() {
 	oc := exutil.NewCLIWithoutNamespace("management-plane-operators")
 
 	g.Describe("low level operators", func() {
-		g.It("should have at least the conditions we had in 4.17", func() {
+		g.It("should have at least the conditions we had in 4.17", g.Label("Size:S"), func() {
 			ctx := context.TODO()
 			if ok, _ := exutil.IsMicroShiftCluster(oc.AdminKubeClient()); ok {
 				g.Skip("microshift does not have operators.")

--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -32,7 +32,7 @@ var (
 var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.openshift.io]", func() {
 	defer g.GinkgoRecover()
 
-	g.It("start all core operators", func() {
+	g.It("start all core operators", g.Label("Size:M"), func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c, err := e2e.LoadClientset()
@@ -144,7 +144,7 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 var _ = g.Describe("[sig-arch] Managed cluster should", func() {
 	defer g.GinkgoRecover()
 
-	g.It("have operators on the cluster version [apigroup:config.openshift.io]", func() {
+	g.It("have operators on the cluster version [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 		cfg, err := e2e.LoadConfig()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		c := configclient.NewForConfigOrDie(cfg)

--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("[sig-arch] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
-	It("ensure control plane pods do not run in best-effort QoS", func() {
+	It("ensure control plane pods do not run in best-effort QoS", Label("Size:M"), func() {
 		// iterate over the references to find valid images
 		pods, err := oc.KubeFramework().ClientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/operators/recover.go
+++ b/test/extended/operators/recover.go
@@ -24,7 +24,7 @@ import (
 var _ = g.Describe("[sig-arch] Managed cluster should recover", func() {
 	defer g.GinkgoRecover()
 
-	g.It("when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]", func() {
+	g.It("when operator-owned objects are deleted [Disruptive][apigroup:config.openshift.io]", g.Label("Size:L"), func() {
 		daemonsets := false
 		deployments := false
 		secrets := true

--- a/test/extended/operators/resources.go
+++ b/test/extended/operators/resources.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 	//
 	// Release architects can justify an exception with text but must ensure CONVENTIONS.md is updated to document
 	// why the exception is granted.
-	g.It("should set requests but not limits", func() {
+	g.It("should set requests but not limits", g.Label("Size:M"), func() {
 		pods, err := oc.KubeFramework().ClientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {
 			e2e.Failf("unable to list pods: %v", err)

--- a/test/extended/operators/routable.go
+++ b/test/extended/operators/routable.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[sig-arch] Managed cluster", func() {
 		}
 	})
 
-	g.It("should expose cluster services outside the cluster [apigroup:route.openshift.io]", func() {
+	g.It("should expose cluster services outside the cluster [apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 		ns := oc.KubeFramework().Namespace.Name
 
 		tester := exurl.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)

--- a/test/extended/operators/server_side_apply_examples.go
+++ b/test/extended/operators/server_side_apply_examples.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-apimachinery]", func() {
 	}
 
 	g.Describe("server-side-apply should function properly", func() {
-		g.It("should clear fields when they are no longer being applied on CRDs", func() {
+		g.It("should clear fields when they are no longer being applied on CRDs", g.Label("Size:M"), func() {
 			ctx := context.Background()
 			isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -90,7 +90,7 @@ var _ = g.Describe("[sig-apimachinery]", func() {
 			}
 		})
 
-		g.It("should clear fields when they are no longer being applied in FeatureGates [apigroup:config.openshift.io]", func() {
+		g.It("should clear fields when they are no longer being applied in FeatureGates [apigroup:config.openshift.io]", g.Label("Size:M"), func() {
 			ctx := context.Background()
 			isSelfManagedHA, err := exutil.IsSelfManagedHA(ctx, oc.AdminConfigClient())
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -154,7 +154,7 @@ var _ = g.Describe("[sig-apimachinery]", func() {
 			}
 		})
 
-		g.It("should clear fields when they are no longer being applied in built-in APIs", func() {
+		g.It("should clear fields when they are no longer being applied in built-in APIs", g.Label("Size:M"), func() {
 			ctx := context.Background()
 
 			_, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Create(ctx, pausePod("test-instance"), metav1.CreateOptions{})

--- a/test/extended/operators/tolerations.go
+++ b/test/extended/operators/tolerations.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("[sig-arch] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
-	It("ensure control plane operators do not make themselves unevictable", func() {
+	It("ensure control plane operators do not make themselves unevictable", Label("Size:M"), func() {
 		// iterate over the references to find valid images
 		pods, err := oc.KubeFramework().ClientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/poddisruptionbudget/poddisruptionbudget.go
+++ b/test/extended/poddisruptionbudget/poddisruptionbudget.go
@@ -51,7 +51,7 @@ var _ = g.Describe("[sig-apps] poddisruptionbudgets", func() {
 			podsLabelSelector = labels.SelectorFromSet(labels.Set{"app": "nginx-with-delayed-ready"})
 		})
 
-		g.It(fmt.Sprintf("should evict according to the IfHealthyBudget policy"), func() {
+		g.It(fmt.Sprintf("should evict according to the IfHealthyBudget policy"), g.Label("Size:L"), func() {
 			g.By(fmt.Sprintf("calling oc create -f %q", ifHealthyBudgetPolicyPDB))
 			err := oc.Run("create").Args("-f", ifHealthyBudgetPolicyPDB).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -159,7 +159,7 @@ var _ = g.Describe("[sig-apps] poddisruptionbudgets", func() {
 			}
 		})
 
-		g.It(fmt.Sprintf("should evict according to the AlwaysAllow policy"), func() {
+		g.It(fmt.Sprintf("should evict according to the AlwaysAllow policy"), g.Label("Size:L"), func() {
 			g.By(fmt.Sprintf("calling oc create -f %q", alwaysAllowPolicyPDB))
 			err := oc.Run("create").Args("-f", alwaysAllowPolicyPDB).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/pods/graceful-shutdown.go
+++ b/test/extended/pods/graceful-shutdown.go
@@ -85,7 +85,7 @@ var _ = Describe("[sig-node][Disruptive][Feature:KubeletGracefulShutdown]", func
 		outputString string
 	)
 
-	It("Kubelet with graceful shutdown configuration should respect pods termination grace period", func() {
+	It("Kubelet with graceful shutdown configuration should respect pods termination grace period", Label("Size:L"), func() {
 		ctx := context.Background()
 
 		createTestBed(ctx, oc)

--- a/test/extended/pods/liveness_override.go
+++ b/test/extended/pods/liveness_override.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-node]", func() {
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 	// upstream e2e will test normal grace period on shutdown
-	g.It("should override timeoutGracePeriodSeconds when annotation is set", func() {
+	g.It("should override timeoutGracePeriodSeconds when annotation is set", g.Label("Size:M"), func() {
 		g.By("creating the pod")
 		podName := naming.GetPodName("pod-liveness-override", string(uuid.NewUUID()))
 		pod := pod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, nil, "bash", "-c", "sleep 1000")

--- a/test/extended/pods/priorityclasses.go
+++ b/test/extended/pods/priorityclasses.go
@@ -49,7 +49,7 @@ var excludedPriorityClassPods = map[string][]string{
 var _ = Describe("[sig-arch] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("pod")
 
-	It("ensure platform components have system-* priority class associated", func() {
+	It("ensure platform components have system-* priority class associated", Label("Size:S"), func() {
 		// iterate over the references to find valid images
 		pods, err := oc.KubeFramework().ClientSet.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 		if err != nil {

--- a/test/extended/pods/systemd.go
+++ b/test/extended/pods/systemd.go
@@ -16,7 +16,7 @@ var _ = g.Describe("[sig-node][Late]", func() {
 
 	oc := exutil.NewCLIWithoutNamespace("no-systemd-timeouts")
 
-	g.It("should not have pod creation failures due to systemd timeouts", func() {
+	g.It("should not have pod creation failures due to systemd timeouts", g.Label("Size:S"), func() {
 		kubeClient := oc.AdminKubeClient()
 
 		events, err := kubeClient.CoreV1().Events("").List(context.TODO(), metav1.ListOptions{})

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	ctx := context.Background()
 
 	g.Describe("TestProjectIsNamespace", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io]"), g.Label("Size:M"), func() {
 			t := g.GinkgoT()
 
 			// create a namespace
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatch", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), g.Label("Size:L"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -158,7 +158,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestProjectWatchWithSelectionPredicate", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:project.openshift.io][apigroup:authorization.openshift.io][apigroup:user.openshift.io]"), g.Label("Size:L"), func() {
 			bobName := oc.CreateUser("bob-").Name
 			bobConfig := oc.GetClientConfigForUser(bobName)
 			bobProjectClient := projectv1client.NewForConfigOrDie(bobConfig)
@@ -340,7 +340,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestScopedProjectAccess", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]"), g.Label("Size:L"), func() {
 			t := g.GinkgoT()
 
 			bobName := oc.CreateUser("bob-").Name
@@ -458,7 +458,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLI("project-api")
 
 	g.Describe("TestInvalidRoleRefs", func() {
-		g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should succeed [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:project.openshift.io]"), g.Label("Size:L"), func() {
 			clusterAdminRbacClient := oc.AdminKubeClient().RbacV1()
 			clusterAdminAuthorizationClient := oc.AdminAuthorizationClient().AuthorizationV1()
 

--- a/test/extended/project/unprivileged_newproject.go
+++ b/test/extended/project/unprivileged_newproject.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("project-api")
 
-	g.It("TestUnprivilegedNewProject [apigroup:project.openshift.io]", func() {
+	g.It("TestUnprivilegedNewProject [apigroup:project.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		valerieProjectClient := oc.ProjectClient()
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI][Serial] ", func() {
 	oc := exutil.NewCLI("project-api")
 	ctx := context.Background()
 
-	g.It("TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("TestUnprivilegedNewProjectDenied [apigroup:authorization.openshift.io][apigroup:project.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminAuthorizationConfig := oc.AdminAuthorizationClient().AuthorizationV1()

--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 
-		g.It("should expose default metrics", func() {
+		g.It("should expose default metrics", g.Label("Size:M"), func() {
 			o.Eventually(func() error {
 				defaultOnlyMetric := "prometheus_engine_query_log_enabled"
 				defaultMetricQuery := fmt.Sprintf("max(%s)", defaultOnlyMetric)
@@ -160,7 +160,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 	})
 
 	g.Context("in a heterogeneous environment,", func() {
-		g.It("should expose information about the applied collection profile using meta-metrics", func() {
+		g.It("should expose information about the applied collection profile using meta-metrics", g.Label("Size:M"), func() {
 			for _, profile := range collectionProfilesSupportedList {
 				err := r.makeCollectionProfileConfigurationFor(tctx, profile)
 				o.Expect(err).To(o.BeNil())
@@ -179,7 +179,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}, pollTimeout, pollInterval).Should(o.BeNil())
 			}
 		})
-		g.It("should have at least one implementation for each collection profile", func() {
+		g.It("should have at least one implementation for each collection profile", g.Label("Size:M"), func() {
 			for _, profile := range collectionProfilesSupportedList {
 				err := r.makeCollectionProfileConfigurationFor(tctx, profile)
 				o.Expect(err).To(o.BeNil())
@@ -197,7 +197,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 				}, pollTimeout, pollInterval).Should(o.BeNil())
 			}
 		})
-		g.It("should revert to default collection profile when an empty collection profile value is specified", func() {
+		g.It("should revert to default collection profile when an empty collection profile value is specified", g.Label("Size:M"), func() {
 			err := r.makeCollectionProfileConfigurationFor(tctx, collectionProfileNone)
 			o.Expect(err).To(o.BeNil())
 
@@ -234,7 +234,7 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 			}, pollTimeout, pollInterval).Should(o.BeNil())
 		})
 
-		g.It("should hide default metrics", func() {
+		g.It("should hide default metrics", g.Label("Size:L"), func() {
 			appNameSelector := "app.kubernetes.io/name"
 			appName := "kube-state-metrics"
 

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -95,7 +95,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Platform Prometheus targets", fu
 		}
 	})
 
-	g.It("should not be accessible without auth [Serial]", func() {
+	g.It("should not be accessible without auth [Serial]", g.Label("Size:L"), func() {
 		expectedStatusCodes := sets.New(http.StatusUnauthorized, http.StatusForbidden)
 
 		g.By("checking that targets reject the requests with 401 or 403")
@@ -372,7 +372,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		}
 	})
 
-	g.It("should have a valid severity label", func() {
+	g.It("should have a valid severity label", g.Label("Size:S"), func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
 			if alertsMissingValidSeverityLevel.Has(alert.Name) {
 				framework.Logf("Alerting rule %q is known to have invalid severity", alert.Name)
@@ -400,7 +400,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		}
 	})
 
-	g.It("should have description and summary annotations", func() {
+	g.It("should have description and summary annotations", g.Label("Size:S"), func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
 			if alertsMissingValidSummaryOrDescription.Has(alert.Name) {
 				framework.Logf("Alerting rule %q is known to have invalid summary or description", alert.Name)
@@ -430,7 +430,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		}
 	})
 
-	g.It("should have a runbook_url annotation if the alert is critical", func() {
+	g.It("should have a runbook_url annotation if the alert is critical", g.Label("Size:S"), func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
 			if criticalAlertsMissingRunbookURLExceptions.Has(alert.Name) {
 				framework.Logf("Critical alerting rule %q is known to have missing runbook_url.", alert.Name)
@@ -453,7 +453,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		}
 	})
 
-	g.It("should link to an HTTP(S) location if the runbook_url annotation is defined", func() {
+	g.It("should link to an HTTP(S) location if the runbook_url annotation is defined", g.Label("Size:S"), func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
 			violations := sets.NewString()
 			runbook_url := string(alert.Annotations["runbook_url"])
@@ -474,7 +474,7 @@ var _ = g.Describe("[sig-instrumentation][Late] OpenShift alerting rules [apigro
 		}
 	})
 
-	g.It("should link to a valid URL if the runbook_url annotation is defined", func() {
+	g.It("should link to a valid URL if the runbook_url annotation is defined", g.Label("Size:M"), func() {
 		err := helper.ForEachAlertingRule(alertingRules, func(alert promv1.AlertingRule) sets.String {
 			violations := sets.NewString()
 			runbook_url := string(alert.Annotations["runbook_url"])
@@ -514,7 +514,7 @@ var _ = g.Describe("[sig-instrumentation][Late] Alerts", func() {
 		}
 	})
 
-	g.It("shouldn't exceed the series limit of total series sent via telemetry from each cluster", func() {
+	g.It("shouldn't exceed the series limit of total series sent via telemetry from each cluster", g.Label("Size:S"), func() {
 		if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 			e2e.Failf("could not determine if Telemetry is enabled: %v", err)
 		} else if enabledErr != nil {
@@ -579,7 +579,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 	})
 
 	g.Describe("when installed on the cluster", func() {
-		g.It("should report telemetry [Serial] [Late]", func() {
+		g.It("should report telemetry [Serial] [Late]", g.Label("Size:M"), func() {
 			if enabledErr, err := telemetryIsEnabled(ctx, oc.AdminKubeClient()); err != nil {
 				e2e.Failf("could not determine if Telemetry is enabled: %v", err)
 			} else if enabledErr != nil {
@@ -614,7 +614,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			}
 		})
 
-		g.It("should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]", func() {
+		g.It("should start and expose a secured proxy and unsecured metrics [apigroup:config.openshift.io]", g.Label("Size:L"), func() {
 			ns := oc.Namespace()
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
 			defer func() {
@@ -761,7 +761,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(insecureTargets).To(o.BeEmpty(), "some services expose metrics over insecure channel")
 		})
 
-		g.It("should have a AlertmanagerReceiversNotConfigured alert in firing state", func() {
+		g.It("should have a AlertmanagerReceiversNotConfigured alert in firing state", g.Label("Size:S"), func() {
 			tests := map[string]bool{
 				`ALERTS{alertstate=~"firing|pending",alertname="AlertmanagerReceiversNotConfigured"} == 1`: true,
 			}
@@ -771,7 +771,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			e2e.Logf("AlertmanagerReceiversNotConfigured alert is firing")
 		})
 
-		g.It("should have important platform topology metrics [apigroup:config.openshift.io]", func() {
+		g.It("should have important platform topology metrics [apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 			exutil.SkipIfExternalControlplaneTopology(oc, "topology metrics are not available for clusters with external controlPlaneTopology")
 
 			tests := map[string]bool{
@@ -793,7 +793,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should have non-Pod host cAdvisor metrics", func() {
+		g.It("should have non-Pod host cAdvisor metrics", g.Label("Size:S"), func() {
 			tests := map[string]bool{
 				`container_cpu_usage_seconds_total{id!~"/kubepods.slice/.*"} >= 1`: true,
 			}
@@ -801,7 +801,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("shouldn't have failing rules evaluation", func() {
+		g.It("shouldn't have failing rules evaluation", g.Label("Size:S"), func() {
 			// we only consider samples since the beginning of the test
 			testDuration := exutil.DurationSinceStartInSeconds().String()
 
@@ -812,7 +812,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]", func() {
+		g.It("shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io]", g.Label("Size:S"), func() {
 			// Copy so we can expand:
 			allowedAlertNames := make([]string, len(allowedalerts.AllowedAlertNames))
 			copy(allowedAlertNames, allowedalerts.AllowedAlertNames)
@@ -852,7 +852,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should provide ingress metrics", func() {
+		g.It("should provide ingress metrics", g.Label("Size:M"), func() {
 			var lastErrs []error
 			o.Expect(wait.PollUntilContextTimeout(context.Background(), 10*time.Second, 4*time.Minute, true, func(ctx context.Context) (bool, error) {
 				contents, err := helper.GetURLWithToken(helper.MustJoinUrlPath(prometheusURL, "api/v1/targets"), bearerToken)
@@ -883,7 +883,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should provide named network metrics [apigroup:project.openshift.io]", func() {
+		g.It("should provide named network metrics [apigroup:project.openshift.io]", g.Label("Size:L"), func() {
 			ns := oc.SetupProject()
 
 			cs, err := newDynClientSet()

--- a/test/extended/prometheus/prometheus_builds.go
+++ b/test/extended/prometheus/prometheus_builds.go
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-instrumentation][sig-builds][Feature:Builds] Prometheus
 	})
 
 	g.Describe("when installed on the cluster", func() {
-		g.It("should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]", func() {
+		g.It("should start and expose a secured proxy and verify build metrics [apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			controlPlaneTopology, infra_err := exutil.GetControlPlaneTopology(oc)
 			o.Expect(infra_err).NotTo(o.HaveOccurred())
 

--- a/test/extended/prometheus/storage.go
+++ b/test/extended/prometheus/storage.go
@@ -39,10 +39,10 @@ var _ = g.Describe("[sig-storage][Late] Metrics", func() {
 		token, err = helper.RequestPrometheusServiceAccountAPIToken(ctx, oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Request prometheus service account API token")
 	})
-	g.It("should report short attach times", func(ctx g.SpecContext) {
+	g.It("should report short attach times", g.Label("Size:M"), func(ctx g.SpecContext) {
 		checkOperation(ctx, oc, url, token, "kube-controller-manager", "volume_attach", expectedAttachTimeSeconds)
 	})
-	g.It("should report short mount times", func(ctx g.SpecContext) {
+	g.It("should report short mount times", g.Label("Size:M"), func(ctx g.SpecContext) {
 		checkOperation(ctx, oc, url, token, "kubelet", "volume_mount", expectedMountTimeSeconds)
 	})
 })

--- a/test/extended/quota/clusterquota.go
+++ b/test/extended/quota/clusterquota.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ClusterResourceQuota]", func() {
 	oc := exutil.NewCLI("crq")
 
 	g.Describe("Cluster resource quota", func() {
-		g.It(fmt.Sprintf("should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io][apigroup:monitoring.coreos.com][apigroup:template.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io][apigroup:monitoring.coreos.com][apigroup:template.openshift.io]"), g.Label("Size:L"), func() {
 			t := g.GinkgoT(1)
 
 			clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/quota/resourcequota.go
+++ b/test/extended/quota/resourcequota.go
@@ -24,7 +24,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 	oc := exutil.NewCLI("object-count-rq")
 
 	g.Describe("Object count", func() {
-		g.It(fmt.Sprintf("should properly count the number of imagestreams resources [apigroup:image.openshift.io]"), func() {
+		g.It(fmt.Sprintf("should properly count the number of imagestreams resources [apigroup:image.openshift.io]"), g.Label("Size:M"), func() {
 			clusterAdminKubeClient := oc.AdminKubeClient()
 			clusterAdminImageClient := oc.AdminImageClient().ImageV1()
 			testProject := oc.SetupProject()
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should properly count the number of persistentvolumeclaims resources [Serial]", func() {
+		g.It("should properly count the number of persistentvolumeclaims resources [Serial]", g.Label("Size:M"), func() {
 			testProject := oc.SetupProject()
 			testResourceQuotaName := "my-resource-quota-" + testProject
 			pvcName := "myclaim-" + testProject
@@ -165,7 +165,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("check the quota after import-image with --all option [Skipped:Disconnected]", func() {
+		g.It("check the quota after import-image with --all option [Skipped:Disconnected]", g.Label("Size:M"), func() {
 			testProject := oc.SetupProject()
 			testResourceQuotaName := "my-imagestream-quota-" + testProject
 			clusterAdminKubeClient := oc.AdminKubeClient()
@@ -217,7 +217,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ResourceQuota]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("when exceed openshift.io/image-tags will ban to create new image references in the project [Skipped:Disconnected]", func() {
+		g.It("when exceed openshift.io/image-tags will ban to create new image references in the project [Skipped:Disconnected]", g.Label("Size:M"), func() {
 			testProject := oc.Namespace()
 			testResourceQuotaName := "my-image-tag-quota"
 			clusterAdminKubeClient := oc.AdminKubeClient()

--- a/test/extended/rorfs/readonly_root_filesystem.go
+++ b/test/extended/rorfs/readonly_root_filesystem.go
@@ -263,7 +263,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:ReadOnlyRootFilesystem]", func()
 	// Generate individual test cases for each namespace using a loop
 	for _, namespace := range namespaces {
 		namespace := namespace // capture loop variable
-		g.It(fmt.Sprintf("Explicitly set readOnlyRootFilesystem to true - %s [OCP-83088][Skipped:Disconnected][Serial]", namespace), func() {
+		g.It(fmt.Sprintf("Explicitly set readOnlyRootFilesystem to true - %s [OCP-83088][Skipped:Disconnected][Serial]", namespace), g.Label("Size:S"), func() {
 			testSingleNamespace(oc, namespace)
 		})
 	}

--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -160,7 +160,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 	g.When("FIPS is enabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should not work when configured with a 1024-bit RSA key", func() {
+			g.It("should not work when configured with a 1024-bit RSA key", g.Label("Size:M"), func() {
 				if !isFIPS {
 					g.Skip("skipping on non-FIPS cluster")
 				}
@@ -194,7 +194,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 	g.When("FIPS is disabled", func() {
 		g.Describe("the HAProxy router", func() {
-			g.It("should serve routes when configured with a 1024-bit RSA key", func() {
+			g.It("should serve routes when configured with a 1024-bit RSA key", g.Label("Size:M"), func() {
 				if isFIPS {
 					g.Skip("skipping on FIPS cluster")
 				}

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -490,7 +490,7 @@ http {
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should serve the correct routes when running with the haproxy config manager", func() {
+		g.It("should serve the correct routes when running with the haproxy config manager", g.Label("Size:L"), func() {
 			// the test has been skipped since July 2018 because it was flaking.
 			// TODO: Fix the test and re-enable it in https://issues.redhat.com/browse/NE-906.
 			g.Skip("HAProxy dynamic config manager tests skipped in 4.x")

--- a/test/extended/router/external_certificate.go
+++ b/test/extended/router/external_certificate.go
@@ -87,7 +87,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 		})
 
 		g.Describe("the router", func() {
-			g.It("should not support external certificate without proper permissions", func() {
+			g.It("should not support external certificate without proper permissions", g.Label("Size:S"), func() {
 				g.By("Creating a TLS certificate secret")
 				secret, _, err := generateTLSCertSecret(oc.Namespace(), "my-tls-secret", corev1.SecretTypeTLS, host)
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -105,7 +105,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				)
 			})
 
-			g.It("should not support external certificate if the secret is in a different namespace", func() {
+			g.It("should not support external certificate if the secret is in a different namespace", g.Label("Size:S"), func() {
 				g.By("Creating a new namespace")
 				differentNamespace := fmt.Sprintf("%s-%s", "router-external-certificate", rand.String(5))
 				err := createNamespace(oc, differentNamespace)
@@ -124,7 +124,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				o.Expect(err.Error()).To(o.ContainSubstring(`Not found: "secrets \"my-tls-secret\" not found"`))
 			})
 
-			g.It("should not support external certificate if the secret is not of type kubernetes.io/tls", func() {
+			g.It("should not support external certificate if the secret is not of type kubernetes.io/tls", g.Label("Size:S"), func() {
 				g.By("Creating a secret with the WRONG type (Opaque)")
 				secret, _, err := generateTLSCertSecret(oc.Namespace(), "my-tls-secret", corev1.SecretTypeOpaque, host) // Incorrect type
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -138,7 +138,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				o.Expect(err.Error()).To(o.ContainSubstring(`Invalid value: "my-tls-secret": secret of type "kubernetes.io/tls" required`))
 			})
 
-			g.It("should not support external certificate if the route termination type is Passthrough", func() {
+			g.It("should not support external certificate if the route termination type is Passthrough", g.Label("Size:S"), func() {
 				g.By("Creating a TLS certificate secret")
 				secret, _, err := generateTLSCertSecret(oc.Namespace(), "my-tls-secret", corev1.SecretTypeTLS, host)
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -152,7 +152,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				o.Expect(err.Error()).To(o.ContainSubstring(`Invalid value: "my-tls-secret": passthrough termination does not support certificates`))
 			})
 
-			g.It("should not support external certificate if inline certificate is also present", func() {
+			g.It("should not support external certificate if inline certificate is also present", g.Label("Size:S"), func() {
 				g.By("Creating a TLS certificate secret")
 				secret, _, err := generateTLSCertSecret(oc.Namespace(), "my-tls-secret", corev1.SecretTypeTLS, host)
 				o.Expect(err).NotTo(o.HaveOccurred())
@@ -217,7 +217,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 		})
 
 		g.Describe("the router should support external certificate", func() {
-			g.It("and routes are reachable", func() {
+			g.It("and routes are reachable", g.Label("Size:M"), func() {
 				g.By("Sending https request")
 				for _, route := range routes {
 					hostName, err := getHostnameForRoute(oc, route.Name)
@@ -235,7 +235,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 					o.Expect(err).NotTo(o.HaveOccurred())
 				})
 
-				g.It("then routes are not reachable", func() {
+				g.It("then routes are not reachable", g.Label("Size:M"), func() {
 					g.By("Checking the route status")
 					for _, route := range routes {
 						checkRouteStatus(oc, route.Name, corev1.ConditionFalse, "ExternalCertificateValidationFailed")
@@ -243,7 +243,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("and re-created again", func() {
-					g.It("then routes are reachable", func() {
+					g.It("then routes are reachable", g.Label("Size:M"), func() {
 						g.By("Re-creating the deleted secret")
 						_, err = oc.KubeClient().CoreV1().Secrets(oc.Namespace()).Create(context.Background(), secret, metav1.CreateOptions{})
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -260,7 +260,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("and re-created again but RBAC permissions are dropped", func() {
-					g.It("then routes are not reachable", func() {
+					g.It("then routes are not reachable", g.Label("Size:M"), func() {
 						g.By("Deleting RBAC permissions")
 						err = oc.KubeClient().RbacV1().RoleBindings(oc.Namespace()).Delete(context.Background(), secretReaderRoleBinding, metav1.DeleteOptions{})
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -278,7 +278,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 			})
 
 			g.Context("and the secret is updated", func() {
-				g.It("then also routes are reachable", func() {
+				g.It("then also routes are reachable", g.Label("Size:M"), func() {
 					g.By("Updating the existing secret")
 					// build a new secret
 					secret, rootDerBytes, err = generateTLSCertSecret(oc.Namespace(), "my-tls-secret", corev1.SecretTypeTLS, hosts...)
@@ -299,7 +299,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 			})
 
 			g.Context("and the secret is updated but RBAC permissions are dropped", func() {
-				g.It("then routes are not reachable", func() {
+				g.It("then routes are not reachable", g.Label("Size:M"), func() {
 					g.By("Deleting RBAC permissions")
 					err = oc.KubeClient().RbacV1().RoleBindings(oc.Namespace()).Delete(context.Background(), secretReaderRoleBinding, metav1.DeleteOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())
@@ -332,7 +332,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("to use new external certificate", func() {
-					g.It("then also the route is reachable", func() {
+					g.It("then also the route is reachable", g.Label("Size:M"), func() {
 						g.By("Creating a new secret")
 						secret, rootDerBytes, err = generateTLSCertSecret(oc.Namespace(), newSecretName, corev1.SecretTypeTLS, hosts...)
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -357,7 +357,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("to use new external certificate, but RBAC permissions are not added", func() {
-					g.It("route update is rejected", func() {
+					g.It("route update is rejected", g.Label("Size:S"), func() {
 						g.By("Creating a new secret")
 						secret, _, err = generateTLSCertSecret(oc.Namespace(), newSecretName, corev1.SecretTypeTLS, hosts...)
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -376,7 +376,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("to use new external certificate, but secret is not of type kubernetes.io/tls", func() {
-					g.It("route update is rejected", func() {
+					g.It("route update is rejected", g.Label("Size:S"), func() {
 						g.By("Creating a secret with the WRONG type (Opaque)")
 						secret, _, err := generateTLSCertSecret(oc.Namespace(), newSecretName, corev1.SecretTypeOpaque, hosts...) // Incorrect type
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -393,7 +393,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 
 				g.Context("to use new external certificate, but secret does not exist", func() {
 					// do not create new secret
-					g.It("route update is rejected", func() {
+					g.It("route update is rejected", g.Label("Size:S"), func() {
 						g.By("Updating the route to use new external certificate")
 						err := patchRouteWithExternalCertificate(oc, routeToTest.Name, newSecretName)
 						o.Expect(err).To(o.HaveOccurred())
@@ -402,7 +402,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("to use same external certificate", func() {
-					g.It("then also the route is reachable", func() {
+					g.It("then also the route is reachable", g.Label("Size:M"), func() {
 						g.By("Adding some label to trigger route update")
 						err := patchRouteWithLabel(oc, routeToTest.Name)
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -418,7 +418,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 				})
 
 				g.Context("to use same external certificate, but RBAC permissions are dropped", func() {
-					g.It("route update is rejected", func() {
+					g.It("route update is rejected", g.Label("Size:S"), func() {
 						g.By("Deleting RBAC permissions")
 						err = oc.KubeClient().RbacV1().RoleBindings(oc.Namespace()).Delete(context.Background(), secretReaderRoleBinding, metav1.DeleteOptions{})
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -441,7 +441,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 						o.Expect(err).NotTo(o.HaveOccurred())
 					})
 
-					g.It("then also the route is reachable and serves the default certificate", func() {
+					g.It("then also the route is reachable and serves the default certificate", g.Label("Size:M"), func() {
 						g.By("Sending in-secure https request")
 						hostName, err := getHostnameForRoute(oc, routeToTest.Name)
 						o.Expect(err).NotTo(o.HaveOccurred())
@@ -466,7 +466,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteExternalCertificate][Featu
 					})
 
 					g.Context("and again re-add the same external certificate", func() {
-						g.It("then also the route is reachable", func() {
+						g.It("then also the route is reachable", g.Label("Size:M"), func() {
 							g.By("Updating the route to re-add the external certificate reference")
 							err = patchRouteWithExternalCertificate(oc, routeToTest.Name, secret.Name)
 							o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/gatewayapi.go
+++ b/test/extended/router/gatewayapi.go
@@ -29,7 +29,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 	)
 
 	g.Describe("Verify Gateway API CRDs", func() {
-		g.It("and ensure required CRDs should already be installed", func() {
+		g.It("and ensure required CRDs should already be installed", g.Label("Size:S"), func() {
 			g.By("Get and check the installed CRDs")
 			for i := range crdNames {
 				crd, err := oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdNames[i], metav1.GetOptions{})
@@ -38,7 +38,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 			}
 		})
 
-		g.It("and ensure existing CRDs can not be deleted", func() {
+		g.It("and ensure existing CRDs can not be deleted", g.Label("Size:S"), func() {
 			g.By("Try to delete the CRDs and fail")
 			for i := range crdNames {
 				err := oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crdNames[i], metav1.DeleteOptions{})
@@ -47,7 +47,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 			}
 		})
 
-		g.It("and ensure existing CRDs can not be updated", func() {
+		g.It("and ensure existing CRDs can not be updated", g.Label("Size:S"), func() {
 			g.By("Get the CRDs firstly, add spec.names.shortNames then update CRD")
 			for i := range crdNames {
 				crd, err := oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().Get(context.Background(), crdNames[i], metav1.GetOptions{})
@@ -60,7 +60,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 			}
 		})
 
-		g.It("and ensure CRD of standard group can not be created", func() {
+		g.It("and ensure CRD of standard group can not be created", g.Label("Size:S"), func() {
 			fakeCRDName := "fakeroutes.gateway.networking.k8s.io"
 			g.By("Try to create CRD of standard group and fail")
 			fakeCRD := buildGWAPICRDFromName(fakeCRDName)
@@ -69,7 +69,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 			o.Expect(err.Error()).To(o.ContainSubstring(errorMessage))
 		})
 
-		g.It("and ensure CRD of experimental group is not installed", func() {
+		g.It("and ensure CRD of experimental group is not installed", g.Label("Size:S"), func() {
 			g.By("Ensure no CRD of experimental group is installed")
 			crdList, err := oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().List(context.Background(), metav1.ListOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -80,7 +80,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][api
 			}
 		})
 
-		g.It("and ensure CRD of experimental group can not be created", func() {
+		g.It("and ensure CRD of experimental group can not be created", g.Label("Size:S"), func() {
 			expCRDName := "xlistenersets.gateway.networking.x-k8s.io"
 			g.By("Try to create CRD of experimental group and fail")
 			expCRD := buildGWAPICRDFromName(expCRDName)

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -188,7 +188,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		}
 	})
 
-	g.It("Ensure OSSM and OLM related resources are created after creating GatewayClass", func() {
+	g.It("Ensure OSSM and OLM related resources are created after creating GatewayClass", g.Label("Size:L"), func() {
 		defer markTestDone(oc, ossmAndOLMResourcesCreated)
 
 		//check the catalogSource
@@ -253,7 +253,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		waitForIstioHealthy(oc)
 	})
 
-	g.It("Ensure default gatewayclass is accepted", func() {
+	g.It("Ensure default gatewayclass is accepted", g.Label("Size:L"), func() {
 		defer markTestDone(oc, defaultGatewayclassAccepted)
 
 		g.By("Check if default GatewayClass is accepted after OLM resources are successful")
@@ -261,7 +261,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q was not installed and accepted", gatewayClassName)
 	})
 
-	g.It("Ensure custom gatewayclass can be accepted", func() {
+	g.It("Ensure custom gatewayclass can be accepted", g.Label("Size:L"), func() {
 		defer markTestDone(oc, customGatewayclassAccepted)
 
 		customGatewayClassName := "custom-gatewayclass"
@@ -290,7 +290,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		waitForIstioHealthy(oc)
 	})
 
-	g.It("Ensure LB, service, and dnsRecord are created for a Gateway object", func() {
+	g.It("Ensure LB, service, and dnsRecord are created for a Gateway object", g.Label("Size:L"), func() {
 		defer markTestDone(oc, lbAndServiceAndDnsrecordAreCreated)
 
 		g.By("Ensure default GatewayClass is accepted")
@@ -315,7 +315,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		assertDNSRecordStatus(oc, gw)
 	})
 
-	g.It("Ensure HTTPRoute object is created", func() {
+	g.It("Ensure HTTPRoute object is created", g.Label("Size:L"), func() {
 		defer markTestDone(oc, httprouteObjectCreated)
 
 		g.By("Ensure default GatewayClass is accepted")
@@ -347,7 +347,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		assertHttpRouteConnection(defaultRoutename)
 	})
 
-	g.It("Ensure GIE is enabled after creating an inferencePool CRD", func() {
+	g.It("Ensure GIE is enabled after creating an inferencePool CRD", g.Label("Size:L"), func() {
 		defer markTestDone(oc, gieEnabled)
 
 		errCheck := checkGatewayClass(oc, gatewayClassName)

--- a/test/extended/router/grpc-interop.go
+++ b/test/extended/router/grpc-interop.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the gRPC interoperability tests [apigroup:route.openshift.io][apigroup:operator.openshift.io]", func() {
+		g.It("should pass the gRPC interoperability tests [apigroup:route.openshift.io][apigroup:operator.openshift.io]", g.Label("Size:L"), func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -58,7 +58,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the h2spec conformance tests [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:operator.openshift.io]", func() {
+		g.It("should pass the h2spec conformance tests [apigroup:authorization.openshift.io][apigroup:user.openshift.io][apigroup:security.openshift.io][apigroup:operator.openshift.io]", g.Label("Size:L"), func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/headers.go
+++ b/test/extended/router/headers.go
@@ -49,7 +49,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should set Forwarded headers appropriately", func() {
+		g.It("should set Forwarded headers appropriately", g.Label("Size:M"), func() {
 			o.Expect(infra).NotTo(o.BeNil())
 			o.Expect(network).NotTo(o.BeNil())
 

--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -96,7 +96,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should pass the http2 tests [apigroup:image.openshift.io][apigroup:operator.openshift.io]", func() {
+		g.It("should pass the http2 tests [apigroup:image.openshift.io][apigroup:operator.openshift.io]", g.Label("Size:L"), func() {
 			isProxyJob, err := exutil.IsClusterProxyEnabled(oc)
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get proxy configuration")
 			if isProxyJob {

--- a/test/extended/router/idle.go
+++ b/test/extended/router/idle.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", func() {
+		g.It("should be able to connect to a service that is idled because a GET on the route will unidle it", g.Label("Size:M"), func() {
 			network, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster network configuration")
 			if !(network.Status.NetworkType == "OVNKubernetes" || network.Status.NetworkType == "OpenShiftSDN") {

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -108,7 +108,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should expose a health check on the metrics port", func() {
+		g.It("should expose a health check on the metrics port", g.Label("Size:S"), func() {
 			execPodName = exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod").Name
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPodName, *metav1.NewDeleteOptions(1))
@@ -119,7 +119,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should expose prometheus metrics for a route [apigroup:route.openshift.io]", func() {
+		g.It("should expose prometheus metrics for a route [apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 			g.By("when a route exists")
 			configPath := exutil.FixturePath("testdata", "router", "router-metrics.yaml")
 			err := oc.Run("create").Args("-f", configPath).Execute()
@@ -246,7 +246,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(findGaugesWithLabels(updatedMetrics["haproxy_server_max_sessions"], serverLabels)[0]).To(o.Equal(float64(0)))
 		})
 
-		g.It("should expose the profiling endpoints", func() {
+		g.It("should expose the profiling endpoints", g.Label("Size:S"), func() {
 			execPodName = exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod").Name
 			defer func() {
 				oc.AdminKubeClient().CoreV1().Pods(ns).Delete(context.Background(), execPodName, *metav1.NewDeleteOptions(1))
@@ -262,7 +262,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 			o.Expect(results).To(o.ContainSubstring("# runtime.MemStats"))
 		})
 
-		g.It("should enable openshift-monitoring to pull metrics", func(ctx g.SpecContext) {
+		g.It("should enable openshift-monitoring to pull metrics", g.Label("Size:M"), func(ctx g.SpecContext) {
 			url, err := prometheus.PrometheusServiceURL(ctx, oc)
 			if errors.IsNotFound(err) {
 				g.Skip("prometheus not found on this cluster")

--- a/test/extended/router/reencrypt.go
+++ b/test/extended/router/reencrypt.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io][a
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should support reencrypt to services backed by a serving certificate automatically", func() {
+		g.It("should support reencrypt to services backed by a serving certificate automatically", g.Label("Size:M"), func() {
 			routerURL := fmt.Sprintf("https://%s", exutil.IPUrl(ip))
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")

--- a/test/extended/router/router.go
+++ b/test/extended/router/router.go
@@ -61,7 +61,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should respond with 503 to unrecognized hosts", func() {
+		g.It("should respond with 503 to unrecognized hosts", g.Label("Size:S"), func() {
 			t := url.NewTester(oc.AdminKubeClient(), ns).WithErrorPassthrough(true)
 			defer t.Close()
 			t.Within(
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:operator.openshift.io
 			)
 		})
 
-		g.It("should serve routes that were created from an ingress [apigroup:route.openshift.io]", func() {
+		g.It("should serve routes that were created from an ingress [apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 			g.By("deploying an ingress rule")
 			err := oc.Run("create").Args("-f", configPath).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -64,7 +64,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should serve the correct routes when scoped to a single namespace and label set", func() {
+		g.It("should serve the correct routes when scoped to a single namespace and label set", g.Label("Size:M"), func() {
 
 			routerPod := createScopedRouterPod(routerImage, "test-scoped", defaultPemData, "true")
 			g.By("creating a router")
@@ -109,7 +109,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			}
 		})
 
-		g.It("should override the route host with a custom value", func() {
+		g.It("should override the route host with a custom value", g.Label("Size:M"), func() {
 
 			routerPod := createOverrideRouterPod(routerImage)
 			g.By("creating a router")
@@ -173,7 +173,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(condition.LastTransitionTime).NotTo(o.BeNil())
 		})
 
-		g.It("should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]", func() {
+		g.It("should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 
 			routerPod := createOverrideDomainRouterPod(routerImage)
 			g.By("creating a router")

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("converges when multiple routers are writing status", func() {
+		g.It("converges when multiple routers are writing status", g.Label("Size:L"), func() {
 			g.By("deploying a scaled out namespace scoped router")
 			routerName := "namespaced"
 			rs, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
@@ -165,7 +165,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			verifyCommandEquivalent(oc.KubeClient(), rs, "md5sum /var/lib/haproxy/conf/*")
 		})
 
-		g.It("converges when multiple routers are writing conflicting status", func() {
+		g.It("converges when multiple routers are writing conflicting status", g.Label("Size:L"), func() {
 			g.By("deploying a scaled out namespace scoped router")
 			routerName := "conflicting"
 			numOfRoutes := 20
@@ -266,7 +266,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(writes).To(o.BeNumerically("<=", 5))
 		})
 
-		g.It("converges when multiple routers are writing conflicting upgrade validation status", func() {
+		g.It("converges when multiple routers are writing conflicting upgrade validation status", g.Label("Size:L"), func() {
 			g.By("deploying a scaled out namespace scoped router that adds the UnservableInFutureVersions condition")
 
 			routerName := "conflicting"

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -74,7 +74,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("reports the expected host names in admitted routes' statuses", func() {
+		g.It("reports the expected host names in admitted routes' statuses", g.Label("Size:M"), func() {
 			g.By("deploying two routers with distinct domains")
 			routers := map[string]string{
 				"router1": "bar.tld",

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -54,7 +54,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", func() {
+		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", g.Label("Size:M"), func() {
 
 			routerPod := createScopedRouterPod(routerImage, "test-unprivileged", defaultPemData, "false")
 			g.By("creating a router")

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -334,7 +334,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 	})
 
 	g.Describe("The HAProxy router", func() {
-		g.It("should serve a route that points to two services and respect weights", func() {
+		g.It("should serve a route that points to two services and respect weights", g.Label("Size:M"), func() {
 			defer func() {
 				if g.CurrentSpecReport().Failed() {
 					dumpWeightedRouterLogs(oc, g.CurrentSpecReport().FullText())

--- a/test/extended/scheduling/pods.go
+++ b/test/extended/scheduling/pods.go
@@ -131,67 +131,67 @@ var _ = g.Describe("[sig-scheduling][Early]", func() {
 	})
 
 	g.Describe("The HAProxy router pods [apigroup:route.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-ingress", deployment: "router-default"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-apiserver pods [apigroup:authorization.openshift.io][apigroup:build.openshift.io][apigroup:image.openshift.io][apigroup:project.openshift.io][apigroup:quota.openshift.io][apigroup:route.openshift.io][apigroup:security.openshift.io][apigroup:template.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-apiserver", deployment: "apiserver"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-authentication pods [apigroup:oauth.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-authentication", deployment: "oauth-openshift"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-console console pods [apigroup:console.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-console", deployment: "console"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-console downloads pods [apigroup:console.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-console", deployment: "downloads"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-etcd pods [apigroup:operator.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-etcd", deployment: "etcd-quorum-guard"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-image-registry pods [apigroup:imageregistry.operator.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-image-registry", deployment: "image-registry"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-monitoring prometheus-adapter pods [apigroup:monitoring.coreos.com]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-monitoring", deployment: "prometheus-adapter"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-monitoring thanos-querier pods [apigroup:monitoring.coreos.com]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-monitoring", deployment: "thanos-querier"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-oauth-apiserver pods [apigroup:oauth.openshift.io][apigroup:user.openshift.io]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-oauth-apiserver", deployment: "apiserver"}.run(oc)
 		})
 	})
 
 	g.Describe("The openshift-operator-lifecycle-manager pods [apigroup:packages.operators.coreos.com]", func() {
-		g.It("should be scheduled on different nodes", func() {
+		g.It("should be scheduled on different nodes", g.Label("Size:S"), func() {
 			requirePodsOnDifferentNodesTest{namespace: "openshift-operator-lifecycle-manager", deployment: "packageserver"}.run(oc)
 		})
 	})

--- a/test/extended/security/fips.go
+++ b/test/extended/security/fips.go
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-arch] [Conformance] FIPS", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("fips", admissionapi.LevelPrivileged)
 
-	g.It("TestFIPS", func() {
+	g.It("TestFIPS", g.Label("Size:S"), func() {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		clusterAdminKubeClientset := oc.AdminKubeClient()

--- a/test/extended/security/labels.go
+++ b/test/extended/security/labels.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-node] [Conformance] Prevent openshift node labeling on 
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("node-label-e2e", admissionapi.LevelPrivileged)
 
-	g.It("TestOpenshiftNodeLabeling", func() {
+	g.It("TestOpenshiftNodeLabeling", g.Label("Size:S"), func() {
 		clusterAdminKubeClientset := oc.AdminKubeClient()
 
 		workerNodes, err := clusterAdminKubeClientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{

--- a/test/extended/security/scc.go
+++ b/test/extended/security/scc.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 	ctx := context.Background()
 
-	g.It("TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("TestPodUpdateSCCEnforcement [apigroup:user.openshift.io][apigroup:authorization.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		projectName := oc.Namespace()
@@ -45,7 +45,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 		RunTestPodUpdateSCCEnforcement(ctx, haroldKubeClient, oc.AdminKubeClient(), projectName, t)
 	})
 
-	g.It("TestPodUpdateSCCEnforcement with service account", func() {
+	g.It("TestPodUpdateSCCEnforcement with service account", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		projectName := oc.Namespace()
@@ -108,7 +108,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	// pods running as root are being started here
 	oc := exutil.NewCLIWithPodSecurityLevel("scc", admissionapi.LevelPrivileged)
 
-	g.It("TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", func() {
+	g.It("TestAllowedSCCViaRBAC [apigroup:project.openshift.io][apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:security.openshift.io]", g.Label("Size:L"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()
@@ -141,7 +141,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 		)
 	})
 
-	g.It("TestAllowedSCCViaRBAC with service account [apigroup:security.openshift.io]", func() {
+	g.It("TestAllowedSCCViaRBAC with service account [apigroup:security.openshift.io]", g.Label("Size:L"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminKubeClientset := oc.AdminKubeClient()
@@ -359,7 +359,7 @@ var _ = g.Describe("[sig-auth][Feature:SecurityContextConstraints] ", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithPodSecurityLevel("ssc", admissionapi.LevelBaseline)
 
-	g.It("TestPodDefaultCapabilities", func() {
+	g.It("TestPodDefaultCapabilities", g.Label("Size:M"), func() {
 		g.By("Running a restricted pod and getting it's inherited capabilities")
 		// This test should use image.ShellImage but this requires having a local image
 		// registry, which not all deployment types have. Using the lightest publicly available

--- a/test/extended/security/supplemental_groups.go
+++ b/test/extended/security/supplemental_groups.go
@@ -36,7 +36,7 @@ var _ = g.Describe("[sig-node] supplemental groups", func() {
 	ctx := context.Background()
 
 	g.Describe("Ensure supplemental groups propagate to docker", func() {
-		g.It("should propagate requested groups to the container [apigroup:security.openshift.io]", func() {
+		g.It("should propagate requested groups to the container [apigroup:security.openshift.io]", g.Label("Size:M"), func() {
 
 			fsGroup := int64(1111)
 			supGroup := int64(2222)

--- a/test/extended/security/sysctl.go
+++ b/test/extended/security/sysctl.go
@@ -19,7 +19,7 @@ import (
 var _ = g.Describe("[sig-arch] [Conformance] sysctl", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("sysctl", admissionapi.LevelPrivileged)
 	ctx := context.Background()
-	g.DescribeTable("whitelists", func(sysctl, value, path, defaultSysctlValue string) {
+	g.DescribeTable("whitelists", g.Label("Size:M"), func(sysctl, value, path, defaultSysctlValue string) {
 		f := oc.KubeFramework()
 		var preexistingPod *v1.Pod
 		var err error
@@ -82,7 +82,7 @@ var _ = g.Describe("[sig-arch] [Conformance] sysctl", func() {
 		g.Entry("net.ipv4.ip_unprivileged_port_start", "net.ipv4.ip_unprivileged_port_start", "1002", "/proc/sys/net/ipv4/ip_unprivileged_port_start", "1024"),
 	)
 
-	g.DescribeTable("pod should not start for sysctl not on whitelist", func(sysctl, value string) {
+	g.DescribeTable("pod should not start for sysctl not on whitelist", g.Label("Size:S"), func(sysctl, value string) {
 		f := oc.KubeFramework()
 		podDefinition := frameworkpod.NewAgnhostPod(f.Namespace.Name, "sysctl-pod", nil, nil, nil)
 		podDefinition.Spec.SecurityContext.Sysctls = []v1.Sysctl{{Name: sysctl, Value: value}}

--- a/test/extended/single_node/topology.go
+++ b/test/extended/single_node/topology.go
@@ -131,7 +131,7 @@ func validateDeploymentReplicas(deployment appsv1.Deployment,
 var _ = ginkgo.Describe("[sig-arch] Cluster topology single node tests", func() {
 	f := framework.NewDefaultFramework("single-node")
 
-	ginkgo.It("Verify that OpenShift components deploy one replica in SingleReplica topology mode", func() {
+	ginkgo.It("Verify that OpenShift components deploy one replica in SingleReplica topology mode", ginkgo.Label("Size:S"), func() {
 		controlPlaneTopology, infraTopology := GetTopologies(f)
 
 		if controlPlaneTopology != v1.SingleReplicaTopologyMode && infraTopology != v1.SingleReplicaTopologyMode {

--- a/test/extended/storage/csi/scsi_overflow.go
+++ b/test/extended/storage/csi/scsi_overflow.go
@@ -63,7 +63,7 @@ func (csiSuite *scsiLUNOverflowCSISuite) DefineTests(driver storageframework.Tes
 	}
 	testName := fmt.Sprintf("should use many PVs on a single node [Serial][Timeout:%s]", timeoutString)
 
-	g.It(testName, func(ctx context.Context) {
+	g.It(testName, g.Label("Size:L"), func(ctx context.Context) {
 		if csiSuite.lunStressTestConfig == nil {
 			g.Skip("lunStressTestConfig is empty")
 		}

--- a/test/extended/storage/driver_configuration.go
+++ b/test/extended/storage/driver_configuration.go
@@ -191,7 +191,7 @@ var _ = g.Describe("[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial
 
 		for _, t := range tests {
 			t := t
-			g.It(t.name, func(ctx g.SpecContext) {
+			g.It(t.name, g.Label("Size:M"), func(ctx g.SpecContext) {
 				defer g.GinkgoRecover()
 				operatorShouldProgress = t.operatorShouldProgress
 

--- a/test/extended/storage/inline.go
+++ b/test/extended/storage/inline.go
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			afterEach(oc)
 		})
 
-		g.It("should allow pods with inline volumes when the driver uses the privileged label", func() {
+		g.It("should allow pods with inline volumes when the driver uses the privileged label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to privileged")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "privileged")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -85,7 +85,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
 		})
 
-		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to restricted")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "restricted")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -113,7 +113,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			afterEach(oc)
 		})
 
-		g.It("should deny pods with inline volumes when the driver uses the privileged label", func() {
+		g.It("should deny pods with inline volumes when the driver uses the privileged label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to privileged")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "privileged")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -128,7 +128,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
 		})
 
-		g.It("should allow pods with inline volumes when the driver uses the baseline label", func() {
+		g.It("should allow pods with inline volumes when the driver uses the baseline label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to baseline")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "baseline")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
 		})
 
-		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to restricted")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "restricted")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -170,7 +170,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			afterEach(oc)
 		})
 
-		g.It("should deny pods with inline volumes when the driver uses the privileged label", func() {
+		g.It("should deny pods with inline volumes when the driver uses the privileged label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to privileged")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "privileged")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -185,7 +185,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
 		})
 
-		g.It("should deny pods with inline volumes when the driver uses the baseline label", func() {
+		g.It("should deny pods with inline volumes when the driver uses the baseline label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to baseline")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "baseline")
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -200,7 +200,7 @@ var _ = g.Describe("[sig-storage][Feature:CSIInlineVolumeAdmission][Serial]", fu
 			defer func() { oc.KubeClient().CoreV1().Pods(oc.Namespace()).Delete(ctx, pod.Name, metav1.DeleteOptions{}) }()
 		})
 
-		g.It("should allow pods with inline volumes when the driver uses the restricted label", func() {
+		g.It("should allow pods with inline volumes when the driver uses the restricted label", g.Label("Size:M"), func() {
 			g.By("setting the csi-ephemeral-volume-profile label to restricted")
 			err := setCSIEphemeralVolumeProfile(ctx, oc, "restricted")
 			o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/storage/s3_configuration.go
+++ b/test/extended/storage/s3_configuration.go
@@ -61,7 +61,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
-	g.It("should set ChunkSizeMiB value", func() {
+	g.It("should set ChunkSizeMiB value", g.Label("Size:S"), func() {
 		g.By("Setting ChunkSizeMiB value")
 		expectedChunkSize := int32(128) // 128MB
 
@@ -86,7 +86,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(imageRegistryConfig.Spec.Storage.S3.ChunkSizeMiB).To(o.Equal(expectedChunkSize))
 	})
 
-	g.It("should not accept invalid ChunkSizeMiB value", func() {
+	g.It("should not accept invalid ChunkSizeMiB value", g.Label("Size:S"), func() {
 		g.By("Setting invalid ChunkSizeMiB value")
 		invalidChunkSize := int32(-1)
 
@@ -104,7 +104,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(err).To(o.HaveOccurred())
 	})
 
-	g.It("should set minimum valid ChunkSizeMiB value", func() {
+	g.It("should set minimum valid ChunkSizeMiB value", g.Label("Size:S"), func() {
 		g.By("Setting minimum valid ChunkSizeMiB value")
 		minValidChunkSize := int32(5) // 5MB
 
@@ -129,7 +129,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(imageRegistryConfig.Spec.Storage.S3.ChunkSizeMiB).To(o.Equal(minValidChunkSize))
 	})
 
-	g.It("should set maximum valid ChunkSizeMiB value", func() {
+	g.It("should set maximum valid ChunkSizeMiB value", g.Label("Size:S"), func() {
 		g.By("Setting maximum valid ChunkSizeMiB value")
 		maxValidChunkSize := int32(5 * 1024) // 5GB
 
@@ -154,7 +154,7 @@ var _ = g.Describe("[sig-imageregistry][OCPFeatureGate:ChunkSizeMiB][Serial][api
 		o.Expect(imageRegistryConfig.Spec.Storage.S3.ChunkSizeMiB).To(o.Equal(maxValidChunkSize))
 	})
 
-	g.It("should reject ChunkSizeMiB value greater than 5 GiB", func() {
+	g.It("should reject ChunkSizeMiB value greater than 5 GiB", g.Label("Size:S"), func() {
 		g.By("Setting zero ChunkSizeMiB value")
 		chunkSize := int32(6 * 1024)
 

--- a/test/extended/storage/storage_networkpolicy.go
+++ b/test/extended/storage/storage_networkpolicy.go
@@ -116,7 +116,7 @@ var _ = g.Describe("[sig-storage][OCPFeature:StorageNetworkPolicy] Storage Netwo
 		}
 	})
 
-	g.It("should verify required labels for CSO related Operators", func() {
+	g.It("should verify required labels for CSO related Operators", g.Label("Size:S"), func() {
 		CSOResourcesToCheck := []resourceCheck{
 			{
 				ResourceType:   ResourceTypeDeployment,
@@ -157,7 +157,7 @@ var _ = g.Describe("[sig-storage][OCPFeature:StorageNetworkPolicy] Storage Netwo
 		runResourceChecks(oc, CSOResourcesToCheck, currentPlatform)
 	})
 
-	g.It("should verify required labels for CSI related Operators", func() {
+	g.It("should verify required labels for CSI related Operators", g.Label("Size:S"), func() {
 		CSIResourcesToCheck := []resourceCheck{
 			{
 				ResourceType:   ResourceTypeDeployment,
@@ -296,7 +296,7 @@ var _ = g.Describe("[sig-storage][OCPFeature:StorageNetworkPolicy] Storage Netwo
 		runResourceChecks(oc, CSIResourcesToCheck, currentPlatform)
 	})
 
-	g.It("should ensure required NetworkPolicies exist with correct labels", func() {
+	g.It("should ensure required NetworkPolicies exist with correct labels", g.Label("Size:S"), func() {
 		for _, c := range networkPolicyChecks {
 			_, err := oc.AdminKubeClient().CoreV1().Namespaces().Get(context.TODO(), c.Namespace, metav1.GetOptions{})
 			if err != nil {

--- a/test/extended/storage/storageclass.go
+++ b/test/extended/storage/storageclass.go
@@ -63,7 +63,7 @@ var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial][apigroup:
 		sctest.SetSCState(savedSCState)
 	})
 
-	g.It("should reconcile the StorageClass when StorageClassState is Managed", func() {
+	g.It("should reconcile the StorageClass when StorageClassState is Managed", g.Label("Size:S"), func() {
 		g.By("verifying StorageClassState is set to Managed")
 		scState := sctest.GetSCState()
 		o.Expect(scState).To(o.Equal(operatorv1.ManagedStorageClass))
@@ -75,7 +75,7 @@ var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial][apigroup:
 		sctest.VerifyAllowExpansion(true, nil)
 	})
 
-	g.It("should not reconcile the StorageClass when StorageClassState is Unmanaged", func() {
+	g.It("should not reconcile the StorageClass when StorageClassState is Unmanaged", g.Label("Size:S"), func() {
 		g.By("setting StorageClassState to Unmanaged")
 		sctest.SetSCState(operatorv1.UnmanagedStorageClass)
 
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-storage][Feature:DisableStorageClass][Serial][apigroup:
 		})
 	})
 
-	g.It("should remove the StorageClass when StorageClassState is Removed", func() {
+	g.It("should remove the StorageClass when StorageClassState is Removed", g.Label("Size:S"), func() {
 		g.By("setting StorageClassState to Removed")
 		sctest.SetSCState(operatorv1.RemovedStorageClass)
 

--- a/test/extended/tbr_health/check.go
+++ b/test/extended/tbr_health/check.go
@@ -11,7 +11,7 @@ var _ = g.Describe("[sig-devex] check registry.redhat.io is available and sample
 	var (
 		oc = exutil.NewCLI("samples-health-check")
 	)
-	g.It("run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]", func() {
+	g.It("run sample related validations [apigroup:config.openshift.io][apigroup:image.openshift.io]", g.Label("Size:S"), func() {
 		err := exutil.WaitForOpenShiftNamespaceImageStreams(oc)
 		if err != nil {
 			// so the error string shows up in the top level ginkgo message

--- a/test/extended/templates/template.go
+++ b/test/extended/templates/template.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplate [apigroup:template.openshift.io]", func() {
+	g.It("TestTemplate [apigroup:template.openshift.io]", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		for _, version := range []schema.GroupVersion{v1.SchemeGroupVersion} {
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] template-api", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("templates")
 
-	g.It("TestTemplateTransformationFromConfig [apigroup:template.openshift.io]", func() {
+	g.It("TestTemplateTransformationFromConfig [apigroup:template.openshift.io]", g.Label("Size:S"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminClientConfig := oc.AdminConfig()

--- a/test/extended/templates/templateinstance_cross_namespace.go
+++ b/test/extended/templates/templateinstance_cross_namespace.go
@@ -33,7 +33,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance cross-namesp
 		cli2 = exutil.NewCLI("templates2")
 	)
 
-	g.It("should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]", func() {
+	g.It("should create and delete objects across namespaces [apigroup:user.openshift.io][apigroup:template.openshift.io]", g.Label("Size:M"), func() {
 		err := cli2.AsAdmin().Run("adm").Args("policy", "add-role-to-user", "admin", cli.Username()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_fail.go
+++ b/test/extended/templates/templateinstance_fail.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance creation wit
 	)
 
 	g.Context("", func() {
-		g.It("should report a failure on creation [apigroup:template.openshift.io]", func() {
+		g.It("should report a failure on creation [apigroup:template.openshift.io]", g.Label("Size:S"), func() {
 			err := cli.Run("create").Args("-f", templatefixture).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/templates/templateinstance_impersonation.go
+++ b/test/extended/templates/templateinstance_impersonation.go
@@ -228,7 +228,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		deleteGroup(cli, impersonategroup)
 	})
 
-	g.It("should pass impersonation creation tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation creation tests [apigroup:template.openshift.io]", g.Label("Size:L"), func() {
 		// check who can create TemplateInstances (anyone with project write access
 		// AND is/can impersonate spec.requester.username)
 		for _, test := range tests {
@@ -249,7 +249,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation update tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation update tests [apigroup:template.openshift.io]", g.Label("Size:L"), func() {
 		// check who can update TemplateInstances.  Via Update(), spec updates
 		// should be rejected (with the exception of spec.metadata fields used
 		// by the garbage collector, not tested here).  Status updates should be
@@ -349,7 +349,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance impersonatio
 		}
 	})
 
-	g.It("should pass impersonation deletion tests [apigroup:template.openshift.io]", func() {
+	g.It("should pass impersonation deletion tests [apigroup:template.openshift.io]", g.Label("Size:M"), func() {
 		// check who can delete TemplateInstances (anyone with project write access)
 		for _, test := range tests {
 			setUser(cli, test.user)

--- a/test/extended/templates/templateinstance_objectkinds.go
+++ b/test/extended/templates/templateinstance_objectkinds.go
@@ -26,7 +26,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance object kinds
 		cli     = exutil.NewCLI("templates")
 	)
 
-	g.It("should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]", func() {
+	g.It("should create and delete objects from varying API groups [apigroup:template.openshift.io][apigroup:route.openshift.io]", g.Label("Size:M"), func() {
 		g.By("creating a template instance")
 		err := cli.Run("create").Args("-f", fixture).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/templates/templateinstance_readiness.go
+++ b/test/extended/templates/templateinstance_readiness.go
@@ -122,7 +122,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			}
 		})
 
-		g.It("should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should report ready soon after all annotated objects are ready [apigroup:template.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			var err error
 
 			templateinstance = &templatev1.TemplateInstance{
@@ -171,7 +171,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance readiness te
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
-		g.It("should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]", func() {
+		g.It("should report failed soon after an annotated objects has failed [apigroup:template.openshift.io][apigroup:build.openshift.io]", g.Label("Size:L"), func() {
 			var err error
 
 			secret, err := cli.KubeClient().CoreV1().Secrets(cli.Namespace()).Create(context.Background(), &v1.Secret{

--- a/test/extended/templates/templateinstance_security.go
+++ b/test/extended/templates/templateinstance_security.go
@@ -127,7 +127,7 @@ var _ = g.Describe("[sig-devex][Feature:Templates] templateinstance security tes
 			deleteGroup(cli, editgroup)
 		})
 
-		g.It("should pass security tests [apigroup:route.openshift.io]", func() {
+		g.It("should pass security tests [apigroup:route.openshift.io]", g.Label("Size:L"), func() {
 			tests := []struct {
 				by              string
 				user            *userv1.User

--- a/test/extended/two_node/arbiter_topology.go
+++ b/test/extended/two_node/arbiter_topology.go
@@ -44,7 +44,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:High
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 
-	g.It("Should validate that there are Master and Arbiter nodes as specified in the cluster", func() {
+	g.It("Should validate that there are Master and Arbiter nodes as specified in the cluster", g.Label("Size:S"), func() {
 		g.By("Counting nodes dynamically based on labels")
 		// TODO: instead of manually comparing 2 with mcp node count we want to get the number from install config and compare it with mcp count
 		// yaml comparation
@@ -70,7 +70,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:High
 	g.BeforeEach(func() {
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
-	g.It("Should verify that the correct number of pods are running on the Arbiter node", func() {
+	g.It("Should verify that the correct number of pods are running on the Arbiter node", g.Label("Size:M"), func() {
 		g.By("Retrieving the Arbiter node name")
 		nodes, err := utils.GetNodes(oc, utils.LabelNodeRoleArbiter)
 		o.Expect(err).To(o.BeNil(), "Expected to retrieve nodes without error")
@@ -100,7 +100,7 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 
-	g.It("should be created on arbiter nodes when arbiter node is selected", func() {
+	g.It("should be created on arbiter nodes when arbiter node is selected", g.Label("Size:M"), func() {
 		g.By("Waiting for Arbiter node to become Ready")
 		var arbiterNodeName string
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -145,7 +145,7 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 		o.Expect(arbiterPod.Spec.NodeName).To(o.Equal(arbiterNodeName), "Expected Arbiter deployment to run on Arbiter node")
 	})
 
-	g.It("should be created on master nodes when no node selected", func() {
+	g.It("should be created on master nodes when no node selected", g.Label("Size:M"), func() {
 		ctx := context.Background()
 		g.By("Retrieving Master nodes")
 		masterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
@@ -195,7 +195,7 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 
-	g.It("should not create a DaemonSet on the Arbiter node", func() {
+	g.It("should not create a DaemonSet on the Arbiter node", g.Label("Size:M"), func() {
 		g.By("Retrieving the Arbiter node")
 		arbiterNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
 			LabelSelector: utils.LabelNodeRoleArbiter,
@@ -245,7 +245,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:High
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 
-	g.It("should have all etcd pods running and quorum met", func() {
+	g.It("should have all etcd pods running and quorum met", g.Label("Size:M"), func() {
 		g.By("Retrieving and validating etcd pods")
 
 		const (

--- a/test/extended/two_node/tna_recovery.go
+++ b/test/extended/two_node/tna_recovery.go
@@ -32,7 +32,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:High
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
 
-	g.It("should maintain etcd quorum and workloads with one master node down", func() {
+	g.It("should maintain etcd quorum and workloads with one master node down", g.Label("Size:L"), func() {
 		ctx := context.Background()
 
 		g.By("Identifying one master node to simulate failure")
@@ -76,7 +76,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:High
 	g.BeforeEach(func() {
 		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
 	})
-	g.It("should regain quorum after arbiter down and master nodes restart", func() {
+	g.It("should regain quorum after arbiter down and master nodes restart", g.Label("Size:L"), func() {
 		g.By("Getting arbiter node")
 		arbiterNodes, err := utils.GetNodes(oc, utils.LabelNodeRoleArbiter)
 		o.Expect(err).To(o.BeNil())

--- a/test/extended/two_node/tnf_degraded.go
+++ b/test/extended/two_node/tnf_degraded.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-apps][OCPFeatureGate:DualReplica][Suite:openshift/two-n
 		utils.EnsureTNFDegradedOrSkip(oc)
 	})
 
-	g.It("should allow a single eviction and block the second when PDB minAvailable=1 [apigroup:policy]", func() {
+	g.It("should allow a single eviction and block the second when PDB minAvailable=1 [apigroup:policy]", g.Label("Size:M"), func() {
 		ctx := context.Background()
 		kubeClient := oc.AdminKubeClient()
 
@@ -99,7 +99,7 @@ var _ = g.Describe("[sig-apps][OCPFeatureGate:DualReplica][Suite:openshift/two-n
 		o.Expect(currentPDB.Status.DisruptionsAllowed).To(o.Equal(int32(0)), "expected disruptionsAllowed=0 after second eviction attempt")
 	})
 
-	g.It("should block a reboot-required MachineConfig rollout on the remaining master [Serial] [apigroup:machineconfiguration.openshift.io]", func() {
+	g.It("should block a reboot-required MachineConfig rollout on the remaining master [Serial] [apigroup:machineconfiguration.openshift.io]", g.Label("Size:L"), func() {
 		ctx := context.Background()
 		kubeClient := oc.AdminKubeClient()
 		ns := oc.Namespace()
@@ -156,7 +156,7 @@ var _ = g.Describe("[sig-apps][OCPFeatureGate:DualReplica][Suite:openshift/two-n
 		o.Expect(err).NotTo(o.HaveOccurred(), "behavior was not enforced correctly")
 	})
 
-	g.It("should rotate etcd serving certs for the remaining master [Serial] [apigroup:operator.openshift.io]", func() {
+	g.It("should rotate etcd serving certs for the remaining master [Serial] [apigroup:operator.openshift.io]", g.Label("Size:M"), func() {
 		ctx := context.Background()
 		kubeClient := oc.AdminKubeClient()
 

--- a/test/extended/two_node/tnf_node_replacement.go
+++ b/test/extended/two_node/tnf_node_replacement.go
@@ -211,7 +211,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		}
 	})
 
-	g.It("should recover from an in-place node replacement", func() {
+	g.It("should recover from an in-place node replacement", g.Label("Size:L"), func() {
 
 		g.By("Backing up the target node's configuration")
 		backupDir := backupTargetNodeConfiguration(&testConfig, oc)

--- a/test/extended/two_node/tnf_recovery.go
+++ b/test/extended/two_node/tnf_recovery.go
@@ -85,7 +85,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		}, nodeIsHealthyTimeout, pollInterval).ShouldNot(o.HaveOccurred(), fmt.Sprintf("expect to ensure Node '%s' healthiness without errors", targetNode.Name))
 	})
 
-	g.It("should recover from graceful node shutdown with etcd member re-addition", func() {
+	g.It("should recover from graceful node shutdown with etcd member re-addition", g.Label("Size:L"), func() {
 		// Note: In graceful shutdown, the targetNode is deliberately shut down while
 		// the peerNode remains running and becomes the etcd leader.
 		survivedNode := peerNode
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			memberPromotedVotingTimeout, pollInterval)
 	})
 
-	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {
+	g.It("should recover from ungraceful node shutdown with etcd member re-addition", g.Label("Size:L"), func() {
 		// Note: In ungraceful shutdown, the targetNode is forcibly shut down while
 		// the peerNode remains running and becomes the etcd leader.
 		survivedNode := peerNode
@@ -150,7 +150,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			memberPromotedVotingTimeout, pollInterval)
 	})
 
-	g.It("should recover from network disruption with etcd member re-addition", func() {
+	g.It("should recover from network disruption with etcd member re-addition", g.Label("Size:L"), func() {
 		// Note: In network disruption, the targetNode runs the disruption command that
 		// isolates the nodes from each other, creating a split-brain where pacemaker
 		// determines which node gets fenced and which becomes the etcd leader.
@@ -184,7 +184,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			memberPromotedVotingTimeout, pollInterval)
 	})
 
-	g.It("should recover from a double node failure", func() {
+	g.It("should recover from a double node failure", g.Label("Size:L"), func() {
 		// Note: In a double node failure both nodes have the same role, hence we
 		// will call them just NodeA and NodeB
 		nodeA := peerNode
@@ -238,7 +238,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			membersHealthyAfterDoubleReboot, pollInterval)
 	})
 
-	g.It("should recover from BMC credential rotation with fencing", func() {
+	g.It("should recover from BMC credential rotation with fencing", g.Label("Size:L"), func() {
 		bmcNode := targetNode
 		survivedNode := peerNode
 

--- a/test/extended/two_node/tnf_topology.go
+++ b/test/extended/two_node/tnf_topology.go
@@ -27,7 +27,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
 	})
 
-	g.It("should only have two control plane nodes and no arbiter nodes", func() {
+	g.It("should only have two control plane nodes and no arbiter nodes", g.Label("Size:S"), func() {
 		const (
 			expectedControlPlanes = 2
 			expectedArbiters      = 0
@@ -43,7 +43,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(len(arbiterNodes.Items)).To(o.Equal(expectedArbiters), fmt.Sprintf("Expected %d Arbiter Nodes, found %d", expectedArbiters, len(arbiterNodes.Items)))
 	})
 
-	g.It("should have infrastructure platform type set correctly", func() {
+	g.It("should have infrastructure platform type set correctly", g.Label("Size:S"), func() {
 		g.By("Checking that the infrastructure platform is set to baremetal or none or external")
 		infrastructure, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).ShouldNot(o.HaveOccurred(), "Expected to retrieve infrastructure configuration without error")
@@ -53,7 +53,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			fmt.Sprintf("Expected infrastructure platform to be baremetal or none or external, but found %s", platformType))
 	})
 
-	g.It("should have BareMetalHost operational status set to detached if they exist", func() {
+	g.It("should have BareMetalHost operational status set to detached if they exist", g.Label("Size:S"), func() {
 		g.By("Checking that BareMetalHost objects have operational status set to detached")
 		dc := oc.AdminDynamicClient()
 
@@ -91,7 +91,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	g.BeforeEach(func() {
 		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
 	})
-	g.It("should have etcd pods and containers configured correctly", func() {
+	g.It("should have etcd pods and containers configured correctly", g.Label("Size:S"), func() {
 		const (
 			expectedEtcdPod           = 2
 			expectedEtcdCtlContainers = 2
@@ -121,7 +121,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(etcdContainerCount).To(o.Equal(expectedEtcdContainers))
 	})
 
-	g.It("should have podman etcd containers running on each node", func() {
+	g.It("should have podman etcd containers running on each node", g.Label("Size:M"), func() {
 		nodes, err := utils.GetNodes(oc, utils.LabelNodeRoleControlPlane)
 		o.Expect(err).To(o.BeNil(), "Expected to retrieve control plane nodes without error")
 		o.Expect(nodes.Items).To(o.HaveLen(2), "Expected to retrieve two control plane nodes for DualReplica topology")

--- a/test/extended/user/basic.go
+++ b/test/extended/user/basic.go
@@ -25,7 +25,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLI("user-api")
 
-	g.It("users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]", func() {
+	g.It("users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
@@ -143,7 +143,7 @@ var _ = g.Describe("[sig-auth][Feature:UserAPI]", func() {
 		})
 	})
 
-	g.It("groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]", func() {
+	g.It("groups should work [apigroup:user.openshift.io][apigroup:project.openshift.io][apigroup:authorization.openshift.io]", g.Label("Size:M"), func() {
 		t := g.GinkgoT()
 		clusterAdminUserClient := oc.AdminUserClient().UserV1()
 

--- a/test/extended/windows/nodes.go
+++ b/test/extended/windows/nodes.go
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-windows] Nodes", func() {
 		}
 	})
 
-	g.It("should fail with invalid version annotation", func() {
+	g.It("should fail with invalid version annotation", g.Label("Size:S"), func() {
 		g.By("process version annotation")
 		for _, node := range windowsNodes {
 			annotations := node.GetAnnotations()


### PR DESCRIPTION
Add Ginkgo Size labels to enable variable parallelism based on test resource intensity. This is a wild experiment to help reduce resource contention. Only impacts tests in origin currently, but I suspect that's where our "heaviest" tests are.  If this proves worthwhile we should be able to apply the same things to OTE and Kube.

Labels were applied with Claude.  I asked Claude to use the criteria below. I have no idea if it is accurate, but the tests I expected to be "L" are indeed tagged "L".

Size label criteria:
- Size:S - Low CPU, quick tests, simple API calls, no pod creation, basic CLI commands.
- Size:M - Moderate complexity, 1-2 pods, basic services, simple deployments. DEFAULT for unlabeled tests.
- Size:L - High resource usage, many pods, image builds, complex workflows, stress tests. Examples: must-gather, multi-replica deployments, complex builds. Run at 0.5x parallelism (e.g., 15).