### PR TITLE
Use curl instead of oc binary copy for testing kubeconfig

### DIFF
--- a/test/extended/apiserver/kubeconfigs.go
+++ b/test/extended/apiserver/kubeconfigs.go
@@ -112,17 +112,17 @@ func testKubeApiserverContainer(oc *exutil.CLI, kubeconfig, masterName string) e
 		return fmt.Errorf("location for %s kubeconfig not found", kubeconfig)
 	}
 
-	framework.Logf("Copying oc binary from host to kube-apiserver container in master %q", masterName)
-	out, err := oc.AsAdmin().Run("debug").Args("node/"+masterName, "--", "chroot", "/host", "/bin/bash", "-euxo", "pipefail", "-c",
-		fmt.Sprintf(`oc --kubeconfig /etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig -n openshift-kube-apiserver cp /usr/bin/oc kube-apiserver-%s:/tmp`, masterName)).Output()
-	framework.Logf("%s", out)
-	if err != nil {
-		return fmt.Errorf("%s", out)
-	}
-
+	// Use curl to verify the kubeconfig is present and functional, extracting
+	// cert paths directly from the kubeconfig file. This avoids copying the oc
+	// binary from the host into the container, which fails when the host OS
+	// (e.g., RHCOS 10 with glibc 2.38) has a newer glibc than the container.
 	framework.Logf("Verifying kubeconfig %q in kube-apiserver container in master %q", kubeconfig, masterName)
-	out, err = oc.AsAdmin().Run("exec").Args("-n", "openshift-kube-apiserver", "kube-apiserver-"+masterName, "--", "/bin/bash", "-euxo", "pipefail", "-c",
-		fmt.Sprintf(`/tmp/oc --kubeconfig "%s" get nodes`, kubeconfigPath)).Output()
+	out, err := oc.AsAdmin().Run("exec").Args("-n", "openshift-kube-apiserver", "kube-apiserver-"+masterName, "--", "/bin/bash", "-euxo", "pipefail", "-c",
+		fmt.Sprintf(`server=$(grep 'server:' "%[1]s" | head -1 | awk '{print $2}')
+cert=$(grep 'client-certificate:' "%[1]s" | head -1 | awk '{print $2}')
+key=$(grep 'client-key:' "%[1]s" | head -1 | awk '{print $2}')
+ca=$(grep 'certificate-authority:' "%[1]s" | head -1 | awk '{print $2}')
+curl -sf --cert "$cert" --key "$key" --cacert "$ca" "${server}/api?timeout=32s"`, kubeconfigPath)).Output()
 	framework.Logf("%s", out)
 	if err != nil {
 		return fmt.Errorf("%s", out)


### PR DESCRIPTION
The latter is causing problems on multi-arch and RHCOS 10.

This is quite ugly and a better version might be a good idea, but it did appear to work in the payload job run below. Coderabbit comment looks worth addressing, but we might want a cleaner version of this anyhow. 

Hoping someone can pick this up and run it down to solve the two related bugs.
