### PR TITLE
OCPEDGE-2303: update test logic for degraded cluster run

### DIFF
--- a/cmd/openshift-tests/openshift-tests.go
+++ b/cmd/openshift-tests/openshift-tests.go
@@ -63,8 +63,15 @@ func main() {
 		os.Unsetenv("ENABLE_STORAGE_GCE_PD_DRIVER")
 	}
 
+	// Detect intentionally degraded clusters (e.g. TNF degraded) based on
+	// CI-provided environment signals and propagate that context to extended tests
+	if os.Getenv("DEGRADED_NODE") == "true" {
+		exutil.ClusterDegraded = true
+		logrus.Infof("openshift-tests targeting intentionally degraded cluster")
+	}
+
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	//pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	// pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
 	extensionRegistry, originExtension, err := extensions.InitializeOpenShiftTestsExtensionFramework()
 	if err != nil {

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -327,7 +327,6 @@ func WaitForOpenShiftNamespaceImageStreams(oc *CLI) error {
 
 	// Check to see if SamplesOperator managementState is Removed
 	out, err := oc.AsAdmin().Run("get").Args("configs.samples.operator.openshift.io", "cluster", "-o", "yaml").Output()
-
 	if err != nil {
 		e2e.Logf("\n  error on getting samples operator CR: %+v\n%#v\n", err, out)
 	}
@@ -781,7 +780,7 @@ func VarSubOnFile(srcFile string, destFile string, vars map[string]string) error
 			k = "${" + k + "}"
 			srcString = strings.Replace(srcString, k, v, -1) // -1 means unlimited replacements
 		}
-		err = ioutil.WriteFile(destFile, []byte(srcString), 0644)
+		err = ioutil.WriteFile(destFile, []byte(srcString), 0o644)
 	}
 	return err
 }
@@ -1654,11 +1653,11 @@ func restoreFixtureAsset(dir, name string) error {
 	if err != nil {
 		return err
 	}
-	err = os.MkdirAll(assetFilePath(dir, filepath.Dir(name)), os.FileMode(0755))
+	err = os.MkdirAll(assetFilePath(dir, filepath.Dir(name)), os.FileMode(0o755))
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(assetFilePath(dir, name), data, 0640)
+	err = ioutil.WriteFile(assetFilePath(dir, name), data, 0o640)
 	if err != nil {
 		return err
 	}
@@ -1990,10 +1989,10 @@ type GitRepo struct {
 // AddAndCommit commits a file with its content to local repo
 func (r GitRepo) AddAndCommit(file, content string) error {
 	dir := filepath.Dir(file)
-	if err := os.MkdirAll(filepath.Join(r.RepoPath, dir), 0777); err != nil {
+	if err := os.MkdirAll(filepath.Join(r.RepoPath, dir), 0o777); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(r.RepoPath, file), []byte(content), 0666); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(r.RepoPath, file), []byte(content), 0o666); err != nil {
 		return err
 	}
 	if err := r.repo.Add(r.RepoPath, file); err != nil {
@@ -2346,6 +2345,8 @@ func IsTwoNodeFencing(ctx context.Context, configClient clientconfigv1.Interface
 
 	return infrastructure.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode
 }
+
+var ClusterDegraded bool
 
 func groupName(groupVersionName string) string {
 	return strings.Split(groupVersionName, "/")[0]


### PR DESCRIPTION
while working on Two Node Fencing in a degraded mode, i ran e2e tests and 3 of these cert tests failed:
<div class="table-wrap">

[sig-arch][Late][Jira:"kube-apiserver"] all registered tls artifacts must have no metadata violation regressions [Suite:openshift/conformance/parallel]
[sig-arch][Late][Jira:"kube-apiserver"] all tls artifacts must be registered [Suite:openshift/conformance/parallel]
[sig-arch][Late][Jira:"kube-apiserver"] collect certificate data [Suite:openshift/conformance/parallel]


</div>
<p>&nbsp;</p>

the lane that runs TNF in a degraded mode can be found in the config: 
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/release/openshift-release-master__nightly-4.22.yaml#L587

an example run in which these 3 failed: (the other failed tests in this run has been handled already - testing locally i receive same timeout error however applying this change resulted in a succeed run) 
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/72974/rehearse-72974-periodic-ci-openshift-release-master-nightly-4.22-e2e-metal-ovn-two-node-fencing-degraded-techpreview/2005532130192396288


the reason these 3 failed because in the before all section in this test we were targeting "all control plane nodes" without considering their state (ready/degraded) so a small adjustment fixed that // without modifying any other logic in these tests