### PR TITLE
NO-JIRA: bump SNO marketplace-operator watch count limit

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_operator_watch_count_tracking.go
@@ -376,7 +376,7 @@ func (s *watchCountTracking) CreateJunits() ([]*junitapi.JUnitTestCase, error) {
 			"kube-controller-manager-operator":       245,
 			"kube-storage-version-migrator-operator": 68,
 			"machine-api-operator":                   65,
-			"marketplace-operator":                   20,
+			"marketplace-operator":                   30,
 			"openshift-apiserver-operator":           280,
 			"openshift-config-operator":              75,
 			"openshift-controller-manager-operator":  285,


### PR DESCRIPTION
We see a small uptick in watch counts for marketplace-operator for SNO upgrades. 