### PR TITLE
STOR-2807: Add e2e test to verify CSI driver operators use service CA signed certificates

### DIFF
--- a/test/extended/storage/csi_certificates.go
+++ b/test/extended/storage/csi_certificates.go
@@ -1,0 +1,89 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe(`[sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates`, func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("csi-cert-check")
+
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Not supported on MicroShift")
+		}
+	})
+
+	g.It("csi driver operators should use service CA signed certificates by default", func() {
+		ctx := context.Background()
+
+		g.By("Verifying the storage cluster operator is healthy")
+		WaitForCSOHealthy(oc)
+
+		g.By("Listing CSI driver operator pods")
+		allPods, err := oc.AdminKubeClient().CoreV1().Pods(CSINamespace).List(ctx, metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to list pods in namespace %s", CSINamespace)
+
+		checked := 0
+		var failures []string
+
+		for _, pod := range allPods.Items {
+			operatorContainer := getCsiDriverOperatorContainerName(pod)
+			if operatorContainer == "" {
+				continue
+			}
+
+			g.By(fmt.Sprintf("Checking logs of %s for secure certificate usage", pod.Name))
+			logStream, err := oc.AdminKubeClient().CoreV1().Pods(CSINamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: operatorContainer,
+			}).Stream(ctx)
+			if err != nil {
+				e2e.Logf("Failed to get logs for pod %s, skipping: %v", pod.Name, err)
+				continue
+			}
+
+			logBytes, err := io.ReadAll(logStream)
+			logStream.Close()
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to read logs for pod %s", pod.Name)
+
+			logOutput := string(logBytes)
+			if strings.Contains(logOutput, "Using insecure, self-signed certificates") {
+				failures = append(failures, fmt.Sprintf("%s (pod %s): insecure self-signed certificates detected", operatorContainer, pod.Name))
+			}
+			if !strings.Contains(logOutput, "Using service-serving-cert provided certificates") {
+				failures = append(failures, fmt.Sprintf("%s (pod %s): secure cert log not found", operatorContainer, pod.Name))
+			}
+			checked++
+		}
+
+		if checked == 0 {
+			g.Skip(fmt.Sprintf("No CSI driver operator pods found on platform %q", e2e.TestContext.Provider))
+		}
+		o.Expect(failures).To(o.BeEmpty(),
+			"CSI driver operators not using service CA signed certificates:\n%s", strings.Join(failures, "\n"))
+	})
+})
+
+// Returns the name of the CSI driver operator
+// container in the pod, or "" if the pod is not a CSI driver operator.
+func getCsiDriverOperatorContainerName(pod corev1.Pod) string {
+	for _, c := range pod.Spec.Containers {
+		if strings.HasSuffix(c.Name, "-csi-driver-operator") {
+			return c.Name
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
**Feature**: https://redhat.atlassian.net/browse/STOR-2770
CSI driver operators should use service-serving-cert provided certificates by default, not insecure self-signed certificates. This PR adds an automated e2e test to enforce that guarantee across all CSI driver operators.

## What does the test do
1. Verifies the storage cluster operator (CSO) is healthy
2. Lists all pods in the `openshift-cluster-csi-drivers` namespace
3. Dynamically identifies CSI driver operator pods by matching containers whose name ends with `-csi-driver-operator` 
4. For each operator pod, reads the container logs and asserts:
   - Log contains "Using service-serving-cert provided certificates"
   - Log does NOT contain "Using insecure, self-signed certificates"
5. Fails with a summary listing all non-compliant operators

## Skip conditions
- MicroShift clusters (no CSI driver operators)
- Platforms with no CSI driver operator pods


## Test results:

**For 4.21 AWS-EBS-CSI-DRIVER-OPERATOR (Test fails as expected):**
```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 13:27:03.129657 1187552 factory.go:195] Registered Plugin "containerd"
  I0408 13:27:03.402731 1187552 binary.go:80] Found 8779 test specs
  I0408 13:27:03.404260 1187552 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-1397a10ce4
  I0408 13:27:04.018236 1187552 test_setup.go:125] Extended test version v0.0.0-unknown-1397a10ce4
  I0408 13:27:04.018275 1187552 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 13:27:04.018655 1187552 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 13:27:04.046741 1187552 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  
  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775669223 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 13:27:04.053
  I0408 13:27:04.054013 1187552 discovery.go:214] Invalidating discovery information
  I0408 13:27:04.497499 1187552 client.go:293] configPath is now "/tmp/configfile1357438822"
  I0408 13:27:04.497519 1187552 client.go:368] The user is now "e2e-test-csi-cert-check-gcq52-user"
  I0408 13:27:04.497529 1187552 client.go:370] Creating project "e2e-test-csi-cert-check-gcq52"
  I0408 13:27:04.730464 1187552 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-gcq52" ...
  I0408 13:27:04.852887 1187552 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 13:27:04.883239 1187552 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 13:27:05.049433 1187552 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 13:27:05.211027 1187552 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 13:27:05.373333 1187552 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 13:27:05.405025 1187552 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 13:27:05.436914 1187552 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 13:27:05.855084 1187552 client.go:469] Project "e2e-test-csi-cert-check-gcq52" has been fully provisioned.
  I0408 13:27:05.855795 1187552 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 13:27:05.884882 1187552 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 13:27:05.884
    STEP: Listing CSI driver operator pods @ 04/08/26 13:27:05.917
    STEP: Checking logs of aws-ebs-csi-driver-operator-7bbf597d7d-9xg4k for secure certificate usage @ 04/08/26 13:27:05.949
    [FAILED] in [It] - github.com/openshift/origin/test/extended/storage/csi_certificates.go:75 @ 04/08/26 13:27:06.014
    STEP: Collecting events from namespace "e2e-test-csi-cert-check-gcq52". @ 04/08/26 13:27:06.014
    STEP: Found 0 events. @ 04/08/26 13:27:06.042
  I0408 13:27:06.072578 1187552 resource.go:151] POD  NODE  PHASE  GRACE  CONDITIONS
  I0408 13:27:06.072602 1187552 resource.go:161] 
  I0408 13:27:06.116670 1187552 dump.go:81] skipping dumping cluster info - cluster too large
  I0408 13:27:06.150585 1187552 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-gcq52-user}, err: <nil>
  I0408 13:27:06.184804 1187552 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-gcq52}, err: <nil>
  I0408 13:27:06.218839 1187552 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~tGv9dXTPImDq44W3e5HE8jKqB3rOShotd38rS0QVUKE}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-gcq52" for this suite. @ 04/08/26 13:27:06.218
  • [FAILED] [2.206 seconds]
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates [It] should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30

    [FAILED] CSI driver operators not using service CA signed certificates:
    aws-ebs-csi-driver-operator (pod aws-ebs-csi-driver-operator-7bbf597d7d-9xg4k): insecure self-signed certificates detected
    aws-ebs-csi-driver-operator (pod aws-ebs-csi-driver-operator-7bbf597d7d-9xg4k): secure cert log not found
    Expected
        <[]string | len:2, cap:2>: [
            "aws-ebs-csi-driver-operator (pod aws-ebs-csi-driver-operator-7bbf597d7d-9xg4k): insecure self-signed certificates detected",
            "aws-ebs-csi-driver-operator (pod aws-ebs-csi-driver-operator-7bbf597d7d-9xg4k): secure cert log not found",
        ]
    to be empty
    In [It] at: github.com/openshift/origin/test/extended/storage/csi_certificates.go:75 @ 04/08/26 13:27:06.014
  ------------------------------

  Summarizing 1 Failure:
    [FAIL] [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates [It] should use service CA signed certificates by default
    github.com/openshift/origin/test/extended/storage/csi_certificates.go:75

  Ran 1 of 1 Specs in 2.206 seconds
  FAIL! -- 0 Passed | 1 Failed | 0 Pending | 0 Skipped
```

**For 4.22 AWS-EBS-CSI-DRIVER-OPERATOR:**
```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 14:03:41.867035 1189348 factory.go:195] Registered Plugin "containerd"
  I0408 14:03:42.122070 1189348 binary.go:80] Found 8779 test specs
  I0408 14:03:42.123629 1189348 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-1397a10ce4
  I0408 14:03:42.728092 1189348 test_setup.go:125] Extended test version v0.0.0-unknown-1397a10ce4
  I0408 14:03:42.728123 1189348 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 14:03:42.728482 1189348 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 14:03:42.757504 1189348 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  
  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775671421 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 14:03:42.763
  I0408 14:03:42.764413 1189348 discovery.go:214] Invalidating discovery information
  I0408 14:03:43.196681 1189348 client.go:293] configPath is now "/tmp/configfile1324853446"
  I0408 14:03:43.196699 1189348 client.go:368] The user is now "e2e-test-csi-cert-check-4xbm4-user"
  I0408 14:03:43.196702 1189348 client.go:370] Creating project "e2e-test-csi-cert-check-4xbm4"
  I0408 14:03:43.432048 1189348 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-4xbm4" ...
  I0408 14:03:43.552052 1189348 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 14:03:43.581581 1189348 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 14:03:43.747562 1189348 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 14:03:43.907711 1189348 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 14:03:44.069502 1189348 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 14:03:44.101671 1189348 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 14:03:44.135174 1189348 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 14:03:44.551935 1189348 client.go:469] Project "e2e-test-csi-cert-check-4xbm4" has been fully provisioned.
  I0408 14:03:44.552447 1189348 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 14:03:44.581484 1189348 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 14:03:44.581
    STEP: Listing CSI driver operator pods @ 04/08/26 14:03:44.611
    STEP: Checking logs of aws-ebs-csi-driver-operator-fdf96c68-q6s5w for secure certificate usage @ 04/08/26 14:03:44.645
  I0408 14:03:44.741580 1189348 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-4xbm4-user}, err: <nil>
  I0408 14:03:44.775504 1189348 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-4xbm4}, err: <nil>
  I0408 14:03:44.809899 1189348 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~T7KWWl29SshdbccO1_W5va0LYn-jSN7V0cP0l1nuqDo}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-4xbm4" for this suite. @ 04/08/26 14:03:44.809
  • [2.100 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 2.100 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

**For GCP-PD-CSI-DRIVER-OPERATOR:**
```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 12:54:25.147535 1185367 factory.go:195] Registered Plugin "containerd"
  I0408 12:54:25.374925 1185367 binary.go:80] Found 8779 test specs
  I0408 12:54:25.376631 1185367 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-1397a10ce4
  I0408 12:54:26.171278 1185367 test_setup.go:125] Extended test version v0.0.0-unknown-1397a10ce4
  I0408 12:54:26.171304 1185367 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 12:54:26.171665 1185367 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 12:54:26.205346 1185367 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  
  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775667265 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 12:54:26.212
  I0408 12:54:26.212475 1185367 discovery.go:214] Invalidating discovery information
  I0408 12:54:26.788381 1185367 client.go:293] configPath is now "/tmp/configfile2628410601"
  I0408 12:54:26.788404 1185367 client.go:368] The user is now "e2e-test-csi-cert-check-9kc4z-user"
  I0408 12:54:26.788409 1185367 client.go:370] Creating project "e2e-test-csi-cert-check-9kc4z"
  I0408 12:54:26.925986 1185367 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-9kc4z" ...
  I0408 12:54:27.145617 1185367 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 12:54:27.179442 1185367 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 12:54:27.347511 1185367 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 12:54:27.593947 1185367 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 12:54:27.789665 1185367 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 12:54:27.823702 1185367 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 12:54:27.855494 1185367 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 12:54:28.237504 1185367 client.go:469] Project "e2e-test-csi-cert-check-9kc4z" has been fully provisioned.
  I0408 12:54:28.238162 1185367 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 12:54:28.273645 1185367 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 12:54:28.273
    STEP: Listing CSI driver operator pods @ 04/08/26 12:54:28.308
    STEP: Checking logs of gcp-pd-csi-driver-operator-7b56cdc6d9-mn4cm for secure certificate usage @ 04/08/26 12:54:28.351
  I0408 12:54:28.447151 1185367 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-9kc4z-user}, err: <nil>
  I0408 12:54:28.483371 1185367 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-9kc4z}, err: <nil>
  I0408 12:54:28.521405 1185367 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~T3W8jjM1_7uyCbSPgwjEN6UkNcUDrFkC3g83gKvIh1o}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-9kc4z" for this suite. @ 04/08/26 12:54:28.521
  • [2.354 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 2.354 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

**For AZURE-DISK & AZURE-FILE-CSI-DRIVER-OPERATOR:**
```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 13:01:26.500980 1186400 factory.go:195] Registered Plugin "containerd"
  I0408 13:01:26.735547 1186400 binary.go:80] Found 8779 test specs
  I0408 13:01:26.737015 1186400 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-1397a10ce4
  I0408 13:01:27.421286 1186400 test_setup.go:125] Extended test version v0.0.0-unknown-1397a10ce4
  I0408 13:01:27.421312 1186400 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 13:01:27.421692 1186400 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 13:01:27.449993 1186400 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  
  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775667686 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 13:01:27.456
  I0408 13:01:27.457336 1186400 discovery.go:214] Invalidating discovery information
  I0408 13:01:27.912491 1186400 client.go:293] configPath is now "/tmp/configfile357358946"
  I0408 13:01:27.912508 1186400 client.go:368] The user is now "e2e-test-csi-cert-check-4rcrr-user"
  I0408 13:01:27.912511 1186400 client.go:370] Creating project "e2e-test-csi-cert-check-4rcrr"
  I0408 13:01:28.204705 1186400 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-4rcrr" ...
  I0408 13:01:28.332781 1186400 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 13:01:28.362153 1186400 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 13:01:28.557948 1186400 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 13:01:28.714116 1186400 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 13:01:28.875987 1186400 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 13:01:28.910037 1186400 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 13:01:28.941888 1186400 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 13:01:29.340143 1186400 client.go:469] Project "e2e-test-csi-cert-check-4rcrr" has been fully provisioned.
  I0408 13:01:29.340703 1186400 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 13:01:29.370028 1186400 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 13:01:29.37
    STEP: Listing CSI driver operator pods @ 04/08/26 13:01:29.398
    STEP: Checking logs of azure-disk-csi-driver-operator-579f79c74d-g25g9 for secure certificate usage @ 04/08/26 13:01:29.434
    STEP: Checking logs of azure-file-csi-driver-operator-5b688f99cb-gch4c for secure certificate usage @ 04/08/26 13:01:29.491
  I0408 13:01:29.576167 1186400 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-4rcrr-user}, err: <nil>
  I0408 13:01:29.614021 1186400 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-4rcrr}, err: <nil>
  I0408 13:01:29.666080 1186400 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~Osif0kyO10qV2Re0vcNZzkpSsS8_uA1zmF20w3TzsIE}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-4rcrr" for this suite. @ 04/08/26 13:01:29.666
  • [2.250 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 2.250 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

**For VMWARE-VSPHERE-CSI-DRIVER-OPERATOR:**
```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 14:17:15.717293 1189906 factory.go:195] Registered Plugin "containerd"
  I0408 14:17:15.959827 1189906 binary.go:80] Found 8779 test specs
  I0408 14:17:15.961431 1189906 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-1397a10ce4
  I0408 14:17:16.852691 1189906 test_setup.go:125] Extended test version v0.0.0-unknown-1397a10ce4
  I0408 14:17:16.852714 1189906 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 14:17:16.853102 1189906 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 14:17:16.905401 1189906 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift

  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775672235 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 14:17:16.912
  I0408 14:17:16.912632 1189906 discovery.go:214] Invalidating discovery information
  I0408 14:17:17.692502 1189906 client.go:293] configPath is now "/tmp/configfile3431521868"
  I0408 14:17:17.692521 1189906 client.go:368] The user is now "e2e-test-csi-cert-check-9phld-user"
  I0408 14:17:17.692534 1189906 client.go:370] Creating project "e2e-test-csi-cert-check-9phld"
  I0408 14:17:17.877596 1189906 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-9phld" ...
  I0408 14:17:18.101505 1189906 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 14:17:18.155486 1189906 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 14:17:18.375550 1189906 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 14:17:18.590379 1189906 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 14:17:18.817314 1189906 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 14:17:18.875578 1189906 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 14:17:18.935608 1189906 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 14:17:19.509612 1189906 client.go:469] Project "e2e-test-csi-cert-check-9phld" has been fully provisioned.
  I0408 14:17:19.510143 1189906 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 14:17:19.561373 1189906 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 14:17:19.561
    STEP: Listing CSI driver operator pods @ 04/08/26 14:17:19.617
    STEP: Checking logs of vmware-vsphere-csi-driver-operator-65fccff7c-clwk2 for secure certificate usage @ 04/08/26 14:17:19.679
  I0408 14:17:19.883349 1189906 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-9phld-user}, err: <nil>
  I0408 14:17:19.943270 1189906 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-9phld}, err: <nil>
  I0408 14:17:20.001260 1189906 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~rF9kiDuE_M_kIvpB0YISfnDcVrQRIkH7Ygm0-K0YgYM}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-9phld" for this suite. @ 04/08/26 14:17:20.001
  • [3.158 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 3.158 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

For IBM-VPC-BLOCK-CSI-DRIVER-OPERATOR:

```
$ ./openshift-tests run-test "[sig-storage][CSI][Jira:\"Storage\"] CSI driver operator secure certificates csi driver operators should use service CA signed certificates by default [Suite:openshift/conformance/parallel]"
I0408 17:28:07.433831 1212960 factory.go:195] Registered Plugin "containerd"
  I0408 17:28:07.687531 1212960 binary.go:80] Found 8779 test specs
  I0408 17:28:07.689006 1212960 binary.go:97] 1110 test specs remain, after filtering out k8s
openshift-tests v0.0.0-unknown-10f486a9a8
  I0408 17:28:09.669353 1212960 test_setup.go:125] Extended test version v0.0.0-unknown-10f486a9a8
  I0408 17:28:09.669379 1212960 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0408 17:28:09.669724 1212960 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 17:28:09.770234 1212960 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift

  Running Suite:  - /home/rdeore/GitHub/origin
  ============================================
  Random Seed: 1775683687 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates csi driver operators should use service CA signed certificates by default
  github.com/openshift/origin/test/extended/storage/csi_certificates.go:30
    STEP: Creating a kubernetes client @ 04/08/26 17:28:09.779
  I0408 17:28:09.779754 1212960 discovery.go:214] Invalidating discovery information
  I0408 17:28:11.423093 1212960 client.go:293] configPath is now "/tmp/configfile3201130524"
  I0408 17:28:11.423110 1212960 client.go:368] The user is now "e2e-test-csi-cert-check-8nwnp-user"
  I0408 17:28:11.423113 1212960 client.go:370] Creating project "e2e-test-csi-cert-check-8nwnp"
  I0408 17:28:11.728989 1212960 client.go:378] Waiting on permissions in project "e2e-test-csi-cert-check-8nwnp" ...
  I0408 17:28:12.148212 1212960 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0408 17:28:12.252198 1212960 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0408 17:28:12.565906 1212960 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0408 17:28:12.875994 1212960 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0408 17:28:13.190026 1212960 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0408 17:28:13.318243 1212960 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0408 17:28:13.444168 1212960 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0408 17:28:14.326517 1212960 client.go:469] Project "e2e-test-csi-cert-check-8nwnp" has been fully provisioned.
  I0408 17:28:14.327085 1212960 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0408 17:28:14.426071 1212960 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Verifying the storage cluster operator is healthy @ 04/08/26 17:28:14.426
    STEP: Listing CSI driver operator pods @ 04/08/26 17:28:14.537
    STEP: Checking logs of ibm-vpc-block-csi-driver-operator-5597d48c47-vwrv9 for secure certificate usage @ 04/08/26 17:28:14.736
  I0408 17:28:14.986572 1212960 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-csi-cert-check-8nwnp-user}, err: <nil>
  I0408 17:28:15.100052 1212960 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-csi-cert-check-8nwnp}, err: <nil>
  I0408 17:28:15.212050 1212960 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~sneGeyGOEYSPTIY-Do1hc6noDePdD_bNF6KglHjQ8Oo}, err: <nil>
    STEP: Destroying namespace "e2e-test-csi-cert-check-8nwnp" for this suite. @ 04/08/26 17:28:15.212
  • [5.569 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 5.569 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```