### PR TITLE
OCPBUGS-83598: Add missing generateIPAMLifecycle in ClusterUDN manifest

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -1333,6 +1333,7 @@ spec:
     ` + params.topology + `: 
       role: ` + nadToUdnParams[params.role] + `
       subnets: ` + subnets + `
+      ` + generateIPAMLifecycle(params) + `
 `
 }
 

--- a/test/extended/storage/csi_certificates.go
+++ b/test/extended/storage/csi_certificates.go
@@ -1,0 +1,89 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = g.Describe(`[sig-storage][CSI][Jira:"Storage"] CSI driver operator secure certificates`, func() {
+	defer g.GinkgoRecover()
+	oc := exutil.NewCLI("csi-cert-check")
+
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Not supported on MicroShift")
+		}
+	})
+
+	g.It("csi driver operators should use service CA signed certificates by default", func() {
+		ctx := context.Background()
+
+		g.By("Verifying the storage cluster operator is healthy")
+		WaitForCSOHealthy(oc)
+
+		g.By("Listing CSI driver operator pods")
+		allPods, err := oc.AdminKubeClient().CoreV1().Pods(CSINamespace).List(ctx, metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to list pods in namespace %s", CSINamespace)
+
+		checked := 0
+		var failures []string
+
+		for _, pod := range allPods.Items {
+			operatorContainer := getCsiDriverOperatorContainerName(pod)
+			if operatorContainer == "" {
+				continue
+			}
+
+			g.By(fmt.Sprintf("Checking logs of %s for secure certificate usage", pod.Name))
+			logStream, err := oc.AdminKubeClient().CoreV1().Pods(CSINamespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+				Container: operatorContainer,
+			}).Stream(ctx)
+			if err != nil {
+				e2e.Logf("Failed to get logs for pod %s, skipping: %v", pod.Name, err)
+				continue
+			}
+
+			logBytes, err := io.ReadAll(logStream)
+			logStream.Close()
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to read logs for pod %s", pod.Name)
+
+			logOutput := string(logBytes)
+			if strings.Contains(logOutput, "Using insecure, self-signed certificates") {
+				failures = append(failures, fmt.Sprintf("%s (pod %s): insecure self-signed certificates detected", operatorContainer, pod.Name))
+			}
+			if !strings.Contains(logOutput, "Using service-serving-cert provided certificates") {
+				failures = append(failures, fmt.Sprintf("%s (pod %s): secure cert log not found", operatorContainer, pod.Name))
+			}
+			checked++
+		}
+
+		if checked == 0 {
+			g.Skip(fmt.Sprintf("No CSI driver operator pods found on platform %q", e2e.TestContext.Provider))
+		}
+		o.Expect(failures).To(o.BeEmpty(),
+			"CSI driver operators not using service CA signed certificates:\n%s", strings.Join(failures, "\n"))
+	})
+})
+
+// Returns the name of the CSI driver operator
+// container in the pod, or "" if the pod is not a CSI driver operator.
+func getCsiDriverOperatorContainerName(pod corev1.Pod) string {
+	for _, c := range pod.Spec.Containers {
+		if strings.HasSuffix(c.Name, "-csi-driver-operator") {
+			return c.Name
+		}
+	}
+	return ""
+}

--- a/test/extended/two_node/tnf_topology.go
+++ b/test/extended/two_node/tnf_topology.go
@@ -16,6 +16,9 @@ import (
 )
 
 const ensurePodmanEtcdContainerIsRunning = "podman inspect --format '{{.State.Running}}' etcd"
+const getEtcdOOMScoreAdj = "GETPID=$(podman inspect etcd --format '{{.State.Pid}}') && cat /proc/$GETPID/oom_score_adj"
+const getPcsEtcdOOMDefault = "pcs resource describe ocf:heartbeat:podman-etcd"
+const expectedOOMScoreAdj = "-997"
 
 var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:DualReplica] Two Node with Fencing topology", func() {
 	defer g.GinkgoRecover()
@@ -131,6 +134,27 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			got, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, node.Name, "openshift-etcd", strings.Split(ensurePodmanEtcdContainerIsRunning, " ")...)
 			o.Expect(err).To(o.BeNil(), fmt.Sprintf("expected to call podman without errors on Node %s: error %v", node.Name, err))
 			o.Expect(got).To(o.Equal("'true'"), fmt.Sprintf("expected a podman etcd container running on Node %s: got running %s", node.Name, got))
+		}
+	})
+
+	g.It("should have etcd OOM score adjustment set to -997 on each node", func() {
+		nodes, err := utils.GetNodes(oc, utils.LabelNodeRoleControlPlane)
+		o.Expect(err).To(o.BeNil(), "Expected to retrieve control plane nodes without error")
+		o.Expect(nodes.Items).To(o.HaveLen(2), "Expected to retrieve two control plane nodes for DualReplica topology")
+
+		g.By("Verifying pcs resource describes etcd with OOM default of -997")
+		firstNode := nodes.Items[0]
+		pcsOutput, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, firstNode.Name, "openshift-etcd", "bash", "-c", getPcsEtcdOOMDefault)
+		o.Expect(err).To(o.BeNil(), fmt.Sprintf("expected pcs resource describe to succeed on Node %s: error %v", firstNode.Name, err))
+		o.Expect(strings.ToLower(pcsOutput)).To(o.ContainSubstring(fmt.Sprintf("default: %s", expectedOOMScoreAdj)),
+			fmt.Sprintf("expected pcs resource describe to show OOM default of %s on Node %s, got: %s", expectedOOMScoreAdj, firstNode.Name, pcsOutput))
+
+		g.By("Ensuring etcd process OOM score adjustment is -997 on each node")
+		for _, node := range nodes.Items {
+			got, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, node.Name, "openshift-etcd", "bash", "-c", getEtcdOOMScoreAdj)
+			o.Expect(err).To(o.BeNil(), fmt.Sprintf("expected to read oom_score_adj without errors on Node %s: error %v", node.Name, err))
+			o.Expect(strings.TrimSpace(got)).To(o.Equal(expectedOOMScoreAdj),
+				fmt.Sprintf("expected etcd oom_score_adj to be %s on Node %s, got: %s", expectedOOMScoreAdj, node.Name, got))
 		}
 	})
 })


### PR DESCRIPTION
## Summary
- Added missing `generateIPAMLifecycle(params)` call in `generateClusterUserDefinedNetworkManifest`, matching the existing pattern in `generateUserDefinedNetworkManifest`
- Without this fix, `ClusterUserDefinedNetwork` manifests were generated without IPAM lifecycle configuration

## Test plan
- [ ] Verify `ClusterUserDefinedNetwork` manifests now include IPAM lifecycle configuration when specified
- [ ] Verify existing `UserDefinedNetwork` manifest generation is unaffected
- [ ] Run network segmentation e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)