### PR TITLE
OCPBUGS-72547: Isolate and reduce parallelism for OrderedNamespaceDeletion tests.

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -516,6 +516,10 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		return strings.Contains(t.name, "[sig-network]")
 	})
 
+	orderedNamespaceDeletionTests, kubeTests := splitTests(kubeTests, func(t *testCase) bool {
+		return strings.Contains(t.name, "OrderedNamespaceDeletion")
+	})
+
 	networkTests, openshiftTests := splitTests(openshiftTests, func(t *testCase) bool {
 		return strings.Contains(t.name, "[sig-network]")
 	})
@@ -537,6 +541,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 	logrus.Infof("Found %d kubernetes tests", len(kubeTests))
 	logrus.Infof("Found %d storage tests", len(storageTests))
 	logrus.Infof("Found %d network k8s tests", len(networkK8sTests))
+	logrus.Infof("Found %d ordered namespace deletion k8s tests", len(orderedNamespaceDeletionTests))
 	logrus.Infof("Found %d network tests", len(networkTests))
 	logrus.Infof("Found %d netpol tests", len(netpolTests))
 	logrus.Infof("Found %d builds tests", len(buildsTests))
@@ -549,6 +554,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		originalOpenshift := openshiftTests
 		originalStorage := storageTests
 		originalNetworkK8s := networkK8sTests
+		originalOrderedNamespaceDeletionTests := orderedNamespaceDeletionTests
 		originalNetwork := networkTests
 		originalNetpol := netpolTests
 		originalBuilds := buildsTests
@@ -559,13 +565,14 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 			openshiftTests = append(openshiftTests, copyTests(originalOpenshift)...)
 			storageTests = append(storageTests, copyTests(originalStorage)...)
 			networkK8sTests = append(networkK8sTests, copyTests(originalNetworkK8s)...)
+			orderedNamespaceDeletionTests = append(orderedNamespaceDeletionTests, copyTests(originalOrderedNamespaceDeletionTests)...)
 			networkTests = append(networkTests, copyTests(originalNetwork)...)
 			netpolTests = append(netpolTests, copyTests(originalNetpol)...)
 			buildsTests = append(buildsTests, copyTests(originalBuilds)...)
 			mustGatherTests = append(mustGatherTests, copyTests(originalMustGather)...)
 		}
 	}
-	expectedTestCount += len(openshiftTests) + len(kubeTests) + len(storageTests) + len(networkK8sTests) + len(networkTests) + len(netpolTests) + len(buildsTests) + len(mustGatherTests)
+	expectedTestCount += len(openshiftTests) + len(kubeTests) + len(storageTests) + len(networkK8sTests) + len(orderedNamespaceDeletionTests) + len(networkTests) + len(netpolTests) + len(buildsTests) + len(mustGatherTests)
 
 	abortFn := neverAbort
 	testCtx := ctx
@@ -611,6 +618,13 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		monitorEventRecorder.EndInterval(networkK8sIntervalID, time.Now())
 		logrus.Infof("Completed NetworkK8s test bucket in %v", time.Since(networkK8sStartTime))
 		tests = append(tests, networkK8sTestsCopy...)
+
+		orderedNamespaceDeletionTestsCopy := copyTests(orderedNamespaceDeletionTests)
+		orderedNamespaceDeletionIntervalID, orderedNamespaceDeletionStartTime := recordTestBucketInterval(monitorEventRecorder, "OrderedNamespaceDeletion")
+		q.Execute(testCtx, orderedNamespaceDeletionTestsCopy, 1, testOutputConfig, abortFn) // Run ordered namespace deletion tests one at a time. They are sensitive to backlogs in the namespace controller's workqueue that have been observed during high test paralellism as many ephemeral test namespaces are being finalized concurrently.
+		monitorEventRecorder.EndInterval(orderedNamespaceDeletionIntervalID, time.Now())
+		logrus.Infof("Completed OrderedNamespaceDeletion test bucket in %v", time.Since(orderedNamespaceDeletionStartTime))
+		tests = append(tests, orderedNamespaceDeletionTestsCopy...)
 
 		networkTestsCopy := copyTests(networkTests)
 		networkIntervalID, networkStartTime := recordTestBucketInterval(monitorEventRecorder, "Network")


### PR DESCRIPTION
These tests directly exercise the namespace controller (in kube-controller-manager), which can fall behind due to a combination of master node CPU saturation and the ephemeral namespace churn generated during parallel E2E runs. We observe flakes (timeouts) when this occurs. The tests are sensitive to CPU saturation, but not causing CPU saturation, so the goal of this change is to improve the CI signal until such time as the incidence of CPU saturation events in CI is reduced.

With this change, it passes 10/10 on the 4.21 job that was the basis of the related component readiness issue (https://issues.redhat.com/browse/OCPBUGS-67016): https://github.com/openshift/origin/pull/30661#issuecomment-3721060786.