### PR TITLE
OCPBUGS-85654: Validate no WAL corruption when both nodes shutdown gracefully

### DIFF
--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -473,6 +473,37 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, targetNode.Name, "openshift-etcd",
 			"bash", "-c", fmt.Sprintf("journalctl -u pacemaker --since=@%s --no-pager | grep -m1 -i 'a new working copy of /etc/kubernetes/static-pod-resources/etcd-certs/configmaps/external-etcd-pod/pod.yaml was created'", rebootEpoch))
 		o.Expect(err).To(o.BeNil(), "Expected pacemaker log to contain pod.yaml recreation entry after reboot")
+
+	})
+
+	g.It("should recover after simultaneous graceful shutdown of both nodes", func() {
+		g.GinkgoT().Printf("Gracefully rebooting both nodes: %s and %s\n",
+			targetNode.Name, peerNode.Name)
+
+		g.By(fmt.Sprintf("Triggering graceful reboot on %s", targetNode.Name))
+		err := exutil.TriggerNodeRebootGraceful(oc.KubeClient(), targetNode.Name)
+		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected to trigger graceful reboot on %s without error", targetNode.Name))
+
+		g.By(fmt.Sprintf("Triggering graceful reboot on %s", peerNode.Name))
+		err = exutil.TriggerNodeRebootGraceful(oc.KubeClient(), peerNode.Name)
+		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected to trigger graceful reboot on %s without error", peerNode.Name))
+
+		g.By("Waiting for graceful shutdown to take effect (shutdown -r 1 schedules reboot in 1 minute)")
+		time.Sleep(90 * time.Second)
+
+		g.By(fmt.Sprintf("Waiting for both etcd members to become healthy (timeout: %v)", membersHealthyAfterDoubleReboot))
+		validateEtcdRecoveryState(oc, etcdClientFactory,
+			&targetNode,
+			&peerNode, true, false,
+			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Verifying etcd containers are running on both nodes")
+		for _, node := range []corev1.Node{targetNode, peerNode} {
+			got, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, node.Name, "openshift-etcd",
+				strings.Split(ensurePodmanEtcdContainerIsRunning, " ")...)
+			o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected no error checking etcd on %s", node.Name))
+			o.Expect(got).To(o.Equal("'true'"), fmt.Sprintf("Expected etcd container running on %s", node.Name))
+		}
 	})
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test scenario for etcd recovery in dual-replica configurations. The test validates that etcd reaches a healthy state after sequential node reboots and confirms the etcd container is operational on both nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->