### PR TITLE
OCPBUGS-83512: add retry in nested container tests

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50452,6 +50452,13 @@ func testExtendedTestdataNodeNested_containerContainersConf() (*asset, error) {
 
 var _testExtendedTestdataNodeNested_containerRun_testsSh = []byte(`#!/usr/bin/env bash
 
+# BATS_TEST_RETRIES must be set inside the test file scope, not as an
+# environment variable, because bats-exec-file unconditionally resets it
+# to 0 at startup. Every podman test file does ` + "`" + `load helpers` + "`" + ` at file
+# scope, so appending it to helpers.bash ensures it takes effect for
+# every test.
+echo "BATS_TEST_RETRIES=3" >> test/system/helpers.bash
+
 mkdir -p serial-junit
 PODMAN=$(pwd)/bin/podman bats -T --report-formatter junit -o serial-junit --filter-tags '!ci:parallel' test/system/ || touch fail
 mkdir -p parallel-junit

--- a/test/extended/testdata/node/nested_container/run_tests.sh
+++ b/test/extended/testdata/node/nested_container/run_tests.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# BATS_TEST_RETRIES must be set inside the test file scope, not as an
+# environment variable, because bats-exec-file unconditionally resets it
+# to 0 at startup. Every podman test file does `load helpers` at file
+# scope, so appending it to helpers.bash ensures it takes effect for
+# every test.
+echo "BATS_TEST_RETRIES=3" >> test/system/helpers.bash
+
 mkdir -p serial-junit
 PODMAN=$(pwd)/bin/podman bats -T --report-formatter junit -o serial-junit --filter-tags '!ci:parallel' test/system/ || touch fail
 mkdir -p parallel-junit


### PR DESCRIPTION
Add retries so that it won't fail by transient network issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled retry behavior for Bats tests by setting BATS_TEST_RETRIES=3 in the test runtime setup, affecting both serial and parallel test executions. No other test command arguments, reporting output locations, or failure-handling behavior were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->