### PR TITLE
OCPBUGS-74151: Add test for CPMS OnDelete strategy with full master replacement

### DIFF
--- a/test/extended/etcd/OWNERS
+++ b/test/extended/etcd/OWNERS
@@ -1,12 +1,11 @@
 reviewers:
   - dusk125
   - hasbro17
-  - Elbehery
+  - jubittajohn
   - tjungblu
 approvers:
   - deads2k
-  - soltysh
   - hasbro17
   - dusk125
-  - Elbehery
+  - jubittajohn
   - tjungblu


### PR DESCRIPTION
E2E test for https://github.com/openshift/cluster-etcd-operator/pull/1540

Creates a new test case that validates the ControlPlaneMachineSet OnDelete strategy by deleting all three master machines simultaneously and verifying CPMS correctly replaces them while maintaining cluster health.

The test switches CPMS to OnDelete strategy, deletes all master machines, and validates that CPMS creates replacements with proper etcd membership transitions. Verifies that all old etcd members are removed from both the cluster and etcd-endpoints ConfigMap, and new members are properly integrated.

TODO: need to wire up the vertical scaling workflow in the openshift/release repo so that this test runs in its own job/presubmit and gets skipped in the regular etcd scaling.