### PR TITLE
CNTRLPLANE-2554: Add ExternalOIDCWithUpstreamParity e2e tests

### DIFF
--- a/test/extended/authentication/keycloak_client.go
+++ b/test/extended/authentication/keycloak_client.go
@@ -65,7 +65,8 @@ func (kc *keycloakClient) CreateGroup(name string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
+		// If the group already exists (409 Conflict), that's fine - we can reuse it
 		respBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("failed creating group %q: %s - %s", name, resp.Status, respBytes)
 	}
@@ -95,11 +96,15 @@ const (
 )
 
 func (kc *keycloakClient) CreateUser(username, password string, groups ...string) error {
+	return kc.CreateUserWithEmail(username, fmt.Sprintf("%s@payload.openshift.io", username), password, groups...)
+}
+
+func (kc *keycloakClient) CreateUserWithEmail(username, email, password string, groups ...string) error {
 	userURL := kc.adminURL.JoinPath("users")
 
 	user := user{
 		Username:      username,
-		Email:         fmt.Sprintf("%s@payload.openshift.io", username),
+		Email:         email,
 		Enabled:       true,
 		EmailVerified: true,
 		Groups:        groups,
@@ -114,18 +119,18 @@ func (kc *keycloakClient) CreateUser(username, password string, groups ...string
 
 	userBytes, err := json.Marshal(user)
 	if err != nil {
-		return fmt.Errorf("marshalling user configuration %v", user)
+		return fmt.Errorf("marshalling user configuration for %q: %w", username, err)
 	}
 
 	resp, err := kc.DoRequest(http.MethodPost, userURL.String(), runtime.ContentTypeJSON, true, bytes.NewBuffer(userBytes))
 	if err != nil {
-		return fmt.Errorf("sending POST request to %q to create user %v", userURL.String(), user)
+		return fmt.Errorf("sending POST request to %q to create user %q: %w", userURL.String(), username, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBytes, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed creating user %v: %s - %s", user, resp.Status, respBytes)
+		return fmt.Errorf("failed creating user %q: %s - %s", username, resp.Status, respBytes)
 	}
 
 	return nil

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -38,6 +38,9 @@ type kubeObject interface {
 	metav1.Object
 }
 
+// Just note for readers: currently g.Ordered and g.BeforeAll don't take effect in openshift-tests. The tests are not run as the order they appear and the BeforeAll (with slow rollout) is run each test instead of only once
+// We've looked into it and have some ideas on a solution but haven't finished (TODO)
+// BTW this won't a problem in future once openshift/enhancements#1907 is done because this won't be disruptive nor need to wait for any rollout
 var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("oidc-e2e")
@@ -381,6 +384,361 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				})
 			})
 		})
+	})
+
+	g.Describe("[OCPFeatureGate:ExternalOIDCWithUpstreamParity]", g.Ordered, func() {
+		var validUser, validUserPassword string
+		var invalidUserValidation, invalidUserValidationPassword string
+		var invalidClaimValidation, invalidClaimValidationPassword string
+
+		g.Describe("with claim-based mappings, discoveryURL, userValidationRules, and CEL claimValidationRules", g.Ordered, func() {
+			g.BeforeAll(func() {
+				testID := rand.String(8)
+
+				// Create multiple test users in Keycloak
+				// Note: CreateUser automatically appends @payload.openshift.io to the username for the email
+				validUser = fmt.Sprintf("user-valid-%s", testID)
+				validUserPassword = fmt.Sprintf("password-valid-%s", testID)
+				o.Expect(keycloakCli.CreateGroup(group)).To(o.Succeed(), "should be able to create/reuse keycloak group")
+				o.Expect(keycloakCli.CreateUser(validUser, validUserPassword, group)).To(o.Succeed(), "should be able to create validUser")
+
+				invalidUserValidation = fmt.Sprintf("noemail-%s", testID)
+				invalidUserValidationPassword = fmt.Sprintf("password-invalid-user-%s", testID)
+				otherGroup := "other-group"
+				o.Expect(keycloakCli.CreateGroup(otherGroup)).To(o.Succeed(), "should be able to create other-group")
+				o.Expect(keycloakCli.CreateUser(invalidUserValidation, invalidUserValidationPassword, otherGroup)).To(o.Succeed(), "should be able to create invalidUserValidation")
+
+				invalidClaimValidation = fmt.Sprintf("user-invalid-%s", testID)
+				invalidClaimValidationPassword = fmt.Sprintf("password-invalid-claim-%s", testID)
+				// For this user, we need the email to end with @example.com to fail the CEL claim validation
+				invalidClaimValidationEmail := fmt.Sprintf("%s@example.com", invalidClaimValidation)
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidClaimValidation, invalidClaimValidationEmail, invalidClaimValidationPassword, group)).To(o.Succeed(), "should be able to create invalidClaimValidation")
+
+				// Configure OIDC provider with all new features
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					idpUrl, err := admittedURLForRoute(ctx, oc, keycloakResourceName, keycloakNamespace)
+					o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting keycloak route URL")
+
+					// Set custom discoveryURL (different from issuerURL)
+					provider.Issuer.DiscoveryURL = fmt.Sprintf("%s/realms/master/.well-known/openid-configuration", idpUrl)
+
+					// Use claim-based mappings (explicit, not expression-based)
+					provider.ClaimMappings.Username = configv1.UsernameClaimMapping{
+						Claim: "email",
+					}
+					provider.ClaimMappings.Groups = configv1.PrefixedClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Claim: "groups",
+						},
+					}
+
+					// Set multiple UserValidationRules
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username.contains('@')",
+							Message:    "username must contain @ symbol",
+						},
+						{
+							Expression: "user.groups.exists(g, g.startsWith('ocp-test-'))",
+							Message:    "user must belong to ocp-test-* group",
+						},
+						{
+							Expression: "user.username.size() > 5",
+							Message:    "username must be longer than 5 characters",
+						},
+					}
+
+					// Set ClaimValidationRules with CEL type
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "has(claims.email) && claims.email.endsWith('@payload.openshift.io')",
+								Message:    "token must have email claim ending with @payload.openshift.io",
+							},
+						},
+					}
+				})
+				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error configuring OIDC authentication")
+
+				waitForRollout(ctx, oc)
+				waitForHealthyOIDCClients(ctx, oc)
+			})
+
+			g.It("should authenticate successfully with custom discoveryURL, AND-logic userValidationRules, and CEL-type claimValidationRules", func() {
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", validUser, validUserPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as validUser")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					ssr, err := tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", validUser),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should be able to create a SelfSubjectReview")
+
+					// Successful authentication implies custom discoveryURL worked
+
+					// Verify userValidationRules (all 3 rules with AND logic passed)
+					// Rule 1: user.username.contains('@')
+					gomega.Expect(ssr.Status.UserInfo.Username).To(o.ContainSubstring("@"), "username should contain @ symbol")
+					// Rule 2: user.groups.exists(g, g.startsWith('ocp-test-'))
+					gomega.Expect(ssr.Status.UserInfo.Groups).To(o.ContainElement(group), "user should belong to ocp-test-* group")
+					// Rule 3: user.username.size() > 5
+					gomega.Expect(len(ssr.Status.UserInfo.Username)).To(o.BeNumerically(">", 5), "username should be longer than 5 characters")
+
+					// Successful authentication implies all claimValidationRules passed (both RequiredClaim and CEL types)
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+
+			g.It("should reject tokens when userValidationRules or CEL claimValidationRules evaluate to false", func() {
+				g.By("checking that userValidationRule evaluating to 'false' causes authorization failure")
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", invalidUserValidation, invalidUserValidationPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidUserValidation")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", invalidUserValidation),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+					gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error")
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+				g.By("checking that CEL claimValidationRule evaluating to 'false' causes authorization failure")
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", invalidClaimValidation, invalidClaimValidationPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidClaimValidation")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", invalidClaimValidation),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+					gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error")
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+		})
+
+		g.Describe("with CEL expression-based claim mappings", g.Ordered, func() {
+			var validExprUser, validExprUserPassword string
+			var invalidExprUsername, invalidExprUsernamePassword string
+			var invalidExprGroups, invalidExprGroupsPassword string
+
+			g.BeforeAll(func() {
+				testID := rand.String(8)
+
+				// Create test users with specific claim values for expression mapping tests
+				// validExprUser: email will be split to produce valid username, has BOTH 'ocp-' and non-'ocp-' groups to test filtering
+				validExprUser = fmt.Sprintf("valid-expr-user-%s", testID)
+				validExprUserPassword = fmt.Sprintf("password-valid-expr-%s", testID)
+				validExprUserEmail := fmt.Sprintf("%s@example.com", validExprUser)
+				otherGroup := "other-group"
+				o.Expect(keycloakCli.CreateGroup(otherGroup)).To(o.Succeed(), "should be able to create other-group")
+				// User belongs to BOTH 'ocp-test-*' group AND 'other-group' to verify filter works
+				o.Expect(keycloakCli.CreateUserWithEmail(validExprUser, validExprUserEmail, validExprUserPassword, group, otherGroup)).To(o.Succeed(), "should be able to create validExprUser")
+
+				// invalidExprUsername: email will be split to produce username that's too short (fails userValidationRules)
+				invalidExprUsername = fmt.Sprintf("a%s", testID[:2])
+				invalidExprUsernamePassword = fmt.Sprintf("password-invalid-expr-username-%s", testID)
+				invalidExprUsernameEmail := fmt.Sprintf("%s@example.com", invalidExprUsername)
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidExprUsername, invalidExprUsernameEmail, invalidExprUsernamePassword, group)).To(o.Succeed(), "should be able to create invalidExprUsername")
+
+				// invalidExprGroups: only in groups that don't start with 'ocp-', so filtered groups will be empty
+				invalidExprGroups = fmt.Sprintf("invalid-groups-%s", testID)
+				invalidExprGroupsPassword = fmt.Sprintf("password-invalid-expr-groups-%s", testID)
+				invalidExprGroupsEmail := fmt.Sprintf("%s@example.com", invalidExprGroups)
+				// User only belongs to 'other-group' (doesn't start with 'ocp-'), so filter produces empty list
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidExprGroups, invalidExprGroupsEmail, invalidExprGroupsPassword, otherGroup)).To(o.Succeed(), "should be able to create invalidExprGroups")
+
+				// Configure OIDC provider with CEL expression-based claim mappings
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					idpUrl, err := admittedURLForRoute(ctx, oc, keycloakResourceName, keycloakNamespace)
+					o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting keycloak route URL")
+
+					// Set custom discoveryURL
+					provider.Issuer.DiscoveryURL = fmt.Sprintf("%s/realms/master/.well-known/openid-configuration", idpUrl)
+
+					// Use CEL expressions for claim mappings
+					// Note: Omitting prefixPolicy for username.expression and prefix for groups.expression
+					// validates that these are allowed (per https://github.com/openshift/api/pull/2771)
+					provider.ClaimMappings.Username = configv1.UsernameClaimMapping{
+						Expression: "claims.email.split('@')[0]", // Extract username part from email
+					}
+					provider.ClaimMappings.Groups = configv1.PrefixedClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Expression: "claims.groups.orValue([]).filter(g, g.startsWith('ocp-'))", // Only keep groups starting with 'ocp-'
+						},
+					}
+
+					// Set UserValidationRules that validate the CEL-mapped username and groups
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username.size() > 5",
+							Message:    "username must be longer than 5 characters",
+						},
+						{
+							Expression: "user.groups.size() > 0",
+							Message:    "user must belong to at least one group after filtering",
+						},
+					}
+
+					// Set ClaimValidationRules to validate claims before mapping
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "has(claims.email) && claims.email.contains('@')",
+								Message:    "token must have valid email claim",
+							},
+						},
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "claims.email_verified == true",
+								Message:    "email must be verified",
+							},
+						},
+					}
+				})
+				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error configuring OIDC authentication with CEL expression mappings")
+
+				waitForRollout(ctx, oc)
+				waitForHealthyOIDCClients(ctx, oc)
+			})
+
+			g.It("should authenticate with CEL expression claim mappings (with omitted prefix configurations), userValidationRules, and claimValidationRules", func() {
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", validExprUser, validExprUserPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as validExprUser")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					ssr, err := tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", validExprUser),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should be able to create a SelfSubjectReview")
+
+					// Verify CEL expression-based username mapping worked
+					// Expression: claims.email.split('@')[0] should extract "valid-expr-user-<testID>" from email
+					gomega.Expect(ssr.Status.UserInfo.Username).To(o.Equal(validExprUser), "username should be extracted from email via CEL expression")
+
+					// Verify CEL expression-based groups mapping worked
+					// The groups expression should keep ONLY groups starting with 'ocp-'
+					gomega.Expect(ssr.Status.UserInfo.Groups).To(o.ContainElement(group), "groups should include 'ocp-test-*' group")
+					gomega.Expect(ssr.Status.UserInfo.Groups).NotTo(o.ContainElement("other-group"), "groups should NOT include 'other-group' (filtered out)")
+					// This test's configuration omits prefixPolicy for username.expression and prefix for groups.expression
+					// Success for far implies that these are allowed (per https://github.com/openshift/api/pull/2771)
+
+					// Verify userValidationRules (applied after CEL mapping)
+					// Rule 1: user.username.size() > 5
+					gomega.Expect(len(ssr.Status.UserInfo.Username)).To(o.BeNumerically(">", 5), "mapped username should be longer than 5 characters")
+					// Rule 2: user.groups.size() > 0
+					gomega.Expect(len(ssr.Status.UserInfo.Groups)).To(o.BeNumerically(">", 0), "user should have at least one group after filtering")
+
+					// Successful authentication implies claimValidationRules passed (before mapping)
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+
+			g.It("should reject when username or groups expression produces value failing userValidationRules", func() {
+				g.By("checking that username expression producing value failing userValidationRules causes authorization failure")
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", invalidExprUsername, invalidExprUsernamePassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidExprUsername")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", invalidExprUsername),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+					gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error due to username length validation failure")
+					// Username expression produces "axx" (length 3), which fails userValidationRules: username.size() > 5
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+				g.By("checking that groups expression producing value failing userValidationRules causes authorization failure")
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", invalidExprGroups, invalidExprGroupsPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidExprGroups")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", invalidExprGroups),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+					gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error due to groups validation failure")
+					// Groups expression filters to only 'ocp-*' groups, producing empty list, which fails userValidationRules: groups.size() > 0
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+		})
+
+		// TODO: this test relies on https://github.com/openshift/kubernetes/pull/2627
+		/*
+			g.It("should reject invalid CEL expressions in admission", func() {
+				// Test invalid CEL expression in userValidationRules
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "!@#$%^&*()",
+							Message:    "invalid expression",
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression")
+
+				// Test non-boolean CEL expression in userValidationRules
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username",
+							Message:    "non-boolean expression",
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with non-boolean CEL expression")
+
+				// Test invalid CEL expression in claimValidationRules
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "invalid syntax",
+								Message:    "invalid expression",
+							},
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in claimValidationRules")
+
+				// Test invalid CEL expression in claimMappings.username.expression
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimMappings.Username.Expression = "!@#$%^&*()"
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in username mapping")
+
+				// Test invalid CEL expression in claimMappings.groups.expression
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimMappings.Groups.TokenClaimMapping.Expression = "!@#$%^&*()"
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in groups mapping")
+			})
+		*/
 	})
 
 	g.AfterAll(func() {

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -38,6 +38,9 @@ type kubeObject interface {
 	metav1.Object
 }
 
+// Just note for readers: currently g.Ordered and g.BeforeAll don't take effect in openshift-tests. The tests are not run as the order they appear and the BeforeAll (with slow rollout) is run each test instead of only once
+// We've looked into it and have some ideas on a solution but haven't finished (TODO)
+// BTW this won't a problem in future once openshift/enhancements#1907 is done because this won't be disruptive nor need to wait for any rollout
 var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow][Disruptive]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("oidc-e2e")
@@ -381,6 +384,429 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 				})
 			})
 		})
+	})
+
+	g.Describe("[OCPFeatureGate:ExternalOIDCWithUpstreamParity]", g.Ordered, func() {
+		var validUser, validUserPassword string
+		var invalidUserValidation, invalidUserValidationPassword string
+		var invalidClaimValidation, invalidClaimValidationPassword string
+
+		g.Describe("with claim-based mappings, discoveryURL, userValidationRules, and CEL claimValidationRules", g.Ordered, func() {
+			g.BeforeAll(func() {
+				testID := rand.String(8)
+
+				// Create multiple test users in Keycloak
+				// Note: CreateUser automatically appends @payload.openshift.io to the username for the email
+				validUser = fmt.Sprintf("user-valid-%s", testID)
+				validUserPassword = fmt.Sprintf("password-valid-%s", testID)
+				o.Expect(keycloakCli.CreateGroup(group)).To(o.Succeed(), "should be able to create/reuse keycloak group")
+				o.Expect(keycloakCli.CreateUser(validUser, validUserPassword, group)).To(o.Succeed(), "should be able to create validUser")
+
+				invalidUserValidation = fmt.Sprintf("noemail-%s", testID)
+				invalidUserValidationPassword = fmt.Sprintf("password-invalid-user-%s", testID)
+				otherGroup := "other-group"
+				o.Expect(keycloakCli.CreateGroup(otherGroup)).To(o.Succeed(), "should be able to create other-group")
+				o.Expect(keycloakCli.CreateUser(invalidUserValidation, invalidUserValidationPassword, otherGroup)).To(o.Succeed(), "should be able to create invalidUserValidation")
+
+				invalidClaimValidation = fmt.Sprintf("user-invalid-%s", testID)
+				invalidClaimValidationPassword = fmt.Sprintf("password-invalid-claim-%s", testID)
+				// For this user, we need the email to end with @example.com to fail the CEL claim validation
+				invalidClaimValidationEmail := fmt.Sprintf("%s@example.com", invalidClaimValidation)
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidClaimValidation, invalidClaimValidationEmail, invalidClaimValidationPassword, group)).To(o.Succeed(), "should be able to create invalidClaimValidation")
+
+				// Configure OIDC provider with all new features
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					idpUrl, err := admittedURLForRoute(ctx, oc, keycloakResourceName, keycloakNamespace)
+					o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting keycloak route URL")
+
+					// Set custom discoveryURL (different from issuerURL)
+					provider.Issuer.DiscoveryURL = fmt.Sprintf("%s/realms/master/.well-known/openid-configuration", idpUrl)
+
+					// Use claim-based mappings (explicit, not expression-based)
+					provider.ClaimMappings.Username = configv1.UsernameClaimMapping{
+						Claim: "email",
+					}
+					provider.ClaimMappings.Groups = configv1.PrefixedClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Claim: "groups",
+						},
+					}
+
+					// Set multiple UserValidationRules
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username.contains('@')",
+							Message:    "username must contain @ symbol",
+						},
+						{
+							Expression: "user.groups.exists(g, g.startsWith('ocp-test-'))",
+							Message:    "user must belong to ocp-test-* group",
+						},
+						{
+							Expression: "user.username.size() > 5",
+							Message:    "username must be longer than 5 characters",
+						},
+					}
+
+					// Set multiple ClaimValidationRules mixing RequiredClaim and CEL types
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeRequiredClaim,
+							RequiredClaim: &configv1.TokenRequiredClaim{
+								Claim:         "aud",
+								RequiredValue: "admin-cli",
+							},
+						},
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "has(claims.email) && claims.email.endsWith('@payload.openshift.io')",
+								Message:    "token must have email claim ending with @payload.openshift.io",
+							},
+						},
+					}
+				})
+				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error configuring OIDC authentication")
+
+				waitForRollout(ctx, oc)
+				waitForHealthyOIDCClients(ctx, oc)
+			})
+
+			g.It("should authenticate successfully with custom discoveryURL, AND-logic userValidationRules, and mixed-type claimValidationRules", func() {
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", validUser, validUserPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as validUser")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					ssr, err := tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", validUser),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should be able to create a SelfSubjectReview")
+
+					// Successful authentication implies custom discoveryURL worked
+
+					// Verify userValidationRules (all 3 rules with AND logic passed)
+					// Rule 1: user.username.contains('@')
+					gomega.Expect(ssr.Status.UserInfo.Username).To(o.ContainSubstring("@"), "username should contain @ symbol")
+					// Rule 2: user.groups.exists(g, g.startsWith('ocp-test-'))
+					gomega.Expect(ssr.Status.UserInfo.Groups).To(o.ContainElement(group), "user should belong to ocp-test-* group")
+					// Rule 3: user.username.size() > 5
+					gomega.Expect(len(ssr.Status.UserInfo.Username)).To(o.BeNumerically(">", 5), "username should be longer than 5 characters")
+
+					// Successful authentication implies all claimValidationRules passed (both RequiredClaim and CEL types)
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+
+			g.It("should reject tokens when userValidationRules or CEL claimValidationRules evaluate to false", func() {
+				testAPassed := false
+				testBPassed := false
+				var testAFailure, testBFailure string
+
+				// Test A: userValidationRules false evaluation
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							testAFailure = fmt.Sprintf("%v", r)
+						}
+					}()
+
+					o.Eventually(func(gomega o.Gomega) {
+						err := keycloakCli.Authenticate("admin-cli", invalidUserValidation, invalidUserValidationPassword)
+						gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidUserValidation")
+
+						copiedOC := *oc
+						tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+						_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: fmt.Sprintf("%s-info", invalidUserValidation),
+							},
+						}, metav1.CreateOptions{})
+						gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+						gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error")
+					}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+					testAPassed = true
+				}()
+
+				// Test B: CEL claimValidationRules false evaluation
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							testBFailure = fmt.Sprintf("%v", r)
+						}
+					}()
+
+					o.Eventually(func(gomega o.Gomega) {
+						err := keycloakCli.Authenticate("admin-cli", invalidClaimValidation, invalidClaimValidationPassword)
+						gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidClaimValidation")
+
+						copiedOC := *oc
+						tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+						_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: fmt.Sprintf("%s-info", invalidClaimValidation),
+							},
+						}, metav1.CreateOptions{})
+						gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+						gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error")
+					}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+					testBPassed = true
+				}()
+
+				// Final assertion: both tests should pass
+				failureMsg := fmt.Sprintf("userValidationRules false evaluation test failed: %t; reason: %s\nCEL claimValidationRules false evaluation test failed: %t; reason: %s",
+					!testAPassed, testAFailure, !testBPassed, testBFailure)
+
+				o.Expect(testAPassed && testBPassed).To(o.BeTrue(), failureMsg)
+			})
+
+		})
+
+		g.Describe("with CEL expression-based claim mappings", g.Ordered, func() {
+			var validExprUser, validExprUserPassword string
+			var invalidExprUsername, invalidExprUsernamePassword string
+			var invalidExprGroups, invalidExprGroupsPassword string
+
+			g.BeforeAll(func() {
+				testID := rand.String(8)
+
+				// Create test users with specific claim values for expression mapping tests
+				// validExprUser: email will be split to produce valid username, has BOTH 'ocp-' and non-'ocp-' groups to test filtering
+				validExprUser = fmt.Sprintf("valid-expr-user-%s", testID)
+				validExprUserPassword = fmt.Sprintf("password-valid-expr-%s", testID)
+				validExprUserEmail := fmt.Sprintf("%s@example.com", validExprUser)
+				otherGroup := "other-group"
+				o.Expect(keycloakCli.CreateGroup(otherGroup)).To(o.Succeed(), "should be able to create other-group")
+				// User belongs to BOTH 'ocp-test-*' group AND 'other-group' to verify filter works
+				o.Expect(keycloakCli.CreateUserWithEmail(validExprUser, validExprUserEmail, validExprUserPassword, group, otherGroup)).To(o.Succeed(), "should be able to create validExprUser")
+
+				// invalidExprUsername: email will be split to produce username that's too short (fails userValidationRules)
+				invalidExprUsername = fmt.Sprintf("a%s", testID[:2])
+				invalidExprUsernamePassword = fmt.Sprintf("password-invalid-expr-username-%s", testID)
+				invalidExprUsernameEmail := fmt.Sprintf("%s@example.com", invalidExprUsername)
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidExprUsername, invalidExprUsernameEmail, invalidExprUsernamePassword, group)).To(o.Succeed(), "should be able to create invalidExprUsername")
+
+				// invalidExprGroups: only in groups that don't start with 'ocp-', so filtered groups will be empty
+				invalidExprGroups = fmt.Sprintf("invalid-groups-%s", testID)
+				invalidExprGroupsPassword = fmt.Sprintf("password-invalid-expr-groups-%s", testID)
+				invalidExprGroupsEmail := fmt.Sprintf("%s@example.com", invalidExprGroups)
+				// User only belongs to 'other-group' (doesn't start with 'ocp-'), so filter produces empty list
+				o.Expect(keycloakCli.CreateUserWithEmail(invalidExprGroups, invalidExprGroupsEmail, invalidExprGroupsPassword, otherGroup)).To(o.Succeed(), "should be able to create invalidExprGroups")
+
+				// Configure OIDC provider with CEL expression-based claim mappings
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					idpUrl, err := admittedURLForRoute(ctx, oc, keycloakResourceName, keycloakNamespace)
+					o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting keycloak route URL")
+
+					// Set custom discoveryURL
+					provider.Issuer.DiscoveryURL = fmt.Sprintf("%s/realms/master/.well-known/openid-configuration", idpUrl)
+
+					// Use CEL expressions for claim mappings
+					// Note: Omitting prefixPolicy for username.expression and prefix for groups.expression
+					// validates that these are allowed (per https://github.com/openshift/api/pull/2771)
+					provider.ClaimMappings.Username = configv1.UsernameClaimMapping{
+						Expression: "claims.email.split('@')[0]", // Extract username part from email
+					}
+					provider.ClaimMappings.Groups = configv1.PrefixedClaimMapping{
+						TokenClaimMapping: configv1.TokenClaimMapping{
+							Expression: "claims.groups.orValue([]).filter(g, g.startsWith('ocp-'))", // Only keep groups starting with 'ocp-'
+						},
+					}
+
+					// Set UserValidationRules that validate the CEL-mapped username and groups
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username.size() > 5",
+							Message:    "username must be longer than 5 characters",
+						},
+						{
+							Expression: "user.groups.size() > 0",
+							Message:    "user must belong to at least one group after filtering",
+						},
+					}
+
+					// Set ClaimValidationRules to validate claims before mapping
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "has(claims.email) && claims.email.contains('@')",
+								Message:    "token must have valid email claim",
+							},
+						},
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "claims.email_verified == true",
+								Message:    "email must be verified",
+							},
+						},
+					}
+				})
+				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error configuring OIDC authentication with CEL expression mappings")
+
+				waitForRollout(ctx, oc)
+				waitForHealthyOIDCClients(ctx, oc)
+			})
+
+			g.It("should authenticate with CEL expression claim mappings (with omitted prefix configurations), userValidationRules, and claimValidationRules", func() {
+				o.Eventually(func(gomega o.Gomega) {
+					err := keycloakCli.Authenticate("admin-cli", validExprUser, validExprUserPassword)
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as validExprUser")
+
+					copiedOC := *oc
+					tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+					ssr, err := tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: fmt.Sprintf("%s-info", validExprUser),
+						},
+					}, metav1.CreateOptions{})
+					gomega.Expect(err).NotTo(o.HaveOccurred(), "should be able to create a SelfSubjectReview")
+
+					// Verify CEL expression-based username mapping worked
+					// Expression: claims.email.split('@')[0] should extract "valid-expr-user-<testID>" from email
+					gomega.Expect(ssr.Status.UserInfo.Username).To(o.Equal(validExprUser), "username should be extracted from email via CEL expression")
+
+					// Verify CEL expression-based groups mapping worked
+					// The groups expression should keep ONLY groups starting with 'ocp-'
+					gomega.Expect(ssr.Status.UserInfo.Groups).To(o.ContainElement(group), "groups should include 'ocp-test-*' group")
+					gomega.Expect(ssr.Status.UserInfo.Groups).NotTo(o.ContainElement("other-group"), "groups should NOT include 'other-group' (filtered out)")
+					// This test's configuration omits prefixPolicy for username.expression and prefix for groups.expression
+					// Success for far implies that these are allowed (per https://github.com/openshift/api/pull/2771)
+
+					// Verify userValidationRules (applied after CEL mapping)
+					// Rule 1: user.username.size() > 5
+					gomega.Expect(len(ssr.Status.UserInfo.Username)).To(o.BeNumerically(">", 5), "mapped username should be longer than 5 characters")
+					// Rule 2: user.groups.size() > 0
+					gomega.Expect(len(ssr.Status.UserInfo.Groups)).To(o.BeNumerically(">", 0), "user should have at least one group after filtering")
+
+					// Successful authentication implies claimValidationRules passed (before mapping)
+				}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+			})
+
+			g.It("should reject when username or groups expression produces value failing userValidationRules", func() {
+				testAPassed := false
+				testBPassed := false
+				var testAFailure, testBFailure string
+
+				// Test A: username expression producing value failing userValidationRules
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							testAFailure = fmt.Sprintf("%v", r)
+						}
+					}()
+
+					o.Eventually(func(gomega o.Gomega) {
+						err := keycloakCli.Authenticate("admin-cli", invalidExprUsername, invalidExprUsernamePassword)
+						gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidExprUsername")
+
+						copiedOC := *oc
+						tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+						_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: fmt.Sprintf("%s-info", invalidExprUsername),
+							},
+						}, metav1.CreateOptions{})
+						gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+						gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error due to username length validation failure")
+						// Username expression produces "axx" (length 3), which fails userValidationRules: username.size() > 5
+					}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+					testAPassed = true
+				}()
+
+				// Test B: groups expression producing value failing userValidationRules
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							testBFailure = fmt.Sprintf("%v", r)
+						}
+					}()
+
+					o.Eventually(func(gomega o.Gomega) {
+						err := keycloakCli.Authenticate("admin-cli", invalidExprGroups, invalidExprGroupsPassword)
+						gomega.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error authenticating as invalidExprGroups")
+
+						copiedOC := *oc
+						tokenOC := copiedOC.WithToken(keycloakCli.AccessToken())
+						_, err = tokenOC.KubeClient().AuthenticationV1().SelfSubjectReviews().Create(ctx, &authnv1.SelfSubjectReview{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: fmt.Sprintf("%s-info", invalidExprGroups),
+							},
+						}, metav1.CreateOptions{})
+						gomega.Expect(err).To(o.HaveOccurred(), "should not be able to create a SelfSubjectReview")
+						gomega.Expect(apierrors.IsUnauthorized(err)).To(o.BeTrue(), "should receive an unauthorized error due to groups validation failure")
+						// Groups expression filters to only 'ocp-*' groups, producing empty list, which fails userValidationRules: groups.size() > 0
+					}).WithTimeout(5 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+
+					testBPassed = true
+				}()
+
+				// Final assertion: both tests should pass
+				failureMsg := fmt.Sprintf("username expression test failed: %t; reason: %s\ngroups expression test failed: %t; reason: %s",
+					!testAPassed, testAFailure, !testBPassed, testBFailure)
+
+				o.Expect(testAPassed && testBPassed).To(o.BeTrue(), failureMsg)
+			})
+		})
+
+		// TODO: this test relies on https://github.com/openshift/kubernetes/pull/2627
+		/*
+			g.It("should reject invalid CEL expressions in admission", func() {
+				// Test invalid CEL expression in userValidationRules
+				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "!@#$%^&*()",
+							Message:    "invalid expression",
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression")
+
+				// Test non-boolean CEL expression in userValidationRules
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.UserValidationRules = []configv1.TokenUserValidationRule{
+						{
+							Expression: "user.username",
+							Message:    "non-boolean expression",
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with non-boolean CEL expression")
+
+				// Test invalid CEL expression in claimValidationRules
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+						{
+							Type: configv1.TokenValidationRuleTypeCEL,
+							CEL: configv1.TokenClaimValidationCELRule{
+								Expression: "invalid syntax",
+								Message:    "invalid expression",
+							},
+						},
+					}
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in claimValidationRules")
+
+				// Test invalid CEL expression in claimMappings.username.expression
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimMappings.Username.Expression = "!@#$%^&*()"
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in username mapping")
+
+				// Test invalid CEL expression in claimMappings.groups.expression
+				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+					provider.ClaimMappings.Groups.TokenClaimMapping.Expression = "!@#$%^&*()"
+				})
+				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in groups mapping")
+			})
+		*/
 	})
 
 	g.AfterAll(func() {

--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -687,58 +687,55 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 			})
 		})
 
-		// TODO: this test relies on https://github.com/openshift/kubernetes/pull/2627
-		/*
-			g.It("should reject invalid CEL expressions in admission", func() {
-				// Test invalid CEL expression in userValidationRules
-				_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
-					provider.UserValidationRules = []configv1.TokenUserValidationRule{
-						{
-							Expression: "!@#$%^&*()",
+		g.It("should reject invalid CEL expressions in admission", func() {
+			// Test invalid CEL expression in userValidationRules
+			_, _, err := configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+				provider.UserValidationRules = []configv1.TokenUserValidationRule{
+					{
+						Expression: "!@#$%^&*()",
+						Message:    "invalid expression",
+					},
+				}
+			})
+			o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression")
+
+			// Test non-boolean CEL expression in userValidationRules
+			_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+				provider.UserValidationRules = []configv1.TokenUserValidationRule{
+					{
+						Expression: "user.username",
+						Message:    "non-boolean expression",
+					},
+				}
+			})
+			o.Expect(err).To(o.HaveOccurred(), "should encounter an error with non-boolean CEL expression")
+
+			// Test invalid CEL expression in claimValidationRules
+			_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+				provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
+					{
+						Type: configv1.TokenValidationRuleTypeCEL,
+						CEL: configv1.TokenClaimValidationCELRule{
+							Expression: "invalid syntax",
 							Message:    "invalid expression",
 						},
-					}
-				})
-				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression")
-
-				// Test non-boolean CEL expression in userValidationRules
-				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
-					provider.UserValidationRules = []configv1.TokenUserValidationRule{
-						{
-							Expression: "user.username",
-							Message:    "non-boolean expression",
-						},
-					}
-				})
-				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with non-boolean CEL expression")
-
-				// Test invalid CEL expression in claimValidationRules
-				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
-					provider.ClaimValidationRules = []configv1.TokenClaimValidationRule{
-						{
-							Type: configv1.TokenValidationRuleTypeCEL,
-							CEL: configv1.TokenClaimValidationCELRule{
-								Expression: "invalid syntax",
-								Message:    "invalid expression",
-							},
-						},
-					}
-				})
-				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in claimValidationRules")
-
-				// Test invalid CEL expression in claimMappings.username.expression
-				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
-					provider.ClaimMappings.Username.Expression = "!@#$%^&*()"
-				})
-				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in username mapping")
-
-				// Test invalid CEL expression in claimMappings.groups.expression
-				_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
-					provider.ClaimMappings.Groups.TokenClaimMapping.Expression = "!@#$%^&*()"
-				})
-				o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in groups mapping")
+					},
+				}
 			})
-		*/
+			o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in claimValidationRules")
+
+			// Test invalid CEL expression in claimMappings.username.expression
+			_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+				provider.ClaimMappings.Username.Expression = "!@#$%^&*()"
+			})
+			o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in username mapping")
+
+			// Test invalid CEL expression in claimMappings.groups.expression
+			_, _, err = configureOIDCAuthentication(ctx, oc, keycloakNamespace, oidcClientSecret, func(provider *configv1.OIDCProvider) {
+				provider.ClaimMappings.Groups.TokenClaimMapping.Expression = "!@#$%^&*()"
+			})
+			o.Expect(err).To(o.HaveOccurred(), "should encounter an error with invalid CEL expression in groups mapping")
+		})
 	})
 
 	g.AfterAll(func() {


### PR DESCRIPTION
This PR adds comprehensive end-to-end tests for the `ExternalOIDCWithUpstreamParity` feature gate, enabling the feature to be tested in TechPreview periodic jobs as a requirement for promotion.

This replaces #30906 which is being closed due to the original author's departure.

### New Tests Added

**ExternalOIDCWithUpstreamParity** 
- Custom discoveryURL configuration
- UserValidationRules with CEL expressions (AND logic)
- ClaimValidationRules (both RequiredClaim and CEL types)
- CEL expression-based username/groups claim mappings
- Validates authentication success/failure based on validation rules
- Tests claim mapping with filtered groups

### Supporting Changes

Modified `keycloak_client.go`:
- Made `CreateGroup()` idempotent (handles existing groups)
- Added `CreateUserWithEmail()` for custom email testing
- Improved error messages

## Notes
- Tests use `g.By()` for clear step documentation instead of immediately invoked functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a feature-gated test suite for external OIDC parity with custom discovery URLs, claim-based username/group mapping, CEL-based mappings and validations, and admission-validation of invalid CEL expressions.
  * Added scenarios asserting successful SSR creation and expected authorization failures for mapping/validation failures.
* **Bug Fixes**
  * User creation: accept conflict (409) as success, allow explicit email during creation, and improve error messages to include username.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->