### PR TITLE
NO-JIRA: ote: fix duplicated topology label on SingleReplica

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -1228,9 +1228,12 @@ func determineEnvironmentFlags(ctx context.Context, upgrade bool, dryRun bool) (
 			envFlagBuilder.AddOptionalCapability(string(optionalCapability))
 		}
 
-		envFlagBuilder.
-			AddTopology(clusterState.ControlPlaneTopology).
-			AddVersion(clusterState.Version.Status.Desired.Version)
+		envFlagBuilder.AddVersion(clusterState.Version.Status.Desired.Version)
+
+		// SingleReplica is duplicated in the topology flag, so we don't need to add it here if it's set.
+		if !config.SingleReplicaTopology {
+			envFlagBuilder.AddTopology(clusterState.ControlPlaneTopology)
+		}
 	}
 
 	return envFlagBuilder.Build(), nil


### PR DESCRIPTION
Previously the SingleReplica job was setting duplicated topology label:

~~~
topology="[SingleReplica SingleReplica]"
~~~
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/openshift-origin-30747-ci-4.22-e2e-aws-upgrade-ovn-single-node/2018312069375332352/artifacts/e2e-aws-upgrade-ovn-single-node/single-node-e2e-test/build-log.txt

This fix skips re-adding the label when running in a SingleReplica cluster.

Issue observed while investigating:
https://github.com/openshift/origin/pull/30747
https://issues.redhat.com//browse/TRT-2536