### PR TITLE
TRT-2545: Extend known image checker to cover openshift-must-gather-* namespaces

### DIFF
--- a/pkg/monitortests/testframework/knownimagechecker/monitortest.go
+++ b/pkg/monitortests/testframework/knownimagechecker/monitortest.go
@@ -56,8 +56,8 @@ func (*clusterImageValidator) ConstructComputedIntervals(ctx context.Context, st
 // EvaluateTestsFromConstructedIntervals checks whether the cluster pulled an image that is
 // outside the allowed list of images. The list is defined as a set of static test case images, the
 // local cluster registry, any repository referenced by the image streams in the cluster's 'openshift'
-// namespace, or the location that input images are cloned from. Only namespaces prefixed with 'e2e-'
-// are checked.
+// namespace, or the location that input images are cloned from. Namespaces prefixed with 'e2e-' or
+// 'openshift-must-gather-' are checked.
 // any image not in the allowed prefixes is considered a failure, as the user
 // may have added a new test image without calling the appropriate helpers
 func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
@@ -146,8 +146,9 @@ func (w *clusterImageValidator) EvaluateTestsFromConstructedIntervals(ctx contex
 		if event.Message.Reason != "Pulled" {
 			continue
 		}
-		// only look at pull events from an e2e-* namespace
-		if !strings.HasPrefix(event.Locator.Keys[monitorapi.LocatorNamespaceKey], "e2e-") {
+		// only look at pull events from test-owned namespaces (e2e-* and openshift-must-gather-*)
+		ns := event.Locator.Keys[monitorapi.LocatorNamespaceKey]
+		if !strings.HasPrefix(ns, "e2e-") && !strings.HasPrefix(ns, "openshift-must-gather-") {
 			continue
 		}
 


### PR DESCRIPTION
The known image checker validates that tests only pull images from approved sources (cluster payload, mirrored repos, internal registry) to ensure disconnected environment compatibility. Previously it only checked e2e-* namespaces, so images pulled by oc adm must-gather in openshift-must-gather-* namespaces were never validated.

This gap allowed operator-discovered must-gather images (e.g. cnv-must-gather-rhel9 from registry.redhat.io) to be pulled without detection, which would break disconnected clusters and caused pathological ImagePullBackOff events on IPv6-only clusters where registry.redhat.io is unreachable.