### PR TITLE
NO-JIRA: Fix Pod.Create() to use --local flag for template processing

### DIFF
--- a/test/extended/util/compat_otp/pods.go
+++ b/test/extended/util/compat_otp/pods.go
@@ -152,7 +152,9 @@ type Pod struct {
 // The pod name parameter must be NAME in the template file
 func (pod *Pod) Create(oc *exutil.CLI) {
 	e2e.Logf("Creating pod: %s", pod.Name)
-	params := []string{"--ignore-unknown-parameters=true", "-f", pod.Template, "-p", "NAME=" + pod.Name}
+	// Use --local to process template locally, avoiding kubeconfig context namespace pollution
+	// from other tests that may have changed the current context to a different/non-existent namespace
+	params := []string{"--local", "--ignore-unknown-parameters=true", "-f", pod.Template, "-p", "NAME=" + pod.Name}
 	CreateNsResourceFromTemplate(oc, pod.Namespace, append(params, pod.Parameters...)...)
 	AssertPodToBeReady(oc, pod.Name, pod.Namespace)
 }


### PR DESCRIPTION
## Summary

Fix `compat_otp.Pod.Create()` to use `--local` flag when processing pod templates to avoid kubeconfig context namespace pollution from other tests.

## Problem

When multiple tests run in sequence (especially in Prow rehearsal jobs), a test may change the kubeconfig's current context to a different namespace. The `oc process` command validates namespace existence using the kubeconfig context **BEFORE** processing template parameters, causing failures when:

1. Previous test sets context to namespace N1
2. Namespace N1 gets deleted after that test completes  
3. Current test calls `Pod.Create()` with namespace N2
4. `oc process` tries to validate N1 (from kubeconfig context)
5. Validation fails because N1 no longer exists

Example error from OCP-10662 test:
```
Error running oc process ... -p NAMESPACE=e2e-test-default-bhtjm:
error: unable to process template
  namespaces "e2e-test-olm-all-o9bvjlxg-7qwkb" not found
```

## Root Cause

The `oc process` command:
- Does NOT support `-n/--namespace` flag to override the context
- Always uses the kubeconfig's current-context namespace for validation
- Validates namespace existence BEFORE substituting template parameters
- Ignores the `NAMESPACE` template parameter during validation

## Solution

Use the `--local` flag for `oc process`, which:
- Processes templates client-side without contacting the API server
- Eliminates namespace validation and kubeconfig context dependency
- Produces identical output to server-side processing for simple templates

## Why This Is Safe

* Only 5 tests use `compat_otp.Pod` (verified with grep)
* All pod templates use basic parameter substitution (no server-side features)
* Local processing produces identical output to server-side (verified with diff)
* Tested with the actual failing template - works correctly

## Testing

Tested with the failing template from OCP-10662:

```bash
# Without --local (fails with wrong kubeconfig context)
oc config set-context --current --namespace=nonexistent-namespace-12345
oc process -f pod-scc-runAsUser.yaml -p NAMESPACE=test-namespace
# Error: namespaces "nonexistent-namespace-12345" not found

# With --local (works regardless of context)
oc process --local -f pod-scc-runAsUser.yaml -p NAMESPACE=test-namespace
# Success - template processed correctly
```

## Impact

* Fixes OCP-10662 test failure in rehearsal jobs
* Prevents future kubeconfig pollution issues for pod creation
* No functional changes to existing tests (output identical)
* Low risk (only affects 5 tests using compat_otp.Pod)

## Related

* Failing Prow job: https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/pr-logs/pull/openshift_release/70890/rehearse-70890-periodic-ci-openshift-verification-tests-main-installer-rehearse-4.21-installer-rehearse-azure/2010891707532447744
* openshift-tests-private PR [#28621](https://github.com/openshift/openshift-tests-private/pull/28621) (attempted fix that didn't work due to this issue)
* Related jira story [OCPERT-289](https://issues.redhat.com/browse/OCPERT-289)