### PR TITLE
OCPBUGS-69936: Try to stagger some test groups to help with high cpu disruption cases

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -662,7 +662,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 
 		kubeTestsCopy := copyTests(kubeTests)
 		kubeIntervalID, kubeStartTime := recordTestBucketInterval(monitorEventRecorder, "Kubernetes")
-		q.ExecuteWithStagger(testCtx, kubeTestsCopy, parallelism, testOutputConfig, abortFn, 200*time.Millisecond)
+		q.ExecuteWithStagger(testCtx, kubeTestsCopy, parallelism, testOutputConfig, abortFn, 10*time.Second)
 		monitorEventRecorder.EndInterval(kubeIntervalID, time.Now())
 		logrus.Infof("Completed Kubernetes test bucket in %v", time.Since(kubeStartTime))
 		tests = append(tests, kubeTestsCopy...)
@@ -716,7 +716,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 
 		openshiftTestsCopy := copyTests(openshiftTests)
 		openshiftIntervalID, openshiftStartTime := recordTestBucketInterval(monitorEventRecorder, "OpenShift")
-		q.ExecuteWithStagger(testCtx, openshiftTestsCopy, parallelism, testOutputConfig, abortFn, 200*time.Millisecond)
+		q.ExecuteWithStagger(testCtx, openshiftTestsCopy, parallelism, testOutputConfig, abortFn, 10*time.Second)
 		monitorEventRecorder.EndInterval(openshiftIntervalID, time.Now())
 		logrus.Infof("Completed OpenShift test bucket in %v", time.Since(openshiftStartTime))
 		tests = append(tests, openshiftTestsCopy...)

--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -662,7 +662,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 
 		kubeTestsCopy := copyTests(kubeTests)
 		kubeIntervalID, kubeStartTime := recordTestBucketInterval(monitorEventRecorder, "Kubernetes")
-		q.Execute(testCtx, kubeTestsCopy, parallelism, testOutputConfig, abortFn)
+		q.ExecuteWithStagger(testCtx, kubeTestsCopy, parallelism, testOutputConfig, abortFn, 200*time.Millisecond)
 		monitorEventRecorder.EndInterval(kubeIntervalID, time.Now())
 		logrus.Infof("Completed Kubernetes test bucket in %v", time.Since(kubeStartTime))
 		tests = append(tests, kubeTestsCopy...)
@@ -716,7 +716,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 
 		openshiftTestsCopy := copyTests(openshiftTests)
 		openshiftIntervalID, openshiftStartTime := recordTestBucketInterval(monitorEventRecorder, "OpenShift")
-		q.Execute(testCtx, openshiftTestsCopy, parallelism, testOutputConfig, abortFn)
+		q.ExecuteWithStagger(testCtx, openshiftTestsCopy, parallelism, testOutputConfig, abortFn, 200*time.Millisecond)
 		monitorEventRecorder.EndInterval(openshiftIntervalID, time.Now())
 		logrus.Infof("Completed OpenShift test bucket in %v", time.Since(openshiftStartTime))
 		tests = append(tests, openshiftTestsCopy...)

--- a/pkg/test/ginkgo/queue.go
+++ b/pkg/test/ginkgo/queue.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -252,6 +253,13 @@ func runTestsUntilDone(ctx context.Context, scheduler TestScheduler, testSuiteRu
 
 // tests are currently being mutated during the run process.
 func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase, parallelism int, testOutput testOutputConfig, maybeAbortOnFailureFn testAbortFunc) {
+	q.ExecuteWithStagger(ctx, tests, parallelism, testOutput, maybeAbortOnFailureFn, 0)
+}
+
+// ExecuteWithStagger is like Execute but staggers the start of parallel workers by the given
+// duration per worker. This smooths out the initial burst of test setup (namespace creation,
+// RBAC bindings, etc.) that can overwhelm the apiserver on small control plane nodes.
+func (q *parallelByFileTestQueue) ExecuteWithStagger(ctx context.Context, tests []*testCase, parallelism int, testOutput testOutputConfig, maybeAbortOnFailureFn testAbortFunc, workerStagger time.Duration) {
 	testSuiteProgress := newTestSuiteProgress(len(tests))
 	testSuiteRunner := &testSuiteRunnerImpl{
 		commandContext:        q.commandContext,
@@ -260,11 +268,11 @@ func (q *parallelByFileTestQueue) Execute(ctx context.Context, tests []*testCase
 		maybeAbortOnFailureFn: maybeAbortOnFailureFn,
 	}
 
-	execute(ctx, testSuiteRunner, tests, parallelism)
+	execute(ctx, testSuiteRunner, tests, parallelism, workerStagger)
 }
 
 // execute is a convenience for unit testing
-func execute(ctx context.Context, testSuiteRunner testSuiteRunner, tests []*testCase, parallelism int) {
+func execute(ctx context.Context, testSuiteRunner testSuiteRunner, tests []*testCase, parallelism int, workerStagger time.Duration) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -283,10 +291,20 @@ func execute(ctx context.Context, testSuiteRunner testSuiteRunner, tests []*test
 		// Each worker polls the scheduler for the next runnable test in order
 		for i := 0; i < parallelism; i++ {
 			wg.Add(1)
-			go func(ctx context.Context) {
+			go func(ctx context.Context, workerID int) {
 				defer wg.Done()
+				// Stagger worker starts to smooth out the initial burst of test
+				// setup (namespace + RBAC creation) that can saturate the apiserver
+				// CPU on small control plane nodes.
+				if workerStagger > 0 && workerID > 0 {
+					select {
+					case <-time.After(time.Duration(workerID) * workerStagger):
+					case <-ctx.Done():
+						return
+					}
+				}
 				runTestsUntilDone(ctx, scheduler, testSuiteRunner)
-			}(ctx)
+			}(ctx, i)
 		}
 
 		wg.Wait()

--- a/pkg/test/ginkgo/queue_test.go
+++ b/pkg/test/ginkgo/queue_test.go
@@ -76,7 +76,7 @@ func Test_execute(t *testing.T) {
 	tests := makeTestCases()
 	testSuiteRunner := &testingSuiteRunner{}
 	parallelism := 30
-	execute(context.TODO(), testSuiteRunner, tests, parallelism)
+	execute(context.TODO(), testSuiteRunner, tests, parallelism, 0)
 
 	testsCompleted := testSuiteRunner.getTestsRun()
 	if len(tests) != len(testsCompleted) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Kubernetes and OpenShift test suites now start workers with a staggered delay (10s) when run via the test runner.
* **New Features**
  * Test execution framework gains a configurable worker-startup delay option while preserving prior default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->