### PR TITLE
Fix 'occured' -> 'occurred' typos across e2e tests and monitors (8 files, 31 instances)

### DIFF
--- a/pkg/monitortests/monitoring/statefulsetsrecreation/monitortest.go
+++ b/pkg/monitortests/monitoring/statefulsetsrecreation/monitortest.go
@@ -177,7 +177,7 @@ func (sc *statefulsetsChecker) getStatefulsetsUID(ctx context.Context) (map[stri
 				err = fmt.Errorf("%w: lastError: %w", err, lastErr)
 			}
 			logrus.Infof(
-				"Error occured while getting statefulset %s/%s: %v",
+				"Error occurred while getting statefulset %s/%s: %v",
 				openshiftMonitoringNs,
 				statefulsetName,
 				err,

--- a/test/extended/kernel/kernel_rt_functional.go
+++ b/test/extended/kernel/kernel_rt_functional.go
@@ -23,17 +23,17 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime][Disruptive] Real 
 
 	g.It("pi_stress to run successfully with the fifo algorithm", func() {
 		err := runPiStressFifo(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the fifo algorithm")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running pi_stress with the fifo algorithm")
 	})
 
 	g.It("pi_stress to run successfully with the round robin algorithm", func() {
 		err := runPiStressRR(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running pi_stress with the round robin algorithm")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running pi_stress with the round robin algorithm")
 	})
 
 	g.It("deadline_test to run successfully", func() {
 		err := runDeadlineTest(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running deadline_test")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running deadline_test")
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/kernel/kernel_rt_latency.go
+++ b/test/extended/kernel/kernel_rt_latency.go
@@ -23,7 +23,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 
 	g.It("hwlatdetect", func() {
 		err := runHwlatdetect(oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running hwlatdetect")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running hwlatdetect")
 	})
 
 	g.It("oslat", func() {
@@ -31,7 +31,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "unable to get the number of processors online")
 
 		err = runOslat(cpuCount, oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running oslat")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running oslat")
 	})
 
 	g.It("cyclictest", func() {
@@ -39,7 +39,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/nodes/realtime/latency][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "unable to get the number of processors online")
 
 		err = runCyclictest(cpuCount, oc)
-		o.Expect(err).NotTo(o.HaveOccurred(), "error occured running cyclictest")
+		o.Expect(err).NotTo(o.HaveOccurred(), "error occurred running cyclictest")
 	})
 
 	g.AfterEach(func() {

--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -603,7 +603,7 @@ func WaitForMCNConditionStatus(clientSet *machineconfigclient.Clientset, mcnName
 		framework.Logf("The desired MCN condition was never met: %v", err)
 		// Handle the situation where there were errors getting the MCN resource
 		if conditionErr != nil {
-			framework.Logf("An error occured waiting for MCN '%v' %v condition to be %v: %v", mcnName, conditionType, status, conditionErr)
+			framework.Logf("An error occurred waiting for MCN '%v' %v condition to be %v: %v", mcnName, conditionType, status, conditionErr)
 			return conditionMet, fmt.Errorf("MCN '%v' %v condition was not %v: %v", mcnName, conditionType, status, conditionErr)
 		}
 		// Handle case when no errors occur grabbing the MCN, but we time out waiting for the condition to be in the desired state

--- a/test/extended/machine_config/machine_config_node.go
+++ b/test/extended/machine_config/machine_config_node.go
@@ -302,87 +302,87 @@ func validateTransitionThroughConditions(clientSet *machineconfigclient.Clientse
 	// a warning will be logged instead of erroring out the test.
 	framework.Logf("Waiting for Updated=False")
 	conditionMet, err := WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionFalse, 1*time.Minute, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Updated=False: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=False: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=False.")
 
 	framework.Logf("Waiting for UpdatePrepared=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePrepared, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdatePrepared=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePrepared=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePrepared=True.")
 
 	framework.Logf("Waiting for UpdateExecuted=Unknown")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdateExecuted=Unknown: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=Unknown: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateExecuted=Unknown.")
 
 	// On standard, non-rebootless, update, check that node transitions through "Cordoned" and "Drained" phases
 	if !isRebootless {
 		framework.Logf("Waiting for Cordoned=True")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateCordoned, metav1.ConditionTrue, 30*time.Second, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Cordoned=True: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Cordoned=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Cordoned=True.")
 
 		framework.Logf("Waiting for Drained=Unknown")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Drained=Unknown: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Drained=Unknown.")
 
 		framework.Logf("Waiting for Drained=True")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateDrained, metav1.ConditionTrue, 4*time.Minute, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Drained=True: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Drained=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Drained=True.")
 	}
 
 	framework.Logf("Waiting for AppliedFilesAndOS=Unknown")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFilesAndOS, metav1.ConditionUnknown, 30*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for AppliedFilesAndOS=Unknown: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFilesAndOS=Unknown: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedFilesAndOS=Unknown.")
 
 	framework.Logf("Waiting for AppliedFilesAndOS=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateFilesAndOS, metav1.ConditionTrue, 3*time.Minute, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for AppliedFilesAndOS=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for AppliedFilesAndOS=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect AppliedFilesAndOS=True.")
 
 	framework.Logf("Waiting for UpdateExecuted=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateExecuted, metav1.ConditionTrue, 20*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdateExecuted=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateExecuted=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateExecuted=True.")
 
 	// On rebootless update, check that node transitions through "UpdatePostActionComplete" phase
 	if isRebootless {
 		framework.Logf("Waiting for UpdatePostActionComplete=True")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdatePostActionComplete, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdatePostActionComplete=True: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdatePostActionComplete=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdatePostActionComplete=True.")
 	} else { // On standard, non-rebootless, update, check that node transitions through "RebootedNode" phase
 		framework.Logf("Waiting for RebootedNode=Unknown")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionUnknown, 15*time.Second, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for RebootedNode=Unknown: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=Unknown: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=Unknown.")
 
 		framework.Logf("Waiting for RebootedNode=True")
 		conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateRebooted, metav1.ConditionTrue, 6*time.Minute, 1*time.Second)
-		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for RebootedNode=True: %v", err))
+		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for RebootedNode=True: %v", err))
 		o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect RebootedNode=True.")
 	}
 	framework.Logf("Waiting for Resumed=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeResumed, metav1.ConditionTrue, 15*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Resumed=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Resumed=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Resumed=True.")
 
 	framework.Logf("Waiting for UpdateComplete=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateComplete, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdateComplete=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateComplete=True.")
 
 	framework.Logf("Waiting for Uncordoned=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdateUncordoned, metav1.ConditionTrue, 10*time.Second, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for UpdateComplete=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for UpdateComplete=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect UpdateComplete=True.")
 
 	framework.Logf("Waiting for Updated=True")
 	conditionMet, err = WaitForMCNConditionStatus(clientSet, updatingNodeName, mcfgv1.MachineConfigNodeUpdated, metav1.ConditionTrue, 1*time.Minute, 1*time.Second)
-	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for Updated=True: %v", err))
+	o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for Updated=True: %v", err))
 	o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect Updated=True.")
 }
 
@@ -414,7 +414,7 @@ func ValidateMCNConditionOnNodeDegrade(oc *exutil.CLI, fixture string, isSno boo
 		// If the test reached checking the MCN ensure the NodeDegraded condition is properly restored
 		if degradedNodeMCN != nil {
 			conditionMet, err := WaitForMCNConditionStatus(clientSet, degradedNodeMCN.Name, mcfgv1.MachineConfigNodeNodeDegraded, metav1.ConditionFalse, 30*time.Second, 1*time.Second)
-			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for NodeDegraded=False: %v", err))
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for NodeDegraded=False: %v", err))
 			o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect NodeDegraded=False.")
 		}
 	}()
@@ -478,7 +478,7 @@ func ValidateMCNOnNodeCreationAndDeletion(oc *exutil.CLI) {
 
 	// Skip test if worker nodes cannot be scaled
 	canBeScaled, canScaleErr := WorkersCanBeScaled(oc, machineClient)
-	o.Expect(canScaleErr).NotTo(o.HaveOccurred(), "Error occured when determining whether worker nodes can be scaled.")
+	o.Expect(canScaleErr).NotTo(o.HaveOccurred(), "Error occurred when determining whether worker nodes can be scaled.")
 	if !canBeScaled {
 		g.Skip("Worker nodes cannot be scaled using MachineSets. This test cannot be executed if workers cannot be scaled via MachineSets.")
 	}

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -496,7 +496,7 @@ func waitForPISStatusX(ctx context.Context, oc *exutil.CLI, kubeClient *kubernet
 			if !success { // handle case when we are expecting the PIS application to fail, so the PIS degraded condition should become true
 				framework.Logf("Waiting for PinnedImageSetsDegraded=True")
 				conditionMet, err := WaitForMCNConditionStatus(clientSet, node.Name, mcfgv1.MachineConfigNodePinnedImageSetsDegraded, metav1.ConditionTrue, 2*time.Minute, 5*time.Second)
-				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for PinnedImageSetsDegraded=True: %v", err))
+				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occurred while waiting for PinnedImageSetsDegraded=True: %v", err))
 				o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect PinnedImageSetsDegraded=True.")
 			} else { // handle cases where we are expecting the PIS application to succeed
 				mcn, err := clientSet.MachineconfigurationV1().MachineConfigNodes().Get(ctx, node.Name, metav1.GetOptions{})


### PR DESCRIPTION
Fix 31 instances of \`occured\` → \`occurred\` across 8 test/monitor files.

## Files

| File | Instances |
|------|-----------|
| \`test/extended/machine_config/machine_config_node.go\` | 18 |
| \`test/extended/kernel/kernel_rt_latency.go\` | 3 |
| \`test/extended/kernel/kernel_rt_functional.go\` | 3 |
| \`test/extended/machine_config/helpers.go\` | 2 |
| \`test/extended/machine_config/pinnedimages.go\` | 2 |
| \`pkg/monitortests/monitoring/statefulsetsrecreation/monitortest.go\` | 1 |
| \`pkg/monitortests/network/legacynetworkmonitortests/disruption.go\` | 1 |
| \`test/extended/machines/machines.go\` | 1 |

All are in Gomega assertion failure-messages (\`o.Expect(err).NotTo(o.HaveOccurred(), "Error occured while ...")\`) or similar. String-literal-only change; no behavior change.

Note: the Gomega \`HaveOccurred\` matcher (already correctly double-R) is untouched — only the human-readable error messages are corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Corrected spelling errors in test assertion and logging messages across kernel, machine config, and related test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->