### PR TITLE
OCPNODE-4047: Implement kubelet TLS 1.3 via KubeletConfig on workers

### DIFF
--- a/test/extended/node/kubeletconfig_tls.go
+++ b/test/extended/node/kubeletconfig_tls.go
@@ -1,0 +1,247 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// This test suite validates that the kubelet TLS configuration can be upgraded
+// from TLS 1.2 to TLS 1.3 via a KubeletConfig resource applied to a custom
+// MachineConfigPool containing a single worker node. Using a custom pool
+// avoids rebooting all workers and makes the test significantly faster.
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration", func() {
+	var (
+		oc                = exutil.NewCLIWithoutNamespace("node-kubeletconfig-tls")
+		kubeletConfigName = "tls13-kubelet-config"
+		testMCPName       = "kubelet-tls-test"
+		testNodeMCPLabel  = fmt.Sprintf("node-role.kubernetes.io/%s", testMCPName)
+	)
+
+	skipUnsupportedTopologies := func() {
+		skipOnSingleNodeTopology(oc)
+		skipOnTwoNodeTopology(oc)
+
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			g.Skip("Skipping test on External (Hypershift) topology - MachineConfig API not available")
+		}
+	}
+
+	g.It("should upgrade kubelet TLS from 1.2 to 1.3 on a custom pool [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
+		skipUnsupportedTopologies()
+
+		mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating machine configuration client")
+
+		g.By("Selecting a worker node for testing")
+		allWorkers, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error listing worker nodes")
+		workerNodes := getPureWorkerNodes(allWorkers)
+		o.Expect(len(workerNodes)).To(o.BeNumerically(">", 0), "No pure worker nodes found in the cluster")
+
+		testNode := workerNodes[0].Name
+		o.Expect(isNodeInReadyState(&workerNodes[0])).To(o.BeTrue(), "Worker node %s is not in Ready state", testNode)
+		framework.Logf("Selected node %s for TLS upgrade test", testNode)
+
+		g.By("Checking default TLS configuration")
+		nodeCfg, err := getKubeletConfigFromNode(ctx, oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error reading kubelet config from node %s", testNode)
+		defaultTLSVersion := nodeCfg.TLSMinVersion
+		framework.Logf("Default TLS version: %q", defaultTLSVersion)
+
+		if defaultTLSVersion == "VersionTLS13" {
+			framework.Failf("Worker kubelet default is already TLS 1.3; test needs to be updated to validate a different TLS configuration change")
+		}
+		if defaultTLSVersion != "" && defaultTLSVersion != "VersionTLS12" {
+			framework.Failf("Unexpected default TLS version %q, expected VersionTLS12 or empty (cluster default)", defaultTLSVersion)
+		}
+
+		g.By(fmt.Sprintf("Creating custom MachineConfigPool %s", testMCPName))
+		testMCP := &mcfgv1.MachineConfigPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testMCPName,
+				Labels: map[string]string{
+					"machineconfiguration.openshift.io/pool": testMCPName,
+				},
+			},
+			Spec: mcfgv1.MachineConfigPoolSpec{
+				MachineConfigSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "machineconfiguration.openshift.io/role",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"worker", testMCPName},
+						},
+					},
+				},
+				NodeSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						testNodeMCPLabel: "",
+					},
+				},
+			},
+		}
+
+		_, err = mcClient.MachineconfigurationV1().MachineConfigPools().Create(ctx, testMCP, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create custom MachineConfigPool %s", testMCPName)
+
+		cleanupMCP := func() {
+			framework.Logf("Cleanup: deleting MachineConfigPool %s", testMCPName)
+			cleanupCtx := context.Background()
+			deleteErr := mcClient.MachineconfigurationV1().MachineConfigPools().Delete(cleanupCtx, testMCPName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(deleteErr) {
+				return
+			}
+			if deleteErr != nil {
+				framework.Logf("Failed to delete MachineConfigPool %s: %v", testMCPName, deleteErr)
+			}
+		}
+		// DeferCleanup runs in LIFO order. Registering MCP first ensures it
+		// is deleted last, after the node label is removed and the node has
+		// transitioned back to the worker pool.
+		g.DeferCleanup(cleanupMCP)
+
+		g.By(fmt.Sprintf("Labeling node %s with %s", testNode, testNodeMCPLabel))
+		patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, testNodeMCPLabel))
+		_, err = oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, testNode, types.MergePatchType, patchData, metav1.PatchOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to label node %s", testNode)
+
+		cleanupNodeLabel := func() {
+			framework.Logf("Cleanup: removing label %s from node %s", testNodeMCPLabel, testNode)
+			cleanupCtx := context.Background()
+			removePatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, testNodeMCPLabel))
+			_, patchErr := oc.AdminKubeClient().CoreV1().Nodes().Patch(cleanupCtx, testNode, types.MergePatchType, removePatch, metav1.PatchOptions{})
+			if apierrors.IsNotFound(patchErr) {
+				return
+			}
+			if patchErr != nil {
+				framework.Logf("Failed to remove label from node %s: %v", testNode, patchErr)
+				return
+			}
+
+			framework.Logf("Cleanup: waiting for node %s to transition back to worker pool", testNode)
+			o.Eventually(func() bool {
+				currentNode, getErr := oc.AdminKubeClient().CoreV1().Nodes().Get(cleanupCtx, testNode, metav1.GetOptions{})
+				if getErr != nil {
+					framework.Logf("Error getting node: %v", getErr)
+					return false
+				}
+				currentConfig := currentNode.Annotations["machineconfiguration.openshift.io/currentConfig"]
+				desiredConfig := currentNode.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+				isWorkerConfig := currentConfig != "" && !strings.Contains(currentConfig, testMCPName) && currentConfig == desiredConfig
+				if isWorkerConfig {
+					framework.Logf("Node %s transitioned back to worker config: %s", testNode, currentConfig)
+				} else {
+					framework.Logf("Node %s still transitioning: current=%s, desired=%s", testNode, currentConfig, desiredConfig)
+				}
+				return isWorkerConfig
+			}, 15*time.Minute, 15*time.Second).Should(o.BeTrue(),
+				"Node %s should transition back to worker pool", testNode)
+		}
+		g.DeferCleanup(cleanupNodeLabel)
+
+		framework.Logf("Waiting for custom MachineConfigPool %s to be ready", testMCPName)
+		err = waitForMCP(ctx, mcClient, testMCPName, 10*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Custom MachineConfigPool %s did not become ready", testMCPName)
+
+		g.By(fmt.Sprintf("Creating KubeletConfig with Modern TLS profile (TLS 1.3) targeting pool %s", testMCPName))
+		kubeletConfig := &mcfgv1.KubeletConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: kubeletConfigName,
+			},
+			Spec: mcfgv1.KubeletConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machineconfiguration.openshift.io/pool": testMCPName,
+					},
+				},
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				},
+			},
+		}
+
+		cleanupKubeletConfig := func() {
+			framework.Logf("Cleanup: deleting KubeletConfig %s", kubeletConfigName)
+			cleanupCtx := context.Background()
+			deleteErr := mcClient.MachineconfigurationV1().KubeletConfigs().Delete(cleanupCtx, kubeletConfigName, metav1.DeleteOptions{})
+			if apierrors.IsNotFound(deleteErr) {
+				return
+			}
+			o.Expect(deleteErr).NotTo(o.HaveOccurred(), "Cleanup: failed to delete KubeletConfig %s", kubeletConfigName)
+
+			framework.Logf("Cleanup: waiting for MCP %s to become ready after KubeletConfig deletion", testMCPName)
+			waitErr := waitForMCP(cleanupCtx, mcClient, testMCPName, 15*time.Minute)
+			if apierrors.IsNotFound(waitErr) {
+				return
+			}
+			o.Expect(waitErr).NotTo(o.HaveOccurred(),
+				"Cleanup: MCP %s did not become ready after KubeletConfig deletion", testMCPName)
+		}
+		g.DeferCleanup(cleanupKubeletConfig)
+
+		_, err = mcClient.MachineconfigurationV1().KubeletConfigs().Create(ctx, kubeletConfig, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating KubeletConfig with TLS 1.3")
+
+		g.By(fmt.Sprintf("Waiting for MachineConfigPool %s to begin updating", testMCPName))
+		err = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			mcp, getErr := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, testMCPName, metav1.GetOptions{})
+			if getErr != nil {
+				framework.Logf("Error getting MCP %s: %v", testMCPName, getErr)
+				return false, nil
+			}
+			for _, condition := range mcp.Status.Conditions {
+				if condition.Type == "Updating" && condition.Status == corev1.ConditionTrue {
+					framework.Logf("MCP %s has started updating", testMCPName)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(),
+			"Timed out waiting for MachineConfigPool %q to start updating", testMCPName)
+
+		g.By(fmt.Sprintf("Waiting for MachineConfigPool %s to complete rollout", testMCPName))
+		err = waitForMCP(ctx, mcClient, testMCPName, 30*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error waiting for MachineConfigPool %q to become ready", testMCPName)
+		framework.Logf("MachineConfigPool %s has completed rollout", testMCPName)
+
+		g.By(fmt.Sprintf("Verifying node %s is Ready and Done after rollout", testNode))
+		updatedNode, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting node %s after rollout", testNode)
+		o.Expect(isNodeInReadyState(updatedNode)).To(o.BeTrue(), "Node %s is not in Ready state after rollout", testNode)
+
+		nodeState := updatedNode.Annotations["machineconfiguration.openshift.io/state"]
+		o.Expect(nodeState).To(o.Equal("Done"), "Node %s is in state %q, expected 'Done'", testNode, nodeState)
+
+		g.By("Verifying TLS version upgraded to 1.3")
+		expectedTLSVersion := "VersionTLS13"
+		nodeCfg, err = getKubeletConfigFromNode(ctx, oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error reading kubelet config from node %s after rollout", testNode)
+		actualTLSVersion := nodeCfg.TLSMinVersion
+
+		o.Expect(actualTLSVersion).To(o.Equal(expectedTLSVersion),
+			"TLS version should be %q, but got %q", expectedTLSVersion, actualTLSVersion)
+
+		framework.Logf("Successfully verified kubelet TLS upgrade from %s to %s on node %s",
+			defaultTLSVersion, actualTLSVersion, testNode)
+	})
+})


### PR DESCRIPTION
This PR adds a disruptive e2e test that validates upgrading kubelet serving TLS from the default (1.2) to TLS 1.3 on the worker pool via `KubeletConfig`.

### What the test does

1. Verifies all worker nodes are Ready and records the default TLS configuration.
2. Applies a `KubeletConfig` (`worker-tls13-config`) that sets `tlsMinVersion: VersionTLS13` with TLS 1.3 cipher suites.
3. Waits for the worker `MachineConfigPool` to start updating, then waits for rollout to complete (reuses `waitForMCP` from `node_utils.go`).
4. Confirms every worker node is Ready and in MCO `Done` state after rollout.
5. Reads `kubelet.conf` from a worker and asserts `tlsMinVersion` is `VersionTLS13`.
6. Cleans up: deletes the `KubeletConfig` on test exit (`defer`).





### Jira
[OCP-88710](https://redhat.atlassian.net/browse/OCPNODE-4047)

Locally executed and it got passed.
**Output** 
origin git:(ocp-88710) ✗ ./openshift-tests run-test '[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on worker pool [apigroup:machineconfiguration.openshift.io] [Serial]'
 

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on worker pool [apigroup:machineconfiguration.openshift.io]
  github.com/openshift/origin/test/extended/node/kubeletconfig_tls.go:52
    
  ------------------------------

  Ran 1 of 1 Specs in 694.514 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration should upgrade kubelet TLS from 1.2 to 1.3 on worker pool [apigroup:machineconfiguration.openshift.io] [Serial]",
    "lifecycle": "blocking",
    "duration": 694515,
    "startTime": "2026-04-20 07:07:47.133133 UTC",
    "endTime": "2026-04-20 07:19:21.648327 UTC",
    "result": "passed",

cc @bitoku @ngopalak-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a disruptive long-running end-to-end test suite that validates upgrading the kubelet TLS minimum version on worker nodes: it skips unsupported topologies, ensures workers are Ready, applies a TLS minimum version change to the worker pool, waits for rollout to complete, and verifies node readiness and the updated TLS version after upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->