### PR TITLE
Fix openshift/network/third-party suite returning 0 tests.

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -317,7 +317,7 @@ var staticSuites = []ginkgo.TestSuite{
 		The conformance testing suite for certified third-party CNI plugins.
 		`),
 		Qualifiers: []string{
-			`name.contains("[Suite:k8s]") && name.contains("[sig-network]") && 
+			`name.contains("[sig-network]") &&
 				(name.contains("[Conformance]") || 
 					(name.contains("NetworkPolicy") && !name.contains("named port")) || 
 					name.contains("[Feature:IPv6DualStack]"))`,


### PR DESCRIPTION
## Description

The suite qualifier references [Suite:k8s] which is no longer appended to test names after the migration to the OpenShift Tests Extension (OTE) framework. The k8s-tests-ext binary does not add [Suite:k8s] to test names, causing the qualifier to match zero tests and breaking CNI certification workflows.

## What

Remove stale `[Suite:k8s]` qualifier from the `openshift/network/third-party` suite definition that causes 0 tests to be selected after the OTE migration.

## Why

After the OTE migration, Kubernetes tests are provided by the `k8s-tests-ext` binary which does not append `[Suite:k8s]` to test names. The qualifier `name.contains("[Suite:k8s]")` matches zero tests, making `openshift-tests run openshift/network/third-party` return "no tests to run".

This breaks the CNI certification workflow documented at [Red Hat CNI Certification §34.6](https://docs.redhat.com/en/documentation/red_hat_software_certification/2026/html/red_hat_software_certification_workflow_guide/con_cni-certification_openshift-sw-cert-workflow-working-with-cloud-native-network-function#running-the-cni-tests_openshift-sw-cert-workflow-working-with-container-network-interface).

## Evidence

```
INFO[0047] Discovered 8265 total tests
INFO[0047] Applying filter: suite-qualifiers             before=8265
INFO[0049] Filter suite-qualifiers completed - removed 8265 tests  after=0 before=8265 removed=8265
Suite run returned error: no tests to run
```

## Fix
Remove the stale [Suite:k8s] requirement from the qualifier so that sig-network conformance and NetworkPolicy tests are correctly selected regardless of which binary provides them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated network conformance test suite selection criteria to refine the test filtering logic for network-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->