### PR TITLE
STOR-2857: Enable MutableCSINodeAllocatableCount tests for all clusters

### DIFF
--- a/test/extended/storage/mutable_csinode_allocatable.go
+++ b/test/extended/storage/mutable_csinode_allocatable.go
@@ -56,10 +56,6 @@ var _ = g.Describe(`[sig-storage][FeatureGate:MutableCSINodeAllocatableCount][Ji
 	)
 
 	g.BeforeEach(func() {
-		// TODO: remove the check when MutableCSINodeAllocatableCount is supported for GA
-		if !exutil.IsTechPreviewNoUpgrade(ctx, oc.AdminConfigClient()) {
-			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-		}
 
 		// Skip if not AWS platform
 		if !e2e.ProviderIs("aws") {


### PR DESCRIPTION
- The MutableCSINodeAllocatableCount graduated to GA in https://github.com/openshift/api/pull/2673, remove the feature gate skip check to enable MutableCSINodeAllocatableCount tests for all clusters.