### PR TITLE
TRT-2565: Add simple benchmark for risk analysis HTTP requests

### DIFF
--- a/pkg/riskanalysis/performance_integration_test.go
+++ b/pkg/riskanalysis/performance_integration_test.go
@@ -1,0 +1,84 @@
+package riskanalysis
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Run this test case with the env var set appropriately and sippy's cache disabled to benchmark RA.
+// An uncached call can take many seconds so run go test with e.g. -test.benchtime=10x
+func BenchmarkRequestRiskAnalysis(b *testing.B) {
+	const raApiUrl = "api/jobs/runs/risk_analysis"
+	sippyUrl := os.Getenv("TEST_RA_SIPPY_URL")
+	if sippyUrl == "" {
+		// not intended to run in CI, human should set env var to run manually
+		b.Skip("set TEST_RA_SIPPY_URL to run this test; e.g. http://localhost:8080/ or https://sippy.dptools.openshift.org/")
+	}
+	// The JSON here can come from any job run that builds a RA summary in the junit directory.
+	// Typically you'll want one with some test failures to exercise the RA code.
+	// From the job artifacts, descend to the junit directory which should be under:
+	//    artifacts/*e2e*/*e2e*/artifacts/junit/
+	// ... and look for the test-failures-summary_*.json files. You can combine them by picking the one with
+	// more test failures, and changing TestCount to the one with a higher TestCount (otherwise RA bails early).
+	//
+	// You can also download the junit directory and simply run the actual command that runs in tests, e.g.:
+	//    openshift-tests risk-analysis --sippy-url http://localhost:8080/api/jobs/runs/risk_analysis --junit-dir ./junit/
+	// Of course, this creates a lot of chaff about disruption that obscures RA output. And it only runs once.
+	const summaryJson = `
+		{
+			    "ID": 2041023444769837056,
+				"ProwJob": {
+					"Name": "periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-ovn-single-node-serial"
+				},
+				"ClusterData": {
+					"Release": "4.22",
+					"FromRelease": "",
+					"Platform": "aws",
+					"Architecture": "amd64",
+					"Network": "ovn",
+					"Topology": "single",
+					"os": {
+						"Default": "",
+						"ControlPlaneMachineConfigPool": "",
+						"WorkerMachineConfigPool": ""
+					},
+					"NetworkStack": "IPv4",
+					"CloudRegion": "us-east-1",
+					"CloudZone": "us-east-1d",
+					"ClusterVersionHistory": [
+						"4.22.0-0.nightly-2026-04-06-051707"
+					],
+					"MasterNodesUpdated": "Y"
+				},
+				"Tests": [
+					{
+						"Test": {
+							"Name": "[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io] Ensure gateway loadbalancer service and dnsrecords could be deleted and then get recreated [Serial] [Suite:openshift/conformance/serial]"
+						},
+						"Suite": {
+							"Name": "openshift-tests"
+						},
+						"Status": 12
+					}
+				],
+				"TestCount": 2149
+		}
+    `
+
+	client := &http.Client{}
+	tmp := b.TempDir()
+	uri, err := url.JoinPath(sippyUrl, raApiUrl)
+	if err != nil {
+		b.Fatalf("could not join %q and %q: %v", sippyUrl, raApiUrl, err)
+	}
+	opt := &Options{SippyURL: uri, JUnitDir: tmp}
+	for b.Loop() {
+		_, err := opt.requestRiskAnalysis([]byte(summaryJson), client, &mockSleeper{})
+		assert.NoError(b, err)
+	}
+	b.ReportMetric(b.Elapsed().Seconds()/float64(b.N), "s/op")
+}


### PR DESCRIPTION
This will be skipped in CI, but a human can run it to exercise risk analysis locally or remotely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarking for the risk analysis HTTP workflow to measure and track operational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->