### PR TITLE
SPLAT-2562: Added VVCDO OTE binary to extensionBinary list

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -333,6 +333,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "service-ca-operator",
 		binaryPath: "/usr/bin/service-ca-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "vsphere-csi-driver-operator",
+		binaryPath: "/usr/bin/vmware-vsphere-csi-driver-operator-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
[SPLAT-2562](https://redhat.atlassian.net/browse/SPLAT-2562)

### Changes
- Added vmware vsphere csi driver operator OTE extension to binary list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for the VSphere CSI driver operator component by registering an additional test binary, improving test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->