### PR TITLE
NO-ISSUE: Update boot image manifests for skew API

### DIFF
--- a/test/extended/machine_config/boot_image_update_aws.go
+++ b/test/extended/machine_config/boot_image_update_aws.go
@@ -18,6 +18,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
 		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
 		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		skewEnforcementDisabledFixture = filepath.Join(MCOMachineConfigurationBaseDir, "skewenforcement-disabled.yaml")
 		emptyMachineSetFixture         = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
@@ -29,6 +30,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImagesAWS][Serial]", fun
 		skipUnlessFunctionalMachineAPI(oc)
 		//skip this test on single node platforms
 		skipOnSingleNodeTopology(oc)
+		// Disable boot image skew enforcement
+		ApplyMachineConfigurationFixture(oc, skewEnforcementDisabledFixture)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/machine_config/boot_image_update_gcp.go
+++ b/test/extended/machine_config/boot_image_update_gcp.go
@@ -18,6 +18,7 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 		partialMachineSetFixture       = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-partial.yaml")
 		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
 		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
+		skewEnforcementDisabledFixture = filepath.Join(MCOMachineConfigurationBaseDir, "skewenforcement-disabled.yaml")
 		emptyMachineSetFixture         = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
@@ -29,6 +30,8 @@ var _ = g.Describe("[sig-mco][OCPFeatureGate:ManagedBootImages][Serial]", func()
 		skipUnlessFunctionalMachineAPI(oc)
 		//skip this test on single node platforms
 		skipOnSingleNodeTopology(oc)
+		// Disable boot image skew enforcement
+		ApplyMachineConfigurationFixture(oc, skewEnforcementDisabledFixture)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/machine_config/boot_image_update_vsphere.go
+++ b/test/extended/machine_config/boot_image_update_vsphere.go
@@ -19,6 +19,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		allMachineSetFixture           = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-all.yaml")
 		noneMachineSetFixture          = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-none.yaml")
 		emptyMachineSetFixture         = filepath.Join(MCOMachineConfigurationBaseDir, "managedbootimages-empty.yaml")
+		skewEnforcementDisabledFixture = filepath.Join(MCOMachineConfigurationBaseDir, "skewenforcement-disabled.yaml")
 		oc                             = exutil.NewCLIWithoutNamespace("machine-config")
 	)
 
@@ -29,6 +30,8 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 		skipUnlessFunctionalMachineAPI(oc)
 		//skip this test on single node platforms
 		skipOnSingleNodeTopology(oc)
+		// Disable boot image skew enforcement
+		ApplyMachineConfigurationFixture(oc, skewEnforcementDisabledFixture)
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -430,6 +430,7 @@
 // test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml
 // test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml
 // test/extended/testdata/machine_config/machineconfigurations/nodedisruptionpolicy-rebootless-path.yaml
+// test/extended/testdata/machine_config/machineconfigurations/skewenforcement-disabled.yaml
 // test/extended/testdata/machine_config/pinnedimage/customGCMCPpis.yaml
 // test/extended/testdata/machine_config/pinnedimage/customInvalidPis.yaml
 // test/extended/testdata/machine_config/pinnedimage/customMCPpis.yaml
@@ -49367,6 +49368,33 @@ func testExtendedTestdataMachine_configMachineconfigurationsNodedisruptionpolicy
 	return a, nil
 }
 
+var _testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYaml = []byte(`apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  bootImageSkewEnforcement:
+    mode: None          
+`)
+
+func testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYaml, nil
+}
+
+func testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/machine_config/machineconfigurations/skewenforcement-disabled.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataMachine_configPinnedimageCustomgcmcppisYaml = []byte(`apiVersion: machineconfiguration.openshift.io/v1
 kind: PinnedImageSet
 metadata:
@@ -56712,6 +56740,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-none.yaml":                testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml,
 	"test/extended/testdata/machine_config/machineconfigurations/managedbootimages-partial.yaml":             testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml,
 	"test/extended/testdata/machine_config/machineconfigurations/nodedisruptionpolicy-rebootless-path.yaml":  testExtendedTestdataMachine_configMachineconfigurationsNodedisruptionpolicyRebootlessPathYaml,
+	"test/extended/testdata/machine_config/machineconfigurations/skewenforcement-disabled.yaml":              testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYaml,
 	"test/extended/testdata/machine_config/pinnedimage/customGCMCPpis.yaml":                                  testExtendedTestdataMachine_configPinnedimageCustomgcmcppisYaml,
 	"test/extended/testdata/machine_config/pinnedimage/customInvalidPis.yaml":                                testExtendedTestdataMachine_configPinnedimageCustominvalidpisYaml,
 	"test/extended/testdata/machine_config/pinnedimage/customMCPpis.yaml":                                    testExtendedTestdataMachine_configPinnedimageCustommcppisYaml,
@@ -57488,6 +57517,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"managedbootimages-none.yaml":               {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesNoneYaml, map[string]*bintree{}},
 						"managedbootimages-partial.yaml":            {testExtendedTestdataMachine_configMachineconfigurationsManagedbootimagesPartialYaml, map[string]*bintree{}},
 						"nodedisruptionpolicy-rebootless-path.yaml": {testExtendedTestdataMachine_configMachineconfigurationsNodedisruptionpolicyRebootlessPathYaml, map[string]*bintree{}},
+						"skewenforcement-disabled.yaml":             {testExtendedTestdataMachine_configMachineconfigurationsSkewenforcementDisabledYaml, map[string]*bintree{}},
 					}},
 					"pinnedimage": {nil, map[string]*bintree{
 						"customGCMCPpis.yaml":   {testExtendedTestdataMachine_configPinnedimageCustomgcmcppisYaml, map[string]*bintree{}},

--- a/test/extended/testdata/machine_config/machineconfigurations/skewenforcement-disabled.yaml
+++ b/test/extended/testdata/machine_config/machineconfigurations/skewenforcement-disabled.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+  namespace: openshift-machine-config-operator
+spec:
+  logLevel: Normal
+  operatorLogLevel: Normal
+  bootImageSkewEnforcement:
+    mode: None          


### PR DESCRIPTION
This PR adds a new skewenforcement-disabled.yaml fixture that disables boot image skew enforcement for the boot image tests. Not disabling them would cause failures when                                                                                        https://github.com/openshift/machine-config-operator/pull/5428 lands.