### PR TITLE
OCPNODE-4381: Migrate OCP-38271 from openshift-tests-private

### DIFF
--- a/test/extended/node/node_e2e/initcontainer.go
+++ b/test/extended/node/node_e2e/initcontainer.go
@@ -1,0 +1,153 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+
+	nodeutils "github.com/openshift/origin/test/extended/node"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] NODE initContainer policy,volume,readiness,quota", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc = exutil.NewCLI("node-initcontainer")
+	)
+
+	// Skip all tests on MicroShift clusters as MachineConfig resources are not available
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
+		}
+	})
+
+	//author: bgudi@redhat.com
+	g.It("[OTP] Init containers should not restart when the exited init container is removed from node [OCP-38271]", func() {
+		g.By("Test for case OCP-38271")
+		oc.SetupProject()
+
+		podName := "initcon-pod"
+		namespace := oc.Namespace()
+		ctx := context.Background()
+
+		g.By("Create a pod with init container")
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    "inittest",
+						Image:   "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest",
+						Command: []string{"/bin/sh", "-ec", "echo running >> /mnt/data/test"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "data",
+								MountPath: "/mnt/data",
+							},
+						},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:    "hello-test",
+						Image:   "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest",
+						Command: []string{"/bin/sh", "-c", "sleep 3600"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "data",
+								MountPath: "/mnt/data",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+				RestartPolicy: corev1.RestartPolicyNever,
+			},
+		}
+
+		_, err := oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() {
+			oc.KubeClient().CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+		}()
+
+		g.By("Check pod status")
+		err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeClient(), pod)
+		o.Expect(err).NotTo(o.HaveOccurred(), "pod is not running")
+
+		g.By("Get pod and verify init container exited normally")
+		pod, err = oc.KubeClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(pod.Status.InitContainerStatuses).To(o.ContainElement(o.SatisfyAll(
+			o.HaveField("Name", "inittest"),
+			o.HaveField("State.Terminated.ExitCode", o.Equal(int32(0))),
+		)), "init container 'inittest' should have terminated with exit code 0")
+
+		nodeName := pod.Spec.NodeName
+		o.Expect(nodeName).NotTo(o.BeEmpty(), "pod node name is empty")
+
+		g.By("Get init container ID from pod status")
+		var containerID string
+		for _, status := range pod.Status.InitContainerStatuses {
+			if status.Name == "inittest" {
+				containerID = status.ContainerID
+				break
+			}
+		}
+		o.Expect(containerID).NotTo(o.BeEmpty(), "init container ID is empty")
+
+		// Extract the actual container ID (remove prefix like "cri-o://")
+		containerIDPattern := regexp.MustCompile(`^[^/]+://(.+)$`)
+		matches := containerIDPattern.FindStringSubmatch(containerID)
+		o.Expect(matches).To(o.HaveLen(2), "failed to parse container ID")
+		actualContainerID := matches[1]
+
+		g.By("Delete init container from node")
+		output, err := nodeutils.ExecOnNodeWithChroot(oc, nodeName, "crictl", "rm", actualContainerID)
+		o.Expect(err).NotTo(o.HaveOccurred(), "fail to delete container")
+		e2e.Logf("Container deletion output: %s", output)
+
+		g.By("Check init container not restart again")
+		err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+			pod, err := oc.KubeClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			for _, status := range pod.Status.InitContainerStatuses {
+				if status.Name == "inittest" {
+					if status.RestartCount > 0 {
+						e2e.Logf("Init container restarted, restart count: %d", status.RestartCount)
+						return true, fmt.Errorf("init container restarted")
+					}
+				}
+			}
+			e2e.Logf("Init container has not restarted")
+			return false, nil
+		})
+		o.Expect(err).To(o.Equal(wait.ErrWaitTimeout), "expected timeout while waiting confirms init container did not restart")
+	})
+})

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -8,11 +8,12 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	nodeutils "github.com/openshift/origin/test/extended/node"
-	exutil "github.com/openshift/origin/test/extended/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	nodeutils "github.com/openshift/origin/test/extended/node"
+	exutil "github.com/openshift/origin/test/extended/util"
 )
 
 var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager", func() {


### PR DESCRIPTION
### Summary                                                                                                                                                                                                       Adds test to verify init containers do not restart when the exited init container is removed from the node.                                                                                                       
                                                                                                                                                                                                                    
### Changes 
  - **Add** `test/extended/node/node_e2e/initcontainer.go` - New test file containing:                                                                                                                              
    - Test `[OTP] Init containers should not restart when the exited init container is removed from node [OCP-38271]`                                                                                               
    - Creates a pod with init container and main container inline (no template files)                                                                                                                               
    - Uses `crictl rm` via `nodeutils.ExecOnNodeWithChroot()` to delete the init container from the node                                                                                                            
    - Verifies init container does not restart by polling RestartCount for 1 minute                                                                                                                                 
    - Expects timeout (no restart) as the success condition                                                                                                                                                         
  - **Modify** `test/extended/node/node_e2e/node.go` - Add MicroShift cluster check to existing tests    

**Original author:** minmli@redhat.com                                                                                                                                                                            
**Migrated by:** bgudi@redhat.com

tested manually on 4.22.0-0.nightly-2026-04-06-051707
```
  [sig-node] [Jira:Node/Kubelet] NODE initContainer policy,volume,readiness,quota [OTP] Init containers should not restart when the exited init container is removed from node [OCP-38271]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:164
    STEP: Creating a kubernetes client @ 04/08/26 17:51:05.821
  I0408 17:51:05.823073 3140600 discovery.go:214] Invalidating discovery information
  I0408 17:51:09.779271 3140600 client.go:293] configPath is now "/tmp/configfile4075894250"
  I0408 17:51:09.779320 3140600 client.go:368] The user is now "e2e-test-node-initcontainer-fztfw-user"
  I0408 17:51:09.779330 3140600 client.go:370] Creating project "e2e-test-node-initcontainer-fztfw"
  I0408 17:51:10.390845 3140600 client.go:378] Waiting on permissions in project "e2e-test-node-initcontainer-fztfw" ...
  I0408 17:51:11.576268 3140600 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 17:51:11.819825 3140600 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 17:51:12.400689 3140600 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 17:51:13.051667 3140600 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 17:51:13.687986 3140600 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 17:51:13.936306 3140600 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 17:51:14.190899 3140600 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 17:51:16.161936 3140600 client.go:469] Project "e2e-test-node-initcontainer-fztfw" has been fully provisioned.
  I0408 17:51:18.164679 3140600 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 17:51:18.403844 3140600 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Test for case OCP-38271 @ 04/08/26 17:51:18.403
  I0408 17:51:22.859554 3140600 client.go:293] configPath is now "/tmp/configfile2728535966"
  I0408 17:51:22.859595 3140600 client.go:368] The user is now "e2e-test-node-initcontainer-xw49d-user"
  I0408 17:51:22.859602 3140600 client.go:370] Creating project "e2e-test-node-initcontainer-xw49d"
  I0408 17:51:23.228723 3140600 client.go:378] Waiting on permissions in project "e2e-test-node-initcontainer-xw49d" ...
  I0408 17:51:25.039634 3140600 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 17:51:25.406429 3140600 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 17:51:26.038125 3140600 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 17:51:26.667111 3140600 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 17:51:27.288762 3140600 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 17:51:27.528494 3140600 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 17:51:27.871855 3140600 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 17:51:29.723241 3140600 client.go:469] Project "e2e-test-node-initcontainer-xw49d" has been fully provisioned.
    STEP: Create a pod with init container @ 04/08/26 17:51:29.723
    STEP: Check pod status @ 04/08/26 17:51:29.995
    STEP: Check init container exit normally @ 04/08/26 17:51:34.819
  I0408 17:51:40.129708 3140600 node.go:236] Init container exited with code 0
    STEP: Get node where pod is running @ 04/08/26 17:51:40.129
    STEP: Get init container ID from pod status @ 04/08/26 17:51:40.602
    STEP: Delete init container from node @ 04/08/26 17:51:40.602
  I0408 17:52:00.218044 3140600 node.go:271] Container deletion output: ed0e810d3307ec87525a6c298f6984cf5c3f84a80483195e113fd77cead7955e
    STEP: Check init container not restart again @ 04/08/26 17:52:00.218
  I0408 17:52:05.466945 3140600 node.go:287] Init container has not restarted
  I0408 17:52:10.478187 3140600 node.go:287] Init container has not restarted
  I0408 17:52:15.462079 3140600 node.go:287] Init container has not restarted
  I0408 17:52:20.570873 3140600 node.go:287] Init container has not restarted
  I0408 17:52:25.642757 3140600 node.go:287] Init container has not restarted
  I0408 17:52:31.225941 3140600 node.go:287] Init container has not restarted
  I0408 17:52:35.485849 3140600 node.go:287] Init container has not restarted
  I0408 17:52:40.473818 3140600 node.go:287] Init container has not restarted
  I0408 17:52:45.474525 3140600 node.go:287] Init container has not restarted
  I0408 17:52:50.503752 3140600 node.go:287] Init container has not restarted
  I0408 17:52:55.763382 3140600 node.go:287] Init container has not restarted
  I0408 17:53:00.506225 3140600 node.go:287] Init container has not restarted
  I0408 17:53:00.744589 3140600 node.go:287] Init container has not restarted
  I0408 17:53:02.803754 3140600 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-node-initcontainer-fztfw-user}, err: <nil>
  I0408 17:53:03.057456 3140600 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-node-initcontainer-fztfw}, err: <nil>
  I0408 17:53:03.300012 3140600 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~DOn8n1Vqz9ZgZGjD8DW-5G-wH_UnrgvhQiCDJQksN6E}, err: <nil>
  I0408 17:53:03.541164 3140600 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-node-initcontainer-xw49d-user}, err: <nil>
  I0408 17:53:03.786028 3140600 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-node-initcontainer-xw49d}, err: <nil>
  I0408 17:53:04.029258 3140600 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~VWK1PIkbSdZflfdpxxX0ZBUxOSjO6QkemzmHFqR3UrI}, err: <nil>
    STEP: Destroying namespace "e2e-test-node-initcontainer-fztfw" for this suite. @ 04/08/26 17:53:04.029
    STEP: Destroying namespace "e2e-test-node-initcontainer-xw49d" for this suite. @ 04/08/26 17:53:04.333
  • [119.399 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 119.399 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```