### PR TITLE
Move oc-adm-upgrade-status and audit-log-analyzer to default

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -153,6 +153,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie(legacytestframeworkmonitortests.PathologicalMonitorName, "Test Framework", legacytestframeworkmonitortests.NewLegacyPathologicalMonitorTests(info))
 	monitorTestRegistry.AddMonitorTestOrDie("legacy-cvo-invariants", "Cluster Version Operator", legacycvomonitortests.NewLegacyTests())
 	monitorTestRegistry.AddMonitorTestOrDie("node-lifecycle", "Node / Kubelet", watchnodes.NewNodeWatcher())
+	monitorTestRegistry.AddMonitorTestOrDie("oc-adm-upgrade-status", "oc / update", admupgradestatus.NewOcAdmUpgradeStatusChecker())
 
 	return monitorTestRegistry
 }
@@ -219,8 +220,6 @@ func newUniversalMonitorTests(info monitortestframework.MonitorTestInitializatio
 	monitorTestRegistry.AddMonitorTestOrDie("azure-metrics-collector", "Test Framework", azuremetrics.NewAzureMetricsCollector())
 	monitorTestRegistry.AddMonitorTestOrDie("watch-namespaces", "Test Framework", watchnamespaces.NewNamespaceWatcher())
 	monitorTestRegistry.AddMonitorTestOrDie("high-cpu-test-analyzer", "Test Framework", highcputestanalyzer.NewHighCPUTestAnalyzer())
-
-	monitorTestRegistry.AddMonitorTestOrDie("oc-adm-upgrade-status", "oc / update", admupgradestatus.NewOcAdmUpgradeStatusChecker())
 
 	return monitorTestRegistry
 }

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -228,6 +228,16 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 					// These usernames are already creating more than 200 applies, so flake instead of fail.
 					// We really want to find a way to track namespaces created by the payload versus everything else.
 					flakes = append(flakes, errorMessage)
+				case "system:serviceaccount:openshift-machine-config-operator:machine-config-daemon",
+					"system:serviceaccount:openshift-machine-config-operator:machine-config-controller":
+
+					// These usernames produce excessive applies in disruptive suites.
+					// Only flake in disruptive suites; fail in stable suites.
+					if w.clusterStability == monitortestframework.Disruptive {
+						flakes = append(flakes, errorMessage)
+					} else {
+						failures = append(failures, errorMessage)
+					}
 				default:
 					failures = append(failures, errorMessage)
 				}


### PR DESCRIPTION
Move oc-adm-upgrade-status  monitoring test to default, so that it is not run when executing disruptive test suites.

Add exceptions for MCO in audit-log-analyzer, since MCO tests last 23 hours and it is normal to exceed the limit.

-  oc-adm-upgrade-status cannot get the necessary information when the cluster is not able to answer, and it fails. (We see it especially when the tests change the TLS configuration in the apiserver "cluster" resource.

```
oc adm upgrade status failed 2 times (of 723)  - 2026-02-04T20:02:55Z: failed to run oc adm upgrade status after 2 attempts: context deadline exceeded
recorded attempts and outputs:
Attempt #1 failed: Error running oc --kubeconfig=/tmp/kubeconfig-681483446 adm upgrade status --details=all:
StdOut>
Error from server (Timeout): the server was unable to return a response in the time allotted, but may still be processing the request (get clusterversions.config.openshift.io version)
``` 

- audit-log-analyzer: MCO is considered as flake

```
                                    "system:serviceaccount:openshift-machine-config-operator:machine-config-daemon"
                                    "system:serviceaccount:openshift-machine-config-operator:machine-config-controller
```