### PR TITLE
NO-JIRA: Fix UpgradeTargetPayloadImagePullSpec

### DIFF
--- a/pkg/cmd/openshift-tests/run-upgrade/flags.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/flags.go
@@ -48,7 +48,7 @@ func NewRunUpgradeSuiteFlags(streams genericclioptions.IOStreams, fromRepository
 func (f *RunUpgradeSuiteFlags) BindFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&f.FromRepository, "from-repository", f.FromRepository, "A container image repository to retrieve test images from.")
 	flags.StringVar(&f.ProviderTypeOrJSON, "provider", f.ProviderTypeOrJSON, "The cluster infrastructure provider. Will automatically default to the correct value.")
-	flags.StringVar(&f.ToImage, "to-image", f.ToImage, "Specify the image to test an upgrade to.")
+	flags.StringVar(&f.ToImage, "to-image", f.ToImage, "Specify the images to test an upgrade to, separated by comma.")
 	flags.StringSliceVar(&f.TestOptions, "options", f.TestOptions, "A set of KEY=VALUE options to control the test. See the help text.")
 	f.GinkgoRunSuiteOptions.BindFlags(flags)
 	f.TestSuiteSelectionFlags.BindFlags(flags)

--- a/pkg/cmd/openshift-tests/run-upgrade/options.go
+++ b/pkg/cmd/openshift-tests/run-upgrade/options.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
 
@@ -109,10 +110,19 @@ func (o *RunUpgradeSuiteOptions) Run(ctx context.Context) error {
 		return err
 	}
 
+	last := o.ToImage
+	if strings.Contains(last, ",") {
+		splits := strings.Split(o.ToImage, ",")
+		last = strings.TrimSpace(splits[len(splits)-1])
+		if last == "" {
+			return fmt.Errorf("failed to get the final upgrade destination from %s", o.ToImage)
+		}
+	}
+
 	// TODO the gingkoRunSuiteOptions needs to have flags then calculated options to express specified versus computed values
 	monitorTestInfo := monitortestframework.MonitorTestInitializationInfo{
 		ClusterStabilityDuringTest:        monitortestframework.Stable,
-		UpgradeTargetPayloadImagePullSpec: o.ToImage,
+		UpgradeTargetPayloadImagePullSpec: last,
 		ExactMonitorTests:                 o.GinkgoRunSuiteOptions.ExactMonitorTests,
 		DisableMonitorTests:               o.GinkgoRunSuiteOptions.DisableMonitorTests,
 	}


### PR DESCRIPTION
This pull updates the flag description of the flag `--to-image`. It supports multi-hop upgrade already [1]. In addition, it fixes `monitorTestInfo.UpgradeTargetPayloadImagePullSpec` which is supposed to be the final destination [2]. We are doing this because currently [periodic-ci-openshift-release-main-ci-4.22-upgrade-from-stable-4.21-from-stable-4.20-e2e-aws-ovn-upgrade](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-4.22-upgrade-from-stable-4.21-from-stable-4.20-e2e-aws-ovn-upgrade) is broken with

```
: [Monitor:apiserver-incluster-availability][Jira:"kube-apiserver"] monitor test apiserver-incluster-availability setup expand_less	1m1s
{  failed during setup
unable to determine openshift-tests image: registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:c5a33a11e09de6c07f7ba449b9d3da7a45b3fa16194a879b35308319998ba5e9,registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:4c2716961dfe4b428bd239d6aa8e1647b3ab0a4419582f3e058cb6071299a0b2: failed to extract image references from release payload: failed extracting image-references from "registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:c5a33a11e09de6c07f7ba449b9d3da7a45b3fa16194a879b35308319998ba5e9,registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:4c2716961dfe4b428bd239d6aa8e1647b3ab0a4419582f3e058cb6071299a0b2": error during image extract: exit status 1 (error: "registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:c5a33a11e09de6c07f7ba449b9d3da7a45b3fa16194a879b35308319998ba5e9,registry.build09.ci.openshift.org/ci-op-ig5jr2tm/release@sha256:4c2716961dfe4b428bd239d6aa8e1647b3ab0a4419582f3e058cb6071299a0b2" is not a valid image reference: invalid reference format
)}
```

[1]. https://github.com/openshift/origin/blob/1a93dad027b5135d67388b359c2b12d87beae0b0/test/e2e/upgrade/upgrade.go#L305

[2]. https://github.com/openshift/origin/blob/23edbc01a32ad0aa55159b63d1a74d9a0fdd7f5e/pkg/monitortestframework/types.go#L29-L30


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The --to-image flag accepts multiple comma-separated target images; the final image in the list is used for the upgrade test.
* **Bug Fixes**
  * Whitespace is trimmed from the selected final image and an error is returned if the final entry is empty.
* **Documentation**
  * Help/usage text for the --to-image flag updated to reflect multi-image support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->