### PR TITLE
OCPBUGS-81340: fix pacemaker CronJob duplicate-event namespace

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -537,14 +537,14 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	twoNodeEtcdEndpointsMatcher := newTwoNodeEtcdEndpointsConfigMissingEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(twoNodeEtcdEndpointsMatcher)
 
-	// cluster-etcd-operator (TNF): the pacemaker status collector CronJob runs on a short schedule; the
-	// kube-controller-manager cronjob-controller emits SuccessfulCreate and SawCompletedJob on the CronJob
-	// InvolvedObject. Long openshift-tests runs can exceed the duplicate-event threshold.
+	// cluster-etcd-operator (TNF): the pacemaker status collector CronJob runs in openshift-etcd on a short
+	// schedule; the kube-controller-manager cronjob-controller emits SuccessfulCreate and SawCompletedJob on
+	// the CronJob InvolvedObject. Long openshift-tests runs can exceed the duplicate-event threshold.
 	// SuccessfulDelete churn is reduced by CEO Job TTL / history tuning (see OCPBUGS-81340).
 	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
 		name: "PacemakerStatusCollectorCronJobEvents",
 		locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
-			monitorapi.LocatorNamespaceKey:   regexp.MustCompile(`^openshift-etcd-operator$`),
+			monitorapi.LocatorNamespaceKey:   regexp.MustCompile(`^openshift-etcd$`),
 			monitorapi.LocatorKey("cronjob"): regexp.MustCompile(`^pacemaker-status-collector$`),
 		},
 		messageReasonRegex: regexp.MustCompile(`^(SuccessfulCreate|SawCompletedJob)$`),

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -215,7 +215,7 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 			name: "pacemaker status collector cronjob successful create (KCM cronjob-controller)",
 			locator: monitorapi.Locator{
 				Keys: map[monitorapi.LocatorKey]string{
-					monitorapi.LocatorNamespaceKey:   "openshift-etcd-operator",
+					monitorapi.LocatorNamespaceKey:   "openshift-etcd",
 					monitorapi.LocatorKey("cronjob"): "pacemaker-status-collector",
 				},
 			},


### PR DESCRIPTION
The pacemaker-status-collector CronJob is created in openshift-etcd (TargetNamespace in cluster-etcd-operator). Match that namespace so SuccessfulCreate/SawCompletedJob repeats are allowed instead of rejected.

Fixes incorrect namespace in https://github.com/openshift/origin/pull/30953

Made-with: Cursor