### PR TITLE
NO-JIRA: test(tnf): add Pacemaker health check scenarios and shared two-node utils

### DIFF
--- a/test/extended/two_node/tnf_node_replacement.go
+++ b/test/extended/two_node/tnf_node_replacement.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/origin/test/extended/two_node/utils"
 	"github.com/openshift/origin/test/extended/two_node/utils/apis"
 	"github.com/openshift/origin/test/extended/two_node/utils/core"
+	"github.com/openshift/origin/test/extended/two_node/utils/services"
 	exutil "github.com/openshift/origin/test/extended/util"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -131,6 +132,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		e2e.Logf("[stage timing] Destroying target VM: %v (no poll timeout; virsh/SSH)", time.Since(stageStart))
 		stageStart = time.Now()
 
+		g.By("Verifying that a fencing event was recorded for the target node")
+		o.Expect(services.WaitForFencingEvent(oc, []string{testConfig.TargetNode.Name}, healthCheckDegradedTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
+
 		g.By("Waiting for etcd to stop on the surviving node")
 		waitForEtcdToStop(&testConfig)
 		e2e.Logf("[stage timing] Waiting for etcd to stop: %v (timeout cap: %v)", time.Since(stageStart), etcdThreeMinutePollTimeout)
@@ -218,6 +222,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		g.By("Verifying the cluster is fully restored")
 		verifyRestoredCluster(&testConfig, oc)
 		e2e.Logf("[stage timing] Verify cluster restored (total): %v (see sub-lines for CO monitor cap)", time.Since(stageStart))
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 
 		g.By("Successfully completed node replacement process")
 		e2e.Logf("Node replacement process completed. Backup files created in: %s", backupDir)

--- a/test/extended/two_node/tnf_pacemaker_healthcheck.go
+++ b/test/extended/two_node/tnf_pacemaker_healthcheck.go
@@ -1,0 +1,200 @@
+package two_node
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/test/extended/etcd/helpers"
+	"github.com/openshift/origin/test/extended/two_node/utils"
+	"github.com/openshift/origin/test/extended/two_node/utils/services"
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	// healthCheckUpdatedTimeout is the time to wait for the Pacemaker health check condition to update (degraded or healthy).
+	healthCheckUpdatedTimeout  = 2 * time.Minute
+	healthCheckDegradedTimeout = healthCheckUpdatedTimeout
+	healthCheckHealthyTimeout  = healthCheckUpdatedTimeout
+	// Longer timeouts for tests that trigger a fencing event (ungraceful shutdown, cold-boot, network disruption):
+	// API server can be slow to recover, so we wait up to 5 minutes before asserting PacemakerHealthCheckDegraded/Healthy.
+	healthCheckDegradedTimeoutAfterFencing = 5 * time.Minute
+	healthCheckHealthyTimeoutAfterFencing  = 5 * time.Minute
+	// StatusUnknownDegradedThreshold and StatusStalenessThreshold in CEO are 5 minutes; we must block for at least this long before asserting degraded.
+	staleMinBlockDuration = 5 * time.Minute
+	// After blocking, allow time for healthcheck controller (30s resync) to observe degraded.
+	staleCRDegradedTimeout        = 2 * time.Minute
+	staleTimestampDegradedTimeout = 2 * time.Minute
+	// Interval for background delete loops: delete as soon as resources appear (match aggressive manual watch cadence).
+	staleTestDeleteInterval = 2 * time.Second
+	pacemakerClusterCRName  = "cluster"
+	statusCollectorLabel    = "app.kubernetes.io/name=pacemaker-status-collector"
+	etcdNamespaceFencing    = "openshift-etcd"
+)
+
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two-node][Serial][Disruptive] Pacemaker health check disruptive scenarios", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                = exutil.NewCLIWithoutNamespace("tnf-pacemaker-healthcheck").AsAdmin()
+		etcdClientFactory *helpers.EtcdClientFactoryImpl
+		peerNode          corev1.Node
+		targetNode        corev1.Node
+	)
+
+	g.BeforeEach(func() {
+		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
+		etcdClientFactory = helpers.NewEtcdClientFactory(oc.KubeClient())
+		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
+
+		nodes, err := utils.GetNodes(oc, utils.AllNodes)
+		o.Expect(err).ShouldNot(o.HaveOccurred(), "Expected to retrieve nodes without error")
+		randomIndex := rand.Intn(len(nodes.Items))
+		peerNode = nodes.Items[randomIndex]
+		targetNode = nodes.Items[(randomIndex+1)%len(nodes.Items)]
+	})
+
+	g.It("should report degraded when a node is in standby then healthy after unstandby", func() {
+		g.By(fmt.Sprintf("Putting %s in standby from %s", targetNode.Name, peerNode.Name))
+		o.Expect(utils.PcsNodeStandby(oc, peerNode.Name, targetNode.Name)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition reports target node in standby")
+		o.Expect(services.WaitForPacemakerHealthCheckDegraded(oc, "standby", healthCheckDegradedTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+		o.Expect(services.AssertPacemakerHealthCheckContains(oc, []string{targetNode.Name, "standby"})).To(o.Succeed())
+
+		g.By(fmt.Sprintf("Bringing %s out of standby", targetNode.Name))
+		o.Expect(utils.PcsNodeUnstandby(oc, peerNode.Name, targetNode.Name)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+	})
+
+	g.It("should report degraded when cluster is in maintenance mode then healthy after clearing", func() {
+		g.By("Setting cluster maintenance mode")
+		o.Expect(utils.PcsPropertySetMaintenanceMode(oc, peerNode.Name, true)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition reports maintenance")
+		o.Expect(services.WaitForPacemakerHealthCheckDegraded(oc, "maintenance", healthCheckDegradedTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+
+		g.By("Clearing cluster maintenance mode")
+		o.Expect(utils.PcsPropertySetMaintenanceMode(oc, peerNode.Name, false)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+	})
+
+	g.It("should report degraded when a node is in maintenance mode then healthy after unmaintenance", func() {
+		g.By(fmt.Sprintf("Putting %s in node maintenance from %s", targetNode.Name, peerNode.Name))
+		o.Expect(utils.PcsNodeMaintenance(oc, peerNode.Name, targetNode.Name)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition reports target node in maintenance")
+		o.Expect(services.WaitForPacemakerHealthCheckDegraded(oc, "maintenance", healthCheckDegradedTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+		o.Expect(services.AssertPacemakerHealthCheckContains(oc, []string{targetNode.Name, "maintenance"})).To(o.Succeed())
+
+		g.By(fmt.Sprintf("Bringing %s out of node maintenance", targetNode.Name))
+		o.Expect(utils.PcsNodeUnmaintenance(oc, peerNode.Name, targetNode.Name)).To(o.Succeed())
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+	})
+
+})
+
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two-node][Serial] Pacemaker health check stale status scenarios", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                = exutil.NewCLIWithoutNamespace("tnf-pacemaker-stale").AsAdmin()
+		etcdClientFactory *helpers.EtcdClientFactoryImpl
+	)
+
+	g.BeforeEach(func() {
+		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
+		etcdClientFactory = helpers.NewEtcdClientFactory(oc.KubeClient())
+		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
+	})
+
+	g.It("should report degraded when PacemakerCluster CR is repeatedly deleted then healthy after CR is allowed to exist", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(staleTestDeleteInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					out, err := oc.AsAdmin().Run("delete").Args("pacemakercluster", pacemakerClusterCRName, "--ignore-not-found").Output()
+					if err != nil {
+						e2e.Logf("Staleness CR delete loop: delete pacemakercluster/%s failed: %v (output: %q)", pacemakerClusterCRName, err, string(out))
+					} else if strings.TrimSpace(string(out)) != "" {
+						e2e.Logf("Staleness CR delete loop: %s", string(out))
+					}
+				}
+			}
+		}()
+
+		g.By("Deleting PacemakerCluster CR for 5 minutes so operator exceeds StatusUnknownDegradedThreshold")
+		time.Sleep(staleMinBlockDuration)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded (CR not found)")
+		o.Expect(services.WaitForPacemakerHealthCheckDegraded(oc, "not found", staleCRDegradedTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+
+		// Only stop the delete loop after asserting degraded; otherwise the operator could recreate the CR before we observe not found.
+		g.By("Stopping CR delete loop and allowing operator to recreate CR")
+		cancel()
+		wg.Wait()
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+	})
+
+	g.It("should report degraded when status collector jobs are repeatedly deleted then healthy after jobs can run", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(staleTestDeleteInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					out, err := oc.AsAdmin().Run("delete").Args("jobs", "-n", etcdNamespaceFencing, "-l", statusCollectorLabel, "--ignore-not-found").Output()
+					if err != nil {
+						e2e.Logf("Staleness job delete loop: delete jobs -l %s -n %s failed: %v (output: %q)", statusCollectorLabel, etcdNamespaceFencing, err, string(out))
+					} else if strings.TrimSpace(string(out)) != "" {
+						e2e.Logf("Staleness job delete loop: %s", string(out))
+					}
+				}
+			}
+		}()
+
+		g.By("Blocking status collector for 5 minutes so CR lastUpdated exceeds StatusStalenessThreshold")
+		time.Sleep(staleMinBlockDuration)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded (stale status)")
+		o.Expect(services.WaitForPacemakerHealthCheckDegraded(oc, "stale", staleTimestampDegradedTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+
+		// Only stop the delete loop after asserting degraded; otherwise a job could complete and update the CR before we observe stale.
+		g.By("Stopping job delete loop and allowing cronjob to run")
+		cancel()
+		wg.Wait()
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
+	})
+})

--- a/test/extended/two_node/tnf_recovery.go
+++ b/test/extended/two_node/tnf_recovery.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openshift/origin/test/extended/two_node/utils/services"
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -34,6 +35,10 @@ const (
 	vmGracefulShutdownTimeout       = 10 * time.Minute // Graceful VM shutdown is typically slow
 	membersHealthyAfterDoubleReboot = 30 * time.Minute // Includes full VM reboot and etcd member healthy
 	progressLogInterval             = time.Minute      // Target interval for progress logging
+
+	fencingJobName        = "tnf-fencing-job"
+	fencingJobNamespace   = "openshift-etcd"
+	fencingJobWaitTimeout = 10 * time.Minute
 )
 
 // computeLogInterval calculates poll attempts between progress logs based on poll interval.
@@ -120,6 +125,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&survivedNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {
@@ -132,6 +140,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err := exutil.TriggerNodeRebootUngraceful(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to ungracefully shutdown the node without errors", targetNode.Name, err)
 		time.Sleep(1 * time.Minute)
+
+		g.By("Verifying that a fencing event was recorded for the node")
+		o.Expect(services.WaitForFencingEvent(oc, []string{targetNode.Name}, healthCheckDegradedTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -150,6 +161,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&survivedNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from network disruption with etcd member re-addition", func() {
@@ -161,6 +175,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		command, err := exutil.TriggerNetworkDisruption(oc.KubeClient(), &targetNode, &peerNode, networkDisruptionDuration)
 		o.Expect(err).To(o.BeNil(), "Expected to disrupt network without errors")
 		g.GinkgoT().Printf("command: '%s'\n", command)
+
+		g.By("Verifying that a fencing event was recorded for one of the nodes")
+		o.Expect(services.WaitForFencingEvent(oc, []string{targetNode.Name, peerNode.Name}, healthCheckDegradedTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 
 		g.By(fmt.Sprintf("Ensuring cluster recovery with proper leader/learner roles after network disruption (timeout: %v)", memberIsLeaderTimeout))
 		// Note: The fenced node may recover quickly and already be started when we get
@@ -184,6 +201,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			leaderNode,
 			learnerNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from a double node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -223,6 +243,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&nodeA,
 			&nodeB, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from double graceful node shutdown (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -262,6 +285,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&nodeA,
 			&nodeB, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from sequential graceful node shutdowns (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -343,6 +369,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&firstToShutdown,
 			&secondToShutdown, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from BMC credential rotation with fencing", func() {
@@ -394,6 +423,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			leaderNode,
 			learnerNode, true, false,
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Verifying PacemakerHealthCheckDegraded condition clears after recovery")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeoutAfterFencing, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 
 	g.It("should recover from etcd process crash", func() {
@@ -473,6 +505,121 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, targetNode.Name, "openshift-etcd",
 			"bash", "-c", fmt.Sprintf("journalctl -u pacemaker --since=@%s --no-pager | grep -m1 -i 'a new working copy of /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/external-etcd-pod/pod.yaml was created'", rebootEpoch))
 		o.Expect(err).To(o.BeNil(), "Expected pacemaker log to contain pod.yaml recreation entry after reboot")
+	})
+})
+
+// Fencing secret rotation test lives in a separate Describe without [OCPFeatureGate:DualReplica];
+// we do not add new tests under the FeatureGate-gated suite.
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two-node][Serial][Disruptive] Two Node fencing secret rotation", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                   = exutil.NewCLIWithoutNamespace("tnf-fencing-secret-rotation").AsAdmin()
+		etcdClientFactory    *helpers.EtcdClientFactoryImpl
+		peerNode, targetNode corev1.Node
+	)
+
+	g.BeforeEach(func() {
+		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
+		etcdClientFactory = helpers.NewEtcdClientFactory(oc.KubeClient())
+		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
+
+		nodes, err := utils.GetNodes(oc, utils.AllNodes)
+		o.Expect(err).ShouldNot(o.HaveOccurred(), "Expected to retrieve nodes without error")
+		randomIndex := rand.Intn(len(nodes.Items))
+		peerNode = nodes.Items[randomIndex]
+		targetNode = nodes.Items[(randomIndex+1)%len(nodes.Items)]
+	})
+
+	g.It("should reject invalid fencing credential updates and keep PacemakerCluster healthy", func() {
+		kubeClient := oc.AdminKubeClient()
+
+		ns, secretName, originalPassword, err := apis.RotateNodeBMCPassword(oc, &targetNode)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to rotate BMC credentials without error")
+
+		defer func() {
+			if err := apis.RestoreBMCPassword(oc, ns, secretName, originalPassword); err != nil {
+				fmt.Fprintf(g.GinkgoWriter,
+					"Warning: failed to restore original BMC password in %s/%s: %v\n",
+					ns, secretName, err)
+			}
+		}()
+		g.By("Ensuring etcd members remain healthy after BMC credential rotation")
+		o.Eventually(func() error {
+			if err := helpers.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, peerNode.Name); err != nil {
+				return err
+			}
+			if err := helpers.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, targetNode.Name); err != nil {
+				return err
+			}
+			return nil
+		}, nodeIsHealthyTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(), "etcd members should be healthy after BMC credential rotation")
+
+		g.By("Triggering fencing job by patching fencing secret so we can assert it refuses to update pacemaker")
+		fencingSecretName := "fencing-credentials-" + targetNode.Name
+		secret, err := kubeClient.CoreV1().Secrets(fencingJobNamespace).Get(context.Background(), fencingSecretName, metav1.GetOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred(), "get fencing secret for node %s", targetNode.Name)
+		patched := secret.DeepCopy()
+		if patched.Data == nil {
+			patched.Data = make(map[string][]byte)
+		}
+		patched.Data["test-trigger"] = []byte("1")
+		_, err = kubeClient.CoreV1().Secrets(fencingJobNamespace).Update(context.Background(), patched, metav1.UpdateOptions{})
+		o.Expect(err).ToNot(o.HaveOccurred(), "patch fencing secret to trigger job")
+
+		g.By("Waiting for fencing job to complete")
+		o.Eventually(func() error {
+			job, err := kubeClient.BatchV1().Jobs(fencingJobNamespace).Get(context.Background(), fencingJobName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if job.Status.CompletionTime == nil {
+				return fmt.Errorf("job %s not yet complete", fencingJobName)
+			}
+			return nil
+		}, fencingJobWaitTimeout, utils.FiveSecondPollInterval).Should(o.Succeed(), "fencing job must complete")
+
+		g.By("Verifying the secret was never rotated in Pacemaker: fencing job logs show it refused to update stonith")
+		pods, err := kubeClient.CoreV1().Pods(fencingJobNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "job-name=" + fencingJobName})
+		o.Expect(err).ToNot(o.HaveOccurred(), "list pods for fencing job")
+		o.Expect(pods.Items).ToNot(o.BeEmpty(), "fencing job should have at least one pod (job may not have been recreated after secret patch)")
+		pod := &pods.Items[0]
+		podName := pod.Name
+		framework.Logf("Fencing job pod: %s (namespace: %s) phase=%s", podName, fencingJobNamespace, pod.Status.Phase)
+		for i, cs := range pod.Status.ContainerStatuses {
+			framework.Logf("  container[%d] %s: ready=%v state=%+v", i, cs.Name, cs.Ready, cs.State)
+		}
+		const logRetries = 3
+		const logRetryDelay = 5 * time.Second
+		var podLogs string
+		for attempt := 0; attempt < logRetries; attempt++ {
+			podLogs, err = oc.AsAdmin().Run("logs").Args(podName, "-n", fencingJobNamespace).Output()
+			if err != nil {
+				framework.Logf("Get fencing job pod logs (attempt %d/%d): %v", attempt+1, logRetries, err)
+				if attempt < logRetries-1 {
+					time.Sleep(logRetryDelay)
+				}
+				continue
+			}
+			if strings.Contains(podLogs, "unable to retrieve container logs") && attempt < logRetries-1 {
+				framework.Logf("Pod logs contained 'unable to retrieve container logs' (attempt %d/%d), retrying in %v", attempt+1, logRetries, logRetryDelay)
+				time.Sleep(logRetryDelay)
+				continue
+			}
+			break
+		}
+		o.Expect(err).ToNot(o.HaveOccurred(), "get fencing job pod logs after %d attempts", logRetries)
+		framework.Logf("Fencing job pod: %s (namespace: %s). Full pod logs:\n%s", podName, fencingJobNamespace, podLogs)
+		if strings.Contains(podLogs, "unable to retrieve container logs") {
+			framework.Failf("could not retrieve container logs for fencing job pod %s (CRI-O may have purged them); pod phase=%s", podName, pod.Status.Phase)
+		}
+		o.Expect(podLogs).To(o.ContainSubstring("already configured and does not need an update"),
+			"fencing job must have refused to update stonith (secret never rotated in Pacemaker). Fencing job pod: %s. Full pod logs:\n%s", podName, podLogs)
+		o.Expect(podLogs).To(o.ContainSubstring(targetNode.Name),
+			"fencing job logs should mention the node %s. Fencing job pod: %s. Full pod logs:\n%s", targetNode.Name, podName, podLogs)
+
+		g.By("Ensuring PacemakerCluster remained healthy: PacemakerHealthCheckDegraded is not set")
+		o.Expect(services.WaitForPacemakerHealthCheckHealthy(oc, healthCheckHealthyTimeout, utils.FiveSecondPollInterval)).To(o.Succeed())
 	})
 })
 

--- a/test/extended/two_node/utils/common.go
+++ b/test/extended/two_node/utils/common.go
@@ -508,6 +508,84 @@ func RemoveConstraint(oc *exutil.CLI, nodeName string, resourceName string) erro
 	return nil
 }
 
+// PcsNodeStandby puts a node in standby mode (resources moved away, node excluded from cluster).
+//
+//	err := PcsNodeStandby(oc, "master-0", "master-1")
+func PcsNodeStandby(oc *exutil.CLI, execNodeName string, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs node standby %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to standby node %s: %v, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsNodeUnstandby brings a node out of standby mode.
+//
+//	err := PcsNodeUnstandby(oc, "master-0", "master-1")
+func PcsNodeUnstandby(oc *exutil.CLI, execNodeName string, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs node unstandby %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to unstandby node %s: %v, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsPropertySetMaintenanceMode sets cluster-wide maintenance mode (true or false).
+//
+//	err := PcsPropertySetMaintenanceMode(oc, "master-0", true)
+func PcsPropertySetMaintenanceMode(oc *exutil.CLI, execNodeName string, enabled bool) error {
+	val := "false"
+	if enabled {
+		val = "true"
+	}
+	cmd := fmt.Sprintf("sudo pcs property set maintenance-mode=%s", val)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to set maintenance-mode=%s: %v, output: %s", val, err, output)
+	}
+	return nil
+}
+
+// PcsNodeMaintenance puts a single node in maintenance mode (its resources become unmanaged).
+//
+//	err := PcsNodeMaintenance(oc, "master-0", "master-1")
+func PcsNodeMaintenance(oc *exutil.CLI, execNodeName string, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs node maintenance %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to put node %s in maintenance: %v, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsNodeUnmaintenance brings a node out of maintenance mode.
+//
+//	err := PcsNodeUnmaintenance(oc, "master-0", "master-1")
+func PcsNodeUnmaintenance(oc *exutil.CLI, execNodeName string, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs node unmaintenance %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to unmaintenance node %s: %v, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsStonithUpdatePassword updates the password for a STONITH device (e.g. master-1_redfish).
+// Used to simulate fencing agent degraded by setting a wrong password; restore via secret recreation.
+//
+//	err := PcsStonithUpdatePassword(oc, "master-0", "master-1_redfish", "wrongpassword")
+func PcsStonithUpdatePassword(oc *exutil.CLI, execNodeName string, stonithID string, password string) error {
+	// Shell-escape the password for use in pcs stonith update
+	cmd := fmt.Sprintf("sudo pcs stonith update %s password=%q", stonithID, password)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to update stonith %s password: %v, output: %s", stonithID, err, output)
+	}
+	return nil
+}
+
 // IsResourceStopped checks if a pacemaker resource is in stopped state.
 //
 //	stopped, err := IsResourceStopped(oc, "master-0", "kubelet-clone")

--- a/test/extended/two_node/utils/services/pacemaker.go
+++ b/test/extended/two_node/utils/services/pacemaker.go
@@ -5,10 +5,14 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/origin/test/extended/two_node/utils/core"
 	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -34,6 +38,23 @@ const (
 	pcsStonithConfirm            = "stonith confirm %s --force"
 	pcsProperty                  = "property"
 )
+
+// PacemakerHealthCheckDegradedType is the condition type set by the cluster-etcd-operator on the etcd CR.
+const PacemakerHealthCheckDegradedType = "PacemakerHealthCheckDegraded"
+
+// Event reasons emitted by cluster-etcd-operator when a node is fenced (used to assert fencing occurred).
+const (
+	EventReasonPacemakerNodeOffline  = "PacemakerNodeOffline"
+	EventReasonPacemakerFencingEvent = "PacemakerFencingEvent"
+	eventNamespaceEtcdOperator       = "openshift-etcd-operator"
+	eventNamespaceEtcd               = "openshift-etcd"
+)
+
+// etcdGetTimeout is the timeout for a single GET of the etcd CR when polling for PacemakerHealthCheckDegraded.
+// During fencing or API slowness the server may respond slowly; a longer timeout improves the chance of
+// getting a real condition value instead of a timeout error. API errors (including timeout) are retried
+// by WaitForPacemakerHealthCheckDegraded and WaitForPacemakerHealthCheckHealthy.
+const etcdGetTimeout = 2 * time.Minute
 
 func formatPcsCommandString(command string, envVars string) string {
 	if envVars != "" {
@@ -374,4 +395,148 @@ func PcsStatusFullViaDebug(ctx context.Context, oc *exutil.CLI, nodeName string)
 		e2e.Logf("PcsStatusFullViaDebug failed on node %s: %v", nodeName, err)
 	}
 	return output, err
+}
+
+// GetPacemakerHealthCheckCondition returns the PacemakerHealthCheckDegraded condition from the etcd CR.
+// The condition is set by the cluster-etcd-operator based on pacemaker cluster status.
+// Returns nil if the condition is not present. Uses etcdGetTimeout so that during API slowness
+// (e.g. after fencing) we get a real response; callers retry on error.
+func GetPacemakerHealthCheckCondition(oc *exutil.CLI) (*operatorv1.OperatorCondition, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), etcdGetTimeout)
+	defer cancel()
+	etcd, err := oc.AdminOperatorClient().OperatorV1().Etcds().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get etcd cluster: %w", err)
+	}
+	for i := range etcd.Status.Conditions {
+		if etcd.Status.Conditions[i].Type == PacemakerHealthCheckDegradedType {
+			return &etcd.Status.Conditions[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// WaitForPacemakerHealthCheckDegraded waits for the PacemakerHealthCheckDegraded condition to become True
+// and the message to match the given pattern (regexp). Pass an empty string to match any message.
+func WaitForPacemakerHealthCheckDegraded(oc *exutil.CLI, messagePattern string, timeout, pollInterval time.Duration) error {
+	var re *regexp.Regexp
+	if messagePattern != "" {
+		var err error
+		re, err = regexp.Compile(messagePattern)
+		if err != nil {
+			return fmt.Errorf("compile message pattern: %w", err)
+		}
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		cond, err := GetPacemakerHealthCheckCondition(oc)
+		if err != nil {
+			e2e.Logf("GetPacemakerHealthCheckCondition: %v", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+		if cond == nil {
+			time.Sleep(pollInterval)
+			continue
+		}
+		if cond.Status != operatorv1.ConditionTrue {
+			e2e.Logf("PacemakerHealthCheckDegraded condition status=%s message=%q (waiting for True)", cond.Status, cond.Message)
+			time.Sleep(pollInterval)
+			continue
+		}
+		if re != nil && !re.MatchString(cond.Message) {
+			e2e.Logf("PacemakerHealthCheckDegraded condition True but message %q does not match pattern %q", cond.Message, messagePattern)
+			time.Sleep(pollInterval)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("PacemakerHealthCheckDegraded did not become True with message matching %q within %v", messagePattern, timeout)
+}
+
+// WaitForPacemakerHealthCheckHealthy waits for the PacemakerHealthCheckDegraded condition to become False (cleared).
+func WaitForPacemakerHealthCheckHealthy(oc *exutil.CLI, timeout, pollInterval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		cond, err := GetPacemakerHealthCheckCondition(oc)
+		if err != nil {
+			time.Sleep(pollInterval)
+			continue
+		}
+		if cond == nil || cond.Status == operatorv1.ConditionFalse {
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("PacemakerHealthCheckDegraded did not become False within %v", timeout)
+}
+
+// WaitForFencingEvent waits until a Kubernetes Event exists that proves a node was fenced.
+// The cluster-etcd-operator emits events with Reason PacemakerNodeOffline or PacemakerFencingEvent
+// when a node is fenced. This is more reliable than waiting for PacemakerHealthCheckDegraded on the
+// etcd CR, since by the time the API server is responsive the node may already be recovering.
+// nodeNames: at least one of these node names must appear in the event message (e.g. master-0, master-1).
+func WaitForFencingEvent(oc *exutil.CLI, nodeNames []string, timeout, pollInterval time.Duration) error {
+	reasons := []string{EventReasonPacemakerNodeOffline, EventReasonPacemakerFencingEvent}
+	namespaces := []string{eventNamespaceEtcdOperator, eventNamespaceEtcd}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), etcdGetTimeout)
+		for _, ns := range namespaces {
+			list, err := oc.AdminKubeClient().CoreV1().Events(ns).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				e2e.Logf("List events in %s: %v", ns, err)
+				continue
+			}
+			for i := range list.Items {
+				ev := &list.Items[i]
+				if !contains(reasons, ev.Reason) {
+					continue
+				}
+				msg := ev.Message
+				for _, name := range nodeNames {
+					if strings.Contains(msg, name) {
+						e2e.Logf("Found fencing event: namespace=%s reason=%s message=%q", ns, ev.Reason, msg)
+						cancel()
+						return nil
+					}
+				}
+			}
+		}
+		cancel()
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("no event with reason %v and message containing any of %v within %v", reasons, nodeNames, timeout)
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// AssertPacemakerHealthCheckContains verifies that the PacemakerHealthCheckDegraded condition message
+// contains all of the expected substrings. If the condition is not True, returns an error.
+// Pass expectedPatterns as substrings that must all appear in the condition message.
+func AssertPacemakerHealthCheckContains(oc *exutil.CLI, expectedPatterns []string) error {
+	cond, err := GetPacemakerHealthCheckCondition(oc)
+	if err != nil {
+		return err
+	}
+	if cond == nil {
+		return fmt.Errorf("PacemakerHealthCheckDegraded condition not found on etcd CR")
+	}
+	if cond.Status != operatorv1.ConditionTrue {
+		return fmt.Errorf("PacemakerHealthCheckDegraded condition status is %s, expected True", cond.Status)
+	}
+	msg := cond.Message
+	for _, sub := range expectedPatterns {
+		if !strings.Contains(msg, sub) {
+			return fmt.Errorf("PacemakerHealthCheckDegraded message %q does not contain %q", msg, sub)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- Add tnf_pacemaker_healthcheck.go with disruptive scenarios for Pacemaker health check (degraded/healthy transitions, stale status, etc.).
- Extend TNF kubelet disruption, node replacement, and recovery tests.
- Add shared utilities in utils/common.go and utils/services/pacemaker.go for two-node topology and Pacemaker service checks.
    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive Pacemaker health check test suites covering disruptive scenarios and stale status conditions
  * Introduced health check verification helpers for monitoring degraded and healthy state transitions
  * Enhanced recovery tests with fencing event tracking and Pacemaker health validation
  * Implemented cluster state management utilities for Pacemaker operations (standby, maintenance mode, node constraints)
  * Added fencing secret rotation test scenarios with validation of operator responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->