### PR TITLE
STOR-2838: fix OTP AsGuestKubeconf

### DIFF
--- a/test/extended/util/util_otp.go
+++ b/test/extended/util/util_otp.go
@@ -243,9 +243,12 @@ func (c *CLI) AsGuestKubeconf() *CLI {
 	// Create a copy of the CLI with guest kubeconfig enabled
 	copy := *c
 	// In OTP this sets a flag and uses guestConfigPath
-	// We'll use the guestConfigPath as the configPath
+	// We'll use the guestConfigPath as the configPath and adminConfigPath to simulate guest kubeconfig usage
+	// We'll also set withoutNamespace to true to comply with OTP behavior: https://github.com/openshift/openshift-tests-private/pull/3841
 	if c.guestConfigPath != "" {
 		copy.configPath = c.guestConfigPath
+		copy.adminConfigPath = c.guestConfigPath
+		copy.withoutNamespace = true
 	}
 	return &copy
 }


### PR DESCRIPTION
- Fix OTP AsGuestKubeconf to comply with OTP behavior: https://github.com/openshift/openshift-tests-private/pull/3841 .

**[Failures](https://qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/qe-private-deck/logs/periodic-ci-openshift-openshift-tests-private-release-4.21-amd64-nightly-aws-ipi-ovn-hypershift-shared-vpc-mgmt-f7/2013758959772504064)** on `aws-ipi-ovn-hypershift-shared-vpc-mgmt-f7`.

**Test record on `versioned-installer-ovn-hypershift-ci`**
- [Hack OTP branch test record](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/ocp-common/job/ginkgo-test/297603/consoleFull) (Hack [commit](https://github.com/Phaow/openshift-tests-private/commit/5ba2d517b04fe20399a8fedfabf46dd49df387b9) to use the fix patch)

```console
01-23 20:10:55.251  [sig-hypershift] Hypershift Author:heli-HyperShiftMGMT-ROSA-Critical-45801-Critical-45821-Test fault resilient HA-capable etcd under network partition[Disruptive] [Serial]
01-23 20:10:55.251  [sig-hypershift] Hypershift HyperShiftMGMT-Author:liangli-Critical-54284-Hypershift creates extra EC2 instances
01-23 20:10:55.251  [sig-networking] SDN OVN hypershift Author:jechen-HyperShiftMGMT-ConnectedOnly-High-74596-Even with a FQDN proxy configured on hostedCluster, connection can be made to the readinessEndpoint under noProxy that bypass the proxy [Disruptive] [Serial]
01-23 20:10:55.251  
01-23 20:10:55.251  Writing JUnit report to junit_e2e_20260123-121044.xml
01-23 20:10:55.251  
01-23 20:10:55.251  error: 3 fail, 42 pass, 7 skip (1h19m9s)
```

Before the fix ->
```console
Failing tests:

[sig-hypershift] Hypershift Author:ema-HyperShiftMGMT-Critical-83131-Setting AWS tags on existing Hosted Clusters and their Nodepools happens without roll out
[sig-hypershift] Hypershift Author:heli-HyperShiftMGMT-ROSA-Critical-45801-Critical-45821-Test fault resilient HA-capable etcd under network partition[Disruptive] [Serial]
[sig-networking] SDN OVN hypershift Author:jechen-HyperShiftMGMT-ConnectedOnly-High-74596-Even with a FQDN proxy configured on hostedCluster, connection can be made to the readinessEndpoint under noProxy that bypass the proxy [Disruptive] [Serial]
[sig-storage] STORAGE Author:ropatil-HyperShiftMGMT-NonHyperShiftHOST-Medium-79814-[CSI][HCP] Verify with single tag and can be update to new tags [Serial]
[sig-storage] STORAGE Author:ropatil-HyperShiftMGMT-NonHyperShiftHOST-Medium-80179-[CSI][HCP] Verify with multiple tags [Serial]
[sig-storage] STORAGE Author:ropatil-HyperShiftMGMT-NonHyperShiftHOST-Medium-80180-[CSI][HCP] Verify that an existing tags can be removed [Serial]

Writing JUnit report to /logs/artifacts/junit/junit_e2e_20260121-021814.xml

error: 6 fail, 41 pass, 5 skip (1h5m13s)
```
