### PR TITLE
OCPBUGS-63307: Fix image policy event intervals and bookkeeping

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1271,9 +1271,10 @@ func newConfigDriftMonitorStoppedTooOftenEventMatcher(finalIntervals monitorapi.
 		return eventInterval.Source == monitorapi.SourceE2ETest &&
 			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
 	})
+
 	for i := range configDriftMonitorStoppedIntervals {
-		configDriftMonitorStoppedIntervals[i].To = configDriftMonitorStoppedIntervals[i].To.Add(time.Second * 30)
-		configDriftMonitorStoppedIntervals[i].From = configDriftMonitorStoppedIntervals[i].From.Add(time.Second * -30)
+		configDriftMonitorStoppedIntervals[i].To = configDriftMonitorStoppedIntervals[i].To.Add(time.Minute * 30)
+		configDriftMonitorStoppedIntervals[i].From = configDriftMonitorStoppedIntervals[i].From.Add(time.Minute * -30)
 	}
 
 	return &OverlapOtherIntervalsPathologicalEventMatcher{
@@ -1291,9 +1292,10 @@ func newAddSigtermProtectionEventMatcher(finalIntervals monitorapi.Intervals) Ev
 		return eventInterval.Source == monitorapi.SourceE2ETest &&
 			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
 	})
+
 	for i := range AddSigtermProtectionIntervals {
-		AddSigtermProtectionIntervals[i].To = AddSigtermProtectionIntervals[i].To.Add(time.Second * 30)
-		AddSigtermProtectionIntervals[i].From = AddSigtermProtectionIntervals[i].From.Add(time.Second * -30)
+		AddSigtermProtectionIntervals[i].To = AddSigtermProtectionIntervals[i].To.Add(time.Minute * 30)
+		AddSigtermProtectionIntervals[i].From = AddSigtermProtectionIntervals[i].From.Add(time.Minute * -30)
 	}
 	return &OverlapOtherIntervalsPathologicalEventMatcher{
 		delegate: &SimplePathologicalEventMatcher{
@@ -1310,9 +1312,10 @@ func newRemoveSigtermProtectionEventMatcher(finalIntervals monitorapi.Intervals)
 		return eventInterval.Source == monitorapi.SourceE2ETest &&
 			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
 	})
+
 	for i := range RemoveSigtermProtectionIntervals {
-		RemoveSigtermProtectionIntervals[i].To = RemoveSigtermProtectionIntervals[i].To.Add(time.Second * 30)
-		RemoveSigtermProtectionIntervals[i].From = RemoveSigtermProtectionIntervals[i].From.Add(time.Second * -30)
+		RemoveSigtermProtectionIntervals[i].To = RemoveSigtermProtectionIntervals[i].To.Add(time.Minute * 30)
+		RemoveSigtermProtectionIntervals[i].From = RemoveSigtermProtectionIntervals[i].From.Add(time.Minute * -30)
 	}
 	return &OverlapOtherIntervalsPathologicalEventMatcher{
 		delegate: &SimplePathologicalEventMatcher{


### PR DESCRIPTION
Assisted by Claude.

All of the other intervals are around 10 minutes. These events are triggered by MCP rollout, which happens for each of the image policy tests.
10 minutes is actually on the lower end for MCP rollout (which is given 20 minutes before timing out), but let's start with this and increase
in the future if necessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal timing parameters for sigstore event pattern matching in test suite to enhance verification accuracy.

---

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->