### PR TITLE
OCPQE-31524: Add conditional SCC wait for Kubernetes compatibility

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -460,7 +460,11 @@ func (c *CLI) setupProject() string {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	}
 
-	WaitForNamespaceSCCAnnotations(c.KubeClient().CoreV1(), newNamespace)
+	// Only wait for SCC annotations if the SCC API exists (OpenShift clusters)
+	// Skip on pure Kubernetes/AKS clusters where SCC is not available
+	if exist, _ := DoesApiResourceExist(c.AdminConfig(), "securitycontextconstraints", "security.openshift.io"); exist {
+		WaitForNamespaceSCCAnnotations(c.KubeClient().CoreV1(), newNamespace)
+	}
 
 	framework.Logf("Project %q has been fully provisioned.", newNamespace)
 	return newNamespace
@@ -516,7 +520,11 @@ func (c *CLI) setupNamespace() string {
 	err = c.setupNamespaceManagedAnnotation(newNamespace)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
-	WaitForNamespaceSCCAnnotations(c.KubeClient().CoreV1(), newNamespace)
+	// Only wait for SCC annotations if the SCC API exists (OpenShift clusters)
+	// Skip on pure Kubernetes/AKS clusters where SCC is not available
+	if exist, _ := DoesApiResourceExist(c.AdminConfig(), "securitycontextconstraints", "security.openshift.io"); exist {
+		WaitForNamespaceSCCAnnotations(c.KubeClient().CoreV1(), newNamespace)
+	}
 
 	framework.Logf("Namespace %q has been fully provisioned.", newNamespace)
 


### PR DESCRIPTION
This commit fixes test hangs on pure Kubernetes/AKS HCP clusters by adding SCC API existence detection before waiting for SCC annotations.
Problem:
- SetupProject() and setupNamespace() unconditionally wait for SCC
  annotations on all clusters
- SCC is OpenShift-specific and doesn't exist on Kubernetes/AKS
- Tests hang indefinitely waiting for annotations that never arrive
Solution:
- Use DoesApiResourceExist() to detect if SCC API is available
- Only call WaitForNamespaceSCCAnnotations() on OpenShift clusters
- Skip SCC wait on pure Kubernetes/AKS clusters

```
passed: (2m39s) 2026-01-29T08:30:29 "[sig-hypershift] Hypershift Author:xiuwang-HyperShiftMGMT-Critical-86974-Update serviceAccountSigningKey to a new custom secret [Serial]"
```