### PR TITLE
OCPBUGS-65674: VsphereConfigurationTestsRollOutTooOften event matcher should use broader regex

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1024,8 +1024,8 @@ func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals moni
 			locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
 				monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
 			},
-			messageReasonRegex: regexp.MustCompile(`(^SuccessfulCreate$|^SuccessfulDelete$|^DeploymentUpdated$|^DaemonSetUpdated$)`),
-			messageHumanRegex:  regexp.MustCompile(`(Created pod.*vmware-vsphere-csi-driver.*|Deleted pod.*vmware-vsphere-csi-driver.*|Updated (Deployment|DaemonSet)\.apps/vmware-vsphere-csi-driver.*)`),
+			messageReasonRegex: regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
+			messageHumanRegex:  regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
 			jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
 		},
 		allowIfWithinIntervals: configurationTestIntervals,


### PR DESCRIPTION
This is a followup to https://github.com/openshift/origin/pull/30547 - we need to match secret related events now. The regex used here should be broad enough to prevent hitting these failures in CI.