### PR TITLE
TRT-2084: terminationmessagepolicy: relax for 5.0

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -27,6 +27,11 @@ func init() {
 	for i := 0; i < 16; i++ {
 		unfixedVersions.Insert(fmt.Sprintf("4.%d", i))
 	}
+
+	// TODO: [lmeyer 2026-04-08] replace this temporary hack.
+	unfixedVersions.Insert("5.0")
+	// the algorithm below has permitted every release since 4.20 to flake because "4.2" is in the version.
+	// predictably, a number of violations have crept in. once those are fixed, fix hasOldVersion determination below.
 }
 
 type terminationMessagePolicyChecker struct {


### PR DESCRIPTION
the `terminationMesagePolicyChecker` has permitted every release since 4.20 to flake because "4.2" is in the version.

predictably, a number of violations have crept in, and are now surfacing in 5.0 jobs. this continues the flaking behavior into 5.0.

once the violations are addressed, we can fix hasOldVersion determination so it stops happening..