### PR TITLE
SPLAT-2337: CCM-AWS OTE binary and skips

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -271,6 +271,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "cluster-authentication-operator",
 		binaryPath: "/usr/bin/cluster-authentication-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "aws-cloud-controller-manager",
+		binaryPath: "/usr/bin/aws-cloud-controller-manager-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
Re-adding the OTE binary extraction for CCM AWS previously added in https://github.com/openshift/origin/pull/30525 and reverted https://github.com/openshift/origin/pull/30744 after SNO job failing with tests exposed by it:

job [aggregated-aws-ovn-single-node-upgrade-4.22-micro](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-aws-ovn-single-node-upgrade-4.22-micro-release-openshift-release-analysis-aggregator/2017969951691771904) failed blocking job for [4.22.0-0.nightly-2026-02-01-095950](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.22.0-0.nightly/release/4.22.0-0.nightly-2026-02-01-095950).

Skips were added to the OTE implementation by https://github.com/openshift/cloud-provider-aws/pull/125

SNO jobs are now passing with skipped tests: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-cloud-provider-aws-125-openshift-origin-30747-ci-4.22-e2e-aws-upgrade-ovn-single-node/2019041978443894784
