### PR TITLE
OCPBUGS-66419: fix: handing static pods not appearing on SNO+RT metal lanes 

### DIFF
--- a/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod.go
+++ b/pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod.go
@@ -109,10 +109,11 @@ func testStaticPodLifecycleFailure(events monitorapi.Intervals, kubeClientConfig
 			matches := regexp.MustCompile("to ([0-9]+) because static pod is ready").FindStringSubmatch(event.Note)
 			if len(matches) == 2 {
 				reachedRevision, _ := strconv.ParseInt(matches[1], 0, 64)
-				if isRevisionUpdate && isForNode && reachedRevision == staticPodFailure.revision {
+				if isRevisionUpdate && isForNode && reachedRevision >= staticPodFailure.revision {
 					// If we reach the level eventually, don't fail the test. We might choose to add an "it's slow" test, but
-					// it hasn't failed. It might be possible to go directly to a later revision, and if we want to account for
-					// that, the above could be changed to >= instead of equality.
+					// it hasn't failed. It is possible to go directly to a later revision such as in a RT environment where
+					// revisions can happen rapidly. In this case, it is okay if a revision never appears and a later revision
+					// is located.
 					foundEventForProperRevision = true
 				}
 			}


### PR DESCRIPTION
## Summary

On SNO+RT (Single Node OpenShift + Realtime) metal upgrade lanes, static pod revisions can happen rapidly enough that an expected revision may be skipped entirely, jumping directly to a later one. The static pod lifecycle test in `testStaticPodLifecycleFailure` was checking for an exact revision match (`==`), which caused false test failures when the expected revision was never observed because a later revision was reached instead.

This change updates the revision check from `==` to `>=` so that reaching a later revision than expected is treated as success rather than a failure. The original code already noted this as a possibility but had not implemented it.

## Changes

- `pkg/monitortests/kubeapiserver/legacykubeapiservermonitortests/static_pod.go`: Changed `reachedRevision == staticPodFailure.revision` to `reachedRevision >= staticPodFailure.revision`

## Validation

Ran the `e2e-metal-ovn-single-node-rt-upgrade` payload job. The target test `[Monitor:legacy-kube-apiserver-invariants][sig-node] static pods should start after being created` and all `pod-lifecycle` monitor tests passed successfully on the SNO+RT metal lane.