### PR TITLE
NO-JIRA: Handle unexpected image configuration media type in getArchitectures

### DIFF
--- a/pkg/clioptions/imagesetup/images.go
+++ b/pkg/clioptions/imagesetup/images.go
@@ -138,6 +138,9 @@ func getArchitectures(image string, requiredArchs []string) ([]string, error) {
 	// and there isn't much else to go off of to tell if it's a manifest list or not.
 	if err != nil && strings.Contains(string(output), "the image is a manifest list") {
 		logrus.Debugf("  Image is a manifest list")
+	} else if err != nil && strings.Contains(string(output), "does not have the expected image configuration media type") {
+		logrus.Debugf("  Image is an artifact")
+		return nil, nil
 	} else if err != nil {
 		return nil, fmt.Errorf("failed to check image %s: %w\nOutput: %s", image, err, string(output))
 	} else {


### PR DESCRIPTION
Skip images that don't have the expected image configuration media type instead of treating them as errors, since they are artifacts rather than runnable container images.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image artifact detection to correctly identify artifact-type images, reducing false error messages and enhancing the accuracy of image validation diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->