### PR TITLE
NO-JIRA: upkeep: skip upstream conformance for sno

### DIFF
--- a/pkg/test/extensions/environment_selectors.go
+++ b/pkg/test/extensions/environment_selectors.go
@@ -207,6 +207,8 @@ func filterByTopology(specs et.ExtensionTestSpecs) {
 	var topologyExclusions = map[string][]string{
 		"SingleReplica": {
 			"should be scheduled on different nodes",
+			"nodes should label nodes with topology network info if instance is supported",
+			"nodes should set zone-id topology label",
 		},
 	}
 


### PR DESCRIPTION
upstream conformance test fails for clusters less then 2 nodes, skipping for SingleReplica topology since we run a single node for those clusters.