### PR TITLE
CNTRLPLANE-2167:Add oc-tests-ext to extension binaries

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -263,6 +263,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-node-tuning-operator",
 		binaryPath: "/usr/bin/cluster-node-tuning-operator-test-ext.gz",
 	},
+	{
+		imageTag:   "cli",
+		binaryPath: "/usr/bin/oc-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Add support for extracting and running oc-tests-ext from the cli image in the release payload.

Changes:
- Add cli image tag to extensionBinaries list
- Configure binary path as /usr/bin/oc-tests-ext.gz

This enables the test framework to automatically:
- Extract oc-tests-ext binary from the cli-tests image
- Decompress and execute extension tests
- Integrate oc CLI tests with the OpenShift test suite

The cli image keeps the test binary separate from the main CLI product image, avoiding size bloat while making tests available for CI.