### PR TITLE
OCPBUGS-83281: Fix Gateway cleanup in parallel e2e test workers

### DIFF
--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -13,7 +13,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -237,29 +236,18 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Gateway")
 	err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(ctx, t.gatewayName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		e2e.Logf("Failed to delete Gateway %q: %v", t.gatewayName, err)
+		e2e.Failf("Failed to delete Gateway %q: %v", t.gatewayName, err)
 	}
 
-	// Wait for Gateway to be fully deleted before removing GatewayClass
-	// This prevents orphaned resources if the controller (defined by GatewayClass) is removed
-	// before Istiod completes cleanup
-	g.By("Waiting for Gateway to be fully deleted")
-	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
-		_, err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Get(ctx, t.gatewayName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			e2e.Logf("Gateway %q successfully deleted", t.gatewayName)
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		e2e.Logf("Gateway %q still exists after 2 minutes, continuing cleanup anyway", t.gatewayName)
+	g.By("Waiting for gateway deployment to be deleted")
+	if err := waitForGatewayDeploymentDeletion(t.oc, t.gatewayName); err != nil {
+		e2e.Failf("Gateway deployment for %q was not cleaned up: %v", t.gatewayName, err)
 	}
 
 	g.By("Deleting the GatewayClass")
 	err = t.oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		e2e.Logf("Failed to delete GatewayClass %q: %v", gatewayClassName, err)
+		e2e.Failf("Failed to delete GatewayClass %q: %v", gatewayClassName, err)
 	}
 
 	g.By("Deleting the Istio CR if it exists")

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -254,7 +254,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// This should get cleaned up by the CIO, but this is here just in case of failure
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "istio", istioName).Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete Istio CR %q: %v", istioName, err)
+		e2e.Failf("Failed to delete Istio CR %q: %v", istioName, err)
 	}
 
 	g.By("Waiting for istiod pods to be deleted")
@@ -264,7 +264,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// This doesn't get deleted by the CIO, so must manually clean up
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName).Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
+		e2e.Failf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
 	}
 
 	g.By("Deleting Sail Operator CSV by label selector")
@@ -272,7 +272,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	labelSelector := fmt.Sprintf("operators.coreos.com/%s", serviceMeshOperatorName)
 	err = t.oc.Run("delete").Args("csv", "-n", expectedSubscriptionNamespace, "-l", labelSelector, "--ignore-not-found=true").Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete CSV with label %q: %v", labelSelector, err)
+		e2e.Failf("Failed to delete CSV with label %q: %v", labelSelector, err)
 	}
 
 	g.By("Deleting OLM-managed Istio CRDs to clean up migration state")
@@ -288,7 +288,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 			if strings.HasSuffix(crd.Name, "istio.io") {
 				err := t.oc.Run("delete").Args("--ignore-not-found=true", "crd", crd.Name).Execute()
 				if err != nil {
-					e2e.Logf("Failed to delete CRD %q: %v", crd.Name, err)
+					e2e.Failf("Failed to delete CRD %q: %v", crd.Name, err)
 				}
 			}
 		}

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -253,7 +253,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Istio CR if it exists")
 	// This should get cleaned up by the CIO, but this is here just in case of failure
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "istio", istioName).Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete Istio CR %q: %v", istioName, err)
 	}
 
@@ -263,7 +263,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Sail Operator subscription")
 	// This doesn't get deleted by the CIO, so must manually clean up
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName).Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
 	}
 
@@ -271,7 +271,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// Delete CSV using label selector to handle any version (e.g., servicemeshoperator3.v3.2.0)
 	labelSelector := fmt.Sprintf("operators.coreos.com/%s", serviceMeshOperatorName)
 	err = t.oc.Run("delete").Args("csv", "-n", expectedSubscriptionNamespace, "-l", labelSelector, "--ignore-not-found=true").Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete CSV with label %q: %v", labelSelector, err)
 	}
 

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -106,12 +106,11 @@ var (
 	}
 )
 
-var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", g.Ordered, g.Serial, func() {
+var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                    = exutil.NewCLIWithPodSecurityLevel("gatewayapi-controller", admissionapi.LevelBaseline)
 		err                   error
-		gateways              []string
 		infPoolCRD            = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/main/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 		managedDNS            bool
 		loadBalancerSupported bool
@@ -145,13 +144,6 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		if !checkAllTestsDone(oc) {
 			e2e.Logf("Skipping cleanup while not all GatewayAPIController tests are done")
 		} else {
-			g.By("Deleting the gateways")
-
-			for _, name := range gateways {
-				err = oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
-				o.Expect(err).NotTo(o.HaveOccurred(), "Gateway %s could not be deleted", name)
-			}
-
 			g.By("Deleting the GatewayClass")
 
 			if err := oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(context.Background(), gatewayClassName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
@@ -365,7 +357,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create the default Gateway")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, defaultDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "failed to create Gateway")
 
@@ -394,7 +386,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create a custom Gateway for the HTTPRoute")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, customDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "Failed to create Gateway")
 
@@ -510,7 +502,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create a custom Gateway")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, customDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "Failed to create Gateway")
 
@@ -1322,6 +1314,40 @@ func waitForIstiodPodDeletion(oc *exutil.CLI) {
 		g.Expect(err).NotTo(o.HaveOccurred())
 		g.Expect(podsList.Items).Should(o.BeEmpty())
 	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+}
+
+// waitForGatewayDeploymentDeletion waits for a Gateway's deployment to be
+// deleted. The deployment is cascade-deleted by GC after the Gateway is
+// removed, but this is asynchronous. Must complete before removing the
+// GatewayClass or istiod to prevent gateway pods from crash-looping.
+func waitForGatewayDeploymentDeletion(oc *exutil.CLI, gatewayName string) error {
+	deploymentName := gatewayName + "-" + gatewayClassName
+	e2e.Logf("Waiting for gateway deployment %q in namespace %q to be deleted", deploymentName, ingressNamespace)
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := oc.AdminKubeClient().AppsV1().Deployments(ingressNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			e2e.Logf("Gateway deployment %q has been deleted", deploymentName)
+			return true, nil
+		}
+		if err != nil {
+			e2e.Logf("Error checking gateway deployment %q: %v, retrying...", deploymentName, err)
+			return false, nil
+		}
+		e2e.Logf("Gateway deployment %q still exists, waiting for GC cascade deletion...", deploymentName)
+		return false, nil
+	})
+}
+
+// deleteGatewayAndWaitForCleanup deletes a Gateway and waits for its proxy deployment to be removed by GC.
+func deleteGatewayAndWaitForCleanup(oc *exutil.CLI, gatewayName string) {
+	e2e.Logf("Deleting Gateway %q", gatewayName)
+	err := oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(context.Background(), gatewayName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Failf("Failed to delete Gateway %q: %v", gatewayName, err)
+	}
+	if err := waitForGatewayDeploymentDeletion(oc, gatewayName); err != nil {
+		e2e.Failf("Failed: Gateway deployment for %q was not deleted: %v", gatewayName, err)
+	}
 }
 
 // validateOLMBasedOSSM validates that Gateway API is using OLM-based provisioning.


### PR DESCRIPTION
The Gateway API controller tests tracked Gateways in a sharedin-memory gateways slice, deleting them during AfterEach cleanup. However, openshift-tests distributes tests across separate parallel worker processes. The annotation-based checkAllTestsDone coordination works correctly because annotations are stored on the cluster-scoped GatewayClass, but the gateways slice is not shared across processes. The process that runs the final AfterEach cleanup has an empty gateways slice, so it deletes the GatewayClass and istiod but never deletes the Gateways created by other processes. This leaves gateway deployments orphaned on the cluster.

As a secondary issue, even when gateways were deleted, the GatewayClass and istiod were removed without waiting for the gateway proxy deployments to be fully cleaned up by GC. Since the deployments have an owner reference to the Gateway (not a finalizer), the cascade deletion is asynchronous, creating a race where gateway pods lose their control plane and crash-loop.

Fix both issues by cleaning up gateways at the individual test level using defer deleteGateway, which deletes the Gateway and waits for its proxy deployment to be removed by GC. Add deleteGateway and waitForGatewayDeploymentDeletion helpers shared by both the controller tests and the upgrade test Teardown. Cleanup errors now hard fail to surface leftover resources immediately rather than causing confusing downstream test failures.

https://redhat.atlassian.net/browse/OCPBUGS-83281