### PR TITLE
CO tests becomes flaky on a cluster upgrade failure

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/monitortest.go
@@ -97,12 +97,13 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	}
 
 	if isUpgrade {
-		junits = append(junits, testUpgradeOperatorStateTransitions(finalIntervals, w.adminRESTConfig, topology)...)
+		upgradeFailed := hasUpgradeFailedEvent(finalIntervals)
+		junits = append(junits, testUpgradeOperatorStateTransitions(finalIntervals, w.adminRESTConfig, topology, upgradeFailed)...)
 		level, err := getUpgradeLevel(w.adminRESTConfig)
 		if err != nil || level == unknownUpgradeLevel {
 			return nil, fmt.Errorf("failed to determine upgrade level: %w", err)
 		}
-		junits = append(junits, testUpgradeOperatorProgressingStateTransitions(finalIntervals, level == patchUpgradeLevel, topology)...)
+		junits = append(junits, testUpgradeOperatorProgressingStateTransitions(finalIntervals, level == patchUpgradeLevel, topology, upgradeFailed)...)
 	} else {
 		junits = append(junits, testStableSystemOperatorStateTransitions(finalIntervals, topology)...)
 	}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -230,16 +230,15 @@ func hasUpgradeFailedEvent(eventList monitorapi.Intervals) bool {
 	return false
 }
 
-func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConfig *rest.Config, topology configv1.TopologyMode) []*junitapi.JUnitTestCase {
+func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConfig *rest.Config, topology configv1.TopologyMode, upgradeFailed bool) []*junitapi.JUnitTestCase {
 	upgradeWindows := getUpgradeWindows(events)
 
 	isTwoNode := topology == configv1.HighlyAvailableArbiterMode || topology == configv1.DualReplicaTopologyMode
-	upgradeFailed := hasUpgradeFailedEvent(events)
 
 	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, eventInterval monitorapi.Interval) string {
 		// When an upgrade was recorded as failed, we will not care about the operator state transitions
 		if upgradeFailed {
-			return "upgrade failed, not recording unexpected operator transitions as failure"
+			return upgradeFailureException
 		}
 
 		if condition.Status == configv1.ConditionTrue {
@@ -585,7 +584,9 @@ func testOperatorStateTransitions(events monitorapi.Intervals, conditionTypes []
 	return ret
 }
 
-func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals, isPatchLevelUpgrade bool, topology configv1.TopologyMode) []*junitapi.JUnitTestCase {
+const upgradeFailureException = "upgrade failed, not recording unexpected operator transitions as failure"
+
+func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals, isPatchLevelUpgrade bool, topology configv1.TopologyMode, upgradeFailed bool) []*junitapi.JUnitTestCase {
 	var ret []*junitapi.JUnitTestCase
 	upgradeWindows := getUpgradeWindows(events)
 	multiUpgrades := platformidentification.UpgradeNumberDuringCollection(events, time.Time{}, time.Time{}) > 1
@@ -631,6 +632,11 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 	}
 
 	except := func(co string, _ string) string {
+		// When an upgrade was recorded as failed, we will not care about the operator state transitions
+		if upgradeFailed {
+			return upgradeFailureException
+		}
+
 		intervals, ok := COWaiting[co]
 		if !ok {
 			// CO have not shown up in CVO Progressing message
@@ -701,6 +707,10 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 	}
 
 	except = func(co string, reason string) string {
+		// When an upgrade was recorded as failed, we will not care about the operator state transitions
+		if upgradeFailed {
+			return upgradeFailureException
+		}
 		switch co {
 		case "authentication":
 			if isTwoNode && reason == "APIServerDeployment_NewGeneration" {


### PR DESCRIPTION
We do not want to report testing results if the upgrade failed.
However, the relevant COs might be the root cause of the upgrade
failure. Instead of completely skipping the test cases, we make
them flaky to still bubble up some signals. However, the signal
for the flakiness is weak so that it does not lead to a job failure.

This strategy is already implemented for Available and Degraded
conditions. We extend it to Progressing as well.

There is another place to check Progressing [1] which is out of
the scope of `monitortest` and thus determining a failing upgrade
is challenging for it. For now, let us ignore that case.

[1]. https://github.com/openshift/origin/blob/50bae192e1195e41949279128562f5e861f35d72/test/extended/machines/scale.go#L269

/hold

will rebase after https://github.com/openshift/origin/pull/30775 gets in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of upgrade failures in cluster version operator monitoring. Upgrade failure events are now properly propagated through monitoring tests, enabling more accurate failure state tracking and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->