### PR TITLE
TRT-2545: Allow pathological Failed/ImagePullBackOff events in must-gather name

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -97,6 +97,42 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 			expectedAllowName: "",
 		},
 		{
+			name: "must-gather image pull backoff",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-must-gather-txc45",
+					monitorapi.LocatorPodKey:       "must-gather-tv4tk",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("Error: ImagePullBackOff").
+				Reason("Failed").Build(),
+			expectedAllowName: "MustGatherImagePullFailed",
+		},
+		{
+			name: "must-gather image pull error",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-must-gather-cfpkb",
+					monitorapi.LocatorPodKey:       "must-gather-nqmhx",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("Error: ErrImagePull").
+				Reason("Failed").Build(),
+			expectedAllowName: "MustGatherImagePullFailed",
+		},
+		{
+			name: "no match for image pull failed in core namespace",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-controller-manager",
+					monitorapi.LocatorPodKey:       "doesntmatter",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("Error: ImagePullBackOff").
+				Reason("Failed").Build(),
+			expectedAllowName: "",
+		},
+		{
 			name: "port-forward",
 			locator: monitorapi.Locator{
 				Keys: map[monitorapi.LocatorKey]string{


### PR DESCRIPTION
…spaces

When an image pull fails, the kubelet fires two event types: a BackOff event (with the image name) and a Failed event (without the image name). The existing AllowImagePullBackOffFromRedHatRegistry matcher covers the BackOff events, but the companion Failed/Error: ImagePullBackOff events have no matcher because they lack the image name in their message.

On IPv6-only clusters, registry.redhat.io is often unreachable, causing must-gather pods to fail image pulls repeatedly. The BackOff event count stays near the DuplicateEventThreshold (20), and whether the companion Failed events tip over the threshold is non-deterministic, leading to flaky test failures.

Add a MustGatherImagePullFailed matcher scoped to openshift-must-gather-* namespaces to allow these Failed events, consistent with the existing allowance for the BackOff events.

Assisted-By: Claude 4.6 Opus High