### PR TITLE
Remove the exception OCPBUGS-62634 for co/storage in cluster-scaling test

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -249,8 +249,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -250,7 +250,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62633"
+				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}


### PR DESCRIPTION
62633 is for co/service-ca and the correct one is 62634 which is fixed.

It should be removed with https://github.com/openshift/origin/pull/30677 but did not up to the above mistable.