### PR TITLE
NO-JIRA: feat(monitor): track test bucket execution intervals

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -184,6 +184,15 @@
       return eventInterval.source === "CPUMonitor" && eventInterval.message.reason === "HighCPUUsage"
     }
 
+    function isTestBucket(eventInterval) {
+        return eventInterval.source === "TestBucket"
+    }
+
+    function testBucketValue(item) {
+        const bucketName = item.locator.keys['test-bucket'] || 'Unknown'
+        return [bucketName, "", "TestBucket"]
+    }
+
     function pathologicalEvents(item) {
         if (item.message.annotations["pathological"] === "true") {
             if (item.message.annotations["interesting"] === "true") {
@@ -479,6 +488,9 @@
         var loc = window.location.href;
 
         var timelineGroups = []
+        timelineGroups.push({group: "test-buckets", data: []})
+        createTimelineData(testBucketValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isTestBucket, regex)
+
         timelineGroups.push({group: "operator-unavailable", data: []})
         createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable, regex)
 
@@ -573,6 +585,7 @@
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'TestBucket', // test bucket intervals
                 'InterestingEvent', 'PathologicalKnown', "PathologicalNew", "PodSandbox", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
@@ -584,6 +597,7 @@
                 'PodLogInfo', 'PodLogWarning', 'PodLogError',
                 'EtcdOther', 'EtcdLeaderFound', 'EtcdLeaderLost', 'EtcdLeaderElected', 'EtcdLeaderMissing'])
             .range([
+                '#9370DB', // test bucket intervals - medium purple
                 '#6E6E6E', '#0000ff', '#d0312d', '#ffa500', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators

--- a/e2echart/non-spyglass-e2e-chart-template.html
+++ b/e2echart/non-spyglass-e2e-chart-template.html
@@ -242,6 +242,7 @@
     categoryInputTemplate = `
                     <select class="positive-selection-fields form-control form-control-sm" type="text" id="category_INPUT_NUMBER">
                         <option value="" selected=true ></option>
+                        <option value="test_buckets">Test Buckets</option>
                         <option value="operator_unavailable">Operator Unavailable</option>
                         <option value="operator_degraded">Operator Degraded</option>
                         <option value="operator_progressing">Operator Progressing</option>
@@ -298,6 +299,7 @@
         eventInterval.categories.e2e_test_passed = isE2EPassed(eventInterval);
         eventInterval.categories.endpoint_availability = isEndpointConnectivity(eventInterval);
         eventInterval.categories.certificate_rotation = isCertificateRotation(eventInterval);
+        eventInterval.categories.test_buckets = isTestBucket(eventInterval);
         eventInterval.categories.uncategorized = !_.some(eventInterval.categories); // will save time later during filtering and re-rendering since we don't render any uncategorized events
     });
 
@@ -326,6 +328,15 @@
         }
         return eventInterval.source === 'EtcdLog';
 
+    }
+
+    function isTestBucket(eventInterval) {
+        return eventInterval.source === "TestBucket"
+    }
+
+    function testBucketValue(item) {
+        const bucketName = item.locator.keys['test-bucket'] || 'Unknown'
+        return [bucketName, "", "TestBucket"]
     }
 
     function isInterestingOrPathological(eventInterval) {
@@ -861,6 +872,9 @@
         }
 
         var timelineGroups = [];
+        timelineGroups.push({group: "test-buckets", data: []});
+        createTimelineData(testBucketValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "test_buckets");
+
         timelineGroups.push({group: "operator-unavailable", data: []});
         createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, filteredEvents, "operator_unavailable");
 
@@ -945,6 +959,7 @@
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'TestBucket', // test bucket intervals
                 'InterestingEvent', 'PathologicalKnown', "PathologicalNew", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
@@ -955,6 +970,7 @@
                 'Degraded', 'Upgradeable', 'False', 'Unknown',
                 'PodLogInfo', 'PodLogWarning', 'PodLogError'])
             .range([
+                '#9370DB', // test bucket intervals - medium purple
                 '#6E6E6E', '#0000ff', '#d0312d', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators

--- a/pkg/monitor/monitorapi/construction.go
+++ b/pkg/monitor/monitorapi/construction.go
@@ -528,6 +528,12 @@ func (b *LocatorBuilder) ClusterOperator(name string) Locator {
 	return b.Build()
 }
 
+func (b *LocatorBuilder) TestBucket(bucketName string) Locator {
+	b.targetType = LocatorTypeTestBucket
+	b.annotations[LocatorTestBucketKey] = bucketName
+	return b.Build()
+}
+
 func (b *LocatorBuilder) Build() Locator {
 	ret := Locator{
 		Type: b.targetType,

--- a/pkg/monitor/monitorapi/types.go
+++ b/pkg/monitor/monitorapi/types.go
@@ -118,6 +118,7 @@ const (
 	LocatorTypeKubeletSyncLoopProbe LocatorType = "KubeletSyncLoopProbe"
 	LocatorTypeKubeletSyncLoopPLEG  LocatorType = "KubeletSyncLoopPLEG"
 	LocatorTypeStaticPodInstall     LocatorType = "StaticPodInstall"
+	LocatorTypeTestBucket           LocatorType = "TestBucket"
 )
 
 type LocatorKey string
@@ -164,6 +165,7 @@ const (
 	LocatorTypeKubeletSyncLoopProbeType LocatorKey = "probe"
 	LocatorTypeKubeletSyncLoopPLEGType  LocatorKey = "plegType"
 	LocatorStaticPodInstallType         LocatorKey = "podType"
+	LocatorTestBucketKey                LocatorKey = "test-bucket"
 )
 
 type Locator struct {
@@ -390,6 +392,7 @@ const (
 	SourceCPUMonitor               IntervalSource = "CPUMonitor"
 	SourceEtcdDiskCommitDuration   IntervalSource = "EtcdDiskCommitDuration"
 	SourceEtcdDiskWalFsyncDuration IntervalSource = "EtcdDiskWalFsyncDuration"
+	SourceTestBucket               IntervalSource = "TestBucket"
 )
 
 type Interval struct {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -54562,6 +54562,15 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
       return eventInterval.source === "CPUMonitor" && eventInterval.message.reason === "HighCPUUsage"
     }
 
+    function isTestBucket(eventInterval) {
+        return eventInterval.source === "TestBucket"
+    }
+
+    function testBucketValue(item) {
+        const bucketName = item.locator.keys['test-bucket'] || 'Unknown'
+        return [bucketName, "", "TestBucket"]
+    }
+
     function pathologicalEvents(item) {
         if (item.message.annotations["pathological"] === "true") {
             if (item.message.annotations["interesting"] === "true") {
@@ -54857,6 +54866,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         var loc = window.location.href;
 
         var timelineGroups = []
+        timelineGroups.push({group: "test-buckets", data: []})
+        createTimelineData(testBucketValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isTestBucket, regex)
+
         timelineGroups.push({group: "operator-unavailable", data: []})
         createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOperatorAvailable, regex)
 
@@ -54951,6 +54963,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'TestBucket', // test bucket intervals
                 'InterestingEvent', 'PathologicalKnown', "PathologicalNew", "PodSandbox", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
@@ -54962,6 +54975,7 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
                 'PodLogInfo', 'PodLogWarning', 'PodLogError',
                 'EtcdOther', 'EtcdLeaderFound', 'EtcdLeaderLost', 'EtcdLeaderElected', 'EtcdLeaderMissing'])
             .range([
+                '#9370DB', // test bucket intervals - medium purple
                 '#6E6E6E', '#0000ff', '#d0312d', '#ffa500', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators
@@ -55257,6 +55271,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
     categoryInputTemplate = ` + "`" + `
                     <select class="positive-selection-fields form-control form-control-sm" type="text" id="category_INPUT_NUMBER">
                         <option value="" selected=true ></option>
+                        <option value="test_buckets">Test Buckets</option>
                         <option value="operator_unavailable">Operator Unavailable</option>
                         <option value="operator_degraded">Operator Degraded</option>
                         <option value="operator_progressing">Operator Progressing</option>
@@ -55313,6 +55328,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         eventInterval.categories.e2e_test_passed = isE2EPassed(eventInterval);
         eventInterval.categories.endpoint_availability = isEndpointConnectivity(eventInterval);
         eventInterval.categories.certificate_rotation = isCertificateRotation(eventInterval);
+        eventInterval.categories.test_buckets = isTestBucket(eventInterval);
         eventInterval.categories.uncategorized = !_.some(eventInterval.categories); // will save time later during filtering and re-rendering since we don't render any uncategorized events
     });
 
@@ -55341,6 +55357,15 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         }
         return eventInterval.source === 'EtcdLog';
 
+    }
+
+    function isTestBucket(eventInterval) {
+        return eventInterval.source === "TestBucket"
+    }
+
+    function testBucketValue(item) {
+        const bucketName = item.locator.keys['test-bucket'] || 'Unknown'
+        return [bucketName, "", "TestBucket"]
     }
 
     function isInterestingOrPathological(eventInterval) {
@@ -55876,6 +55901,9 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         }
 
         var timelineGroups = [];
+        timelineGroups.push({group: "test-buckets", data: []});
+        createTimelineData(testBucketValue, timelineGroups[timelineGroups.length - 1].data, filteredEvents, "test_buckets");
+
         timelineGroups.push({group: "operator-unavailable", data: []});
         createTimelineData("OperatorUnavailable", timelineGroups[timelineGroups.length - 1].data, filteredEvents, "operator_unavailable");
 
@@ -55960,6 +55988,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
         const myChart = TimelinesChart();
         var ordinalScale = d3.scaleOrdinal()
             .domain([
+                'TestBucket', // test bucket intervals
                 'InterestingEvent', 'PathologicalKnown', "PathologicalNew", // interesting and pathological events
                 'AlertInfo', 'AlertPending', 'AlertWarning', 'AlertCritical', // alerts
                 'OperatorUnavailable', 'OperatorDegraded', 'OperatorProgressing', // operators
@@ -55970,6 +55999,7 @@ var _e2echartNonSpyglassE2eChartTemplateHtml = []byte(`<html lang="en">
                 'Degraded', 'Upgradeable', 'False', 'Unknown',
                 'PodLogInfo', 'PodLogWarning', 'PodLogError'])
             .range([
+                '#9370DB', // test bucket intervals - medium purple
                 '#6E6E6E', '#0000ff', '#d0312d', // pathological and interesting events
                 '#fada5e','#fada5e','#ffa500', '#d0312d',  // alerts
                 '#d0312d', '#ffa500', '#fada5e', // operators


### PR DESCRIPTION
Add TestBucket locator type and record intervals for each e2e test bucket phase to enable timeline visualization and execution timing logs.