### PR TITLE
OCPBUGS-81638: Add openshift/disruptive-longrunning testsuite in release-4.21 branch

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -462,6 +462,20 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout:                120 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
+	{
+		Name: "openshift/disruptive-longrunning",
+		Description: templates.LongDesc(`
+		Long-running disruptive test suite. Tests in this suite are disruptive (cause node reboots,
+		configuration changes, or cluster-wide disruptions) and take significant time to complete.
+		Multiple teams can use this suite for their long-running disruptive tests.
+		`),
+		Qualifiers: []string{
+			`name.contains("[Suite:openshift/disruptive-longrunning")`,
+		},
+		Parallelism:                1,
+		TestTimeout:                40 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
 }
 
 func withExcludedTestsFilter(baseExpr string) string {

--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -1,0 +1,28 @@
+# Node E2E Tests
+
+## Running Long-Running Disruptive Tests
+
+The `openshift/disruptive-longrunning` suite is a general-purpose suite for long-running disruptive tests
+across all teams. Node team tests are tagged with `[sig-node]` to identify them.
+
+To run the entire long-running disruptive test suite on a cluster manually, use the command:
+
+```bash
+./openshift-tests run "openshift/disruptive-longrunning" --cluster-stability=Disruptive
+```
+
+To run only node-specific long-running disruptive tests:
+
+```bash
+./openshift-tests run "openshift/disruptive-longrunning" --dry-run | grep "\[sig-node\]" | ./openshift-tests run -f - --cluster-stability=Disruptive
+```
+
+## Prerequisites
+
+- Make sure to set `oc` binary to match the cluster version
+- Make sure to set the kubeconfig to point to a live OCP cluster
+
+## Important Notes
+
+- Note that dry-run option won't list the test as it does not connect to a live cluster
+- Run `make update` if the test data is changed


### PR DESCRIPTION
Add openshift/disruptive-longrunning testsuite in release-4.21 branch
related PR: https://github.com/openshift/origin/pull/30648/changes#diff-6f59ac4ffef01ed6ee14ebe27baed2d4eb20e438e60a5a32f42d795ac2683d32

CI job: https://github.com/openshift/release/pull/77488 

The test can be executed only after the CI job is merged.