### PR TITLE
OCPBUGS-78063: Allow test to tolerate running on minimal images

### DIFF
--- a/test/extended/testdata/signer-buildconfig.yaml
+++ b/test/extended/testdata/signer-buildconfig.yaml
@@ -18,13 +18,17 @@ items:
       dockerfile: |
         FROM quay.io/openshift/origin-cli:latest
         WORKDIR /var/lib/origin
+        ENV ART_DNF_WRAPPER_POLICY=skip
         RUN source /etc/os-release \
             && rhel_major=${VERSION_ID%.*} \
-            && yum config-manager \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
-            --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/"
-        RUN yum install -y skopeo && \
-            yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
+            && if ! yum install -y skopeo; then \
+                echo "Unable to install skopeo; adding UBI repositories and retrying" && \
+                yum config-manager \
+                --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/baseos/os/" \
+                --add-repo "https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi${rhel_major}/${rhel_major}/\$basearch/appstream/os/" && \
+                yum install -y skopeo ; \
+              fi  
+        RUN yum clean all && mkdir -p gnupg && chmod -R 0777 /var/lib/origin
         RUN echo $'%echo Generating openpgp key ...\n\
             Key-Type: RSA \n\
             Key-Length: 2048 \n\


### PR DESCRIPTION
minimal images provide microdnf instead of dnf/yum. ART attempts to insulate most images from this change by providing a thin wrapper around dnf/yum. However, microdnf fundamentally lacks some features.
config-manager is an example that is currently unsupported. In the case of ubi minimal, it should not be necessary to use config-manager to install ubi repositories, so instead of assuming it is necessary, it is only attempted after an attempt to install skopeo fails.
ART_DNF_WRAPPER_POLICY=skip is a subtle change which prevents the CI variant of cli image from trying to detect and install repositories suitable to provide access to RPMs not typically available to UBI.