### PR TITLE
NO-JIRA: Allow etcd Available=False during TNF jobs

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -303,6 +303,11 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					strings.Contains(condition.Message, `Waiting for Deployment`) {
 					return "csi snapshot controller is allowed to have Available=False due to CSI webhook test on two node"
 				}
+			case "etcd":
+				if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
+					strings.Contains(condition.Reason, "tnf-") {
+					return "etcd is allowed to have Available=False during TNF jobs on two node"
+				}
 			}
 		}
 


### PR DESCRIPTION
During TNF test jobs on two-node clusters, the etcd operator can transiently lose availability. This is expected behavior and should not cause test failures.
Adds an exception in `testUpgradeOperatorStateTransitions` for the `etcd` operator reporting `Available=False` when the reason contains "tnf-", matching TNF job scenarios on two-node clusters.