### PR TITLE
OCPEDGE-2379: new test to add an extra worker on TNA cluster

### DIFF
--- a/test/extended/two_node/tna_extra_worker.go
+++ b/test/extended/two_node/tna_extra_worker.go
@@ -1,0 +1,451 @@
+package two_node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	v1 "github.com/openshift/api/config/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	"github.com/openshift/origin/test/extended/baremetal"
+	"github.com/openshift/origin/test/extended/two_node/utils"
+	"github.com/openshift/origin/test/extended/two_node/utils/apis"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	extraWorkerProvisioningTimeout = 15 * time.Minute
+)
+
+// initialState holds the cluster state recorded before the test begins,
+// so that post-test assertions can compare against the baseline.
+type initialState struct {
+	nodes          *corev1.NodeList
+	nodeCount      int
+	mcoClient      machineconfigclient.Interface
+	workerMCPCount int32
+}
+
+var bmhGVR = schema.GroupVersionResource{
+	Group: "metal3.io", Resource: "baremetalhosts", Version: "v1alpha1",
+}
+
+var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Serial] Extra worker scaling in HighlyAvailableArbiterMode", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithoutNamespace("").AsAdmin()
+	var helper *baremetal.BaremetalTestHelper
+
+	g.BeforeEach(func() {
+		g.By("SETUP: Validating cluster topology is HighlyAvailableArbiter")
+		utils.SkipIfNotTopology(oc, v1.HighlyAvailableArbiterMode)
+
+		// We intentionally do NOT call helper.Setup() here: its internal waitForDeletion
+		// has a hardcoded 5-minute timeout with o.Expect, which fails the test if a stale
+		// BMH from a previous (killed) run is still deprovisioning. Instead, we use our
+		// own cleanup with a 30-minute timeout that logs instead of failing.
+		g.By("SETUP: Cleaning up stale extra worker BMHs from previous runs")
+		bmhClient := oc.AdminDynamicClient().Resource(bmhGVR).Namespace(machineAPINamespace)
+		deleteExtraWorkerBMHs(bmhClient)
+
+		g.By("SETUP: Initializing baremetal test helper")
+		helper = baremetal.NewBaremetalTestHelper(oc.AdminDynamicClient())
+
+		g.By("SETUP: Ensuring extra worker data is available")
+		if !helper.CanDeployExtraWorkers() {
+			g.Skip("Extra worker data not available - deploy with NUM_EXTRA_WORKERS=1 in dev-scripts config")
+		}
+	})
+
+	g.AfterEach(func() {
+		if helper == nil {
+			return
+		}
+		// Do NOT call helper.DeleteAllExtraWorkers() here: its internal waitForDeletion has a
+		// hardcoded 5-minute timeout, which is insufficient for a provisioned BMH — Metal3 must
+		// complete a full deprovisioning cycle (power-off + disk clean via Redfish) before the
+		// object is removed, which routinely takes >5 minutes.
+		//
+		// Instead, we delete only the extraworker BMHs (by name prefix) and wait up to 30 minutes.
+		g.By("CLEANUP: Deleting extra worker BMHs and waiting for Metal3 deprovisioning")
+		bmhClient := oc.AdminDynamicClient().Resource(bmhGVR).Namespace(machineAPINamespace)
+		deleteExtraWorkerBMHs(bmhClient)
+
+		g.By("CLEANUP: Removing stale extra worker Node objects from the cluster")
+		deleteExtraWorkerNodes(oc)
+	})
+
+	g.It("should deploy an extra worker node that joins the cluster and becomes Ready [Timeout:60m][Slow]", func() {
+		g.By("STEP-01: Recording initial values for the test")
+		state := recordInitialState(oc)
+
+		g.By("STEP-02: Provisioning extra worker BMH")
+		provisionExtraWorker(oc, helper)
+
+		g.By("STEP-03: Approving pending CSRs for the new worker")
+		approveWorkerCSRs(oc)
+
+		g.By("STEP-04: Waiting for a new worker node to become Ready")
+		newWorkerName := waitForNewWorkerReady(oc, state.nodes)
+
+		g.By("STEP-05: Verifying new node membership and worker label")
+		newNode := verifyNodeMembership(oc, newWorkerName, state.nodeCount)
+
+		g.By("STEP-06: Verifying the new node has no pressure conditions")
+		verifyNodeHealth(newNode)
+
+		g.By("STEP-07: Verifying a pod can be scheduled and run on the new node")
+		verifyPodSchedulable(oc, newWorkerName)
+
+		g.By("STEP-08: Verifying the worker MachineConfigPool converges with the new node")
+		waitForWorkerMCPConvergence(state.mcoClient, state.workerMCPCount)
+
+		g.By("STEP-09: Verifying the new node's kubelet version matches existing nodes")
+		verifyKubeletVersion(oc, newNode)
+
+		e2e.Logf("Extra worker %s joined the cluster successfully", newWorkerName)
+	})
+})
+
+// --- Test step helpers ---
+
+func recordInitialState(oc *exutil.CLI) initialState {
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	mcoClient := machineconfigclient.NewForConfigOrDie(oc.AdminConfig())
+	mcpCount := getWorkerMCPMachineCount(mcoClient)
+	e2e.Logf("Initial state: %d nodes, %d machines in worker MCP", len(nodes.Items), mcpCount)
+	return initialState{
+		nodes:          nodes,
+		nodeCount:      len(nodes.Items),
+		mcoClient:      mcoClient,
+		workerMCPCount: mcpCount,
+	}
+}
+
+func getWorkerMCPMachineCount(mcoClient machineconfigclient.Interface) int32 {
+	mcp, err := mcoClient.MachineconfigurationV1().MachineConfigPools().Get(context.Background(), "worker", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get worker MachineConfigPool")
+	return mcp.Status.MachineCount
+}
+
+// provisionExtraWorker deploys the extra worker BMH from extraworkers-secret, patches it with
+// the fields needed for provisioning, and waits for it to reach the "provisioned" state.
+func provisionExtraWorker(oc *exutil.CLI, helper *baremetal.BaremetalTestHelper) {
+	// DeployExtraWorker returns (BMH, BMC secret) — we only need the BMH object.
+	host, _ := helper.DeployExtraWorker(0)
+	e2e.Logf("Extra worker BMH %s deployed and reached available state", host.GetName())
+
+	bmhClient := oc.AdminDynamicClient().Resource(bmhGVR).Namespace(machineAPINamespace)
+
+	triggerBMHProvisioning(bmhClient, host.GetName())
+	waitForBMHProvisioned(bmhClient, host.GetName())
+}
+
+func approveWorkerCSRs(oc *exutil.CLI) {
+	approvedCount := apis.ApproveCSRs(oc, 10*time.Minute, 1*time.Minute, 2)
+	o.Expect(approvedCount).To(o.BeNumerically(">=", 2),
+		fmt.Sprintf("Expected at least 2 CSRs (kubelet client + serving) but only approved %d", approvedCount))
+}
+
+// waitForNewWorkerReady polls until a new worker node (not present in initialNodes) becomes Ready.
+func waitForNewWorkerReady(oc *exutil.CLI, initialNodes *corev1.NodeList) string {
+	var newWorkerName string
+
+	err := wait.PollUntilContextTimeout(context.Background(), utils.ThirtySecondPollInterval, 10*time.Minute, true, func(ctx context.Context) (bool, error) {
+		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: utils.LabelNodeRoleWorker,
+		})
+		if err != nil {
+			e2e.Logf("Failed to list worker nodes: %v", err)
+			return false, nil
+		}
+		for i := range nodes.Items {
+			node := &nodes.Items[i]
+			if isNodeInList(node.Name, initialNodes.Items) {
+				continue
+			}
+			if utils.IsNodeReady(oc, node.Name) {
+				newWorkerName = node.Name
+				e2e.Logf("New worker node %s is Ready", node.Name)
+				return true, nil
+			}
+			e2e.Logf("New worker node %s found but not yet Ready", node.Name)
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for new worker node to become Ready")
+	o.Expect(newWorkerName).NotTo(o.BeEmpty(), "Expected to find a new worker node")
+	return newWorkerName
+}
+
+// verifyNodeMembership checks that the new node increased the cluster node count and has the worker label.
+func verifyNodeMembership(oc *exutil.CLI, newWorkerName string, initialNodeCount int) *corev1.Node {
+	finalNodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(len(finalNodes.Items)).To(o.Equal(initialNodeCount+1),
+		fmt.Sprintf("Expected %d nodes but found %d", initialNodeCount+1, len(finalNodes.Items)))
+
+	newNode, err := oc.AdminKubeClient().CoreV1().Nodes().Get(context.Background(), newWorkerName, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	_, hasWorkerLabel := newNode.Labels[utils.LabelNodeRoleWorker]
+	o.Expect(hasWorkerLabel).To(o.BeTrue(),
+		fmt.Sprintf("Expected node %s to have label %s", newWorkerName, utils.LabelNodeRoleWorker))
+
+	return newNode
+}
+
+func verifyNodeHealth(newNode *corev1.Node) {
+	for _, condition := range newNode.Status.Conditions {
+		switch condition.Type {
+		case corev1.NodeMemoryPressure, corev1.NodeDiskPressure, corev1.NodePIDPressure:
+			o.Expect(condition.Status).To(o.Equal(corev1.ConditionFalse),
+				fmt.Sprintf("Expected node %s condition %s to be False but got %s",
+					newNode.Name, condition.Type, condition.Status))
+		}
+	}
+	e2e.Logf("Node %s has no pressure conditions", newNode.Name)
+}
+
+func verifyPodSchedulable(oc *exutil.CLI, nodeName string) {
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "extra-worker-sched-",
+			Namespace:    "default",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:      nodeName,
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   image.ShellImage(),
+					Command: []string{"/bin/bash", "-c", "echo schedulability-ok"},
+				},
+			},
+		},
+	}
+	createdPod, err := oc.AdminKubeClient().CoreV1().Pods("default").Create(context.Background(), testPod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create test pod on node %s", nodeName)
+	defer func() {
+		_ = oc.AdminKubeClient().CoreV1().Pods("default").Delete(context.Background(), createdPod.Name, metav1.DeleteOptions{})
+	}()
+
+	err = wait.PollUntilContextTimeout(context.Background(), utils.FiveSecondPollInterval, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := oc.AdminKubeClient().CoreV1().Pods("default").Get(ctx, createdPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		e2e.Logf("Test pod %s phase: %s", createdPod.Name, pod.Status.Phase)
+		return pod.Status.Phase == corev1.PodSucceeded, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Test pod did not reach Succeeded on node %s", nodeName)
+
+	logs := getPodLogs(oc, "default", createdPod.Name)
+	o.Expect(logs).To(o.ContainSubstring("schedulability-ok"),
+		fmt.Sprintf("Expected test pod output to contain 'schedulability-ok' but got: %s", logs))
+	e2e.Logf("Pod successfully scheduled and ran on node %s", nodeName)
+}
+
+func getPodLogs(oc *exutil.CLI, namespace, podName string) string {
+	req := oc.AdminKubeClient().CoreV1().Pods(namespace).GetLogs(podName, &corev1.PodLogOptions{})
+	logBytes, err := req.DoRaw(context.Background())
+	if err != nil {
+		e2e.Logf("Failed to get logs for pod %s/%s: %v", namespace, podName, err)
+		return ""
+	}
+	return string(logBytes)
+}
+
+func waitForWorkerMCPConvergence(mcoClient machineconfigclient.Interface, initialMachineCount int32) {
+	expectedCount := initialMachineCount + 1
+	err := wait.PollUntilContextTimeout(context.Background(), utils.ThirtySecondPollInterval, 20*time.Minute, true, func(ctx context.Context) (bool, error) {
+		mcp, err := mcoClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, "worker", metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Failed to get worker MCP: %v", err)
+			return false, nil
+		}
+		s := mcp.Status
+		e2e.Logf("Worker MCP: machineCount=%d, readyMachineCount=%d, updatedMachineCount=%d, degradedMachineCount=%d",
+			s.MachineCount, s.ReadyMachineCount, s.UpdatedMachineCount, s.DegradedMachineCount)
+		return s.MachineCount == expectedCount &&
+			s.ReadyMachineCount == s.MachineCount &&
+			s.UpdatedMachineCount == s.MachineCount &&
+			s.DegradedMachineCount == 0, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Worker MachineConfigPool did not converge after adding new node")
+	e2e.Logf("Worker MachineConfigPool converged with %d machines", expectedCount)
+}
+
+func verifyKubeletVersion(oc *exutil.CLI, newNode *corev1.Node) {
+	masterNodes, err := utils.GetNodes(oc, utils.LabelNodeRoleControlPlane)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(masterNodes.Items).NotTo(o.BeEmpty(), "Expected at least one control-plane node")
+
+	workerVersion := newNode.Status.NodeInfo.KubeletVersion
+	masterVersions := make(map[string]bool)
+	for i := range masterNodes.Items {
+		masterVersions[masterNodes.Items[i].Status.NodeInfo.KubeletVersion] = true
+	}
+	e2e.Logf("Control-plane kubelet versions: %v, new worker kubelet version: %s", masterVersions, workerVersion)
+	o.Expect(masterVersions).To(o.HaveKey(workerVersion),
+		fmt.Sprintf("New node %s kubelet version %s does not match any control-plane kubelet version %v",
+			newNode.Name, workerVersion, masterVersions))
+}
+
+// --- BMH lifecycle helpers ---
+
+// triggerBMHProvisioning patches an available BMH with the fields needed to start provisioning:
+// customDeploy method, bootMode, rootDeviceHints, and userData. The extraworkers-secret BMH only
+// contains basic connectivity fields (bmc, bootMACAddress) — without customDeploy the BMH stays
+// "available" forever, and without userData the node boots CoreOS but never fetches its ignition
+// config from MCS, so no kubelet starts and no CSRs are generated.
+//
+// NOTE: bootMode=UEFI and rootDeviceHints=/dev/sda are specific to dev-scripts VMs (libvirt/QEMU).
+// Real hardware deployments would need values derived from the actual hardware inventory.
+func triggerBMHProvisioning(bmhClient dynamic.ResourceInterface, bmhName string) {
+	patch := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"customDeploy": map[string]interface{}{
+				"method": "install_coreos",
+			},
+			"bootMode": "UEFI",
+			"rootDeviceHints": map[string]interface{}{
+				"deviceName": "/dev/sda",
+			},
+			"userData": map[string]interface{}{
+				"name":      "worker-user-data-managed",
+				"namespace": machineAPINamespace,
+			},
+		},
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	_, err = bmhClient.Patch(context.Background(), bmhName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to patch BMH %s with provisioning config", bmhName)
+
+	e2e.Logf("Patched BMH %s with customDeploy=install_coreos, bootMode=UEFI, rootDeviceHints=/dev/sda, userData=worker-user-data-managed", bmhName)
+}
+
+// waitForBMHProvisioned polls until the BMH reaches the "provisioned" state.
+func waitForBMHProvisioned(bmhClient dynamic.ResourceInterface, bmhName string) {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, extraWorkerProvisioningTimeout, true, func(ctx context.Context) (bool, error) {
+		host, err := bmhClient.Get(ctx, bmhName, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Failed to get BMH %s: %v", bmhName, err)
+			return false, nil
+		}
+
+		state, found, err := unstructured.NestedString(host.Object, "status", "provisioning", "state")
+		if err != nil || !found {
+			e2e.Logf("BMH %s provisioning state not found yet", bmhName)
+			return false, nil
+		}
+
+		e2e.Logf("BMH %s provisioning state: %s", bmhName, state)
+
+		if state == "provisioned" {
+			return true, nil
+		}
+		if state == "error" {
+			errMsg, _, _ := unstructured.NestedString(host.Object, "status", "errorMessage")
+			return false, fmt.Errorf("BMH %s entered error state: %s", bmhName, errMsg)
+		}
+		return false, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for BMH %s to reach provisioned state", bmhName)
+}
+
+// --- Cleanup helpers ---
+
+// deleteExtraWorkerBMHs deletes all BMHs whose name contains "extraworker" and waits up to
+// 30 minutes for each to disappear. The long timeout is necessary because Metal3 deprovisioning
+// a provisioned BMH (power-off + disk clean via Redfish) routinely takes >5 minutes.
+//
+// This intentionally does NOT touch arbiter/master BMHs: a name-prefix filter avoids the
+// mistake of targeting all provisioned BMHs in the namespace.
+func deleteExtraWorkerBMHs(bmhClient dynamic.ResourceInterface) {
+	bmhList, err := bmhClient.List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		e2e.Logf("Failed to list BMHs for cleanup: %v", err)
+		return
+	}
+
+	for i := range bmhList.Items {
+		name := bmhList.Items[i].GetName()
+		if !strings.Contains(name, "extraworker") {
+			continue
+		}
+
+		e2e.Logf("Deleting extraworker BMH %s", name)
+		if err := bmhClient.Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+			if kerrors.IsNotFound(err) {
+				e2e.Logf("BMH %s already deleted", name)
+				continue
+			}
+			e2e.Logf("Failed to delete BMH %s: %v", name, err)
+			continue
+		}
+
+		err := wait.PollUntilContextTimeout(context.Background(), 15*time.Second, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
+			_, err := bmhClient.Get(ctx, name, metav1.GetOptions{})
+			if kerrors.IsNotFound(err) {
+				e2e.Logf("BMH %s deleted", name)
+				return true, nil
+			}
+			e2e.Logf("Waiting for BMH %s to be deleted...", name)
+			return false, nil
+		})
+		if err != nil {
+			e2e.Logf("BMH %s was not deleted within timeout: %v", name, err)
+		}
+	}
+}
+
+// deleteExtraWorkerNodes removes any Node objects whose name contains "extraworker" from the
+// cluster. After BMH deletion, Metal3 powers off the host but the Node object persists in
+// NotReady state. Cleaning it up prevents stale nodes from accumulating on long-lived clusters.
+func deleteExtraWorkerNodes(oc *exutil.CLI) {
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		e2e.Logf("Failed to list nodes for cleanup: %v", err)
+		return
+	}
+	for i := range nodes.Items {
+		name := nodes.Items[i].Name
+		if !strings.Contains(name, "extraworker") {
+			continue
+		}
+		e2e.Logf("Deleting stale extra worker node %s", name)
+		if err := oc.AdminKubeClient().CoreV1().Nodes().Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil && !kerrors.IsNotFound(err) {
+			e2e.Logf("Failed to delete node %s: %v", name, err)
+		}
+	}
+}
+
+// isNodeInList checks whether a node name exists in the given node list.
+func isNodeInList(name string, nodes []corev1.Node) bool {
+	for i := range nodes {
+		if nodes[i].Name == name {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Adding a new Test Case to create a extra worker on a TNA cluster as a 2 day operation.

| Phase | Step | Description |
|-------|------|-------------|
| Setup | SETUP-01 | Validate cluster topology is HighlyAvailableArbiter |
| Setup | SETUP-02 | Clean up stale extra worker BMHs from previous runs (30-min timeout) |
| Setup | SETUP-03 | Initialize baremetal test helper |
| Setup | SETUP-04 | Verify extra worker data is available (`extraworkers-secret`) |
| Test | STEP-01 | Record initial node count and worker MachineConfigPool state |
| Test | STEP-02 | Provision extra worker BMH from `extraworkers-secret` |
| Test | STEP-03 | Approve pending CSRs for the new worker (kubelet client + serving) |
| Test | STEP-04 | Wait for the new worker node to become Ready |
| Test | STEP-05 | Verify new node membership (node count +1) and worker label |
| Test | STEP-06 | Verify the new node has no pressure conditions (memory, disk, PID) |
| Test | STEP-07 | Verify a pod can be scheduled and run on the new node |
| Test | STEP-08 | Verify the worker MachineConfigPool converges with the new node |
| Test | STEP-09 | Verify the new node's kubelet version matches control-plane nodes |
| Cleanup | CLEANUP-01 | Delete extra worker BMHs and wait for Metal3 deprovisioning (30-min timeout) |
| Cleanup | CLEANUP-02 | Remove stale extra worker Node objects from the cluster |

This is a successful log example:
```
$ ./openshift-tests run-test '[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Serial] Extra worker scaling in HighlyAvailableArbiterMode should deploy an extra worker node that joins the cluster and becomes Ready [Timeout:60m][Slow]'

  I0312 16:33:58.731594   50194 i18n.go:139] Couldn't find translations for C, using default
  I0312 16:33:58.866736   50194 binary.go:78] Found 8524 test specs
  I0312 16:33:58.867806   50194 binary.go:95] 1074 test specs remain, after filtering out k8s
openshift-tests v4.1.0-10870-gfbba1c2
  I0312 16:33:59.705199   50194 test_setup.go:125] Extended test version v4.1.0-10870-gfbba1c2
  I0312 16:33:59.705234   50194 test_context.go:559] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0312 16:33:59.705589 50194 framework.go:2324] [precondition-check] checking if cluster is MicroShift
  I0312 16:33:59.752027 50194 framework.go:2348] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  I0312 16:33:59.752470   50194 binary.go:122] Loaded test configuration: &framework.TestContextType{KubeConfig:"/Users/agullon/workspace/two-node-toolbox/deploy/openshift-clusters/kubeconfig", KubeContext:"", KubeAPIContentType:"application/vnd.kubernetes.protobuf", KubeletRootDir:"/var/lib/kubelet", KubeletConfigDropinDir:"", CertDir:"", Host:"https://api.ostest.test.metalkube.org:6443", BearerToken:"<redacted>", RepoRoot:"../../", ListImages:false, listTests:false, listLabels:false, ListConformanceTests:false, Provider:"skeleton", Tooling:"", timeouts:framework.TimeoutContext{Poll:2000000000, PodStart:300000000000, PodStartShort:120000000000, PodStartSlow:900000000000, PodDelete:300000000000, ClaimProvision:300000000000, DataSourceProvision:300000000000, ClaimProvisionShort:60000000000, ClaimBound:180000000000, PVReclaim:180000000000, PVBound:180000000000, PVCreate:180000000000, PVDelete:300000000000, PVDeleteSlow:1200000000000, SnapshotCreate:300000000000, SnapshotDelete:300000000000, SnapshotControllerMetrics:300000000000, SystemPodsStartup:600000000000, NodeSchedulable:1800000000000, SystemDaemonsetStartup:300000000000, NodeNotReady:180000000000}, CloudConfig:framework.CloudConfig{APIEndpoint:"", ProjectID:"", Zone:"", Zones:[]string{}, Region:"", MultiZone:false, MultiMaster:true, Cluster:"", MasterName:"", NodeInstanceGroup:"", NumNodes:2, ClusterIPRange:"", ClusterTag:"", Network:"", ConfigFile:"", NodeTag:"", MasterTag:"", Provider:framework.NullProvider{}}, KubectlPath:"kubectl", OutputDir:"/tmp", ReportDir:"", ReportPrefix:"", ReportCompleteGinkgo:false, ReportCompleteJUnit:false, Prefix:"e2e", MinStartupPods:-1, EtcdUpgradeStorage:"", EtcdUpgradeVersion:"", GCEUpgradeScript:"", ContainerRuntimeEndpoint:"unix:///run/containerd/containerd.sock", ContainerRuntimeProcessName:"containerd", ContainerRuntimePidFile:"/run/containerd/containerd.pid", SystemdServices:"containerd*", DumpSystemdJournal:false, ImageServiceEndpoint:"", MasterOSDistro:"custom", NodeOSDistro:"custom", NodeOSArch:"amd64", VerifyServiceAccount:true, DeleteNamespace:true, DeleteNamespaceOnFailure:true, AllowedNotReadyNodes:-1, CleanStart:false, GatherKubeSystemResourceUsageData:"false", GatherLogsSizes:false, GatherMetricsAfterTest:"false", GatherSuiteMetricsAfterTest:false, MaxNodesToGather:0, IncludeClusterAutoscalerMetrics:false, OutputPrintType:"json", CreateTestingNS:(framework.CreateTestingNSFn)(0x107bda660), DumpLogsOnFailure:true, DisableLogDump:false, LogexporterGCSPath:"", NodeTestContextType:framework.NodeTestContextType{NodeE2E:false, NodeName:"", NodeConformance:false, PrepullImages:false, ImageDescription:"", RuntimeConfig:map[string]string(nil), SystemSpecName:"", RestartKubelet:false, ExtraEnvs:map[string]string(nil), StandaloneMode:false, CriProxyEnabled:false}, ClusterDNSDomain:"cluster.local", NodeKiller:framework.NodeKillerConfig{Enabled:false, FailureRatio:0.01, Interval:60000000000, JitterFactor:60, SimulatedDowntime:600000000000, NodeKillerStopCtx:context.Context(nil), NodeKillerStop:(func())(nil)}, IPFamily:"ipv4", NonblockingTaints:"node-role.kubernetes.io/control-plane", ProgressReportURL:"", SriovdpConfigMapFile:"", SpecSummaryOutput:"", DockerConfigFile:"", E2EDockerConfigFile:"", KubeTestRepoList:"", SnapshotControllerPodName:"", SnapshotControllerHTTPPort:0, RequireDevices:false, EnabledVolumeDrivers:[]string(nil)}
  Running Suite:  - /Users/agullon/workspace/origin
  =================================================
  Random Seed: 1773329638 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Serial] Extra worker scaling in HighlyAvailableArbiterMode should deploy an extra worker node that joins the cluster and becomes Ready [Timeout:60m][Slow]
  github.com/openshift/origin/test/extended/two_node/tna_extra_worker.go:93
    STEP: Creating a kubernetes client @ 03/12/26 16:33:59.76
  I0312 16:33:59.760839   50194 discovery.go:214] Invalidating discovery information
    STEP: SETUP: Validating cluster topology is HighlyAvailableArbiter @ 03/12/26 16:33:59.76
  I0312 16:33:59.760992 50194 common.go:109] [precondition-check] validating cluster topology is HighlyAvailableArbiter
    STEP: SETUP: Cleaning up stale extra worker BMHs from previous runs @ 03/12/26 16:33:59.809
    STEP: SETUP: Initializing baremetal test helper @ 03/12/26 16:34:00.966
    STEP: SETUP: Ensuring extra worker data is available @ 03/12/26 16:34:00.968
    STEP: STEP-01: Recording initial values for the test @ 03/12/26 16:34:01.014
  I0312 16:34:01.169957 50194 tna_extra_worker.go:132] Initial state: 3 nodes, 0 machines in worker MCP
    STEP: STEP-02: Provisioning extra worker BMH @ 03/12/26 16:34:01.17
    STEP: wait until ostest-extraworker-0 becomes available @ 03/12/26 16:34:01.383
  I0312 16:36:56.543657 50194 tna_extra_worker.go:152] Extra worker BMH ostest-extraworker-0 deployed and reached available state
  I0312 16:36:56.614026 50194 tna_extra_worker.go:344] Patched BMH ostest-extraworker-0 with customDeploy=install_coreos, bootMode=UEFI, rootDeviceHints=/dev/sda, userData=worker-user-data-managed
  I0312 16:36:56.670014 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: available
  I0312 16:37:06.663389 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:37:16.663525 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:37:26.664017 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:37:36.662165 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:37:46.675360 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:37:56.668122 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:38:06.667721 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning
  I0312 16:38:16.666742 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioned
    STEP: STEP-03: Approving pending CSRs for the new worker @ 03/12/26 16:38:16.666
  I0312 16:38:16.666883 50194 csr.go:23] Starting CSR approval monitoring for 10m0s
  I0312 16:41:16.770274 50194 csr.go:39] Approving CSR: csr-gjz7g
  I0312 16:41:16.870699 50194 csr.go:61] Approved CSR csr-gjz7g (total approved: 1)
  I0312 16:41:16.870791 50194 csr.go:69] Approved 1 CSRs this iteration, continuing to monitor (elapsed: 3m0.199850833s)
  I0312 16:42:16.819227 50194 csr.go:39] Approving CSR: csr-6v2fn
  I0312 16:42:16.922483 50194 csr.go:61] Approved CSR csr-6v2fn (total approved: 2)
  I0312 16:42:16.922520 50194 csr.go:69] Approved 1 CSRs this iteration, continuing to monitor (elapsed: 4m0.250732958s)
  I0312 16:42:16.922531 50194 csr.go:74] All 2 expected CSRs approved! (elapsed: 4m0.250745416s)
  I0312 16:42:16.922544 50194 csr.go:80] CSR approval monitoring complete: approved 2 CSRs in 4m0.250758875s
    STEP: STEP-04: Waiting for a new worker node to become Ready @ 03/12/26 16:42:16.922
  I0312 16:42:17.021811 50194 tna_extra_worker.go:185] New worker node extraworker-0 is Ready
    STEP: STEP-05: Verifying new node membership and worker label @ 03/12/26 16:42:17.021
    STEP: STEP-06: Verifying the new node has no pressure conditions @ 03/12/26 16:42:17.121
  I0312 16:42:17.121938 50194 tna_extra_worker.go:222] Node extraworker-0 has no pressure conditions
    STEP: STEP-07: Verifying a pod can be scheduled and run on the new node @ 03/12/26 16:42:17.121
  I0312 16:42:17.234400 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:22.234409 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:27.232393 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:32.235067 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:37.237223 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:42.234168 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending
  I0312 16:42:47.235259 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Succeeded
  I0312 16:42:47.294940 50194 tna_extra_worker.go:262] Pod successfully scheduled and ran on node extraworker-0
    STEP: STEP-08: Verifying the worker MachineConfigPool converges with the new node @ 03/12/26 16:42:47.36
  I0312 16:42:47.409102 50194 tna_extra_worker.go:284] Worker MCP: machineCount=1, readyMachineCount=1, updatedMachineCount=1, degradedMachineCount=0
  I0312 16:42:47.409332 50194 tna_extra_worker.go:292] Worker MachineConfigPool converged with 1 machines
    STEP: STEP-09: Verifying the new node's kubelet version matches existing nodes @ 03/12/26 16:42:47.409
  I0312 16:42:47.502612 50194 tna_extra_worker.go:305] Control-plane kubelet versions: map[v1.34.2:true], new worker kubelet version: v1.34.2
  I0312 16:42:47.502692 50194 tna_extra_worker.go:121] Extra worker extraworker-0 joined the cluster successfully
    STEP: CLEANUP: Deleting extra worker BMHs and waiting for Metal3 deprovisioning @ 03/12/26 16:42:47.504
  I0312 16:42:47.557551 50194 tna_extra_worker.go:397] Deleting extraworker BMH ostest-extraworker-0
  I0312 16:42:47.663250 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:43:02.664446 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:43:17.664284 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:43:32.668089 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:43:47.664791 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:44:02.664577 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:44:17.664681 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:44:32.666638 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:44:47.666547 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:45:02.665981 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:45:17.665362 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:45:32.665374 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:45:47.666957 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
^[[B^[[B  I0312 16:46:02.666800 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:46:17.668567 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:46:32.670286 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:46:47.669244 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:47:02.669048 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:47:17.671916 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:47:32.668483 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:47:47.671125 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:48:02.669652 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:48:17.670213 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:48:32.669910 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...
  I0312 16:48:47.666651 50194 tna_extra_worker.go:410] BMH ostest-extraworker-0 deleted
    STEP: CLEANUP: Removing stale extra worker Node objects from the cluster @ 03/12/26 16:48:47.666
  I0312 16:48:47.763990 50194 tna_extra_worker.go:436] Deleting stale extra worker node extraworker-0
  • [888.047 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 888.047 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-node][apigroup:config.openshift.io][OCPFeatureGate:HighlyAvailableArbiter][Serial] Extra worker scaling in HighlyAvailableArbiterMode should deploy an extra worker node that joins the cluster and becomes Ready [Timeout:60m][Slow]",
    "lifecycle": "blocking",
    "duration": 888061,
    "startTime": "2026-03-12 15:33:59.752713 UTC",
    "endTime": "2026-03-12 15:48:47.813882 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 03/12/26 16:33:59.76\n  STEP: SETUP: Validating cluster topology is HighlyAvailableArbiter @ 03/12/26 16:33:59.76\nI0312 16:33:59.760992 50194 common.go:109] [precondition-check] validating cluster topology is HighlyAvailableArbiter\n  STEP: SETUP: Cleaning up stale extra worker BMHs from previous runs @ 03/12/26 16:33:59.809\n  STEP: SETUP: Initializing baremetal test helper @ 03/12/26 16:34:00.966\n  STEP: SETUP: Ensuring extra worker data is available @ 03/12/26 16:34:00.968\n  STEP: STEP-01: Recording initial values for the test @ 03/12/26 16:34:01.014\nI0312 16:34:01.169957 50194 tna_extra_worker.go:132] Initial state: 3 nodes, 0 machines in worker MCP\n  STEP: STEP-02: Provisioning extra worker BMH @ 03/12/26 16:34:01.17\n  STEP: wait until ostest-extraworker-0 becomes available @ 03/12/26 16:34:01.383\nI0312 16:36:56.543657 50194 tna_extra_worker.go:152] Extra worker BMH ostest-extraworker-0 deployed and reached available state\nI0312 16:36:56.614026 50194 tna_extra_worker.go:344] Patched BMH ostest-extraworker-0 with customDeploy=install_coreos, bootMode=UEFI, rootDeviceHints=/dev/sda, userData=worker-user-data-managed\nI0312 16:36:56.670014 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: available\nI0312 16:37:06.663389 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:37:16.663525 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:37:26.664017 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:37:36.662165 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:37:46.675360 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:37:56.668122 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:38:06.667721 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioning\nI0312 16:38:16.666742 50194 tna_extra_worker.go:362] BMH ostest-extraworker-0 provisioning state: provisioned\n  STEP: STEP-03: Approving pending CSRs for the new worker @ 03/12/26 16:38:16.666\nI0312 16:38:16.666883 50194 csr.go:23] Starting CSR approval monitoring for 10m0s\nI0312 16:41:16.770274 50194 csr.go:39] Approving CSR: csr-gjz7g\nI0312 16:41:16.870699 50194 csr.go:61] Approved CSR csr-gjz7g (total approved: 1)\nI0312 16:41:16.870791 50194 csr.go:69] Approved 1 CSRs this iteration, continuing to monitor (elapsed: 3m0.199850833s)\nI0312 16:42:16.819227 50194 csr.go:39] Approving CSR: csr-6v2fn\nI0312 16:42:16.922483 50194 csr.go:61] Approved CSR csr-6v2fn (total approved: 2)\nI0312 16:42:16.922520 50194 csr.go:69] Approved 1 CSRs this iteration, continuing to monitor (elapsed: 4m0.250732958s)\nI0312 16:42:16.922531 50194 csr.go:74] All 2 expected CSRs approved! (elapsed: 4m0.250745416s)\nI0312 16:42:16.922544 50194 csr.go:80] CSR approval monitoring complete: approved 2 CSRs in 4m0.250758875s\n  STEP: STEP-04: Waiting for a new worker node to become Ready @ 03/12/26 16:42:16.922\nI0312 16:42:17.021811 50194 tna_extra_worker.go:185] New worker node extraworker-0 is Ready\n  STEP: STEP-05: Verifying new node membership and worker label @ 03/12/26 16:42:17.021\n  STEP: STEP-06: Verifying the new node has no pressure conditions @ 03/12/26 16:42:17.121\nI0312 16:42:17.121938 50194 tna_extra_worker.go:222] Node extraworker-0 has no pressure conditions\n  STEP: STEP-07: Verifying a pod can be scheduled and run on the new node @ 03/12/26 16:42:17.121\nI0312 16:42:17.234400 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:22.234409 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:27.232393 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:32.235067 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:37.237223 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:42.234168 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Pending\nI0312 16:42:47.235259 50194 tna_extra_worker.go:254] Test pod extra-worker-sched-pq9nz phase: Succeeded\nI0312 16:42:47.294940 50194 tna_extra_worker.go:262] Pod successfully scheduled and ran on node extraworker-0\n  STEP: STEP-08: Verifying the worker MachineConfigPool converges with the new node @ 03/12/26 16:42:47.36\nI0312 16:42:47.409102 50194 tna_extra_worker.go:284] Worker MCP: machineCount=1, readyMachineCount=1, updatedMachineCount=1, degradedMachineCount=0\nI0312 16:42:47.409332 50194 tna_extra_worker.go:292] Worker MachineConfigPool converged with 1 machines\n  STEP: STEP-09: Verifying the new node's kubelet version matches existing nodes @ 03/12/26 16:42:47.409\nI0312 16:42:47.502612 50194 tna_extra_worker.go:305] Control-plane kubelet versions: map[v1.34.2:true], new worker kubelet version: v1.34.2\nI0312 16:42:47.502692 50194 tna_extra_worker.go:121] Extra worker extraworker-0 joined the cluster successfully\n  STEP: CLEANUP: Deleting extra worker BMHs and waiting for Metal3 deprovisioning @ 03/12/26 16:42:47.504\nI0312 16:42:47.557551 50194 tna_extra_worker.go:397] Deleting extraworker BMH ostest-extraworker-0\nI0312 16:42:47.663250 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:43:02.664446 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:43:17.664284 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:43:32.668089 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:43:47.664791 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:44:02.664577 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:44:17.664681 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:44:32.666638 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:44:47.666547 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:45:02.665981 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:45:17.665362 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:45:32.665374 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:45:47.666957 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:46:02.666800 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:46:17.668567 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:46:32.670286 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:46:47.669244 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:47:02.669048 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:47:17.671916 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:47:32.668483 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:47:47.671125 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:48:02.669652 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:48:17.670213 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:48:32.669910 50194 tna_extra_worker.go:413] Waiting for BMH ostest-extraworker-0 to be deleted...\nI0312 16:48:47.666651 50194 tna_extra_worker.go:410] BMH ostest-extraworker-0 deleted\n  STEP: CLEANUP: Removing stale extra worker Node objects from the cluster @ 03/12/26 16:48:47.666\nI0312 16:48:47.763990 50194 tna_extra_worker.go:436] Deleting stale extra worker node extraworker-0\n"
  }
]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for dynamically adding worker nodes to two-node OpenShift clusters configured with highly available arbiter mode, including validation of bare metal provisioning, node readiness, pod scheduling, machine configuration pool convergence, and kubelet compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->