### PR TITLE
OCPNODE-4224: Migrating test case OCP-70987 from OTP to origin

### DIFF
--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,7 +15,9 @@ import (
 
 var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager", func() {
 	var (
-		oc = exutil.NewCLIWithoutNamespace("node")
+		oc             = exutil.NewCLIWithoutNamespace("node")
+		nodeE2EBaseDir = exutil.FixturePath("testdata", "node", "node_e2e")
+		podDevFuseYAML = filepath.Join(nodeE2EBaseDir, "pod-dev-fuse.yaml")
 	)
 
 	// Skip all tests on MicroShift clusters as MachineConfig resources are not available
@@ -102,5 +105,41 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		output, err := oc.AsAdmin().WithoutNamespace().Run("patch").Args("nodes.config.openshift.io", "cluster", "-p", `{"spec": {"cgroupMode": "v1"}}`, "--type=merge").Output()
 		o.Expect(err).Should(o.HaveOccurred())
 		o.Expect(output).To(o.ContainSubstring("spec.cgroupMode: Unsupported value: \"v1\": supported values: \"v2\", \"\""))
+	})
+
+	//author: cmaurya@redhat.com
+	g.It("[OTP] Allow dev fuse by default in CRI-O [OCP-70987]", func() {
+		podName := "pod-devfuse"
+		ns := "devfuse-test"
+
+		g.By("Create a test namespace")
+		err := oc.AsAdmin().WithoutNamespace().Run("create").Args("namespace", ns).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("namespace", ns, "--ignore-not-found").Execute()
+
+		g.By("Create a pod with dev fuse annotation")
+		err = oc.AsAdmin().WithoutNamespace().Run("apply").Args("-f", podDevFuseYAML, "-n", ns).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Wait for pod to be ready")
+		err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+			status, pollErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", ns, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
+			if pollErr != nil {
+				e2e.Logf("Error polling pod status: %v", pollErr)
+				return false, nil
+			}
+			return status == "True", nil
+		})
+		if err != nil {
+			podStatus, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", ns, "-o=jsonpath={.status}").Output()
+			e2e.Logf("Pod status on timeout: %s", podStatus)
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "pod did not become ready")
+
+		g.By("Check /dev/fuse is mounted inside the pod")
+		output, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args(podName, "-n", ns, "--", "stat", "/dev/fuse").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("/dev/fuse mount output: %s", output)
+		o.Expect(output).To(o.ContainSubstring("fuse"), "dev fuse is not mounted inside pod")
 	})
 })

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -457,6 +457,7 @@
 // test/extended/testdata/node/nested_container/containers.conf
 // test/extended/testdata/node/nested_container/run_tests.sh
 // test/extended/testdata/node/nested_container/skip_tests.sh
+// test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml
 // test/extended/testdata/node_tuning/nto-stalld.yaml
 // test/extended/testdata/oauthserver/cabundle-cm.yaml
 // test/extended/testdata/oauthserver/oauth-network.yaml
@@ -50593,6 +50594,43 @@ func testExtendedTestdataNodeNested_containerSkip_testsSh() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataNodeNode_e2ePodDevFuseYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-devfuse
+  annotations:
+    io.kubernetes.cri-o.Devices: "/dev/fuse"
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: pod-devfuse
+    image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+    command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+`)
+
+func testExtendedTestdataNodeNode_e2ePodDevFuseYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataNodeNode_e2ePodDevFuseYaml, nil
+}
+
+func testExtendedTestdataNodeNode_e2ePodDevFuseYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataNodeNode_e2ePodDevFuseYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataNode_tuningNtoStalldYaml = []byte(`apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
@@ -56726,6 +56764,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/node/nested_container/containers.conf":                                           testExtendedTestdataNodeNested_containerContainersConf,
 	"test/extended/testdata/node/nested_container/run_tests.sh":                                              testExtendedTestdataNodeNested_containerRun_testsSh,
 	"test/extended/testdata/node/nested_container/skip_tests.sh":                                             testExtendedTestdataNodeNested_containerSkip_testsSh,
+	"test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml":                                                 testExtendedTestdataNodeNode_e2ePodDevFuseYaml,
 	"test/extended/testdata/node_tuning/nto-stalld.yaml":                                                     testExtendedTestdataNode_tuningNtoStalldYaml,
 	"test/extended/testdata/oauthserver/cabundle-cm.yaml":                                                    testExtendedTestdataOauthserverCabundleCmYaml,
 	"test/extended/testdata/oauthserver/oauth-network.yaml":                                                  testExtendedTestdataOauthserverOauthNetworkYaml,
@@ -57525,6 +57564,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 						"containers.conf": {testExtendedTestdataNodeNested_containerContainersConf, map[string]*bintree{}},
 						"run_tests.sh":    {testExtendedTestdataNodeNested_containerRun_testsSh, map[string]*bintree{}},
 						"skip_tests.sh":   {testExtendedTestdataNodeNested_containerSkip_testsSh, map[string]*bintree{}},
+					}},
+					"node_e2e": {nil, map[string]*bintree{
+						"pod-dev-fuse.yaml": {testExtendedTestdataNodeNode_e2ePodDevFuseYaml, map[string]*bintree{}},
 					}},
 				}},
 				"node_tuning": {nil, map[string]*bintree{

--- a/test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml
+++ b/test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-devfuse
+  annotations:
+    io.kubernetes.cri-o.Devices: "/dev/fuse"
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: pod-devfuse
+    image: image-registry.openshift-image-registry.svc:5000/openshift/cli:latest
+    command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL


### PR DESCRIPTION
Adds automated test case OCP-70987 migrated from openshift-tests-private. The test validates:

- Pod with io.kubernetes.cri-o.Devices annotation for /dev/fuse starts successfully
- /dev/fuse device is mounted and accessible inside the pod

Here is the test case link: [Polarian-70987](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-70987)

It passed successfully while executing on a live OCP 4.22 cluster:

```
  ~ oc version
Client Version: 4.21.0
Kustomize Version: v5.7.1
Server Version: 4.22.0-0.nightly-2026-03-29-173136
Kubernetes Version: v1.35.2

./openshift-tests run-test "[sig-node] [Jira:Node/CRI-O] CRI-O [OTP] Allow dev fuse by default in CRI-O [OCP-70987] [Suite:openshift/conformance/parallel]"

   Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1775132337 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111
    STEP: Creating a kubernetes client @ 04/02/26 17:49:01.925
  I0402 17:49:01.926739   19285 discovery.go:214] Invalidating discovery information
  I0402 17:49:01.931666 19285 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0402 17:49:02.216955 19285 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Create a test namespace @ 04/02/26 17:49:02.217
  namespace/devfuse-test created
    STEP: Create a pod with dev fuse annotation @ 04/02/26 17:49:03.048
  pod/pod-devfuse created
    STEP: Wait for pod to be ready @ 04/02/26 17:49:04.395
    STEP: Check /dev/fuse is mounted inside the pod @ 04/02/26 17:49:10.108
  I0402 17:49:11.492082 19285 node.go:142] /dev/fuse mount output: File: /dev/fuse
    Size: 0             Blocks: 0          IO Block: 4096   character special file
  Device: 1000b8h/1048760d      Inode: 6           Links: 1     Device type: a,e5
  Access: (0666/crw-rw-rw-)  Uid: (    0/    root)   Gid: (    0/    root)
  Access: 2026-04-02 12:19:05.137101693 +0000
  Modify: 2026-04-02 12:19:05.137101693 +0000
  Change: 2026-04-02 12:19:05.137101693 +0000
   Birth: -
  namespace "devfuse-test" deleted
  • [22.133 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 22.134 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987] [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 22134,
    "startTime": "2026-04-02 12:19:01.906036 UTC",
    "endTime": "2026-04-02 12:19:24.040780 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 04/02/26 17:49:01.925\nI0402 17:49:01.931666 19285 framework.go:2330] [precondition-check] checking if cluster is MicroShift\nI0402 17:49:02.216955 19285 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift\n  STEP: Create a test namespace @ 04/02/26 17:49:02.217\nnamespace/devfuse-test created\n  STEP: Create a pod with dev fuse annotation @ 04/02/26 17:49:03.048\npod/pod-devfuse created\n  STEP: Wait for pod to be ready @ 04/02/26 17:49:04.395\n  STEP: Check /dev/fuse is mounted inside the pod @ 04/02/26 17:49:10.108\nI0402 17:49:11.492082 19285 node.go:142] /dev/fuse mount output: File: /dev/fuse\n  Size: 0         \tBlocks: 0          IO Block: 4096   character special file\nDevice: 1000b8h/1048760d\tInode: 6           Links: 1     Device type: a,e5\nAccess: (0666/crw-rw-rw-)  Uid: (    0/    root)   Gid: (    0/    root)\nAccess: 2026-04-02 12:19:05.137101693 +0000\nModify: 2026-04-02 12:19:05.137101693 +0000\nChange: 2026-04-02 12:19:05.137101693 +0000\n Birth: -\nnamespace \"devfuse-test\" deleted\n",
    "error": "    STEP: Creating a kubernetes client @ 04/02/26 17:49:01.925\n  I0402 17:49:01.926739   19285 discovery.go:214] Invalidating discovery information\n  I0402 17:49:01.931666 19285 framework.go:2330] [precondition-check] checking if cluster is MicroShift\n  I0402 17:49:02.216955 19285 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift\n    STEP: Create a test namespace @ 04/02/26 17:49:02.217\n  namespace/devfuse-test created\n    STEP: Create a pod with dev fuse annotation @ 04/02/26 17:49:03.048\n  pod/pod-devfuse created\n    STEP: Wait for pod to be ready @ 04/02/26 17:49:04.395\n    STEP: Check /dev/fuse is mounted inside the pod @ 04/02/26 17:49:10.108\n  I0402 17:49:11.492082 19285 node.go:142] /dev/fuse mount output: File: /dev/fuse\n    Size: 0         \tBlocks: 0          IO Block: 4096   character special file\n  Device: 1000b8h/1048760d\tInode: 6           Links: 1     Device type: a,e5\n  Access: (0666/crw-rw-rw-)  Uid: (    0/    root)   Gid: (    0/    root)\n  Access: 2026-04-02 12:19:05.137101693 +0000\n  Modify: 2026-04-02 12:19:05.137101693 +0000\n  Change: 2026-04-02 12:19:05.137101693 +0000\n   Birth: -\n  namespace \"devfuse-test\" deleted\n"

```

cc: @asahay19 , @lyman9966 