### PR TITLE
NO-JIRA: Remove exceptions for NTO

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -776,10 +776,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "Deploying" || reason == "MachineConfig" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			}
-		case "node-tuning":
-			if reason == "Reconciling" || reason == "ProfileProgressing" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved
 			// RouteControllerManager_DesiredStateNotYetAchieved

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -247,8 +247,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
-			case "node-tuning":
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			case "storage":
 				return "https://issues.redhat.com/browse/OCPBUGS-62633"
 			default:


### PR DESCRIPTION
NTO should now correctly report ClusterOperator status conditions Available, Progressing and Degraded.  See: OCPBUGS-62632