### PR TITLE
NO-JIRA: Remove exceptions for storage operators

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -769,10 +769,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 			if reason == "SyncLoopRefresh_InProgress" {
 				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
-		case "csi-snapshot-controller":
-			if reason == "CSISnapshotController_Deploying" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62624"
-			}
 		case "dns":
 			if reason == "DNSReportsProgressingIsTrue" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62623"
@@ -806,16 +802,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals)
 		case "service-ca":
 			if reason == "_ManagedDeploymentsAvailable" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62633"
-			}
-		case "storage":
-			// GCPPDCSIDriverOperatorCR_GCPPDDriverControllerServiceController_Deploying
-			// GCPPDCSIDriverOperatorCR_GCPPDDriverNodeServiceController_Deploying
-			// AWSEBSCSIDriverOperatorCR_AWSEBSDriverNodeServiceController_Deploying
-			// VolumeDataSourceValidatorDeploymentController_Deploying
-			// GCPPD_Deploying
-			// AWSEBS_Deploying
-			if strings.HasSuffix(reason, "_Deploying") {
-				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			}
 		case "olm":
 			// CatalogdDeploymentCatalogdControllerManager_Deploying


### PR DESCRIPTION
storage and csi-snapshot-controller should report Available, Progressing and Degraded correctly on standard highly-available clusters.

They can go Available=false on SNO.