### PR TITLE
OCPBUGS-82072 OCPBUGS-82077: fix: skip unused tests for two node

### DIFF
--- a/test/extended/baremetal/common.go
+++ b/test/extended/baremetal/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -16,14 +17,45 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
+var (
+	clusterInfraMu      sync.Mutex
+	clusterInfra        *configv1.Infrastructure
+	clusterInfraFetched bool
+)
+
+// clusterInfrastructure returns the cluster Infrastructure object. A successful fetch is cached for
+// the rest of the process; if Get fails, nothing is cached and the next call retries.
+func clusterInfrastructure(oc *exutil.CLI) (*configv1.Infrastructure, error) {
+	clusterInfraMu.Lock()
+	defer clusterInfraMu.Unlock()
+	if clusterInfraFetched {
+		return clusterInfra, nil
+	}
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(
+		context.Background(), "cluster", metav1.GetOptions{})
+	if err == nil {
+		clusterInfra = infra
+		clusterInfraFetched = true
+	}
+	return infra, err
+}
+
 func skipIfNotBaremetal(oc *exutil.CLI) {
 	g.By("checking platform type")
 
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := clusterInfrastructure(oc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
 		e2eskipper.Skipf("No baremetal platform detected")
+	}
+}
+
+func skipIfTwoNode(oc *exutil.CLI) {
+	infra, err := clusterInfrastructure(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode {
+		e2eskipper.Skipf("This test does not apply to two-node")
 	}
 }
 
@@ -35,7 +67,7 @@ func skipIfNotBaremetal(oc *exutil.CLI) {
 func skipIfUnsupportedPlatformOrConfig(oc *exutil.CLI, dc dynamic.Interface) {
 	g.By("checking supported platforms")
 
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := clusterInfrastructure(oc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	switch infra.Status.PlatformStatus.Type {

--- a/test/extended/baremetal/common.go
+++ b/test/extended/baremetal/common.go
@@ -16,14 +16,27 @@ import (
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 )
 
+func clusterInfrastructure(oc *exutil.CLI) (*configv1.Infrastructure, error) {
+	return oc.AdminConfigClient().ConfigV1().Infrastructures().Get(
+		context.Background(), "cluster", metav1.GetOptions{})
+}
+
 func skipIfNotBaremetal(oc *exutil.CLI) {
 	g.By("checking platform type")
 
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := clusterInfrastructure(oc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
 		e2eskipper.Skipf("No baremetal platform detected")
+	}
+}
+
+func skipIfTwoNode(oc *exutil.CLI) {
+	infra, err := clusterInfrastructure(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if infra.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode {
+		e2eskipper.Skipf("This test does not apply to two-node")
 	}
 }
 
@@ -35,7 +48,7 @@ func skipIfNotBaremetal(oc *exutil.CLI) {
 func skipIfUnsupportedPlatformOrConfig(oc *exutil.CLI, dc dynamic.Interface) {
 	g.By("checking supported platforms")
 
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := clusterInfrastructure(oc)
 	o.Expect(err).NotTo(o.HaveOccurred())
 
 	switch infra.Status.PlatformStatus.Type {

--- a/test/extended/baremetal/high_availability.go
+++ b/test/extended/baremetal/high_availability.go
@@ -149,13 +149,21 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 func checkMetal3DeploymentHealthy(oc *exutil.CLI) {
 	dc := oc.AdminDynamicClient()
 	bmc := baremetalClient(dc)
+	operationalStatus := "OK"
+	infra, err := clusterInfrastructure(oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if infra.Status.ControlPlaneTopology == configv1.DualReplicaTopologyMode {
+		g.By("detected DualReplica control plane topology, for DualReplica operationalStatus is expected to be detached, setting to detached")
+		operationalStatus = "detached"
+	}
 
 	hosts, err := bmc.List(context.Background(), v1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(hosts.Items).ToNot(o.BeEmpty())
 
 	for _, h := range hosts.Items {
-		expectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo("OK"))
+		expectStringField(h, "baremetalhost", "status.operationalStatus").To(o.BeEquivalentTo(operationalStatus))
 		expectStringField(h, "baremetalhost", "status.provisioning.state").To(o.Or(o.BeEquivalentTo("provisioned"), o.BeEquivalentTo("externally provisioned")))
 		expectBoolField(h, "baremetalhost", "spec.online").To(o.BeTrue())
 	}

--- a/test/extended/baremetal/hosts.go
+++ b/test/extended/baremetal/hosts.go
@@ -165,6 +165,7 @@ var _ = g.Describe("[sig-installer][Feature:baremetal][Serial] Baremetal platfor
 
 	g.BeforeEach(func() {
 		skipIfNotBaremetal(oc)
+		skipIfTwoNode(oc)
 		helper = NewBaremetalTestHelper(oc.AdminDynamicClient())
 		helper.Setup()
 	})


### PR DESCRIPTION
currently for two node fencing we do not support extra workers, skipping these tests for DualReplica topology

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Skip baremetal tests automatically on two-node (dual-replica) control plane deployments.
  * Make health checks adapt expected host status based on the cluster control plane topology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->