### PR TITLE
DNM: Test with VRF-Lite disabled

### DIFF
--- a/test/extended/networking/route_advertisements.go
+++ b/test/extended/networking/route_advertisements.go
@@ -467,6 +467,7 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:RouteAdvertisements][Feature:Ro
 			// VRF-Lite test cases are serial as they depend on shared provider network configuration
 			g.Describe("Over a VRF-Lite configuration", func() {
 				g.BeforeEach(func() {
+					skipper.Skipf("Temporarily disabled")
 					g.By("Verifying that RoutingViaHost is enabled")
 					network, err := oc.AdminOperatorClient().OperatorV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 					o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled VRF-Lite test suite to allow continued development and testing of other networking features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->