### PR TITLE
OCPBUGS-78016: Fix double counting of pod restart events

### DIFF
--- a/pkg/monitortests/node/watchpods/collection.go
+++ b/pkg/monitortests/node/watchpods/collection.go
@@ -218,29 +218,39 @@ func startPodMonitoring(ctx context.Context, recorderWriter monitorapi.RecorderW
 				// on the event stream
 
 			case lastTerminated && oldContainerStatus.LastTerminationState.Terminated == nil:
-				// if we are transitioning to a terminated state
-				if containerStatus.LastTerminationState.Terminated.ExitCode != 0 {
-					intervals = append(intervals,
-						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
-							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
-							Message(monitorapi.NewMessage().
-								Reason(monitorapi.ContainerReasonContainerExit).
-								WithAnnotation(monitorapi.AnnotationContainerExitCode, fmt.Sprintf("%d", containerStatus.LastTerminationState.Terminated.ExitCode)).
-								Cause(containerStatus.LastTerminationState.Terminated.Reason).
-								HumanMessage(containerStatus.LastTerminationState.Terminated.Message),
-							).BuildNow(),
-					)
-				} else {
-					intervals = append(intervals,
-						monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
-							Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
-							Message(monitorapi.NewMessage().
-								Reason(monitorapi.ContainerReasonContainerExit).
-								WithAnnotation(monitorapi.AnnotationContainerExitCode, "0").
-								Cause(containerStatus.LastTerminationState.Terminated.Reason).
-								HumanMessage(containerStatus.LastTerminationState.Terminated.Message)).
-							BuildNow(),
-					)
+				// if we are transitioning to a terminated state in LastTerminationState
+				// Check if we already recorded this exit when it was in State.Terminated
+				// If oldContainerStatus.State.Terminated matches the current LastTerminationState.Terminated,
+				// then we already recorded this exit and should skip to avoid double-counting
+				alreadyRecorded := oldContainerStatus.State.Terminated != nil &&
+					containerStatus.State.Terminated == nil &&
+					oldContainerStatus.State.Terminated.FinishedAt.Equal(&containerStatus.LastTerminationState.Terminated.FinishedAt)
+
+				if !alreadyRecorded {
+					// We missed the original exit event, record it now as a safety net
+					if containerStatus.LastTerminationState.Terminated.ExitCode != 0 {
+						intervals = append(intervals,
+							monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Error).
+								Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
+								Message(monitorapi.NewMessage().
+									Reason(monitorapi.ContainerReasonContainerExit).
+									WithAnnotation(monitorapi.AnnotationContainerExitCode, fmt.Sprintf("%d", containerStatus.LastTerminationState.Terminated.ExitCode)).
+									Cause(containerStatus.LastTerminationState.Terminated.Reason).
+									HumanMessage(containerStatus.LastTerminationState.Terminated.Message),
+								).BuildNow(),
+						)
+					} else {
+						intervals = append(intervals,
+							monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+								Locator(monitorapi.NewLocator().ContainerFromPod(pod, containerName)).
+								Message(monitorapi.NewMessage().
+									Reason(monitorapi.ContainerReasonContainerExit).
+									WithAnnotation(monitorapi.AnnotationContainerExitCode, "0").
+									Cause(containerStatus.LastTerminationState.Terminated.Reason).
+									HumanMessage(containerStatus.LastTerminationState.Terminated.Message)).
+								BuildNow(),
+						)
+					}
 				}
 
 			case currentTerminated && oldContainerStatus.State.Terminated == nil:


### PR DESCRIPTION
  Fix double-counting of container restart events

  Problem

  Container exit events are being double-counted when containers restart with non-zero exit codes. This causes inflated failure metrics in test monitoring.

  Root Cause

  When a container exits and restarts, Kubernetes moves the termination state through this sequence:
  1. Container exits → State.Terminated appears → Monitor fires Event
  2. Container restarts → termination moves to LastTerminationState.Terminated → Monitor fires Event (duplicate!)

  The monitor has two code paths that detect container exits:
  - Case 1: LastTerminationState.Terminated appears (line 220)
  - Case 2: State.Terminated appears (line 256)

  Both fire for the same exit, creating duplicate events.

  Fix

  Added deduplication check in Case 1 to skip events when we already recorded the exit in Case 2:

  alreadyRecorded := oldContainerStatus.State.Terminated != nil &&
      containerStatus.State.Terminated == nil &&
      oldContainerStatus.State.Terminated.FinishedAt.Equal(&containerStatus.LastTerminationState.Terminated.FinishedAt)

  This prevents double-counting by checking if:
  1. We previously saw this termination in State.Terminated
  2. It has now moved to LastTerminationState.Terminated
  3. The timestamps match (same termination event)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate container termination events in pod monitoring. Improved detection now skips repeated termination records and emits a single, accurate event (error or normal completion), ensuring correct event counts and more reliable pod lifecycle dashboards and alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->