### PR TITLE
OCPBUGS-82144: Remove EnsureMemberRemoved from graceful shutdown test

### DIFF
--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -52,7 +52,7 @@ func computeLogInterval(pollInterval time.Duration) int {
 // Emits a structured [RecoveryPath] log line for CI tracking.
 func logRecoveryPath(oc *exutil.CLI, survivedNode, targetNode *corev1.Node) {
 	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, survivedNode.Name, "openshift-etcd",
-		"bash", "-c", "journalctl --since '30 min ago' --no-pager 2>/dev/null | grep -m1 'force.new.cluster' || true")
+		"bash", "-c", "journalctl --since '60 min ago' --no-pager | grep -m1 'force.new.cluster' || true")
 	if err != nil {
 		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=unknown: journal check failed: %v", targetNode.Name, err)
 		return

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -24,7 +24,6 @@ import (
 const (
 	nodeIsHealthyTimeout            = time.Minute
 	etcdOperatorIsHealthyTimeout    = time.Minute
-	memberHasLeftTimeout            = 5 * time.Minute
 	memberIsLeaderTimeout           = 20 * time.Minute
 	memberRejoinedLearnerTimeout    = 20 * time.Minute
 	memberPromotedVotingTimeout     = 15 * time.Minute
@@ -46,6 +45,24 @@ func computeLogInterval(pollInterval time.Duration) int {
 		return 1
 	}
 	return n
+}
+
+// logRecoveryPath reads the surviving node's journal to detect whether the
+// graceful shutdown used the clean-leave or force-new-cluster recovery path.
+// Emits a structured [RecoveryPath] log line for CI tracking.
+func logRecoveryPath(oc *exutil.CLI, survivedNode, targetNode *corev1.Node) {
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, survivedNode.Name, "openshift-etcd",
+		"bash", "-c", "journalctl --since '30 min ago' --no-pager 2>/dev/null | grep -m1 'force.new.cluster' || true")
+	if err != nil {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=unknown: journal check failed: %v", targetNode.Name, err)
+		return
+	}
+	if strings.TrimSpace(output) != "" {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=force-new-cluster journal=%q",
+			targetNode.Name, strings.TrimSpace(output))
+	} else {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=clean-leave", targetNode.Name)
+	}
 }
 
 type hypervisorExtendedConfig struct {
@@ -98,11 +115,6 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to gracefully shutdown the node without errors")
 		time.Sleep(time.Minute)
 
-		g.By(fmt.Sprintf("Ensuring %s leaves the member list (timeout: %v)", targetNode.Name, memberHasLeftTimeout))
-		o.Eventually(func() error {
-			return helpers.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, targetNode.Name)
-		}, memberHasLeftTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred())
-
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&survivedNode,
@@ -120,6 +132,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&survivedNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By(fmt.Sprintf("Checking recovery path for %s from %s journal", targetNode.Name, survivedNode.Name))
+		logRecoveryPath(oc, &survivedNode, &targetNode)
 	})
 
 	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {

--- a/test/extended/two_node/tnf_recovery.go
+++ b/test/extended/two_node/tnf_recovery.go
@@ -52,7 +52,7 @@ func computeLogInterval(pollInterval time.Duration) int {
 // Emits a structured [RecoveryPath] log line for CI tracking.
 func logRecoveryPath(oc *exutil.CLI, survivedNode, targetNode *corev1.Node) {
 	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, survivedNode.Name, "openshift-etcd",
-		"bash", "-c", "journalctl --since '30 min ago' --no-pager 2>/dev/null | grep -m1 'force.new.cluster' || true")
+		"bash", "-c", "journalctl --since '60 min ago' --no-pager | grep -m1 'force.new.cluster' || true")
 	if err != nil {
 		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=unknown: journal check failed: %v", targetNode.Name, err)
 		return

--- a/test/extended/two_node/tnf_recovery.go
+++ b/test/extended/two_node/tnf_recovery.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -23,7 +24,6 @@ import (
 const (
 	nodeIsHealthyTimeout            = time.Minute
 	etcdOperatorIsHealthyTimeout    = time.Minute
-	memberHasLeftTimeout            = 5 * time.Minute
 	memberIsLeaderTimeout           = 20 * time.Minute
 	memberRejoinedLearnerTimeout    = 20 * time.Minute
 	memberPromotedVotingTimeout     = 15 * time.Minute
@@ -45,6 +45,24 @@ func computeLogInterval(pollInterval time.Duration) int {
 		return 1
 	}
 	return n
+}
+
+// logRecoveryPath reads the surviving node's journal to detect whether the
+// graceful shutdown used the clean-leave or force-new-cluster recovery path.
+// Emits a structured [RecoveryPath] log line for CI tracking.
+func logRecoveryPath(oc *exutil.CLI, survivedNode, targetNode *corev1.Node) {
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, survivedNode.Name, "openshift-etcd",
+		"bash", "-c", "journalctl --since '30 min ago' --no-pager 2>/dev/null | grep -m1 'force.new.cluster' || true")
+	if err != nil {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=unknown: journal check failed: %v", targetNode.Name, err)
+		return
+	}
+	if strings.TrimSpace(output) != "" {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=force-new-cluster journal=%q",
+			targetNode.Name, strings.TrimSpace(output))
+	} else {
+		framework.Logf("[sig-etcd][RecoveryPath] node=%s path=clean-leave", targetNode.Name)
+	}
 }
 
 type hypervisorExtendedConfig struct {
@@ -91,11 +109,6 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to gracefully shutdown the node without errors")
 		time.Sleep(time.Minute)
 
-		g.By(fmt.Sprintf("Ensuring %s leaves the member list (timeout: %v)", targetNode.Name, memberHasLeftTimeout))
-		o.Eventually(func() error {
-			return helpers.EnsureMemberRemoved(g.GinkgoT(), etcdClientFactory, targetNode.Name)
-		}, memberHasLeftTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred())
-
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&survivedNode,
@@ -113,6 +126,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&survivedNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By(fmt.Sprintf("Checking recovery path for %s from %s journal", targetNode.Name, survivedNode.Name))
+		logRecoveryPath(oc, &survivedNode, &targetNode)
 	})
 
 	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {


### PR DESCRIPTION
## Summary
- Remove `EnsureMemberRemoved` assertion from the graceful shutdown recovery test — it's incompatible with the force-new-cluster recovery path where member removal + re-addition happens in ~1s (invisible to the test's 5s polling)
- Replace with a post-recovery journal check that logs which recovery path was taken (`path=clean-leave` vs `path=force-new-cluster`) as a structured `[RecoveryPath]` line
- Remove unused `memberHasLeftTimeout` constant

## The race between clean-leave and force-new-cluster

When `shutdown -r 1` is issued, systemd sets a shutdown inhibitor that pacemaker detects **immediately** (~1s) via the shutdown attribute — it does not wait for the 1-minute reboot delay. Pacemaker then schedules a transition to stop `etcd:0` on the departing node, which runs the RA's `podman_stop()` → `leave_etcd_member_list()` sequence.

At the same time, the node is in the process of shutting down. knet (corosync's network layer) monitors the link to the departing node with ~84ms detection granularity, and TOTEM has a 3000ms token timeout.

**The race**: `podman_stop()` must complete `etcdctl member remove` before knet detects the link is down and TOTEM expires. If it wins, the departing node cleanly removes itself from the etcd cluster (clean-leave path). If it loses — because the node's network stack goes down before the RA finishes — the surviving node loses quorum and falls back to force-new-cluster.

| Path | When it fires | Member absent window | Observable at 5s polling? |
|------|--------------|---------------------|--------------------------|
| **Clean leave** | `podman_stop()` completes before knet drops | ~28s (until `manage_peer_membership()` re-adds as learner) | Yes |
| **Force-new-cluster** | Node dies before RA stop completes | ~1s (implicit removal + immediate re-add) | No |

In validation across 6 runs with a patched payload, clean-leave won 5/6 times, but looking at past data it is happening much less frequently. The 1 failure was the force-new-cluster path — `podman_stop()` never ran, knet dropped 2s after pacemaker detected the shutdown attribute, and the test's `EnsureMemberRemoved` assertion waited 1800s for a member removal that had already happened and been reversed within 1 second.

**This is not a regression** — it's a pre-existing race inherent to the graceful shutdown mechanism. The `EnsureMemberRemoved` assertion tested a guarantee the system does not provide.

## What this PR does

Removes the flaky assertion and replaces it with a `logRecoveryPath()` call that runs **after** recovery completes. It reads the surviving node's journal and emits a structured log line:
```
[sig-etcd][RecoveryPath] node=master-0 path=clean-leave
[sig-etcd][RecoveryPath] node=master-0 path=force-new-cluster journal="..."
```

This gives us parseable data to track how often each path fires in CI without failing the test.

## Test plan
- [x] `e2e-metal-ovn-two-node-fencing-ipv6-recovery-techpreview` passes the graceful shutdown test
- [x] Ungraceful, network disruption, sequential, and all other recovery tests unchanged
- [x] No other test files modified


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced graceful shutdown recovery test diagnostics with detailed logging that identifies the recovery path used (force-new-cluster or clean-leave).
  * Improved test observability by adding journal inspection of the surviving node to determine the recovery method.
  * Streamlined test flow by removing unnecessary polling for node removal from the etcd member list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->