### PR TITLE
OCPBUGS-82557: DCM tests need to be backward compatible

### DIFF
--- a/test/extended/router/config_manager_ingress.go
+++ b/test/extended/router/config_manager_ingress.go
@@ -93,7 +93,7 @@ var _ = g.Describe("[sig-network-edge][Feature:Router][apigroup:route.openshift.
 					ConfigurationManagement: operatorv1.IngressControllerConfigurationManagementDynamic,
 				},
 				UnsupportedConfigOverrides: runtime.RawExtension{
-					Raw: fmt.Appendf(nil, `{"maxDynamicServers":"%d"}`, maxDynamicServers),
+					Raw: fmt.Appendf(nil, `{"dynamicConfigManager":"true","maxDynamicServers":"%d"}`, maxDynamicServers),
 				},
 			},
 		}


### PR DESCRIPTION
DCM tests need to be backward compatible with unsupported annotation. This is a temporary override during the API promotion.

https://redhat.atlassian.net/browse/OCPBUGS-82557