### PR TITLE
OCPBUGS-76955: co/kube-storage-version-migrator reports Available=False in a non-upgrade job

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -105,6 +105,9 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 					condition.Reason == "APIServices_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23746"
 			}
+			if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
+				return "https://issues.redhat.com/browse/OCPBUGS-65984"
+			}
 			return ""
 		}
 		if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {


### PR DESCRIPTION
This one picks up https://github.com/openshift/origin/pull/30588/changes/3f541bc00bd138ea4fc9675c6bf4d22882260bf0

It impacts 4.21 component readiness. This exception will give the component team some air to bring its fix.

`co/console` seems alright on Sippy and thus https://github.com/openshift/origin/pull/30588/changes/37d20ef6f5265dad41c7025e3946f10e8f51fe8e was left there.

/cc @dgoodwin @sanchezl 