### PR TITLE
OCPBUGS-82070: Skip machine scale test when bare metal lacks extra workers.

### DIFF
--- a/test/extended/baremetal/helper.go
+++ b/test/extended/baremetal/helper.go
@@ -64,9 +64,15 @@ func (b *BaremetalTestHelper) extraWorkerKey(index int) string {
 
 // CanDeployExtraWorkers checks if current platform contains
 // the necessary data to deploy additional workers
-func (b *BaremetalTestHelper) CanDeployExtraWorkers() bool {
+func (b *BaremetalTestHelper) CanDeployExtraWorkers() (bool, error) {
 	_, err := b.extraWorkersRetrieveData()
-	return err == nil
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // getExtraWorkerSecretData gets and decodes the secret associated for the

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -770,7 +770,9 @@ func InitPlatformSpecificConfiguration(oc *exutil.CLI) func() {
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		helper := bmhelper.NewBaremetalTestHelper(dc)
-		if helper.CanDeployExtraWorkers() {
+		canDeployExtraWorkers, err := helper.CanDeployExtraWorkers()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if canDeployExtraWorkers {
 			helper.Setup()
 			helper.DeployExtraWorker(0)
 		}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -220,17 +220,25 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		o.Expect(err).NotTo(o.HaveOccurred())
 		dc, err = dynamic.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		configClient, err = configclient.NewForConfig(cfg)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// For baremetal platforms, an extra worker must be previously
-		// deployed to allow subsequent scaling operations
+		infrastructure, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// For baremetal platforms, this test needs pre-created extra worker
+		// data so a spare BareMetalHost can be made available before scaling.
 		helper = bmhelper.NewBaremetalTestHelper(dc)
-		if helper.CanDeployExtraWorkers() {
+		if infrastructure.Status.Platform == configv1.BareMetalPlatformType {
+			canDeployExtraWorkers, err := helper.CanDeployExtraWorkers()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if !canDeployExtraWorkers {
+				e2eskipper.Skipf("baremetal cluster has no extra worker definitions available for MachineSet scaling")
+			}
+
 			helper.Setup()
 			helper.DeployExtraWorker(0)
 		}
-
-		configClient, err = configclient.NewForConfig(cfg)
-		o.Expect(err).NotTo(o.HaveOccurred())
 		operatorsNotProgressing = getOperatorsNotProgressing(configClient)
 	})
 


### PR DESCRIPTION
Treat bare-metal extra-worker data as a hard precondition so fixed-capacity clusters skip cleanly instead of timing out on impossible MachineSet scale-ups.