### PR TITLE
[release-4.20]: OCPBUGS-77313: Add test for CPMS OnDelete strategy with full master replacement

### DIFF
--- a/test/extended/etcd/OWNERS
+++ b/test/extended/etcd/OWNERS
@@ -1,12 +1,11 @@
 reviewers:
   - dusk125
   - hasbro17
-  - Elbehery
+  - jubittajohn
   - tjungblu
 approvers:
   - deads2k
-  - soltysh
   - hasbro17
   - dusk125
-  - Elbehery
+  - jubittajohn
   - tjungblu

--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1273,6 +1273,8 @@ var Annotations = map[string]string{
 
 	"[sig-etcd][Feature:DisasterRecovery][Suite:openshift/etcd/recovery][Timeout:30m] [Feature:EtcdRecovery][Disruptive] Restore snapshot from node on another single unhealthy node": " [Serial]",
 
+	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to delete all masters with OnDelete strategy and wait for CPMSO to replace them [Timeout:120m][apigroup:machine.openshift.io]": "",
+
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to vertically scale up and down when CPMS is disabled [apigroup:machine.openshift.io]": "",
 
 	"[sig-etcd][Feature:EtcdVerticalScaling][Suite:openshift/etcd/scaling][Serial] etcd is able to vertically scale up and down with a single node [Timeout:60m][apigroup:machine.openshift.io]": "",


### PR DESCRIPTION
Replaces https://github.com/openshift/origin/pull/30811

This is a manual cherry-pick of https://github.com/openshift/origin/pull/30802

/cherrypick release-4.19 release-4.18