### PR TITLE
[MON-4455] add EndpointSlices e2e test

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -604,11 +604,7 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			jobsUsingEndpoints := sets.NewString() // Use a set to avoid duplicate job names
 			for _, target := range targets.Data.ActiveTargets {
 				if _, ok := target.DiscoveredLabels["__meta_kubernetes_endpoints_name"]; ok {
-					jobName, hasJob := target.Labels["job"]
-					namespace, hasNamespace := target.DiscoveredLabels["__meta_kubernetes_namespace"]
-
-					if hasJob && hasNamespace {
-						identifier := fmt.Sprintf("%s/%s", namespace, jobName)
+					if identifier, ok := target.DiscoveredLabels["job"]; ok {
 						jobsUsingEndpoints.Insert(identifier)
 					}
 				}


### PR DESCRIPTION
link to: https://issues.redhat.com/browse/MON-4439

local test result:
```
% oc get co/monitoring
NAME         VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
monitoring   4.21.0-0.nightly-2025-12-15-125449   True        False         False      33m

% ./openshift-tests run-test "[sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster should use endpoint slices for service discovery [Suite:openshift/conformance/parallel]"
...
  Dec 16 14:25:32.266: INFO: The following jobs are still using Endpoints for service discovery instead of EndpointSlices:
   - serviceMonitor/openshift-apiserver-operator/openshift-apiserver-operator/0
   - serviceMonitor/openshift-apiserver/openshift-apiserver/0
...
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```