### PR TITLE
SPLAT-2562: Added 3CMO OTE binary to extensionBinary list

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -234,6 +234,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cloud-controller-manager-aws-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-cloud-controller-manager-operator",
+		binaryPath: "/usr/bin/cluster-cloud-controller-manager-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-config-operator",
 		binaryPath: "/usr/bin/cluster-config-operator-tests-ext.gz",
 	},

--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -234,6 +234,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cloud-controller-manager-aws-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-cloud-controller-manager-operator",
+		binaryPath: "/usr/bin/cloud-controller-manager-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-config-operator",
 		binaryPath: "/usr/bin/cluster-config-operator-tests-ext.gz",
 	},


### PR DESCRIPTION
[SPLAT-2562](https://redhat.atlassian.net/browse/SPLAT-2562)

### Changes
- Added 3CMO OTE binary to extensionBinary list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added support for an additional test binary for the cluster-cloud-controller-manager-operator, expanding available extension test artifacts and improving automated test coverage and validation for that component. No existing test entries were removed, enabling broader scenario validation in CI without altering current test configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->