### PR TITLE
NO-JIRA: correct issues found while rebasing bump(api,client-go)

### DIFF
--- a/test/e2e/upgrade/monitor.go
+++ b/test/e2e/upgrade/monitor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -39,7 +38,12 @@ func (m *versionMonitor) Check(initialGeneration int64, desired configv1.Update)
 	m.lastCV = cv
 
 	if cv.Status.ObservedGeneration > initialGeneration {
-		if cv.Spec.DesiredUpdate == nil || !reflect.DeepEqual(desired, *cv.Spec.DesiredUpdate) {
+		// configv1.Update is not directly comparable (e.g., ==), so compare
+		// only the fields that identify the update target.
+		if cv.Spec.DesiredUpdate == nil ||
+			desired.Architecture != cv.Spec.DesiredUpdate.Architecture ||
+			desired.Version != cv.Spec.DesiredUpdate.Version ||
+			desired.Image != cv.Spec.DesiredUpdate.Image {
 			return nil, "", fmt.Errorf("desired cluster version was changed by someone else: %v", cv.Spec.DesiredUpdate)
 		}
 	}

--- a/test/extended/util/configv1shim.go
+++ b/test/extended/util/configv1shim.go
@@ -294,8 +294,8 @@ type ConfigV1ClientShim struct {
 }
 
 func (c *ConfigV1ClientShim) InsightsDataGathers() configv1.InsightsDataGatherInterface {
-	if c.v1Kinds["APIServer"] {
-		panic(fmt.Errorf("APIServer not implemented"))
+	if c.v1Kinds["InsightsDataGather"] {
+		panic(fmt.Errorf("InsightsDataGather not implemented"))
 	}
 	return c.configv1.InsightsDataGathers()
 }


### PR DESCRIPTION
## Summary

While rebasing the `bump(api,client-go)` PR, I noticed a couple of discrepancies that needed fixing:

- **test/e2e/upgrade/monitor.go:** `configv1.Update` is no longer directly comparable (e.g., `==` or `reflect.DeepEqual`) after the API bump. Replaced `reflect.DeepEqual` with field-by-field comparison of the fields that identify the update target (`Architecture`, `Version`, `Image`).
- **test/extended/util/configv1shim.go:** `InsightsDataGathers()` was incorrectly checking `c.v1Kinds["APIServer"]` and panicking with an `"APIServer not implemented"` message. Corrected both to reference `"InsightsDataGather"`.