### PR TITLE
CNTRLPLANE-1683: added the OTE binary for cluster-image-registry-operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -252,6 +252,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-kube-scheduler-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-image-registry-operator",
+		binaryPath: "/usr/bin/cluster-image-registry-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-version-operator",
 		binaryPath: "/usr/bin/cluster-version-operator-tests.gz",
 	},


### PR DESCRIPTION
Register the OTE binary cluster-image-registry-operator as part of JIRA [ticket](https://issues.redhat.com/browse/CNTRLPLANE-1683) (first [PR](https://github.com/openshift/cluster-image-registry-operator/pull/1269) already merged).