### PR TITLE
OCPBUGS-84237: skip on BM which has insufficient host

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -275,6 +275,24 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 	// and deleting it. The extra timeout amount should be enough to cover future slower execution
 	// environments.
 	g.It("grow and decrease when scaling different machineSets simultaneously [Timeout:30m][apigroup:machine.openshift.io]", func() {
+		g.By("checking for the openshift machine api operator")
+		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+
+		g.By("fetching worker machineSets")
+		machineSets, err := listWorkerMachineSets(dc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if len(machineSets) == 0 {
+			e2eskipper.Skipf("Expects at least one worker machineset. Found none!!!")
+		}
+
+		// Skip test if any worker machineSet has 0 replicas
+		// This happens on two-node clusters where workers are not managed by machineSets
+		for _, machineSet := range machineSets {
+			if getMachineSetReplicaNumber(machineSet) == 0 {
+				e2eskipper.Skipf("Skipping test on cluster with worker machineSet %q having 0 replicas (likely a two-node cluster)", machineName(machineSet))
+			}
+		}
+
 		// expect new nodes to come up for machineSet
 		verifyNodeScalingFunc := func(c *kubernetes.Clientset, dc dynamic.Interface, expectedScaleOut int, machineSet objx.Map) bool {
 			nodes, err := getNodesFromMachineSet(c, dc, machineName(machineSet))
@@ -292,17 +310,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				}
 			}
 			return !notReady && len(nodes) == expectedScaleOut
-		}
-
-		g.By("checking for the openshift machine api operator")
-		// TODO: skip if platform != aws
-		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
-
-		g.By("fetching worker machineSets")
-		machineSets, err := listWorkerMachineSets(dc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if len(machineSets) == 0 {
-			e2eskipper.Skipf("Expects at least one worker machineset. Found none!!!")
 		}
 
 		g.By("checking initial cluster workers size")

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -14,7 +14,9 @@ import (
 	bmhelper "github.com/openshift/origin/test/extended/baremetal"
 	"github.com/stretchr/objx"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
@@ -221,12 +223,28 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		dc, err = dynamic.NewForConfig(cfg)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// For baremetal platforms, an extra worker must be previously
-		// deployed to allow subsequent scaling operations
+		// For baremetal platforms, extra workers must be previously
+		// deployed to allow subsequent scaling operations. We need to
+		// deploy one extra worker per machineSet since the test scales
+		// all machineSets simultaneously.
 		helper = bmhelper.NewBaremetalTestHelper(dc)
 		if helper.CanDeployExtraWorkers() {
 			helper.Setup()
-			helper.DeployExtraWorker(0)
+			// Deploy extra workers for each machineSet that will be scaled
+			machineSets, err := listWorkerMachineSets(dc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Verify that extraworkers-secret has enough worker data for all machineSets
+			// before attempting deployment. GetExtraWorkerData will fail if the index
+			// doesn't exist in the secret.
+			for i := range machineSets {
+				_, _ = helper.GetExtraWorkerData(i)
+			}
+
+			// All extra worker data validated, now deploy them
+			for i := range machineSets {
+				helper.DeployExtraWorker(i)
+			}
 		}
 
 		configClient, err = configclient.NewForConfig(cfg)
@@ -297,6 +315,59 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 		g.By("checking for the openshift machine api operator")
 		// TODO: skip if platform != aws
 		skipUnlessMachineAPIOperator(dc, c.CoreV1().Namespaces())
+
+		// For baremetal platforms without extraworkers-secret (non-dev-scripts deployments),
+		// we need to verify sufficient BareMetalHosts are available before attempting to scale.
+		// If extra workers were not deployed in BeforeEach, check for available hosts and skip if insufficient.
+		if !helper.CanDeployExtraWorkers() {
+			g.By("checking if baremetal platform has sufficient available hosts for scaling")
+
+			// First check if BareMetalHost resource exists via discovery API
+			cfg, err := e2e.LoadConfig()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			discoveryClient, err := discovery.NewDiscoveryClientForConfig(cfg)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			resourceList, err := discoveryClient.ServerResourcesForGroupVersion("metal3.io/v1alpha1")
+			bmhResourceExists := false
+			if err == nil {
+				for _, resource := range resourceList.APIResources {
+					if resource.Name == "baremetalhosts" {
+						bmhResourceExists = true
+						break
+					}
+				}
+			}
+
+			// If BareMetalHost resource exists, this is a baremetal platform - check for available hosts
+			if bmhResourceExists {
+				bmhGVR := schema.GroupVersionResource{Group: "metal3.io", Resource: "baremetalhosts", Version: "v1alpha1"}
+				bmhClient := dc.Resource(bmhGVR).Namespace(machineAPINamespace)
+				bmhList, err := bmhClient.List(context.Background(), metav1.ListOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred(), "failed to list BareMetalHosts for scaling preflight check")
+
+				if len(bmhList.Items) > 0 {
+					availableHosts := 0
+					for _, item := range bmhList.Items {
+						consumerRef, _, _ := unstructured.NestedMap(item.Object, "spec", "consumerRef")
+						state, _, _ := unstructured.NestedString(item.Object, "status", "provisioning", "state")
+						// Count both "available" and "ready" (deprecated alias) states
+						if consumerRef == nil && (state == "available" || state == "ready") {
+							availableHosts++
+						}
+					}
+
+					// Fetch machineSets to determine how many hosts we need
+					machineSetsTemp, err := listWorkerMachineSets(dc)
+					o.Expect(err).NotTo(o.HaveOccurred())
+
+					e2e.Logf("Baremetal platform detected: %d available BareMetalHosts, %d worker machineSets", availableHosts, len(machineSetsTemp))
+					if availableHosts < len(machineSetsTemp) {
+						e2eskipper.Skipf("Insufficient BareMetalHosts for scaling test: need %d available hosts (one per machineSet), but only %d are available. This test requires extraworkers-secret (dev-scripts) or pre-provisioned available BareMetalHosts.", len(machineSetsTemp), availableHosts)
+					}
+				}
+			}
+		}
 
 		g.By("fetching worker machineSets")
 		machineSets, err := listWorkerMachineSets(dc)

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -14,7 +14,6 @@ import (
 	bmhelper "github.com/openshift/origin/test/extended/baremetal"
 	"github.com/stretchr/objx"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
Hi Team, 

Failure logs: 
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.22-e2e-metal-ovn-two-node-fencing-serial-techpreview-3of3/2043511398402625536/artifacts/e2e-metal-ovn-two-node-fencing-serial-techpreview/baremetalds-e2e-test/artifacts/e2e.log
```

Problem Statement                                                                                                                                                           
  The machineSet scaling E2E test (grow and decrease when scaling different machineSets simultaneously) fails on baremetal clusters deployed via IPI or manual installation methods (non-dev-scripts environments) due to two critical issues:       
  1. Insufficient BareMetalHost deployment - Only 1 host deployed for multiple machineSets                                                                                      
  2. Missing skip logic - Test runs on clusters without available hosts, creating stuck machines
                                                                                                                                                                                
Symptoms 
  Observed Behavior                                                                                                                                                             
  When running the test on baremetal clusters without extraworkers-secret:                                                                                                      
  - Machines get stuck in "Provisioning" phase indefinitely                                                                                                                   
  - Error message: No available BareMetalHost found (InsufficientResources)                                                                                                     
  - Controller logs show repeated failures every 30 seconds:                                                                                                                  
  0 hosts available while choosing host for machine 'ostest-srzj8-worker-0-4kr9j'  No available BareMetalHost found                                                                                                                                              
  failed to create machine: requeue in: 30s                                                                                                                                     
  - Test times out after 15 minutes with machines never reaching "Running" phase      

```
oc get machines -n openshift-machine-api                                                                                                                                    
  NAME                          PHASE          NODEREF                                                                                                                          
  ostest-srzj8-master-0         Running        master-0
  ostest-srzj8-master-1         Running        master-1                                                                                                                         
  ostest-srzj8-worker-0-4kr9j   Provisioning   null      ← STUCK                                                                                                              
                                                                                                                                                                                
  $ oc get baremetalhosts -n openshift-machine-api                                                                                                                            
  NAME               STATE        CONSUMER                                                                                                                                      
  ostest-master-0    provisioned  ostest-srzj8-master-0                                                                                                                         
  ostest-master-1    provisioned  ostest-srzj8-master-1
```

No breaking changes
  - Dev-scripts: Enhanced to deploy N hosts instead of 1 (improvement)
  - Cloud platforms: Unaffected                                       
  - Baremetal with spare hosts: Works as before
  - Baremetal without spare hosts: Now skips instead of failing (improvement) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded baremetal scaling tests to deploy extra workers for each worker machine set instead of a single deployment.
  * Added validation to ensure extra-worker data exists for every required index before deployment.
  * Added a preflight capacity check that counts available baremetal hosts and skips tests with a clear message if resources are insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->