### PR TITLE
OCPBUGS-76334: Without library-go bump from TLS 1.3 test fixes

### DIFF
--- a/test/extended/apiserver/tls.go
+++ b/test/extended/apiserver/tls.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"context"
+	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/library-go/pkg/crypto"
+	"github.com/openshift/origin/test/extended/apiserver/tlsutil"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -121,10 +122,26 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 		config, err := oc.AdminConfigClient().ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		if config.Spec.TLSSecurityProfile != nil &&
-			config.Spec.TLSSecurityProfile.Type != configv1.TLSProfileIntermediateType {
-			g.Skip("Cluster TLS profile is not default (intermediate), skipping cipher defaults check")
+		g.By("Determining expected TLS behavior based on the cluster's TLS profile")
+		var minTLSVersion uint16
+		var testCipherSuites bool
+		switch {
+		case config.Spec.TLSSecurityProfile == nil,
+			config.Spec.TLSSecurityProfile.Type == configv1.TLSProfileIntermediateType:
+			minTLSVersion = tlsutil.DefaultTLSVersion() // TLS 1.2
+			testCipherSuites = true
+			g.By("Using intermediate TLS profile: TLS ≥1.2 should work")
+		case config.Spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType:
+			minTLSVersion = tls.VersionTLS13
+			testCipherSuites = false // TLS 1.3 cipher suites are not configurable
+			g.By("Using modern TLS profile: only TLS 1.3 should work")
+		default:
+			g.Skip("Only intermediate or modern profiles are tested")
 		}
+
+		g.By("Checking if the cluster is running in FIPS mode")
+		isFIPS, err := exutil.IsFIPS(oc.AdminKubeClient().CoreV1())
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Verifying TLS version and cipher behavior via port-forward to apiserver")
 		err = forwardPortAndExecute("apiserver", "openshift-kube-apiserver", "443", func(port int) error {
@@ -132,9 +149,9 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 			t.Logf("Testing TLS versions and ciphers against %s", host)
 
 			// Test TLS versions
-			for _, tlsVersionName := range crypto.ValidTLSVersions() {
-				tlsVersion := crypto.TLSVersionOrDie(tlsVersionName)
-				expectSuccess := tlsVersion >= crypto.DefaultTLSVersion()
+			for _, tlsVersionName := range tlsutil.ValidTLSVersions() {
+				tlsVersion := tlsutil.TLSVersionOrDie(tlsVersionName)
+				expectSuccess := tlsVersion >= minTLSVersion
 				cfg := &tls.Config{MinVersion: tlsVersion, MaxVersion: tlsVersion, InsecureSkipVerify: true}
 
 				t.Logf("Testing TLS version %s (0x%04x), expectSuccess=%v", tlsVersionName, tlsVersion, expectSuccess)
@@ -153,35 +170,82 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 				}
 			}
 
-			// Test cipher suites
-			defaultCiphers := map[uint16]bool{}
-			for _, c := range crypto.DefaultCiphers() {
-				defaultCiphers[c] = true
-			}
-
-			for _, cipherName := range crypto.ValidCipherSuites() {
-				cipher, err := crypto.CipherSuite(cipherName)
-				if err != nil {
-					return err
-				}
-				expectFailure := !defaultCiphers[cipher]
-				// Constrain to TLS 1.2 because the intermediate profile allows both TLS 1.2 and TLS 1.3.
-				// If MaxVersion is unspecified, the client negotiates TLS 1.3 when the server supports it.
-				// TLS 1.3 does not support configuring cipher suites (predetermined by the spec), so
-				// specifying any cipher suite (RC4 or otherwise) has no effect with TLS 1.3.
-				// By forcing TLS 1.2, we can actually test the cipher suite restrictions.
-				cfg := &tls.Config{
-					CipherSuites:       []uint16{cipher},
-					MinVersion:         tls.VersionTLS12,
-					MaxVersion:         tls.VersionTLS12,
-					InsecureSkipVerify: true,
+			// Test cipher suites (only for profiles where cipher suites are configurable)
+			if testCipherSuites {
+				defaultCiphers := map[uint16]bool{}
+				for _, c := range tlsutil.DefaultCiphers() {
+					defaultCiphers[c] = true
 				}
 
-				conn, dialErr := tls.Dial("tcp", host, cfg)
-				if dialErr == nil {
-					closeErr := conn.Close()
-					if expectFailure {
-						return fmt.Errorf("expected failure on cipher %s, got success. Closing conn: %v", cipherName, closeErr)
+				// Detect the server's key type by inspecting the peer certificate.
+				// ECDSA cipher suites require an ECDSA server key; RSA cipher suites
+				// require an RSA server key. Go's TLS stack silently skips cipher
+				// suites incompatible with the server's key during negotiation, so
+				// a mismatched cipher will always fail the handshake.
+				serverKeyIsRSA := true // default conservative assumption
+				probeConn, probeErr := tls.Dial("tcp", host, &tls.Config{InsecureSkipVerify: true})
+				if probeErr != nil {
+					return fmt.Errorf("failed to connect to determine server key type: %v", probeErr)
+				}
+				certs := probeConn.ConnectionState().PeerCertificates
+				if len(certs) > 0 {
+					_, serverKeyIsRSA = certs[0].PublicKey.(*rsa.PublicKey)
+				}
+				probeConn.Close()
+				t.Logf("Server key type RSA: %v", serverKeyIsRSA)
+
+				for _, cipherName := range tlsutil.ValidCipherSuites() {
+					cipher, err := tlsutil.CipherSuite(cipherName)
+					if err != nil {
+						return err
+					}
+
+					// Skip TLS 1.3 cipher suites when testing with TLS 1.2.
+					// TLS 1.3 ciphers are predetermined and cannot be configured via CipherSuites.
+					if isTLS13Cipher(cipher) {
+						continue
+					}
+
+					expectFailure := !defaultCiphers[cipher]
+
+					// ECDSA cipher suites require an ECDSA server certificate/key.
+					// Go's TLS server silently skips cipher suites incompatible
+					// with the server's key type during negotiation, so an ECDSA
+					// cipher against an RSA-keyed server will always fail.
+					if strings.Contains(cipherName, "ECDSA") && serverKeyIsRSA {
+						expectFailure = true
+					}
+
+					// ChaCha20-Poly1305 is not a FIPS 140-2/140-3 approved algorithm.
+					// In FIPS mode, Go's crypto library disables ChaCha20-Poly1305,
+					// so the kube-apiserver cannot negotiate these ciphers even when
+					// they appear in the configured cipher list.
+					if isFIPS && strings.Contains(cipherName, "CHACHA20") {
+						expectFailure = true
+					}
+
+					// Constrain to TLS 1.2 because the intermediate profile allows both TLS 1.2 and TLS 1.3.
+					// If MaxVersion is unspecified, the client negotiates TLS 1.3 when the server supports it.
+					// TLS 1.3 does not support configuring cipher suites (predetermined by the spec), so
+					// specifying any cipher suite (RC4 or otherwise) has no effect with TLS 1.3.
+					// By forcing TLS 1.2, we can actually test the cipher suite restrictions.
+					cfg := &tls.Config{
+						CipherSuites:       []uint16{cipher},
+						MinVersion:         tls.VersionTLS12,
+						MaxVersion:         tls.VersionTLS12,
+						InsecureSkipVerify: true,
+					}
+
+					conn, dialErr := tls.Dial("tcp", host, cfg)
+					if dialErr != nil {
+						if !expectFailure {
+							return fmt.Errorf("expected success on cipher %s, got error: %v", cipherName, dialErr)
+						}
+					} else {
+						closeErr := conn.Close()
+						if expectFailure {
+							return fmt.Errorf("expected failure on cipher %s, got success. Closing conn: %v", cipherName, closeErr)
+						}
 					}
 				}
 			}
@@ -191,6 +255,14 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer]", func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 })
+
+// isTLS13Cipher returns true if the cipher suite is TLS 1.3-specific.
+// TLS 1.3 cipher suites are predetermined and cannot be configured via CipherSuites.
+func isTLS13Cipher(cipher uint16) bool {
+	return cipher == tls.TLS_AES_128_GCM_SHA256 ||
+		cipher == tls.TLS_AES_256_GCM_SHA384 ||
+		cipher == tls.TLS_CHACHA20_POLY1305_SHA256
+}
 
 func forwardPortAndExecute(serviceName, namespace, remotePort string, toExecute func(localPort int) error) error {
 	var err error

--- a/test/extended/apiserver/tlsutil/crypto.go
+++ b/test/extended/apiserver/tlsutil/crypto.go
@@ -1,0 +1,142 @@
+// Package tlsutil provides TLS version and cipher suite helpers for API server tests.
+//
+// The definitions in this file (versions, supportedVersions, ciphers maps and the
+// TLSVersion*, ValidTLSVersions, DefaultTLSVersion, CipherSuite, ValidCipherSuites
+// functions) are copied verbatim from:
+//
+//	github.com/openshift/library-go/pkg/crypto/crypto.go
+//
+// They were extracted here to avoid a library-go dependency bump that caused test
+// instability (see OCPBUGS-76334, origin#30746, origin#30895).
+//
+// If library-go/pkg/crypto/crypto.go is updated (e.g. new TLS versions, new cipher
+// suites, or changed defaults), the corresponding sections below must be synced manually.
+// The only function NOT from library-go is DefaultCiphers(), which was added locally.
+package tlsutil
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sort"
+)
+
+// TLS versions that are known to golang.
+// Copied from github.com/openshift/library-go/pkg/crypto/crypto.go
+var versions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+// TLS versions that are enabled.
+// Copied from github.com/openshift/library-go/pkg/crypto/crypto.go
+var supportedVersions = map[string]uint16{
+	"VersionTLS10": tls.VersionTLS10,
+	"VersionTLS11": tls.VersionTLS11,
+	"VersionTLS12": tls.VersionTLS12,
+	"VersionTLS13": tls.VersionTLS13,
+}
+
+func TLSVersion(versionName string) (uint16, error) {
+	if len(versionName) == 0 {
+		return DefaultTLSVersion(), nil
+	}
+	if version, ok := versions[versionName]; ok {
+		return version, nil
+	}
+	return 0, fmt.Errorf("unknown tls version %q", versionName)
+}
+
+func TLSVersionOrDie(versionName string) uint16 {
+	version, err := TLSVersion(versionName)
+	if err != nil {
+		panic(err)
+	}
+	return version
+}
+
+// ValidTLSVersions returns the build enabled TLS versions.
+func ValidTLSVersions() []string {
+	validVersions := []string{}
+	for k := range supportedVersions {
+		validVersions = append(validVersions, k)
+	}
+	sort.Strings(validVersions)
+	return validVersions
+}
+
+func DefaultTLSVersion() uint16 {
+	// Can't use SSLv3 because of POODLE and BEAST
+	// Can't use TLSv1.0 because of POODLE and BEAST using CBC cipher
+	// Can't use TLSv1.1 because of RC4 cipher usage
+	return tls.VersionTLS12
+}
+
+// ciphers maps IANA cipher suite names to their uint16 identifiers.
+// Copied from github.com/openshift/library-go/pkg/crypto/crypto.go
+var ciphers = map[string]uint16{
+	"TLS_RSA_WITH_RC4_128_SHA":                      tls.TLS_RSA_WITH_RC4_128_SHA,
+	"TLS_RSA_WITH_3DES_EDE_CBC_SHA":                 tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA":                  tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_RSA_WITH_AES_256_CBC_SHA":                  tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_RSA_WITH_AES_128_CBC_SHA256":               tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_RSA_WITH_AES_128_GCM_SHA256":               tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_RSA_WITH_AES_256_GCM_SHA384":               tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_RC4_128_SHA":              tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA":          tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_RC4_128_SHA":                tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+	"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA":           tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":            tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":       tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":       tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305":          tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305":        tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"TLS_AES_128_GCM_SHA256":                        tls.TLS_AES_128_GCM_SHA256,
+	"TLS_AES_256_GCM_SHA384":                        tls.TLS_AES_256_GCM_SHA384,
+	"TLS_CHACHA20_POLY1305_SHA256":                  tls.TLS_CHACHA20_POLY1305_SHA256,
+}
+
+func CipherSuite(cipherName string) (uint16, error) {
+	if cipher, ok := ciphers[cipherName]; ok {
+		return cipher, nil
+	}
+	return 0, fmt.Errorf("unknown cipher name %q", cipherName)
+}
+
+func ValidCipherSuites() []string {
+	validCipherSuites := []string{}
+	for k := range ciphers {
+		validCipherSuites = append(validCipherSuites, k)
+	}
+	sort.Strings(validCipherSuites)
+	return validCipherSuites
+}
+
+// DefaultCiphers returns the default cipher suites for TLS connections.
+// Aligned with intermediate profile of the 5.7 version of the Mozilla Server
+// Side TLS guidelines found at: https://ssl-config.mozilla.org/guidelines/5.7.json
+func DefaultCiphers() []uint16 {
+	return []uint16{
+		// TLS 1.2 cipher suites with ECDHE + AEAD
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+
+		// TLS 1.3 cipher suites (not configurable, predetermined by spec)
+		tls.TLS_AES_128_GCM_SHA256,
+		tls.TLS_AES_256_GCM_SHA384,
+		tls.TLS_CHACHA20_POLY1305_SHA256,
+	}
+}


### PR DESCRIPTION
## Summary

This PR re-adds the TLS 1.3 test improvements from PR #30746 (which was reverted in #30895) but uses a local `tlsutil` package instead of depending on library-go/pkg/crypto. This provides the test enhancements without the dependency issues that caused the original revert.

## Background

PR #30746 introduced valuable TLS 1.3 (Modern profile) test support but bundled it with a library-go dependency bump that caused test instability in 4.22 payloads. PR #30895 reverted #30746 to restore stability. This PR reintroduces only the test improvements without the problematic dependency changes.

## What This PR Does

### 1. Re-adds TLS 1.3 test improvements from #30746
- ✅ Support for testing Modern TLS profile (TLS 1.3 only)
- ✅ FIPS mode detection for ChaCha20-Poly1305 cipher handling
- ✅ ECDSA cipher suite handling (expect failure with RSA keys)
- ✅ Improved test logging and error messages

### 2. Creates local crypto helper package (`test/extended/apiserver/tlsutil/`)

Extracted six simple utility functions into a local package:
- `DefaultTLSVersion()` - Returns `tls.VersionTLS12`
- `ValidTLSVersions()` - Returns list of TLS version names
- `TLSVersionOrDie(name)` - Converts version name to uint16
- `DefaultCiphers()` - Returns list of default cipher suites
- `ValidCipherSuites()` - Returns list of cipher suite names
- `CipherSuite(name)` - Converts cipher suite name to uint16

These are all simple lookup/conversion functions with no transitive dependencies beyond `crypto/tls`.

### 3. No library-go dependency bump

- Uses local tlsutil package instead of library-go/pkg/crypto
- No changes to go.mod, go.sum, or vendor/ for library-go
- Removes coupling between test logic and library-go versions

## Benefits

✅ **Restores TLS 1.3 test coverage** - Modern profile validation is back  
✅ **Removes dependency coupling** - Test logic no longer tied to library-go versions  
✅ **Avoids supply chain risk** - No dependency updates in test improvements  
✅ **Maintains stability** - Based on #30895 revert, adds only test logic  
✅ **Better separation of concerns** - Test improvements isolated from dependency management  

## Testing

- [x] `go build ./test/extended/apiserver/...` passes
- [x] Code compiles successfully
- [x] `gofmt` formatting verified
- [x] Rebased on latest upstream/main (includes #30895 revert)

## CI Payload Validation (`/payload 4.22 nightly blocking`)

14 blocking jobs were triggered. Results across the original run and 3 reruns:

### TestTLSDefaults Results

| Job | Suite | TestTLSDefaults | Notes |
|-----|-------|-----------------|-------|
| `periodics-e2e-aws-ovn-conformance` (HyperShift) | `conformance/parallel` | **Skipped** (correct) | HyperShift cluster has `controlPlaneTopology: External`; `IsHypershift()=true` triggers intentional skip at `tls.go:46`. Control-plane pods are not accessible from the hosted cluster. |
| `ci-4.22-e2e-aws-ovn-techpreview` | `conformance/parallel` | **Passed** (rerun) | Standard OCP cluster; `IsHypershift()=false`; test ran and passed normally. |
| `nightly-4.22-e2e-aws-ovn-serial-1of2`, `-2of2` | Serial only | Not run (by design) | Serial suite excludes `[Suite:openshift/conformance/parallel]`. |
| `ci-4.22-e2e-aws-ovn-techpreview-serial-1/2/3of3` | Serial only | Not run (by design) | Serial suite excludes `[Suite:openshift/conformance/parallel]`. |
| All upgrade/install jobs | No conformance | Not run (by design) | Upgrade/install jobs do not run the conformance suite. |

### Job Failures — All Unrelated to This PR

| Job | Status | Root Cause |
|-----|--------|------------|
| `periodics-e2e-aws-ovn-conformance` (HyperShift) | Failed (both runs) | 2 pre-existing flakes: `[sig-node] Pod InPlace Resize` + `[sig-network] EgressFirewall`. 1,867 passed / 2 failed / 2,106 skipped (99.9% pass rate). No TLS failures. |
| `ci-4.22-e2e-aws-ovn-techpreview` (original) | Failed → **Passed on rerun** | GatewayAPIController/OSSM/OLM tests timing out. Unrelated to TLS. |
| `ci-4.22-e2e-aws-ovn-techpreview-serial-3of3` (original) | Failed → not rerun needed (serial suite doesn't test `TestTLSDefaults`) | GatewayAPIController istiod serial test. Unrelated to TLS. |
| `nightly-4.22-e2e-metal-ipi-ovn-ipv6` (original) | Failed → **Passed on rerun** | Baremetal devscripts infra: local registry `manifest unknown`. Unrelated to TLS. |

All failures are pre-existing CI noise with no connection to TLS or apiserver configuration changes.

### Rerun Summary

| Rerun | Job | Status | Link |
|-------|-----|--------|------|
| `0f0fb1b0-...` | `periodics-e2e-aws-ovn-conformance` | Failed (pre-existing flakes) | [Prow](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-30894-periodics-e2e-aws-ovn-conformance/2037484712720601088) |
| `15fbb280-...` | `ci-4.22-e2e-aws-ovn-techpreview` | **Passed** | [Prow](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-30894-ci-4.22-e2e-aws-ovn-techpreview/2037484761315807232) |
| `232b8d40-...` | `nightly-4.22-e2e-metal-ipi-ovn-ipv6` | **Passed** | [Prow](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-30894-nightly-4.22-e2e-metal-ipi-ovn-ipv6/2037484854899118080) |

## Related

- **Original PR**: #30746 (merged, then reverted)
- **Revert PR**: #30895 (merged - restored stability)
- **JIRA**: [OCPBUGS-76334](https://issues.redhat.com/browse/OCPBUGS-76334)
- **Follow-up issue**: #30890 (organization fork migration for filepath-securejoin)

## Commit Structure

Single commit that:
1. Creates tlsutil package with crypto helpers
2. Updates test to use tlsutil instead of library-go
3. Re-adds Modern TLS profile support, FIPS handling, ECDSA handling

**Note**: This PR is now based on upstream/main which includes the revert (#30895), so the library-go dependency revert is no longer needed as a separate commit.