### PR TITLE
[release-4.15] Fix bearer token exposure in exit condition as well

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -909,7 +909,7 @@ func (c *CLI) start(stdOutBuff, stdErrBuff *bytes.Buffer) (*exec.Cmd, error) {
 	cmd := exec.Command(c.execPath, c.finalArgs...)
 	cmd.Stdin = c.stdin
 	// Redact any bearer token information from the log.
-	framework.Logf("Running '%s %s'", c.execPath, redactBearerToken(c.finalArgs))
+	framework.Logf("Running '%s %s'", c.execPath, RedactBearerToken(strings.Join(c.finalArgs, " ")))
 	cmd.Stdout = stdOutBuff
 	cmd.Stderr = stdErrBuff
 	err := cmd.Start()
@@ -917,8 +917,7 @@ func (c *CLI) start(stdOutBuff, stdErrBuff *bytes.Buffer) (*exec.Cmd, error) {
 	return cmd, err
 }
 
-func redactBearerToken(finalArgs []string) string {
-	args := strings.Join(finalArgs, " ")
+func RedactBearerToken(args string) string {
 	if strings.Contains(args, "Authorization: Bearer") {
 		// redact bearer token
 		re := regexp.MustCompile(`Authorization:\s+Bearer.*\s+`)
@@ -956,8 +955,8 @@ func (c *CLI) outputs(stdOutBuff, stdErrBuff *bytes.Buffer) (string, string, err
 		c.stderr = bytes.NewBuffer(stdErrBytes)
 		return stdOut, stdErr, nil
 	case *exec.ExitError:
-		framework.Logf("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n", cmd, stdOut, stdErr)
-		wrappedErr := fmt.Errorf("Error running %v:\nStdOut>\n%s\nStdErr>\n%s\n%w\n", cmd, stdOut[getStartingIndexForLastN(stdOutBytes, 4096):], stdErr[getStartingIndexForLastN(stdErrBytes, 4096):], err)
+		framework.Logf("Error running %s %s:\nStdOut>\n%s\nStdErr>\n%s\n", c.execPath, RedactBearerToken(strings.Join(c.finalArgs, " ")), stdOut, stdErr)
+		wrappedErr := fmt.Errorf("Error running %s %s:\nStdOut>\n%s\nStdErr>\n%s\n%w\n", c.execPath, RedactBearerToken(strings.Join(c.finalArgs, " ")), stdOut[getStartingIndexForLastN(stdOutBytes, 4096):], stdErr[getStartingIndexForLastN(stdErrBytes, 4096):], err)
 		return stdOut, stdErr, wrappedErr
 	default:
 		FatalErr(fmt.Errorf("unable to execute %q: %v", c.execPath, err))

--- a/test/extended/util/prometheus/helpers.go
+++ b/test/extended/util/prometheus/helpers.go
@@ -435,7 +435,7 @@ func GetBearerTokenURLViaPod(oc *exutil.CLI, execPodName, url, bearer string) (s
 	auth := fmt.Sprintf("Authorization: Bearer %s", bearer)
 	stdout, stderr, err := oc.AsAdmin().Run("exec").Args(execPodName, "--", "curl", "-s", "-k", "-H", auth, url).Outputs()
 	if err != nil {
-		return "", fmt.Errorf("command failed: %v\nstderr: %s\nstdout:%s", err, stderr, stdout)
+	   return "", fmt.Errorf("command failed: %v\nstderr: %s\nstdout:%s", exutil.RedactBearerToken(err.Error()), exutil.RedactBearerToken(stderr), exutil.RedactBearerToken(stdout))
 	}
 	// Terminate stdout with a newline to avoid an unexpected end of stream error.
 	if len(stdout) > 0 {


### PR DESCRIPTION
 Fix bearer token exposure in exit condition as well
 Updated client.go and helpers.go files