### PR TITLE
OCPNODE-3944: Create e2e automation in origin for case OCP-84149

### DIFF
--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -286,6 +286,8 @@ func getKubeletMetrics(ctx context.Context, oc *exutil.CLI, nodeName string) (st
 }
 
 // parseMetricValue parses a Prometheus metric value from metrics output
+// it returns (value, true) when it finds expected metricName, and value is x in example 'kubelet_image_volume_requested_total x'
+// it returns (0, false) when it can't find expected metricName
 func parseMetricValue(metrics, metricName string) (int, bool) {
 	// Look for lines like: kubelet_image_volume_requested_total 1
 	// Skip HELP and TYPE lines


### PR DESCRIPTION
Add automation case: ImageVolume should report kubelet image volume metrics correctly. 
Case link: [OCP-84149](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-84149)
Jira: https://issues.redhat.com/browse/OCPNODE-3944 

- The case tested passed locally, and the log as below: 

- ./openshift-tests run-test  "[sig-node] [FeatureGate:ImageVolume] ImageVolume should report kubelet image volume metrics correctly [OCP-84149] [Suite:openshift/conformance/parallel]"

...
  Running Suite:  - /home/lyman/workspace/origin
..................................................
  Random Seed: 1767788049 - will randomize all specs

  Will run 1 of 1 specs
..................................................
  [sig-node] [FeatureGate:ImageVolume] ImageVolume should report kubelet image volume metrics correctly [OCP-84149]
  github.com/openshift/origin/test/extended/node/image_volume.go:94
    STEP: Creating a kubernetes client @ 01/07/26 07:14:10.336
  I0107 07:14:10.337720   12987 discovery.go:214] Invalidating discovery information
    STEP: Building a namespace api object, basename image-volume @ 01/07/26 07:14:10.337
    STEP: Waiting for a default service account to be provisioned in namespace @ 01/07/26 07:14:10.455
    STEP: Waiting for kube-root-ca.crt to be provisioned in namespace @ 01/07/26 07:14:10.53
  I0107 07:14:10.727310 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.767256 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.807302 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.848144 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.888409 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.928265 12987 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0107 07:14:10.928437 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-9-74.us-east-2.compute.internal
  I0107 07:14:10.928483 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-54-90.us-east-2.compute.internal
    STEP: Creating a kubernetes client @ 01/07/26 07:14:10.928
  I0107 07:14:10.928635 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-47-138.us-east-2.compute.internal
  I0107 07:14:10.928652 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-71-4.us-east-2.compute.internal
  I0107 07:14:10.928666 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-76-158.us-east-2.compute.internal
  I0107 07:14:10.929497   12987 discovery.go:214] Invalidating discovery information
  I0107 07:14:11.039582 12987 resource_usage_gatherer.go:340] Closing worker for ip-10-0-25-179.us-east-2.compute.internal
  I0107 07:14:11.471038 12987 client.go:293] configPath is now "/tmp/configfile2535694360"
  I0107 07:14:11.471076 12987 client.go:368] The user is now "e2e-test-image-volume-5lcg9-user"
  I0107 07:14:11.471089 12987 client.go:370] Creating project "e2e-test-image-volume-5lcg9"
  I0107 07:14:11.573913 12987 client.go:378] Waiting on permissions in project "e2e-test-image-volume-5lcg9" ...
  I0107 07:14:11.738371 12987 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0107 07:14:11.779957 12987 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0107 07:14:11.961556 12987 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0107 07:14:12.143502 12987 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0107 07:14:12.325313 12987 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0107 07:14:12.400533 12987 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0107 07:14:12.475249 12987 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0107 07:14:12.840445 12987 client.go:465] Project "e2e-test-image-volume-5lcg9" has been fully provisioned.
  I0107 07:14:12.881162 12987 framework.go:2334] microshift-version configmap not found
    STEP: Creating a pod with OCI image as volume source @ 01/07/26 07:14:12.881
    STEP: Creating a pod @ 01/07/26 07:14:12.881
    STEP: Waiting for pod to be running @ 01/07/26 07:14:12.952
    STEP: Verifying image volume is mounted into the container @ 01/07/26 07:14:15.075
    STEP: Checking if volume is mounted at /mnt/image @ 01/07/26 07:14:15.075
  I0107 07:14:15.075364 12987 exec_util.go:63] ExecWithOptions {Command:[ls -la /mnt/image] Namespace:e2e-image-volume-6771 PodName:image-volume-metrics-test ContainerName:test-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I0107 07:14:15.075399 12987 exec_util.go:68] ExecWithOptions: Clientset creation
  I0107 07:14:15.075453 12987 exec_util.go:84] ExecWithOptions: execute(https://api.akoudelk.qe.devcluster.openshift.com:6443/api/v1/namespaces/e2e-image-volume-6771/pods/image-volume-metrics-test/exec?command=ls&command=-la&command=%2Fmnt%2Fimage&container=test-container&stderr=true&stdout=true)
  I0107 07:14:15.212564 12987 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:15.212637   12987 fallback.go:56] RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:15.472280 12987 exec_util.go:112] Exec stderr: ""
  I0107 07:14:15.472347 12987 image_volume.go:248] Files in /mnt/image:
  total 4
  dr-xr-xr-x. 1 root root  29 Jan  7 09:37 .
  drwxr-xr-x. 1 root root  19 Jan  7 12:58 ..
  drwxr-xr-x. 2 1000 users 18 Jun 18  2024 dir
  -rw-r--r--. 1 1000 users  2 Jun 18  2024 file
  I0107 07:14:15.472402 12987 exec_util.go:63] ExecWithOptions {Command:[ls /mnt/image/file] Namespace:e2e-image-volume-6771 PodName:image-volume-metrics-test ContainerName:test-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I0107 07:14:15.472415 12987 exec_util.go:68] ExecWithOptions: Clientset creation
  I0107 07:14:15.472471 12987 exec_util.go:84] ExecWithOptions: execute(https://api.akoudelk.qe.devcluster.openshift.com:6443/api/v1/namespaces/e2e-image-volume-6771/pods/image-volume-metrics-test/exec?command=ls&command=%2Fmnt%2Fimage%2Ffile&container=test-container&stderr=true&stdout=true)
  I0107 07:14:15.610023 12987 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:15.610078   12987 fallback.go:56] RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:15.862936 12987 exec_util.go:112] Exec stderr: ""
  I0107 07:14:15.863010 12987 exec_util.go:63] ExecWithOptions {Command:[cat /mnt/image/file] Namespace:e2e-image-volume-6771 PodName:image-volume-metrics-test ContainerName:test-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I0107 07:14:15.863025 12987 exec_util.go:68] ExecWithOptions: Clientset creation
  I0107 07:14:15.863086 12987 exec_util.go:84] ExecWithOptions: execute(https://api.akoudelk.qe.devcluster.openshift.com:6443/api/v1/namespaces/e2e-image-volume-6771/pods/image-volume-metrics-test/exec?command=cat&command=%2Fmnt%2Fimage%2Ffile&container=test-container&stderr=true&stdout=true)
  I0107 07:14:15.996159 12987 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:15.996211   12987 fallback.go:56] RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:16.244208 12987 exec_util.go:112] Exec stderr: ""
  I0107 07:14:16.244263 12987 image_volume.go:259] File content verified: 2
    STEP: Verifying the mounted volume is read-only @ 01/07/26 07:14:16.244
    STEP: Verifying the volume is mounted as read-only @ 01/07/26 07:14:16.244
  I0107 07:14:16.244347 12987 exec_util.go:63] ExecWithOptions {Command:[mount] Namespace:e2e-image-volume-6771 PodName:image-volume-metrics-test ContainerName:test-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I0107 07:14:16.244360 12987 exec_util.go:68] ExecWithOptions: Clientset creation
  I0107 07:14:16.244426 12987 exec_util.go:84] ExecWithOptions: execute(https://api.akoudelk.qe.devcluster.openshift.com:6443/api/v1/namespaces/e2e-image-volume-6771/pods/image-volume-metrics-test/exec?command=mount&container=test-container&stderr=true&stdout=true)
  I0107 07:14:16.378166 12987 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:16.378220   12987 fallback.go:56] RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:16.626228 12987 exec_util.go:112] Exec stderr: ""
  I0107 07:14:16.626340 12987 image_volume.go:277] Mount info: overlay on /mnt/image type overlay (ro,relatime,context="system_u:object_r:container_file_t:s0:c528,c553",lowerdir=/var/lib/containers/storage/overlay/82099f56ba7822d8408ac8517b90bde2aa036ac32ee2dd3db810348302edd618/merged:/var/run/crio/image-volumes)
    STEP: Attempting to write to the read-only volume (should fail) @ 01/07/26 07:14:16.626
  I0107 07:14:16.626420 12987 exec_util.go:63] ExecWithOptions {Command:[touch /mnt/image/testfile] Namespace:e2e-image-volume-6771 PodName:image-volume-metrics-test ContainerName:test-container Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:false Quiet:false}
  I0107 07:14:16.626450 12987 exec_util.go:68] ExecWithOptions: Clientset creation
  I0107 07:14:16.626522 12987 exec_util.go:84] ExecWithOptions: execute(https://api.akoudelk.qe.devcluster.openshift.com:6443/api/v1/namespaces/e2e-image-volume-6771/pods/image-volume-metrics-test/exec?command=touch&command=%2Fmnt%2Fimage%2Ftestfile&container=test-container&stderr=true&stdout=true)
  I0107 07:14:16.755066 12987 exec_util.go:198] fallback to secondary dialer from primary dialer err: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:16.755119   12987 fallback.go:56] RemoteCommand fallback: unable to upgrade streaming request: websocket: bad handshake (403 Forbidden)
  I0107 07:14:17.006332 12987 image_volume.go:287] Write attempt correctly failed (volume is read-only)
    STEP: Checking kubelet metrics for image volume @ 01/07/26 07:14:17.006
    STEP: Verifying kubelet_image_volume_requested_total metric @ 01/07/26 07:14:17.097
  I0107 07:14:17.098135 12987 image_volume.go:122] kubelet_image_volume_requested_total: 3
    STEP: Verifying kubelet_image_volume_mounted_succeed_total metric @ 01/07/26 07:14:17.098
  I0107 07:14:17.098318 12987 image_volume.go:128] kubelet_image_volume_mounted_succeed_total: 3
    STEP: Verifying kubelet_image_volume_mounted_errors_total metric @ 01/07/26 07:14:17.098
  I0107 07:14:17.098484 12987 image_volume.go:134] kubelet_image_volume_mounted_errors_total: 0
  I0107 07:14:17.098494 12987 image_volume.go:136] All image volume metrics are reporting correctly
  I0107 07:14:17.145763 12987 client.go:681] Deleted {user.openshift.io/v1, Resource=users  e2e-test-image-volume-5lcg9-user}, err: <nil>
  I0107 07:14:17.193522 12987 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-image-volume-5lcg9}, err: <nil>
  I0107 07:14:17.238118 12987 client.go:681] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~wcCo0yPR-DNHSgFmTYDg7KAm_btVu6U5dwUpbrk2d9A}, err: <nil>
    STEP: Destroying namespace "e2e-test-image-volume-5lcg9" for this suite. @ 01/07/26 07:14:17.238
    STEP: Collecting resource usage data @ 01/07/26 07:14:17.284
  I0107 07:14:17.284084 12987 resource_usage_gatherer.go:512] Closed stop channel. Waiting for 6 workers
  I0107 07:14:17.284118 12987 resource_usage_gatherer.go:520] Waitgroup finished.
  I0107 07:14:17.284212 12987 framework.go:310] Printing summary: ResourceUsageSummary
  I0107 07:14:17.284313 12987 framework.go:329] ResourceUsageSummary JSON
  {}
  I0107 07:14:17.284331 12987 framework.go:330] Finished
    STEP: Destroying namespace "e2e-image-volume-6771" for this suite. @ 01/07/26 07:14:17.284
  • [7.002 seconds]
...........................................................
  Ran 1 of 1 Specs in 7.002 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped