### PR TITLE
OCPNODE-4037: Move usernamespace test into longrunning

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -411,16 +411,6 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout: 30 * time.Minute,
 	},
 	{
-		Name: "openshift/usernamespace",
-		Description: templates.LongDesc(`
-		This test suite runs tests to validate user namespace functionality.
-		`),
-		Qualifiers: []string{
-			`name.contains("[Suite:openshift/usernamespace")`,
-		},
-		TestTimeout: 60 * time.Minute,
-	},
-	{
 		Name: "openshift/two-node",
 		Description: templates.LongDesc(`
 		This test suite runs tests to validate two-node.

--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -7,9 +7,6 @@ This directory contains OpenShift end-to-end tests for node-related features.
 ### Suite: openshift/disruptive-longrunning
 
 - **kubeletconfig_features.go** - Tests applying KubeletConfig to custom machine config pools, requires node reboots
-
-### Suite: openshift/usernamespace
-
 - **nested_container.go** - Tests running nested containers (podman-in-pod) with user namespaces and nested-container SCC
 
 ### Default Suite
@@ -51,12 +48,6 @@ To run only node-specific long-running disruptive tests:
 
 ```bash
 ./openshift-tests run "openshift/disruptive-longrunning" --dry-run | grep "\[sig-node\]" | ./openshift-tests run -f - --cluster-stability=Disruptive
-```
-
-### Running User Namespace Tests
-
-```bash
-./openshift-tests run "openshift/usernamespace"
 ```
 
 ## Prerequisites

--- a/test/extended/node/nested_container.go
+++ b/test/extended/node/nested_container.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("nested-podman", admissionapi.LevelBaseline)
 	g.It("should pass podman localsystem test in baseline mode",
 		func(ctx context.Context) {


### PR DESCRIPTION
- Moving the usernamespace test into the longrunning test suite.
- The tech preview cluster is not needed in OCP 4.22, hence `FEATURE_SET: TechPreviewNoUpgrade` is not required.
- Ran payload job https://github.com/openshift/origin/pull/30792#issuecomment-3911257008
- The test suite is already configured to run once in 24 hours
- I will remove the release job https://github.com/openshift/release/pull/63161/changes after this is merged