### PR TITLE
OCPEDGE-2355: feat: skip unsupported commatrix tests for two node

### DIFF
--- a/test/extended/networking/commatrix.go
+++ b/test/extended/networking/commatrix.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openshift-kni/commatrix/pkg/types"
 	configv1 "github.com/openshift/api/config/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
 	clientOptions "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift-kni/commatrix/pkg/client"
@@ -47,11 +48,10 @@ var (
 )
 
 var _ = Describe("[sig-network][Feature:commatrix][apigroup:config.openshift.io][Serial]", func() {
+	oc := exutil.NewCLI("")
+
 	BeforeEach(func() {
-		kubeconfig := os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			Fail("KUBECONFIG not set")
-		}
+		skipUnsupportedControlPlaneTopology(oc)
 
 		By("Creating output folder")
 		artifactsDir = os.Getenv("ARTIFACT_DIR")

--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -1040,3 +1040,16 @@ func runOcWithRetryIgnoreOutput(oc *exutil.CLI, cmd string, args ...string) erro
 	_, err := runOcWithRetry(oc, cmd, args...)
 	return err
 }
+
+func skipUnsupportedControlPlaneTopology(oc *exutil.CLI) {
+	controlPlane, err := exutil.GetControlPlaneTopology(oc)
+	if err != nil || controlPlane == nil {
+		e2e.Logf("Failed : failed to get control plane topology, errored(%v) or controlPlane was nil", err)
+		return
+	}
+
+	switch *controlPlane {
+	case configv1.DualReplicaTopologyMode, configv1.HighlyAvailableArbiterMode:
+		Skip(fmt.Sprintf("Unsupported control plane topology, skipping (%v)", *controlPlane))
+	}
+}


### PR DESCRIPTION
Adding simple skip for commatrix tests that were determined to not be supported on two node.

Original skip was reverted, https://github.com/openshift/origin/pull/30670, this is a much simpler implementation that only targets two node.

/assign @aabughosh 