### PR TITLE
OCPBUGS-82160: Skip image-registry operator tests for Libvirt platform in upgrade jobs.

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -436,6 +436,18 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 						return "https://issues.redhat.com/browse/OCPBUGS-22382"
 					}
 				}
+				ppc64le, err := isppc64le(clientConfig)
+				if err != nil {
+					logrus.WithError(err).Debug("failed to determine cluster architecture for image-registry exception")
+				} else if ppc64le {
+					replicaCount, err := checkReplicas("openshift-image-registry", operator, clientConfig)
+					if err != nil {
+						logrus.WithError(err).Debug("failed to determine image-registry replica count for ppc64le exception")
+
+					} else if replicaCount == 1 {
+						return "https://redhat.atlassian.net/browse/OCPBUGS-82160"
+					}
+				}
 			}
 		case "openshift-samples":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "APIServerServiceUnavailableError" {
@@ -481,6 +493,23 @@ func isVSphere(config *rest.Config) (bool, error) {
 		return false, err
 	}
 	return infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType, nil
+}
+
+func isppc64le(config *rest.Config) (bool, error) {
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	nodes, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	for _, node := range nodes.Items {
+		if node.Status.NodeInfo.Architecture == "ppc64le" {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func checkReplicas(namespace string, operator string, clientConfig *rest.Config) (int32, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-registry operator reliability on PPC64LE clusters during upgrades by adding PPC64LE-specific exception handling that validates registry replica state (allows operator availability transition only when replica count is 1) — addresses OCPBUGS-82160.
  * Failures to determine architecture or replica count are now logged at debug level; existing vSphere exception behavior is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->