### PR TITLE
OCPBUGS-83286: Fix case-sensitive error matching in Whereabouts IP allocation test

### DIFF
--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -173,7 +173,7 @@ func testPodSandboxCreation(events monitorapi.Intervals, clientConfig *rest.Conf
 		}
 		if strings.Contains(event.Locator.Keys[monitorapi.LocatorPodKey], "whereabouts-pod") &&
 			strings.Contains(event.Message.HumanMessage, "error adding container to network") &&
-			strings.Contains(event.Message.HumanMessage, "Error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 ") {
+			strings.Contains(event.Message.HumanMessage, "error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 ") {
 			// This failed to create sandbox case is expected due to the whereabouts-e2e test which creates a pod that is expected to
 			// not come up due to IP range exhausted.
 			// See https://github.com/openshift/origin/blob/93eb467cc8d293ba977549b05ae2e4b818c64327/test/extended/networking/whereabouts.go#L52


### PR DESCRIPTION
Update the test to match the exact error string returned by the cmd add operation.

Reference:
https://github.com/openshift/whereabouts-cni/blob/release-4.22/cmd/whereabouts.go#L90

```
: [Monitor:legacy-networking-invariants][sig-network] pods should successfully create sandboxes by adding pod to network 
{  5 failures to create the sandbox
...
': StdinData: {"auxiliaryCNIChainName":"vendor-cni-chain","binDir":"/var/lib/cni/bin","clusterNetwork":"/host/run/multus/cni/net.d/10-ovn-kubernetes.conf","cniVersion":"0.3.1","daemonSocketDir":"/run/multus/socket","globalNamespaces":"default,openshift-multus,openshift-sriov-network-operator,openshift-cnv","logLevel":"verbose","logToStderr":true,"name":"multus-cni-network","namespaceIsolation":true,"type":"multus-shim"}
namespace/e2e-test-whereabouts-e2e-rn69f node/ci-op-s9md65n3-5bc1c-lsqlc-worker-eastus2-pdd8k pod/whereabouts-pod-cb6ld hmsg/32f45005d9 - race condition: sandbox failure at pod creation time (new pod created -34.35 seconds after deletion started) - firstTimestamp/2026-04-12T16:43:23Z interesting/true lastTimestamp/2026-04-12T16:43:23Z reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_whereabouts-pod-cb6ld_e2e-test-whereabouts-e2e-rn69f_784dd26c-4e4d-4f92-90e9-ef57502c9845_0(1f8d5feb513d355dedff9d5ec4a076407c50ead09de650df44a5f4214764df99): error adding pod e2e-test-whereabouts-e2e-rn69f_whereabouts-pod-cb6ld to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"1f8d5feb513d355dedff9d5ec4a076407c50ead09de650df44a5f4214764df99" Netns:"/var/run/netns/43532160-5396-417e-8cb3-221c162a04d8" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=e2e-test-whereabouts-e2e-rn69f;K8S_POD_NAME=whereabouts-pod-cb6ld;K8S_POD_INFRA_CONTAINER_ID=1f8d5feb513d355dedff9d5ec4a076407c50ead09de650df44a5f4214764df99;K8S_POD_UID=784dd26c-4e4d-4f92-90e9-ef57502c9845" Path:"" ERRORED: error configuring pod [e2e-test-whereabouts-e2e-rn69f/whereabouts-pod-cb6ld] networking: [e2e-test-whereabouts-e2e-rn69f/whereabouts-pod-cb6ld/784dd26c-4e4d-4f92-90e9-ef57502c9845:whereaboutstestbridge]: error adding container to network "whereaboutstestbridge": error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 / range: 192.168.2.224/29 / excludeRanges: [192.168.2.225/30]
': StdinData: {"auxiliaryCNIChainName":"vendor-cni-chain","binDir":"/var/lib/cni/bin","clusterNetwork":"/host/run/multus/cni/net.d/10-ovn-kubernetes.conf","cniVersion":"0.3.1","daemonSocketDir":"/run/multus/socket","globalNamespaces":"default,openshift-multus,openshift-sriov-network-operator,openshift-cnv","logLevel":"verbose","logToStderr":true,"name":"multus-cni-network","namespaceIsolation":true,"type":"multus-shim"}
namespace/e2e-test-whereabouts-e2e-rn69f node/ci-op-s9md65n3-5bc1c-lsqlc-worker-eastus2-pdd8k pod/whereabouts-pod-cb6ld hmsg/f2578ad644 - race condition: sandbox failure at pod creation time (new pod created -30.35 seconds after deletion started) - firstTimestamp/2026-04-12T16:43:27Z interesting/true lastTimestamp/2026-04-12T16:43:27Z reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_whereabouts-pod-cb6ld_e2e-test-whereabouts-e2e-rn69f_784dd26c-4e4d-4f92-90e9-ef57502c9845_0(920cde6f35a6a0c1f4c68a61bf0f2317fff087cfd9db6c817a8fb06401f71fae): error adding pod e2e-test-whereabouts-e2e-rn69f_whereabouts-pod-cb6ld to CNI network "multus-cni-network": plugin type="multus-shim" name="multus-cni-network" failed (add): CmdAdd (shim): CNI request failed with status 400: 'ContainerID:"920cde6f35a6a0c1f4c68a61bf0f2317fff087cfd9db6c817a8fb06401f71fae" Netns:"/var/run/netns/dd8abd81-1fbf-448e-97a8-2a580559ec28" IfName:"eth0" Args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=e2e-test-whereabouts-e2e-rn69f;K8S_POD_NAME=whereabouts-pod-cb6ld;K8S_POD_INFRA_CONTAINER_ID=920cde6f35a6a0c1f4c68a61bf0f2317fff087cfd9db6c817a8fb06401f71fae;K8S_POD_UID=784dd26c-4e4d-4f92-90e9-ef57502c9845" Path:"" ERRORED: error configuring pod [e2e-test-whereabouts-e2e-rn69f/whereabouts-pod-cb6ld] networking: [e2e-test-whereabouts-e2e-rn69f/whereabouts-pod-cb6ld/784dd26c-4e4d-4f92-90e9-ef57502c9845:whereaboutstestbridge]: error adding container to network "whereaboutstestbridge": error at storage engine: Could not allocate IP in range: ip: 192.168.2.225 / - 192.168.2.230 / range: 192.168.2.224/29 / excludeRanges: [192.168.2.225/30]
```
'
'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved network testing to more reliably detect IP-range exhaustion errors during pod sandbox creation, enhancing test accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->