### PR TITLE
OCPBUGS-65623: Remove exception for monitoring OLM Progression condition

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -687,8 +687,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return "https://issues.redhat.com/browse/OCPBUGS-65941"
 		case "marketplace":
 			return "https://issues.redhat.com/browse/OCPBUGS-65581"
-		case "olm":
-			return "https://issues.redhat.com/browse/OCPBUGS-65623"
 		case "operator-lifecycle-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-65583"
 		case "openshift-samples":


### PR DESCRIPTION
With merge of https://github.com/openshift/origin/pull/30626 we can remove the exception for OLM
monitoring tests.
