### PR TITLE
Add commit status validation test

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,3 @@
+inheritance: true
+reviews:
+  fail_commit_status: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
 inheritance: true
 reviews:
+  request_changes_workflow: true
   fail_commit_status: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,15 @@
 inheritance: true
 reviews:
+  # This only controls approval or not
   request_changes_workflow: true
+  # This setting is actually only if coderabbit can complete the review,
+  # not if it actually finds any unresolved issues.
   fail_commit_status: true
 pre_merge_checks:
-  mode: "error"
+  # This might be the only way to get a red status?
+  custom_checks:
+    - name: "Critical and Major Issue Guardrail"
+      mode: "error"
+      instructions: >
+        Ensure that any review comments by CodeRabbit are resolved. This check must run
+        last. Any unresolved CodeRabbit comments must cause this check to fail.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,3 +2,5 @@ inheritance: true
 reviews:
   request_changes_workflow: true
   fail_commit_status: true
+pre_merge_checks:
+  mode: "error"

--- a/test/extended/operators/commit_status.go
+++ b/test/extended/operators/commit_status.go
@@ -1,0 +1,42 @@
+package operators
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var _ = g.Describe("[sig-arch] Commit status validation", func() {
+	defer g.GinkgoRecover()
+
+	g.It("should validate all pods are running", func() {
+		cfg, err := rest.InClusterConfig()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		client, err := kubernetes.NewForConfig(cfg)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+
+		pods, err := client.CoreV1().Pods("").List(ctx, metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		cancel()
+
+		totalPods := 0
+		runningPods := 0
+		for i := 0; i < len(pods.Items); i++ {
+			totalPods = totalPods + 1
+			if pods.Items[i].Status.Phase == "Running" {
+				runningPods = runningPods + 1
+			}
+		}
+
+		o.Expect(runningPods).To(o.Equal(totalPods), "all pods should be running")
+	})
+})


### PR DESCRIPTION
## Summary
- Adds a new `[sig-arch]` Ginkgo test that validates all pods are running
- Adds `.coderabbit.yaml` configuration with `fail_commit_status: true`

## Test plan
- [ ] Verify CodeRabbit reviews the PR and sets a failing commit status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test suite that validates cluster health by asserting all pods reach the Running state.

* **Chores**
  * Added configuration to enable inheritance, enforce a request-changes review workflow, treat failing commit status as failure, and introduce a pre-merge guard that errors if review comments remain unresolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->