### PR TITLE
OCPBUGS-83402: Bump oc request-timeout to deflake tests

### DIFF
--- a/test/extended/cli/timeout.go
+++ b/test/extended/cli/timeout.go
@@ -25,11 +25,11 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 		// from server or from context it's ok
 		o.Expect(out).Should(o.SatisfyAny(o.ContainSubstring("request canceled"), o.ContainSubstring("context deadline exceeded")))
 
-		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=2s").Output()
+		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=5s").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
-		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=2").Output()
+		out, err = oc.Run("get", "dc/testdc").Args("--request-timeout=5").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
@@ -53,11 +53,11 @@ var _ = g.Describe("[sig-cli] oc --request-timeout", func() {
 		// from server or from context it's ok
 		o.Expect(out).Should(o.SatisfyAny(o.ContainSubstring("request canceled"), o.ContainSubstring("context deadline exceeded")))
 
-		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=2s").Output()
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=5s").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 
-		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=2").Output()
+		out, err = oc.Run("get", "deployment/testdc").Args("--request-timeout=5").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("testdc"))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted test timeout configurations for improved test robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->