### PR TITLE
OCPBUGS-83598: Add missing generateIPAMLifecycle in ClusterUDN manifest

### DIFF
--- a/test/extended/networking/network_segmentation.go
+++ b/test/extended/networking/network_segmentation.go
@@ -1311,7 +1311,7 @@ spec:
   ` + params.topology + `: 
     role: ` + nadToUdnParams[params.role] + `
     subnets: ` + subnets + `
-    ` + generateIPAMLifecycle(params) + `
+    ` + generateIPAMLifecycle(params, "      ") + `
 `
 }
 
@@ -1333,6 +1333,7 @@ spec:
     ` + params.topology + `: 
       role: ` + nadToUdnParams[params.role] + `
       subnets: ` + subnets + `
+      ` + generateIPAMLifecycle(params, "        ") + `
 `
 }
 
@@ -1361,12 +1362,11 @@ func generateLayer3Subnets(cidrs string) []string {
 	return subnets
 }
 
-func generateIPAMLifecycle(params *networkAttachmentConfigParams) string {
+func generateIPAMLifecycle(params *networkAttachmentConfigParams, lifecycleIndent string) string {
 	if !params.allowPersistentIPs {
 		return ""
 	}
-	return `ipam:
-      lifecycle: Persistent`
+	return "ipam:\n" + lifecycleIndent + "lifecycle: Persistent"
 }
 
 func createManifest(namespace, manifest string) (func(), error) {


### PR DESCRIPTION
## Summary
- Added missing `generateIPAMLifecycle(params)` call in `generateClusterUserDefinedNetworkManifest`, matching the existing pattern in `generateUserDefinedNetworkManifest`
- Without this fix, `ClusterUserDefinedNetwork` manifests were generated without IPAM lifecycle configuration

## Test plan
- [ ] Verify `ClusterUserDefinedNetwork` manifests now include IPAM lifecycle configuration when specified
- [ ] Verify existing `UserDefinedNetwork` manifest generation is unaffected
- [ ] Run network segmentation e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)