### PR TITLE
Migrate rodoo cases from ote to origin

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -59,4 +59,5 @@ import (
 	_ "github.com/openshift/origin/test/extended/two_node"
 	_ "github.com/openshift/origin/test/extended/user"
 	_ "github.com/openshift/origin/test/extended/windows"
+	_ "github.com/openshift/origin/test/extended/workloads"
 )

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -509,6 +509,13 @@
 // test/extended/testdata/two_node/baremetalhost-template.yaml
 // test/extended/testdata/two_node/machine-template.yaml
 // test/extended/testdata/verifyservice-pipeline-template.yaml
+// test/extended/testdata/workloads/pod_with_active_dead_line_seconds.yaml
+// test/extended/testdata/workloads/pod_with_ads_greater_than_operator.yaml
+// test/extended/testdata/workloads/pod_with_on_failure_policy.yaml
+// test/extended/testdata/workloads/pod_with_restart_policy.yaml
+// test/extended/testdata/workloads/rodo_ds.yaml
+// test/extended/testdata/workloads/rodo_operatorgroup.yaml
+// test/extended/testdata/workloads/rodo_subscription.yaml
 // e2echart/e2e-chart-template.html
 // e2echart/non-spyglass-e2e-chart-template.html
 // e2echart/test-risk-analysis.html
@@ -54376,6 +54383,287 @@ func testExtendedTestdataVerifyservicePipelineTemplateYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: podwithactivedeadlineseconds62690
+  name: podwithactivedeadlineseconds62690
+spec:
+  activeDeadlineSeconds: 120
+  restartPolicy: OnFailure
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done
+`)
+
+func testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYaml, nil
+}
+
+func testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/pod_with_active_dead_line_seconds.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: podwithadsgo62690
+  name: podwithadsgo62690
+spec:
+  activeDeadlineSeconds: 240
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done
+`)
+
+func testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYaml, nil
+}
+
+func testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/pod_with_ads_greater_than_operator.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsPod_with_on_failure_policyYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: onfailurepod60352
+  name: onfailurepod60352
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done
+`)
+
+func testExtendedTestdataWorkloadsPod_with_on_failure_policyYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsPod_with_on_failure_policyYaml, nil
+}
+
+func testExtendedTestdataWorkloadsPod_with_on_failure_policyYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsPod_with_on_failure_policyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/pod_with_on_failure_policy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsPod_with_restart_policyYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: restartpod60352
+  name: restartpod60352
+spec:
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done
+`)
+
+func testExtendedTestdataWorkloadsPod_with_restart_policyYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsPod_with_restart_policyYaml, nil
+}
+
+func testExtendedTestdataWorkloadsPod_with_restart_policyYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsPod_with_restart_policyYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/pod_with_restart_policy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsRodo_dsYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: runoncedurationoverride-template
+objects:
+- kind: RunOnceDurationOverride
+  apiVersion: operator.openshift.io/v1
+  metadata:
+    name: cluster
+    namespace: "${NAMESPACE}"
+  spec:
+    runOnceDurationOverride:
+      spec:
+        activeDeadlineSeconds: ${{ACTIVEDEADLINESECONDS}}
+parameters:
+- name: NAMESPACE
+- name: ACTIVEDEADLINESECONDS
+`)
+
+func testExtendedTestdataWorkloadsRodo_dsYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsRodo_dsYaml, nil
+}
+
+func testExtendedTestdataWorkloadsRodo_dsYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsRodo_dsYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/rodo_ds.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsRodo_operatorgroupYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: operatorgroup-template
+objects:
+- kind: OperatorGroup
+  apiVersion: operators.coreos.com/v1
+  metadata:
+    annotations:
+      olm.providedAPIs: RunOnceDurationOverride.v1.operator.openshift.io
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    targetNamespaces:
+    - "${NAMESPACE}"
+    upgradeStrategy: Default
+
+parameters:
+- name: NAME
+- name: NAMESPACE
+`)
+
+func testExtendedTestdataWorkloadsRodo_operatorgroupYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsRodo_operatorgroupYaml, nil
+}
+
+func testExtendedTestdataWorkloadsRodo_operatorgroupYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsRodo_operatorgroupYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/rodo_operatorgroup.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataWorkloadsRodo_subscriptionYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- kind: Subscription
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    labels:
+      operators.coreos.com/run-once-duration-override-operator.openshift-run-once-duration: ""
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    channel: "${CHANNELNAME}"
+    installPlanApproval: Automatic
+    name: "${NAME}"
+    source: "${OPSRCNAME}"
+    sourceNamespace: "${SOURCENAME}"
+    startingCSV: "${STARTINGCSV}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: CHANNELNAME
+- name: OPSRCNAME
+- name: SOURCENAME
+- name: STARTINGCSV
+`)
+
+func testExtendedTestdataWorkloadsRodo_subscriptionYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataWorkloadsRodo_subscriptionYaml, nil
+}
+
+func testExtendedTestdataWorkloadsRodo_subscriptionYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataWorkloadsRodo_subscriptionYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/workloads/rodo_subscription.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 <head>
     <meta charset="UTF-8">
@@ -56761,6 +57049,13 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/two_node/baremetalhost-template.yaml":                                            testExtendedTestdataTwo_nodeBaremetalhostTemplateYaml,
 	"test/extended/testdata/two_node/machine-template.yaml":                                                  testExtendedTestdataTwo_nodeMachineTemplateYaml,
 	"test/extended/testdata/verifyservice-pipeline-template.yaml":                                            testExtendedTestdataVerifyservicePipelineTemplateYaml,
+	"test/extended/testdata/workloads/pod_with_active_dead_line_seconds.yaml":                                testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYaml,
+	"test/extended/testdata/workloads/pod_with_ads_greater_than_operator.yaml":                               testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYaml,
+	"test/extended/testdata/workloads/pod_with_on_failure_policy.yaml":                                       testExtendedTestdataWorkloadsPod_with_on_failure_policyYaml,
+	"test/extended/testdata/workloads/pod_with_restart_policy.yaml":                                          testExtendedTestdataWorkloadsPod_with_restart_policyYaml,
+	"test/extended/testdata/workloads/rodo_ds.yaml":                                                          testExtendedTestdataWorkloadsRodo_dsYaml,
+	"test/extended/testdata/workloads/rodo_operatorgroup.yaml":                                               testExtendedTestdataWorkloadsRodo_operatorgroupYaml,
+	"test/extended/testdata/workloads/rodo_subscription.yaml":                                                testExtendedTestdataWorkloadsRodo_subscriptionYaml,
 	"e2echart/e2e-chart-template.html":                                                                       e2echartE2eChartTemplateHtml,
 	"e2echart/non-spyglass-e2e-chart-template.html":                                                          e2echartNonSpyglassE2eChartTemplateHtml,
 	"e2echart/test-risk-analysis.html":                                                                       e2echartTestRiskAnalysisHtml,
@@ -57589,6 +57884,15 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"machine-template.yaml":       {testExtendedTestdataTwo_nodeMachineTemplateYaml, map[string]*bintree{}},
 				}},
 				"verifyservice-pipeline-template.yaml": {testExtendedTestdataVerifyservicePipelineTemplateYaml, map[string]*bintree{}},
+				"workloads": {nil, map[string]*bintree{
+					"pod_with_active_dead_line_seconds.yaml":  {testExtendedTestdataWorkloadsPod_with_active_dead_line_secondsYaml, map[string]*bintree{}},
+					"pod_with_ads_greater_than_operator.yaml": {testExtendedTestdataWorkloadsPod_with_ads_greater_than_operatorYaml, map[string]*bintree{}},
+					"pod_with_on_failure_policy.yaml":         {testExtendedTestdataWorkloadsPod_with_on_failure_policyYaml, map[string]*bintree{}},
+					"pod_with_restart_policy.yaml":            {testExtendedTestdataWorkloadsPod_with_restart_policyYaml, map[string]*bintree{}},
+					"rodo_ds.yaml":                            {testExtendedTestdataWorkloadsRodo_dsYaml, map[string]*bintree{}},
+					"rodo_operatorgroup.yaml":                 {testExtendedTestdataWorkloadsRodo_operatorgroupYaml, map[string]*bintree{}},
+					"rodo_subscription.yaml":                  {testExtendedTestdataWorkloadsRodo_subscriptionYaml, map[string]*bintree{}},
+				}},
 			}},
 		}},
 	}},

--- a/test/extended/testdata/workloads/pod_with_active_dead_line_seconds.yaml
+++ b/test/extended/testdata/workloads/pod_with_active_dead_line_seconds.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: podwithactivedeadlineseconds62690
+  name: podwithactivedeadlineseconds62690
+spec:
+  activeDeadlineSeconds: 120
+  restartPolicy: OnFailure
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done

--- a/test/extended/testdata/workloads/pod_with_ads_greater_than_operator.yaml
+++ b/test/extended/testdata/workloads/pod_with_ads_greater_than_operator.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: podwithadsgo62690
+  name: podwithadsgo62690
+spec:
+  activeDeadlineSeconds: 240
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done

--- a/test/extended/testdata/workloads/pod_with_on_failure_policy.yaml
+++ b/test/extended/testdata/workloads/pod_with_on_failure_policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: onfailurepod60352
+  name: onfailurepod60352
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done

--- a/test/extended/testdata/workloads/pod_with_restart_policy.yaml
+++ b/test/extended/testdata/workloads/pod_with_restart_policy.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: restartpod60352
+  name: restartpod60352
+spec:
+  restartPolicy: Never
+  containers:
+    - name: busybox
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        runAsNonRoot:
+          true
+        seccompProfile:
+          type: "RuntimeDefault"
+      image: quay.io/openshifttest/busybox@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          while sleep 5; do date; done

--- a/test/extended/testdata/workloads/rodo_ds.yaml
+++ b/test/extended/testdata/workloads/rodo_ds.yaml
@@ -1,0 +1,17 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: runoncedurationoverride-template
+objects:
+- kind: RunOnceDurationOverride
+  apiVersion: operator.openshift.io/v1
+  metadata:
+    name: cluster
+    namespace: "${NAMESPACE}"
+  spec:
+    runOnceDurationOverride:
+      spec:
+        activeDeadlineSeconds: ${{ACTIVEDEADLINESECONDS}}
+parameters:
+- name: NAMESPACE
+- name: ACTIVEDEADLINESECONDS

--- a/test/extended/testdata/workloads/rodo_operatorgroup.yaml
+++ b/test/extended/testdata/workloads/rodo_operatorgroup.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: operatorgroup-template
+objects:
+- kind: OperatorGroup
+  apiVersion: operators.coreos.com/v1
+  metadata:
+    annotations:
+      olm.providedAPIs: RunOnceDurationOverride.v1.operator.openshift.io
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    targetNamespaces:
+    - "${NAMESPACE}"
+    upgradeStrategy: Default
+
+parameters:
+- name: NAME
+- name: NAMESPACE

--- a/test/extended/testdata/workloads/rodo_subscription.yaml
+++ b/test/extended/testdata/workloads/rodo_subscription.yaml
@@ -1,0 +1,27 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: subscription-template
+objects:
+- kind: Subscription
+  apiVersion: operators.coreos.com/v1alpha1
+  kind: Subscription
+  metadata:
+    labels:
+      operators.coreos.com/run-once-duration-override-operator.openshift-run-once-duration: ""
+    name: "${NAME}"
+    namespace: "${NAMESPACE}"
+  spec:
+    channel: "${CHANNELNAME}"
+    installPlanApproval: Automatic
+    name: "${NAME}"
+    source: "${OPSRCNAME}"
+    sourceNamespace: "${SOURCENAME}"
+    startingCSV: "${STARTINGCSV}"
+parameters:
+- name: NAME
+- name: NAMESPACE
+- name: CHANNELNAME
+- name: OPSRCNAME
+- name: SOURCENAME
+- name: STARTINGCSV

--- a/test/extended/workloads/run_once_duration_operator.go
+++ b/test/extended/workloads/run_once_duration_operator.go
@@ -1,0 +1,472 @@
+package workloads
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/compat_otp/architecture"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe("[sig-scheduling][Serial] Workloads Set activeDeadLineseconds using the run-once-duration-override-operator", func() {
+	defer g.GinkgoRecover()
+	var (
+		oc                       = exutil.NewCLI("rodo-operator")
+		kubeNamespace            = "openshift-run-once-duration-override-operator"
+		buildPruningBaseDir      string
+		rodoOperatorGroupT       string
+		rodoSubscriptionT        string
+		runOnceDurationOverrideT string
+		sub                      rodoSubscription
+		og                       rodoOperatorgroup
+		rodods                   runOnceDurationOverride
+		dsPodString              string
+	)
+
+	g.BeforeEach(func() {
+		buildPruningBaseDir = exutil.FixturePath("testdata", "workloads")
+		rodoOperatorGroupT = filepath.Join(buildPruningBaseDir, "rodo_operatorgroup.yaml")
+		rodoSubscriptionT = filepath.Join(buildPruningBaseDir, "rodo_subscription.yaml")
+		runOnceDurationOverrideT = filepath.Join(buildPruningBaseDir, "rodo_ds.yaml")
+
+		// Dynamically fetch all packagemanifest values instead of hardcoding
+		sub = getPackageManifestValues(oc, "run-once-duration-override-operator", "openshift-marketplace")
+		sub.template = rodoSubscriptionT
+		sub.namespace = kubeNamespace
+
+		og = rodoOperatorgroup{
+			name:      "openshift-run-once-duration-override-operator",
+			namespace: kubeNamespace,
+			template:  rodoOperatorGroupT,
+		}
+
+		rodods = runOnceDurationOverride{
+			namespace:             kubeNamespace,
+			activeDeadlineSeconds: 60,
+			template:              runOnceDurationOverrideT,
+		}
+		// Set expected number of Daemon set pods if cluster is SNO vs normal
+		dsPodString = "Running Running Running"
+
+		if isSNOCluster(oc) {
+			dsPodString = "Running"
+		}
+
+		// Skip tests on arm64 single-arch and multi-arch clusters
+		architecture.SkipNonAmd64SingleArch(oc)
+		architecture.SkipArchitectures(oc, architecture.MULTI)
+		sub.skipMissingCatalogsources(oc)
+	})
+
+	// author: knarra@redhat.com
+	// OCP-60351, OCP-60352
+	g.It("should install Run Once Duration Override operator and verify it works [apigroup:config.openshift.io]", func() {
+
+		podWithRestartPolicy := filepath.Join(buildPruningBaseDir, "pod_with_restart_policy.yaml")
+		podWithOnFailurePolicy := filepath.Join(buildPruningBaseDir, "pod_with_on_failure_policy.yaml")
+
+		g.By("Create the run once duration override  namespace")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("ns", kubeNamespace).Execute()
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("ns", kubeNamespace).Output()
+		e2e.Logf("err %v, msg %v", err, msg)
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", kubeNamespace, "openshift.io/cluster-monitoring=true", "--overwrite").Output()
+		e2e.Logf("err %v, msg %v", err, msg)
+
+		g.By("Create the operatorgroup")
+		defer og.deleteOperatorGroup(oc)
+		og.createOperatorGroup(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Create the subscription")
+		defer sub.deleteSubscription(oc)
+		sub.createSubscription(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for the runOnceDurationOverride operator pod running")
+		if ok := waitForAvailableRsRunning(oc, "deploy", "run-once-duration-override-operator", kubeNamespace, "1"); ok {
+			e2e.Logf("RunOnceDurationOverride operator runnnig now\n")
+		} else {
+			checkOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deploy", "run-once-duration-override-operator", "-n", kubeNamespace).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("Output of runoncedurationoverrideoperator after waiting for 5 mins: %s", checkOutput)
+			e2e.Failf("Runoncedurationoverrideoperator is not running even after waiting for 5 mins")
+		}
+
+		g.By("Create runoncedurationoverride cluster")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("runoncedurationoverride", "--all", "-n", kubeNamespace).Execute()
+		rodods.createrunOnceDurationOverride(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = wait.Poll(10*time.Second, 180*time.Second, func() (bool, error) {
+			outputReady, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.numberReady}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			outputDesired, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.desiredNumberScheduled}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if err != nil {
+				e2e.Logf("deploy is still inprogress, error: %s. Trying again", err)
+				return false, nil
+			}
+			if outputReady == outputDesired {
+				e2e.Logf("daemonset pods are up:\n%s %s", outputReady, outputDesired)
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Expected number of daemonset pods are not ready")
+
+		g.By("Validate that right version of RODO  is running")
+		err = wait.Poll(10*time.Second, 180*time.Second, func() (bool, error) {
+			rodoDSStatus, rodoPodError := oc.WithoutNamespace().AsAdmin().Run("get").Args("po", "-n", "openshift-run-once-duration-override-operator", "-l=runoncedurationoverride=true", "-ojsonpath='{.items[*].status.phase}'").Output()
+			if rodoPodError != nil {
+				e2e.Logf("deploy is still inprogress, error: %s. Trying again", err)
+				return false, nil
+			}
+			if matched, _ := regexp.MatchString(dsPodString, rodoDSStatus); !matched {
+				e2e.Logf("All the ds pods are not still in running state, retrying  %s", rodoDSStatus)
+				return false, nil
+			}
+			e2e.Logf("All the ds pods are running %s", rodoDSStatus)
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "All rodo pods are not still running after 3 minutes")
+
+		rodoCsvOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", "-n", kubeNamespace).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.Contains(rodoCsvOutput, sub.startingCSV)).To(o.BeTrue())
+
+		//Add the k8 dependencies checkpoint for RODO
+		g.By("Get the latest version of Kubernetes")
+		ocVersion, versionErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("node", "-o=jsonpath={.items[0].status.nodeInfo.kubeletVersion}").Output()
+		o.Expect(versionErr).NotTo(o.HaveOccurred())
+		kubenetesVersion := strings.Split(strings.Split(ocVersion, "+")[0], "v")[1]
+		kuberVersion := strings.Split(kubenetesVersion, ".")[0] + "." + strings.Split(kubenetesVersion, ".")[1]
+		e2e.Logf("kuberVersion is %s", kuberVersion)
+
+		g.By("Get rebased version of kubernetes from runoncedurationoverride operator")
+		minkuberversion, rodoErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", "-l=operators.coreos.com/run-once-duration-override-operator.openshift-run-once-duration=", "-n", kubeNamespace, "-o=jsonpath={.items[0].spec.minKubeVersion}").Output()
+		o.Expect(rodoErr).NotTo(o.HaveOccurred())
+		rebasedVersion := strings.Split(minkuberversion, ".")[0] + "." + strings.Split(minkuberversion, ".")[1]
+		e2e.Logf("rebasedVersion is %s", rebasedVersion)
+
+		if strings.Contains(rebasedVersion, kuberVersion) || strings.Contains(rebasedVersion, "1.32") {
+			e2e.Logf("RODO operator has been rebased with latest kubernetes")
+		} else {
+			// Mark as e2e.Failf after 4.20 GA
+			e2e.Logf("RODO operator not rebased with latest kubernetes")
+		}
+
+		// Create test project
+		g.By("Create test project")
+		oc.SetupProject()
+
+		// Label the test project
+		patch := `[{"op":"add", "path":"/metadata/labels/runoncedurationoverrides.admission.runoncedurationoverride.openshift.io~1enabled", "value":"true"}]`
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("ns", oc.Namespace(), "--type=json", "-p", patch).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait and check to see if the project has got the label applied
+		err = wait.Poll(5*time.Second, 110*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ns", oc.Namespace(), "-o=jsonpath={.metadata.labels}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			if strings.Contains(output, "runoncedurationoverrides.admission.runoncedurationoverride.openshift.io") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Admission label has not been applied correctly")
+
+		// Debug code adding sleep for sometime to determine if the issue is with timing or RODO
+		time.Sleep(30 * time.Second)
+
+		// Create pods with Restart & OnFailure Policy
+		podFileList := []string{podWithRestartPolicy, podWithOnFailurePolicy}
+		for _, podFile := range podFileList {
+			createPodErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", podFile, "-n", oc.Namespace()).Execute()
+			o.Expect(createPodErr).NotTo(o.HaveOccurred())
+		}
+
+		// Retrieve the pod list and make sure they are running
+		podList := []string{"restartpod60352", "onfailurepod60352"}
+		for _, pod := range podList {
+			checkPodStatus(oc, "app="+pod, oc.Namespace(), "Running")
+			// Make sure activeDeadLineSeconds field is set to 60
+			err = wait.Poll(15*time.Second, 180*time.Second, func() (bool, error) {
+				activeDeadLineSeconds, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", pod, "-n", oc.Namespace(), "-o=jsonpath={.spec.activeDeadlineSeconds}").Output()
+				if err != nil {
+					e2e.Logf("err: %v, and try next round...", err.Error())
+					return false, nil
+				}
+				if matched, _ := regexp.MatchString("60", activeDeadLineSeconds); !matched {
+					e2e.Logf("ActiveDeadLineSeconds on pod %s was not set correctly:%s\n, retrying", pod, activeDeadLineSeconds)
+					return false, nil
+				}
+				e2e.Logf("ActiveDeadLineSeconds on pod %s was set correctly:\n%s", pod, activeDeadLineSeconds)
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("ActiveDeadLineSeconds on pod was not set correctly even after waiting for 3 minutes"))
+		}
+		// Verify that pod no longer runs actively after the activeDeadLineSeconds have reached
+		for _, pod := range podList {
+			checkPodStatus(oc, "app="+pod, oc.Namespace(), "Failed")
+			checkMessage, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("pod", pod, "-n", oc.Namespace()).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if matched, _ := regexp.MatchString("DeadlineExceeded", checkMessage); !matched {
+				e2e.Failf("Pod %s has not gone into error state even after reaching activeDeadLineSeconds set in the operator\n", pod)
+			}
+		}
+	})
+
+	// author: knarra@redhat.com
+	// OCP-62690
+	g.It("should set activeDeadlineSeconds to minimum of pod and RODO values [apigroup:config.openshift.io]", func() {
+		podWithActiveDeadLineSeconds := filepath.Join(buildPruningBaseDir, "pod_with_active_dead_line_seconds.yaml")
+		podWithAdsGreaterThanOperator := filepath.Join(buildPruningBaseDir, "pod_with_ads_greater_than_operator.yaml")
+
+		g.By("Create the run once duration override  namespace")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("ns", kubeNamespace).Execute()
+		msg, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("ns", kubeNamespace).Output()
+		e2e.Logf("err %v, msg %v", err, msg)
+		msg, err = oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", kubeNamespace, "openshift.io/cluster-monitoring=true", "--overwrite").Output()
+		e2e.Logf("err %v, msg %v", err, msg)
+
+		g.By("Create the operatorgroup")
+		defer og.deleteOperatorGroup(oc)
+		og.createOperatorGroup(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Create the subscription")
+		defer sub.deleteSubscription(oc)
+		sub.createSubscription(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for the runOnceDurationOverride operator pod running")
+		if ok := waitForAvailableRsRunning(oc, "deploy", "run-once-duration-override-operator", kubeNamespace, "1"); ok {
+			e2e.Logf("RunOnceDurationOverride operator runnnig now\n")
+		} else {
+			checkOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deploy", "run-once-duration-override-operator", "-n", kubeNamespace).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("Output of runoncedurationoverrideoperator after waiting for 5 mins: %s", checkOutput)
+			e2e.Failf("Runoncedurationoverrideoperator is not running even after waiting for 5 mins")
+		}
+
+		g.By("Create runoncedurationoverride cluster")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("runoncedurationoverride", "--all", "-n", kubeNamespace).Execute()
+		rodods.createrunOnceDurationOverride(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = wait.Poll(10*time.Second, 180*time.Second, func() (bool, error) {
+			outputReady, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.numberReady}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			outputDesired, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.desiredNumberScheduled}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if err != nil {
+				e2e.Logf("deploy is still inprogress, error: %s. Trying again", err)
+				return false, nil
+			}
+			if outputReady == outputDesired {
+				e2e.Logf("daemonset pods are up:\n%s %s", outputReady, outputDesired)
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Expected number of daemonset pods are not ready")
+
+		g.By("Check the daemonset pods are running well inside openshift-run-once-duration-override-operator")
+		err = wait.Poll(10*time.Second, 180*time.Second, func() (bool, error) {
+			rodoDSStatus, rodoPodError := oc.WithoutNamespace().AsAdmin().Run("get").Args("po", "-n", "openshift-run-once-duration-override-operator", "-l=runoncedurationoverride=true", "-ojsonpath='{.items[*].status.phase}'").Output()
+			if rodoPodError != nil {
+				e2e.Logf("deploy is still inprogress, error: %s. Trying again", err)
+				return false, nil
+			}
+			if matched, _ := regexp.MatchString(dsPodString, rodoDSStatus); !matched {
+				e2e.Logf("All the ds pods are not still in running state, retrying  %s", rodoDSStatus)
+				return false, nil
+			}
+			e2e.Logf("All the ds pods are running %s", rodoDSStatus)
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "All rodo pods are not still running after 3 minutes")
+
+		// Create test project
+		g.By("Create test project")
+		oc.SetupProject()
+
+		// Label the test project
+		patch := `[{"op":"add", "path":"/metadata/labels/runoncedurationoverrides.admission.runoncedurationoverride.openshift.io~1enabled", "value":"true"}]`
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("ns", oc.Namespace(), "--type=json", "-p", patch).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait and check to see if the project has got the label applied
+		err = wait.Poll(5*time.Second, 110*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ns", oc.Namespace(), "-o=jsonpath={.metadata.labels}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("Namespace label output is :%v", output)
+			if strings.Contains(output, "runoncedurationoverrides.admission.runoncedurationoverride.openshift.io") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Admission label has not been applied correctly")
+
+		// Debug code adding sleep for sometime to determine if the issue is with timing or RODO
+		time.Sleep(30 * time.Second)
+
+		// Verify that activeDeadLineSeconds value is set as the min value of pod.spec.ActiveDeadLineSeconds & RODO activeDeadLineSeconds
+		createPodADSErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", podWithActiveDeadLineSeconds, "-n", oc.Namespace()).Execute()
+		o.Expect(createPodADSErr).NotTo(o.HaveOccurred())
+
+		// Make sure activeDeadLineSeconds field is set to 60
+		checkPodStatus(oc, "app=podwithactivedeadlineseconds62690", oc.Namespace(), "Running")
+		err = wait.Poll(15*time.Second, 180*time.Second, func() (bool, error) {
+			activeDeadLineSeconds, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "podwithactivedeadlineseconds62690", "-n", oc.Namespace(), "-o=jsonpath={.spec.activeDeadlineSeconds}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			if matched, _ := regexp.MatchString("60", activeDeadLineSeconds); !matched {
+				e2e.Logf("ActiveDeadLineSeconds was not set as the min value between pod & RODO, retrying\n")
+				return false, nil
+			}
+			e2e.Logf("ActiveDeadLineSeconds was set as %s which is the min value between pod & RODO", activeDeadLineSeconds)
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("ActiveDeadLineSeconds on pod was not set as the min value between pod&rodo even after waiting for 3 minutes"))
+
+		// Verify that pod no longer runs actively after the activeDeadLineSeconds have reached
+		err = wait.Poll(5*time.Second, 110*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", oc.Namespace(), "-l", "app=podwithactivedeadlineseconds62690", "-o=jsonpath={.items[*].status.phase}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			if strings.Contains(output, "Failed") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "The current state of pod podwithactivedeadlineseconds62690 is not expected")
+
+		checkMessage, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("pod", "podwithactivedeadlineseconds62690", "-n", oc.Namespace()).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if matched, _ := regexp.MatchString("DeadlineExceeded", checkMessage); !matched {
+			e2e.Failf("Pod podwithactivedeadlineseconds62690 has not gone into error state even after reaching activeDeadLineSeconds\n")
+		}
+
+		// Update runoncedurationoverride to have activeDeadLineseconds set to the value lesser than the pod
+		g.By("Patch the runoncedurationoverride object to set the activeDeadLineSeconds")
+		patch = `[{"op":"replace", "path":"/spec/runOnceDurationOverride/spec/activeDeadlineSeconds", "value":80}]`
+		err = oc.AsAdmin().WithoutNamespace().Run("patch").Args("runoncedurationoverride", "cluster", "-n", kubeNamespace, "--type=json", "-p", patch).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify ds pods are running fine after patching the runoncedurationoverride operator
+		err = wait.Poll(10*time.Second, 180*time.Second, func() (bool, error) {
+			outputReady, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.numberReady}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			outputDesired, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("ds", "runoncedurationoverride", "-n", kubeNamespace, "-o=jsonpath={.status.desiredNumberScheduled}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if err != nil {
+				e2e.Logf("deploy is still inprogress, error: %s. Trying again", err)
+				return false, nil
+			}
+			if outputReady == outputDesired {
+				e2e.Logf("daemonset pods are up:\n%s %s", outputReady, outputDesired)
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Expected number of daemonset pods are not ready")
+
+		// Debug code adding sleep for sometime to determine if the issue is with timing or RODO
+		time.Sleep(30 * time.Second)
+
+		createPodADSGOErr := oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", podWithAdsGreaterThanOperator, "-n", oc.Namespace()).Execute()
+		o.Expect(createPodADSGOErr).NotTo(o.HaveOccurred())
+
+		// Make sure activeDeadLineSeconds field is set to 80
+		checkPodStatus(oc, "app=podwithadsgo62690", oc.Namespace(), "Running")
+		err = wait.Poll(15*time.Second, 180*time.Second, func() (bool, error) {
+			activeDeadLineSeconds, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "podwithadsgo62690", "-n", oc.Namespace(), "-o=jsonpath={.spec.activeDeadlineSeconds}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			if matched, _ := regexp.MatchString("80", activeDeadLineSeconds); !matched {
+				e2e.Logf("ActiveDeadLineSeconds was not set as the min value between pod & RODO, value is %s retrying\n", activeDeadLineSeconds)
+				return false, nil
+			}
+			e2e.Logf("ActiveDeadLineSeconds was set as %s which is the min value between pod & RODO", activeDeadLineSeconds)
+			return true, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("ActiveDeadLineSeconds on pod was not set correctly even after waiting for 3 minutes"))
+
+		// Verify that pod no longer runs actively after the activeDeadLineSeconds have reached
+		err = wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", oc.Namespace(), "-l", "app=podwithadsgo62690", "-o=jsonpath={.items[*].status.phase}").Output()
+			if err != nil {
+				e2e.Logf("err: %v, and try next round...", err.Error())
+				return false, nil
+			}
+			e2e.Logf("the result of pod:%v", output)
+			if strings.Contains(output, "Failed") {
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "The current state of pod podwithadsgo62690 is not expected")
+
+		checkMessage, err = oc.AsAdmin().WithoutNamespace().Run("describe").Args("pod", "podwithadsgo62690", "-n", oc.Namespace()).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if matched, _ := regexp.MatchString("DeadlineExceeded", checkMessage); !matched {
+			e2e.Failf("Pod podwithadsgo62690 has not gone into error state even after reaching activeDeadLineSeconds\n")
+		}
+
+	})
+
+	// author: yinzhou@redhat.com
+	// OCP-83033
+	g.It("should define .spec.relatedImages to support disconnected cluster [apigroup:config.openshift.io]", func() {
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("ns", kubeNamespace).Execute()
+		defer og.deleteOperatorGroup(oc)
+		defer sub.deleteSubscription(oc)
+
+		createOperator(oc, sub, og)
+
+		g.By("Wait for the runOnceDurationOverride operator pod running")
+		if ok := waitForAvailableRsRunning(oc, "deploy", "run-once-duration-override-operator", kubeNamespace, "1"); ok {
+			e2e.Logf("RunOnceDurationOverride operator runnnig now\n")
+		} else {
+			checkOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deploy", "run-once-duration-override-operator", "-n", kubeNamespace).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			e2e.Logf("Output of runoncedurationoverrideoperator after waiting for 5 mins: %s", checkOutput)
+			e2e.Failf("Runoncedurationoverrideoperator is not running even after waiting for 5 mins")
+		}
+
+		g.By("Check the .spec.relatedImages define correctly")
+		relatedImages, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("csv", "-n", kubeNamespace, "-o=jsonpath={.items[0].spec.relatedImages}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if sub.startingCSV != "runoncedurationoverrideoperator.v1.3.0" && strings.Contains(relatedImages, "run-once-duration-override-operator") {
+			e2e.Logf("Found the correct related images")
+		} else if strings.Contains(relatedImages, "run-once-duration-override-operand") && strings.Contains(relatedImages, "run-once-duration-override-operator") {
+			e2e.Logf("Found the correct related images")
+		} else {
+			e2e.Failf("run-once-duration-override-operator related images are not defined correctly")
+		}
+	})
+})

--- a/test/extended/workloads/runoncedurationoverride_util.go
+++ b/test/extended/workloads/runoncedurationoverride_util.go
@@ -1,0 +1,261 @@
+package workloads
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type rodoOperatorgroup struct {
+	name      string
+	namespace string
+	template  string
+}
+
+type rodoSubscription struct {
+	name        string
+	namespace   string
+	channelName string
+	opsrcName   string
+	sourceName  string
+	startingCSV string
+	template    string
+}
+
+type runOnceDurationOverride struct {
+	namespace             string
+	activeDeadlineSeconds int
+	template              string
+}
+
+func (sub *rodoSubscription) createSubscription(oc *exutil.CLI) {
+	err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err1 := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", sub.template, "-p", "NAME="+sub.name, "NAMESPACE="+sub.namespace,
+			"CHANNELNAME="+sub.channelName, "OPSRCNAME="+sub.opsrcName, "SOURCENAME="+sub.sourceName, "STARTINGCSV="+sub.startingCSV)
+		if err1 != nil {
+			e2e.Logf("the err:%v, and try next round", err1)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "sub "+sub.name+" is not created successfully")
+}
+
+func (sub *rodoSubscription) deleteSubscription(oc *exutil.CLI) {
+	err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err1 := oc.AsAdmin().WithoutNamespace().Run("delete").Args("subscription", sub.name, "-n", sub.namespace).Execute()
+		if err1 != nil {
+			e2e.Logf("the err:%v, and try next round", err1)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "sub "+sub.name+" is not deleted successfully")
+}
+
+func (og *rodoOperatorgroup) createOperatorGroup(oc *exutil.CLI) {
+	err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err1 := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", og.template, "-p", "NAME="+og.name, "NAMESPACE="+og.namespace)
+		if err1 != nil {
+			e2e.Logf("the err:%v, and try next round", err1)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "og "+og.name+" is not created successfully")
+}
+
+func (og *rodoOperatorgroup) deleteOperatorGroup(oc *exutil.CLI) {
+	err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err1 := oc.AsAdmin().WithoutNamespace().Run("delete").Args("operatorgroup", og.name, "-n", og.namespace).Execute()
+		if err1 != nil {
+			e2e.Logf("the err:%v, and try next round", err1)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "og "+og.name+" is not deleted successfully")
+}
+
+func (rodods *runOnceDurationOverride) createrunOnceDurationOverride(oc *exutil.CLI) {
+	err := wait.Poll(5*time.Second, 20*time.Second, func() (bool, error) {
+		err1 := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", rodods.template, "-p", "NAMESPACE="+rodods.namespace,
+			"ACTIVEDEADLINESECONDS="+strconv.Itoa(rodods.activeDeadlineSeconds))
+		if err1 != nil {
+			e2e.Logf("the err:%v, and try next round", err1)
+			return false, nil
+		}
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "RunOnceDurationOverrideOperator has not been created successfully")
+}
+
+func (sub *rodoSubscription) skipMissingCatalogsources(oc *exutil.CLI) {
+	output, errRed := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", "openshift-marketplace", "catalogsource", "redhat-operators").Output()
+	if errRed != nil && strings.Contains(output, "NotFound") {
+		g.Skip("Skip since redhat-operators catalogsource is not available")
+	} else if errRed != nil && strings.Contains(output, "doesn't have a resource type \"catalogsource\"") {
+		g.Skip("Skip since catalogsource is not available")
+	} else {
+		o.Expect(errRed).NotTo(o.HaveOccurred())
+	}
+}
+
+func getRandomNum(m int64, n int64) int64 {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Int63n(n-m+1) + m
+}
+
+func createSubscription(oc *exutil.CLI, sub rodoSubscription) {
+	err := wait.Poll(5*time.Second, 15*time.Second, func() (bool, error) {
+		output, errGet := oc.AsAdmin().WithoutNamespace().Run("get").Args("sub", sub.name, "-n", sub.namespace).Output()
+		if errGet == nil {
+			return true, nil
+		}
+		if errGet != nil && (strings.Contains(output, "NotFound")) {
+			randomExpandInt64 := getRandomNum(3, 8)
+			time.Sleep(time.Duration(randomExpandInt64) * time.Second)
+			return false, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		err1 := applyResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", sub.template, "-p", "NAME="+sub.name, "NAMESPACE="+sub.namespace,
+			"CHANNELNAME="+sub.channelName, "OPSRCNAME="+sub.opsrcName, "SOURCENAME="+sub.sourceName, "STARTINGCSV="+sub.startingCSV)
+		e2e.Logf("err %v", err1)
+	}
+}
+
+func createOperator(oc *exutil.CLI, subD rodoSubscription, ogD rodoOperatorgroup) {
+	g.By("Create namespace !!!")
+	msg, err := oc.AsAdmin().WithoutNamespace().Run("create").Args("ns", subD.namespace).Output()
+	e2e.Logf("err %v, msg %v", err, msg)
+	msg, err = oc.AsAdmin().WithoutNamespace().Run("label").Args("namespace", subD.namespace, "openshift.io/cluster-monitoring=true", "--overwrite").Output()
+	e2e.Logf("err %v, msg %v", err, msg)
+
+	g.By("Create operatorGroup !!!")
+	ogFile, err := oc.AsAdmin().Run("process").Args("--ignore-unknown-parameters=true", "-f", ogD.template, "-p", "NAME="+ogD.name, "NAMESPACE="+ogD.namespace, "-n", ogD.namespace).OutputToFile(getRandomString() + "og.json")
+	e2e.Logf("Created the operator-group yaml %s, %v", ogFile, err)
+	msg, err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", ogFile).Output()
+	e2e.Logf("err %v, msg %v", err, msg)
+
+	g.By("Create subscription for above catalogsource !!!")
+	createSubscription(oc, subD)
+}
+
+// getPackageManifestValues dynamically fetches all required values from packagemanifest
+// instead of hardcoding them in the test
+func getPackageManifestValues(oc *exutil.CLI, packageName string, namespace string) rodoSubscription {
+	g.By("Fetching packagemanifest values dynamically")
+
+	// Get catalogSource (e.g., "redhat-operators")
+	catalogSource, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", packageName, "-n", namespace, "-o=jsonpath={.status.catalogSource}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("Catalog Source (opsrcName): %v", catalogSource)
+
+	// Get catalogSourceNamespace (e.g., "openshift-marketplace")
+	catalogSourceNamespace, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", packageName, "-n", namespace, "-o=jsonpath={.status.catalogSourceNamespace}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("Catalog Source Namespace (sourceName): %v", catalogSourceNamespace)
+
+	// Get defaultChannel (e.g., "stable")
+	defaultChannel, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", packageName, "-n", namespace, "-o=jsonpath={.status.defaultChannel}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("Default Channel (channelName): %v", defaultChannel)
+
+	// Get currentCSV from the default channel
+	currentCSV, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("packagemanifest", packageName, "-n", namespace, "-o=jsonpath={.status.channels[?(@.name==\""+defaultChannel+"\")].currentCSV}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("Current CSV (startingCSV): %v", currentCSV)
+
+	// Return populated rodoSubscription struct with dynamically fetched values
+	return rodoSubscription{
+		name:        packageName,
+		namespace:   "openshift-run-once-duration-override-operator",
+		channelName: defaultChannel,
+		opsrcName:   catalogSource,
+		sourceName:  catalogSourceNamespace,
+		startingCSV: currentCSV,
+	}
+}
+
+func applyResourceFromTemplate(oc *exutil.CLI, parameters ...string) error {
+	var configFile string
+	err := wait.Poll(3*time.Second, 15*time.Second, func() (bool, error) {
+		output, err := oc.AsAdmin().Run("process").Args(parameters...).OutputToFile(getRandomString() + "workload-config.json")
+		if err != nil {
+			e2e.Logf("the err:%v, and try next round", err)
+			return false, nil
+		}
+		configFile = output
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "fail to process parameters")
+
+	e2e.Logf("the file of resource is %s", configFile)
+
+	return oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", configFile).Execute()
+}
+
+func getRandomString() string {
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buffer := make([]byte, 8)
+	for index := range buffer {
+		buffer[index] = chars[seed.Intn(len(chars))]
+	}
+	return string(buffer)
+}
+
+func checkPodStatus(oc *exutil.CLI, podLabel string, namespace string, expected string) {
+	err := wait.Poll(20*time.Second, 300*time.Second, func() (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", namespace, "-l", podLabel, "-o=jsonpath={.items[*].status.phase}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("the result of pod:%v", output)
+		if strings.Contains(output, expected) && (!(strings.Contains(strings.ToLower(output), "error"))) && (!(strings.Contains(strings.ToLower(output), "crashLoopbackOff"))) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", namespace, "-l", podLabel, "-o", "yaml").Execute()
+	}
+	o.Expect(err).NotTo(o.HaveOccurred(), "the state of pod with "+podLabel+" is not expected "+expected)
+}
+
+func isSNOCluster(oc *exutil.CLI) bool {
+	//Only 1 master, 1 worker node and with the same hostname.
+	masterNodes, err1 := exutil.GetClusterNodesByRole(oc, "master")
+	workerNodes, err2 := exutil.GetClusterNodesByRole(oc, "worker")
+	if err1 == nil && err2 == nil && len(masterNodes) == 1 && len(workerNodes) == 1 && masterNodes[0] == workerNodes[0] {
+		return true
+	}
+	return false
+}
+
+func waitForAvailableRsRunning(oc *exutil.CLI, rsKind string, rsName string, namespace string, expected string) bool {
+	err := wait.Poll(20*time.Second, 180*time.Second, func() (bool, error) {
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(rsKind, rsName, "-n", namespace, "-o=jsonpath={.status.availableReplicas}").Output()
+		if err != nil {
+			e2e.Logf("object is still inprogress, error: %s. Trying again", err)
+			return false, nil
+		}
+		if matched, _ := regexp.MatchString(expected, output); matched {
+			e2e.Logf("object is up:\n%s", output)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Hi Team,

Trying to migrate rodoo cases from OTE repo to origin repo as part of task: https://issues.redhat.com/browse/CNTRLPLANE-2197 

Execution logs:
./openshift-tests run-test "[sig-scheduling][Serial] Workloads Set activeDeadLineseconds using the run-once-duration-override-operator should define .spec.relatedImages to support disconnected cluster [apigroup:config.openshift.io] [Suite:openshift/conformance/serial]"
```
  I1219 16:19:38.580578  149298 factory.go:195] Registered Plugin "containerd"
  I1219 16:19:39.057891  149298 binary.go:77] Found 8508 test specs
  I1219 16:19:39.062482  149298 binary.go:94] 1058 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-26236ded5e
  I1219 16:19:47.287600  149298 test_setup.go:125] Extended test version v0.0.0-unknown-26236ded5e
  I1219 16:19:47.287656  149298 test_context.go:559] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I1219 16:19:47.635851 149298 framework.go:2334] microshift-version configmap not found
  I1219 16:19:47.636543  149298 binary.go:114] Loaded test configuration: ....
  Running Suite:  - /home/ropatil/Downloads/Automation/origin
  ===========================================================
  Random Seed: 1766141378 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-scheduling][Serial] Workloads Set activeDeadLineseconds using the run-once-duration-override-operator should define .spec.relatedImages to support disconnected cluster [apigroup:config.openshift.io]
  github.com/openshift/origin/test/extended/workloads/run_once_duration_operator.go:443
    STEP: Creating a kubernetes client @ 12/19/25 16:19:47.649
  I1219 16:19:47.650368  149298 discovery.go:214] Invalidating discovery information
  I1219 16:19:52.336764 149298 client.go:293] configPath is now "/tmp/configfile3803202654"
  I1219 16:19:52.336857 149298 client.go:368] The user is now "e2e-test-rodo-operator-85jkb-user"
  I1219 16:19:52.336872 149298 client.go:370] Creating project "e2e-test-rodo-operator-85jkb"
  I1219 16:19:52.905384 149298 client.go:378] Waiting on permissions in project "e2e-test-rodo-operator-85jkb" ...
  I1219 16:19:54.964909 149298 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I1219 16:19:55.362010 149298 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I1219 16:19:56.542059 149298 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I1219 16:19:57.619066 149298 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I1219 16:19:58.545296 149298 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I1219 16:19:59.224363 149298 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I1219 16:20:00.069952 149298 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I1219 16:20:01.325444 149298 client.go:465] Project "e2e-test-rodo-operator-85jkb" has been fully provisioned.
    STEP: Fetching packagemanifest values dynamically @ 12/19/25 16:20:01.328
  I1219 16:20:02.541591 149298 runoncedurationoverride_util.go:162] Catalog Source (opsrcName): redhat-operators
  I1219 16:20:04.095726 149298 runoncedurationoverride_util.go:167] Catalog Source Namespace (sourceName): openshift-marketplace
  I1219 16:20:05.829935 149298 runoncedurationoverride_util.go:172] Default Channel (channelName): stable
  I1219 16:20:07.061934 149298 runoncedurationoverride_util.go:177] Current CSV (startingCSV): runoncedurationoverrideoperator.v1.2.0
    STEP: Create namespace !!! @ 12/19/25 16:20:18.658
  I1219 16:20:19.851433 149298 runoncedurationoverride_util.go:140] err <nil>, msg namespace/openshift-run-once-duration-override-operator created
  I1219 16:20:21.561230 149298 runoncedurationoverride_util.go:142] err <nil>, msg namespace/openshift-run-once-duration-override-operator labeled
    STEP: Create operatorGroup !!! @ 12/19/25 16:20:21.561
  I1219 16:20:22.717689 149298 runoncedurationoverride_util.go:146] Created the operator-group yaml /tmp/e2e-test-rodo-operator-85jkb-s518w9tpog.json, <nil>
  I1219 16:20:25.067852 149298 runoncedurationoverride_util.go:148] err <nil>, msg operatorgroup.operators.coreos.com/openshift-run-once-duration-override-operator created
    STEP: Create subscription for above catalogsource !!! @ 12/19/25 16:20:25.067
  I1219 16:20:32.030749 149298 client.go:1086] Error running oc --kubeconfig=/home/ropatil/Downloads/kubeconfig get sub run-once-duration-override-operator -n openshift-run-once-duration-override-operator:
  StdOut>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found
  StdErr>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found

  I1219 16:20:42.137383 149298 client.go:1086] Error running oc --kubeconfig=/home/ropatil/Downloads/kubeconfig get sub run-once-duration-override-operator -n openshift-run-once-duration-override-operator:
  StdOut>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found
  StdErr>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found

  I1219 16:20:51.282448 149298 client.go:1086] Error running oc --kubeconfig=/home/ropatil/Downloads/kubeconfig get sub run-once-duration-override-operator -n openshift-run-once-duration-override-operator:
  StdOut>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found
  StdErr>
  Error from server (NotFound): subscriptions.operators.coreos.com "run-once-duration-override-operator" not found

  I1219 16:21:01.120972 149298 runoncedurationoverride_util.go:203] the file of resource is /tmp/e2e-test-rodo-operator-85jkb-kh6mrovuworkload-config.json
  subscription.operators.coreos.com/run-once-duration-override-operator created
  I1219 16:21:03.202942 149298 runoncedurationoverride_util.go:133] err <nil>
    STEP: Wait for the runOnceDurationOverride operator pod running @ 12/19/25 16:21:03.203
  I1219 16:21:24.807135 149298 runoncedurationoverride_util.go:252] object is up:
  1
  I1219 16:21:24.807246 149298 run_once_duration_operator.go:452] RunOnceDurationOverride operator runnnig now

    STEP: Check the .spec.relatedImages define correctly @ 12/19/25 16:21:24.807
  I1219 16:21:26.996795 149298 run_once_duration_operator.go:465] Found the correct related images
  subscription.operators.coreos.com "run-once-duration-override-operator" deleted
  operatorgroup.operators.coreos.com "openshift-run-once-duration-override-operator" deleted
  namespace "openshift-run-once-duration-override-operator" deleted
  I1219 16:21:58.938427 149298 client.go:681] Deleted {user.openshift.io/v1, Resource=users  e2e-test-rodo-operator-85jkb-user}, err: <nil>
  I1219 16:21:59.293532 149298 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-rodo-operator-85jkb}, err: <nil>
  I1219 16:21:59.634163 149298 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~SDB6oGEsXLvChFszl0D6OWvmRVtuvVbynKER5sDEAYc}, err: <nil>
    STEP: Destroying namespace "e2e-test-rodo-operator-85jkb" for this suite. @ 12/19/25 16:21:59.634
  • [132.348 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 132.348 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

/assign @gangwgr @wangke19 @zhouying7780 
/hold 
hold till the dependency PR: https://github.com/openshift/origin/pull/30596 gets merged