### PR TITLE
Revert "SPLAT-2337: Added OTE binary for ccm-aws"

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -267,10 +267,6 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cli",
 		binaryPath: "/usr/bin/oc-tests-ext.gz",
 	},
-	{
-		imageTag:   "aws-cloud-controller-manager",
-		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
-	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Reverts openshift/origin#30525

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

[4.22.0-0.nightly-2026-02-01-095950](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2026-02-01-095950) is failing [aggregated-aws-ovn-single-node-upgrade-4.22-micro](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-aws-ovn-single-node-upgrade-4.22-micro-release-openshift-release-analysis-aggregator/2017969951691771904) due to [failures](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-ci-4.22-e2e-aws-upgrade-ovn-single-node/2017901563112067072) caused by `Conformance requires at least two nodes` which won't work for single node.

Tracking the issue in [TRT-2536](https://issues.redhat.com/browse/TRT-2536)

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-ci-4.22-e2e-aws-upgrade-ovn-single-node
```

CC: @mtulio 

