### PR TITLE
update operator-lifecycle-manager-packageserver exception

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -820,7 +820,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 			}
 		case "operator-lifecycle-manager-packageserver":
 			if reason == "" {
-				return "https://issues.redhat.com/browse/OCPBUGS-63672"
+				return "https://issues.redhat.com/browse/OCPBUGS-67210"
 			}
 		}
 		return ""


### PR DESCRIPTION
As the title shows, details: https://issues.redhat.com/browse/OCPBUGS-63672 