### PR TITLE
[WIP] Increase pod-network-availability timeout to 15 minutes

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -178,7 +178,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	}
 
 	// we need to have the service network pollers wait until we have at least one healthy endpoint before starting.
-	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 300*time.Second, true, pna.serviceHasEndpoints)
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 15*time.Minute, true, pna.serviceHasEndpoints)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The pod-network-availability monitor tests are consistently failing on PowerVS infrastructure during the collection phase. Containers are stuck in ContainerCreating state, causing timeouts.

Failing tests:
[Monitor:pod-network-availability][Jira:"Network / ovn-kubernetes"] monitor test pod-network-availability collection
[Monitor:pod-network-availability][Jira:"Network / ovn-kubernetes"] monitor test pod-network-availability cleanup

Root Cause
Analysis of deployment timestamps from test runs shows that containers are taking approximately 12 minutes to start on PowerVS, exceeding the current 5-minute (300 second) timeout.

Evidence from deployment timestamps:

4.22 Test Run:

pod-network-to-host-network-disruption-poller:

Started: 2026-04-15T06:03:17Z
Finished: 2026-04-15T06:15:15Z
Duration: ~12 minutes
host-network-to-host-network-disruption-poller:

Started: 2026-04-15T06:03:17Z
Finished: 2026-04-15T06:15:15Z
Duration: ~12 minutes
Test run links:

4.22: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-multiarch-main-nightly-4.22-ocp-e2e-ovn-powervs-capi-multi-p-p/2044264624701837312/
4.21: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-multiarch-main-nightly-4.21-ocp-e2e-ovn-powervs-capi-multi-p-p/2043404000346247168/

Workaround:
This PR increases the service endpoint wait timeout from 5 minutes to 15 minutes to accommodate the slower container startup times observed on PowerVS infrastructure.

Related
Bug: https://redhat.atlassian.net/browse/OCPBUGS-83579
Similar fix: https://github.com/openshift/origin/pull/29970 (OCPBUGS-58354)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the verification timeout and reduced polling frequency for service endpoint checks in network monitoring tests, extending the wait to 15 minutes. This improves test reliability, reduces intermittent timeout failures during startup, and lowers churn from frequent polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->