### PR TITLE
NO-JIRA: CO must go Progressing during a minor-level upgrade

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
@@ -2,6 +2,7 @@ package legacycvomonitortests
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -91,7 +92,11 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
 		junits = append(junits, testUpgradeOperatorStateTransitions(finalIntervals, w.adminRESTConfig)...)
-		junits = append(junits, testUpgradeOperatorProgressingStateTransitions(finalIntervals, w.adminRESTConfig)...)
+		level, err := getUpgradeLevel(w.adminRESTConfig)
+		if err != nil || level == unknownUpgradeLevel {
+			return nil, fmt.Errorf("failed to determine upgrade level: %w", err)
+		}
+		junits = append(junits, testUpgradeOperatorProgressingStateTransitions(finalIntervals, level == patchUpgradeLevel)...)
 	} else {
 		junits = append(junits, testStableSystemOperatorStateTransitions(finalIntervals, w.adminRESTConfig)...)
 	}


### PR DESCRIPTION
Follow up [1]: in CI tests there are many patch-level upgrade we made between the same payload manifests with a renamed version.

In those cases, it is OK that CO does not report Progressing. Ideally, CI should enforce Progressing only when there are changes. Before there is a practical way to achieve it, we focus on minor upgrades only.

[1]. https://issues.redhat.com/browse/OCPSTRAT-2484?focusedId=28681908&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28681908