### PR TITLE
no-jira: test/monitoring: increase load balancer readiness and curl connection timeout

### DIFF
--- a/pkg/monitor/backenddisruption/disruption_backend_sampler.go
+++ b/pkg/monitor/backenddisruption/disruption_backend_sampler.go
@@ -231,6 +231,12 @@ func (b *BackendSampler) WithSamplerHooks(samplerHooks []SamplerHook) *BackendSa
 	return b
 }
 
+// WithTimeout sets a custom timeout for HTTP requests including DNS resolution and connection establishment
+func (b *BackendSampler) WithTimeout(timeout time.Duration) *BackendSampler {
+	b.timeout = &timeout
+	return b
+}
+
 // bodyMatches checks the body content and returns an error if it doesn't match the expected.
 func (b *BackendSampler) bodyMatches(body []byte) error {
 	switch {

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -256,7 +256,7 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 
 	// Hit it once before considering ourselves ready
 	fmt.Fprintf(os.Stderr, "hitting pods through the service's LoadBalancer\n")
-	timeout := 10 * time.Minute
+	timeout := 20 * time.Minute
 	// require thirty seconds of passing requests to continue (in case the SLB becomes available and then degrades)
 	// TODO this seems weird to @deads2k, why is status not trustworthy
 	baseURL := fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort)))

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -256,7 +256,11 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 
 	// Hit it once before considering ourselves ready
 	fmt.Fprintf(os.Stderr, "hitting pods through the service's LoadBalancer\n")
-	timeout := 20 * time.Minute
+	// Use longer timeout for platforms (e.g. EUSC) known to experience slow DNS propagation.
+	timeout := 10 * time.Minute
+	if infra.Status.PlatformStatus.AWS != nil && strings.HasPrefix(infra.Status.PlatformStatus.AWS.Region, "eusc-") {
+		timeout = 20 * time.Minute
+	}
 	// require thirty seconds of passing requests to continue (in case the SLB becomes available and then degrades)
 	// TODO this seems weird to @deads2k, why is status not trustworthy
 	baseURL := fmt.Sprintf("http://%s", net.JoinHostPort(tcpIngressIP, strconv.Itoa(svcPort)))
@@ -266,23 +270,25 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 		return fmt.Errorf("could not reach %v reliably: %w", url, err)
 	}
 
-	// Use longer timeout to accommodate slow DNS resolution.
-	// Set timeout high enough to allow DNS retries during this propagation period.
-	connectionTimeout := 120 * time.Second
 	newConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
 		baseURL,
 		"service-load-balancer-with-pdb-new-connections",
 		path,
 		monitorapi.NewConnectionType).
-		WithExpectedBody("hello").
-		WithTimeout(connectionTimeout)
+		WithExpectedBody("hello")
 	reusedConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
 		baseURL,
 		"service-load-balancer-with-pdb-reused-connections",
 		path,
 		monitorapi.ReusedConnectionType).
-		WithExpectedBody("hello").
-		WithTimeout(connectionTimeout)
+		WithExpectedBody("hello")
+
+	// Use longer timeout for platforms (e.g. EUSC) known to experience slow DNS propagation.
+	if infra.Status.PlatformStatus.AWS != nil && strings.HasPrefix(infra.Status.PlatformStatus.AWS.Region, "eusc-") {
+		connectionTimeout := 120 * time.Second
+		newConnectionDisruptionSampler.WithTimeout(connectionTimeout)
+		reusedConnectionDisruptionSampler.WithTimeout(connectionTimeout)
+	}
 
 	w.disruptionChecker = disruptionlibrary.NewAvailabilityInvariant(
 		newConnectionTestName, reusedConnectionTestName,

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -266,18 +266,23 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 		return fmt.Errorf("could not reach %v reliably: %w", url, err)
 	}
 
+	// Use longer timeout to accommodate slow DNS resolution.
+	// Set timeout high enough to allow DNS retries during this propagation period.
+	connectionTimeout := 120 * time.Second
 	newConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
 		baseURL,
 		"service-load-balancer-with-pdb-new-connections",
 		path,
 		monitorapi.NewConnectionType).
-		WithExpectedBody("hello")
+		WithExpectedBody("hello").
+		WithTimeout(connectionTimeout)
 	reusedConnectionDisruptionSampler := backenddisruption.NewSimpleBackendFromOpenshiftTests(
 		baseURL,
 		"service-load-balancer-with-pdb-reused-connections",
 		path,
 		monitorapi.ReusedConnectionType).
-		WithExpectedBody("hello")
+		WithExpectedBody("hello").
+		WithTimeout(connectionTimeout)
 
 	w.disruptionChecker = disruptionlibrary.NewAvailabilityInvariant(
 		newConnectionTestName, reusedConnectionTestName,


### PR DESCRIPTION
This PR increases the timeout for load balancer readiness and curl connection to address slow DNS propagation on cloud provider, for example, AWS EU Sovereign Cloud.

## Background

AWS Load balancer DNS SOA records for AWS ELB in EUSC region show a 900s (15-minute) retry interval, which can cause the load balancer hostname resolution (if first hit `NXDOMAIN`) to take longer than the previous 10-minute timeout. Additionally, it can take a few more minutes for DNS to fully propagate to its nameserver.

```bash
$ nslookup -q=SOA eusc-de-east-1.elb.amazonaws.eu
Server:		8.8.8.8
Address:	8.8.8.8#53

Non-authoritative answer:
eusc-de-east-1.elb.amazonaws.eu
	origin = ns-501.awsdns-eusc-62.fr
	mail addr = awsdns-hostmaster.amazon.com
	serial = 1
	refresh = 7200
	retry = 900
	expire = 1209600
	minimum = 86400

```

## References

We are seeing a similar issue in CCM hairpin tests: https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/449.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout settings for backend network sampling.

* **Improvements**
  * Extended HTTP readiness timeouts for AWS eusc- regions to enhance reliability.
  * Optimized connection timeout handling for improved performance in specific AWS regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->