### PR TITLE
OCPEDGE-2510: fix(two-node): bump node replacement timeouts for new node installer pods

### DIFF
--- a/test/extended/two_node/tnf_node_replacement_const.go
+++ b/test/extended/two_node/tnf_node_replacement_const.go
@@ -189,6 +189,7 @@ const (
 	// Same value as ovnkubeRestartSettleWait: brief settle after Trace so installers can start before reverting to Normal.
 	staticPodRevisionBumpSettleWait = ovnkubeRestartSettleWait
 	// After revision bump, static-pod installers must write manifests on the replacement control-plane node.
-	staticPodManifestsWaitTimeout  = 2 * time.Minute
-	staticPodManifestsPollInterval = 45 * time.Second
+	// CI can be slow to converge NodeInstaller; use 5m window to be generous
+	staticPodManifestsWaitTimeout  = 5 * time.Minute
+	staticPodManifestsPollInterval = 30 * time.Second
 )


### PR DESCRIPTION
Align wait windows with observed runtimes when installer pods run longer on bare-metal two-node fencing (TNF).

Made-with: Cursor
Agent: Auto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced control-plane node replacement validation by adjusting static pod manifest initialization timing. Extended the timeout window and modified the polling frequency to improve test reliability when replacement nodes prepare their configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->