### PR TITLE
OCPBUGS-63307: honor firstTimestamp annotation value

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1009,9 +1009,19 @@ func (ade *OverlapOtherIntervalsPathologicalEventMatcher) Allows(i monitorapi.In
 		return false
 	}
 
+	// Pathological event intervals set From to LastTimestamp (the most recent occurrence),
+	// but the event may have first fired much earlier. Use firstTimestamp from the
+	// annotations when available so the overlap check covers the full span of the event.
+	eventFrom := i.From
+	if ft, ok := i.Message.Annotations["firstTimestamp"]; ok {
+		if parsed, err := time.Parse(time.RFC3339, ft); err == nil {
+			eventFrom = parsed
+		}
+	}
+
 	// Match the pathological event if it overlaps with any of the given set of intervals.
 	for _, nui := range ade.allowIfWithinIntervals {
-		if nui.From.Before(i.From) && nui.To.After(i.To) {
+		if nui.From.Before(eventFrom) && nui.To.After(i.To) {
 			logrus.Infof("%s was found to overlap with %s, ignoring pathological event as they fall within range of specified intervals", i, nui)
 			return true
 		}

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
@@ -1,11 +1,89 @@
 package pathologicaleventlibrary
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
+	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_OverlapMatcherUsesFirstTimestamp(t *testing.T) {
+	// Simulate the real-world scenario: an event fires 23 times over 90 minutes.
+	// The interval's From is set to LastTimestamp (the final occurrence), but
+	// firstTimestamp in annotations records when the event actually started.
+	testStart := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	firstTimestamp := testStart.Add(15 * time.Minute) // 12:15
+	lastTimestamp := testStart.Add(105 * time.Minute) // 13:45
+	testEnd := testStart.Add(110 * time.Minute)       // 13:50
+
+	// The "test interval" that the event should overlap with (12:00 - 13:50).
+	testInterval := monitorapi.NewInterval(monitorapi.SourceE2ETest, monitorapi.Info).
+		Locator(monitorapi.NewLocator().NodeFromName("test")).
+		Message(monitorapi.NewMessage().HumanMessage("test interval")).
+		Build(testStart, testEnd)
+
+	// Build a pathological event interval the way watchevents/event.go does:
+	// From = lastTimestamp, To = lastTimestamp + 1s, firstTimestamp in annotations.
+	pathologicalInterval := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Warning).
+		Locator(monitorapi.NewLocator().PodFromNames("openshift-test", "test-pod", "")).
+		Message(
+			monitorapi.NewMessage().
+				Reason("TestReason").
+				HumanMessage("test pathological event").
+				WithAnnotation(monitorapi.AnnotationCount, fmt.Sprintf("%d", 23)).
+				WithAnnotation("firstTimestamp", firstTimestamp.Format(time.RFC3339)).
+				WithAnnotation("lastTimestamp", lastTimestamp.Format(time.RFC3339))).
+		Build(lastTimestamp, lastTimestamp.Add(1*time.Second))
+
+	matcher := &OverlapOtherIntervalsPathologicalEventMatcher{
+		delegate: &SimplePathologicalEventMatcher{
+			name:               "TestMatcher",
+			messageReasonRegex: regexp.MustCompile(`^TestReason$`),
+		},
+		allowIfWithinIntervals: monitorapi.Intervals{testInterval},
+	}
+
+	// Should be allowed because firstTimestamp (12:15) falls within the test interval (12:00-13:50).
+	assert.True(t, matcher.Allows(pathologicalInterval, v1.HighlyAvailableTopologyMode),
+		"event should be allowed when firstTimestamp falls within the overlap interval")
+
+	// Now test with a test interval that ends before lastTimestamp but after firstTimestamp.
+	// The event's firstTimestamp (12:15) is within [12:00, 13:00], and To (13:45:01) is NOT.
+	shorterTestInterval := monitorapi.NewInterval(monitorapi.SourceE2ETest, monitorapi.Info).
+		Locator(monitorapi.NewLocator().NodeFromName("test")).
+		Message(monitorapi.NewMessage().HumanMessage("short test interval")).
+		Build(testStart, testStart.Add(60*time.Minute)) // 12:00 - 13:00
+
+	matcherShort := &OverlapOtherIntervalsPathologicalEventMatcher{
+		delegate: &SimplePathologicalEventMatcher{
+			name:               "TestMatcher",
+			messageReasonRegex: regexp.MustCompile(`^TestReason$`),
+		},
+		allowIfWithinIntervals: monitorapi.Intervals{shorterTestInterval},
+	}
+
+	// Should NOT be allowed because the event's To (13:45:01) extends past the test interval's end (13:00).
+	assert.False(t, matcherShort.Allows(pathologicalInterval, v1.HighlyAvailableTopologyMode),
+		"event should not be allowed when its To extends beyond the overlap interval")
+
+	// Test without firstTimestamp annotation — should fall back to From (lastTimestamp).
+	noAnnotationInterval := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Warning).
+		Locator(monitorapi.NewLocator().PodFromNames("openshift-test", "test-pod", "")).
+		Message(
+			monitorapi.NewMessage().
+				Reason("TestReason").
+				HumanMessage("test pathological event").
+				WithAnnotation(monitorapi.AnnotationCount, fmt.Sprintf("%d", 23))).
+		Build(lastTimestamp, lastTimestamp.Add(1*time.Second))
+
+	// Without firstTimestamp, From is lastTimestamp (13:45). The test interval [12:00, 13:50] contains it.
+	assert.True(t, matcher.Allows(noAnnotationInterval, v1.HighlyAvailableTopologyMode),
+		"event without firstTimestamp should fall back to From for overlap check")
+}
 
 func Test_singleEventThresholdCheck_getNamespacedFailuresAndFlakes(t *testing.T) {
 	namespace := "openshift-etcd-operator"


### PR DESCRIPTION
Alternative to https://github.com/openshift/origin/pull/30991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event interval overlap detection to use actual event start timestamps from annotations when available, improving matching accuracy.

* **Tests**
  * Added test coverage validating overlap detection behavior with various timestamp scenarios, including fallback handling when annotations are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->