### PR TITLE
NO-JIRA: extended/cli: Align oc project output check

### DIFF
--- a/test/extended/cli/project.go
+++ b/test/extended/cli/project.go
@@ -67,7 +67,7 @@ var _ = g.Describe("[sig-cli] oc project", func() {
 		g.By("new project should be created")
 		out, err = oc.Run("new-project").Args(testProject1).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring(fmt.Sprintf("Now using project \"%s\" on server ", testProject1)))
+		o.Expect(out).To(o.MatchRegexp(fmt.Sprintf("Now using project \"%s\"( from context named \"admin\")? on server ", testProject1)))
 		defer func() {
 			err = oc.Run("delete", "namespace").Args(testProject1).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
`oc project` will allow specifying a custom context,
which causes the message to include the context name.

The check is aligned to accept both the current and changed output.

Needed for https://github.com/openshift/oc/pull/2187