### PR TITLE
WIP MON-4432: Add e2e test for network DaemonSet target discovery

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -883,6 +883,17 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 
+		// This test validates that network DaemonSet ServiceMonitors work correctly
+		// with EndpointSlice service discovery (CNO PR #2839 / MON-4432)
+		g.It("should have working network DaemonSet ServiceMonitor target", func() {
+			g.By("verifying network DaemonSet metrics are being scraped")
+			queries := map[string]bool{
+				`count(up{job="network-metrics-daemon"} == 1) >= 1`: true,
+			}
+			err := helper.RunQueries(context.TODO(), oc.NewPrometheusClient(context.TODO()), queries, oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+		})
+
 		g.It("should provide named network metrics [apigroup:project.openshift.io]", func() {
 			ns := oc.SetupProject()
 


### PR DESCRIPTION
Add a test to verify that network DaemonSet ServiceMonitor targets
are correctly discovered.

This validates the changes from https://github.com/openshift/cluster-network-operator/pull/2839
which migrates DaemonSet ServiceMonitors to use EndpointSlice
instead of the Endpoints API.