### PR TITLE
OCPBUGS-83801:skip serial and disruptive cases from suite

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -191,7 +191,7 @@ var staticSuites = []ginkgo.TestSuite{
 		Tests that exercise the OpenShift image-registry functionality.
 		`),
 		Qualifiers: []string{
-			withStandardEarlyOrLateTests("name.contains('[sig-imageregistry]') && !name.contains('[Local]')"),
+			withStandardEarlyOrLateTests("name.contains('[sig-imageregistry]') && !name.contains('[Local]') && !name.contains('[Disruptive]') && !name.contains('[Serial]')"),
 		},
 	},
 	{


### PR DESCRIPTION
skip serial and disruptive cases from suite which causing monitor cases failure 
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-image-registry-operator/1322/pull-ci-openshift-cluster-image-registry-operator-release-4.22-e2e-aws-ovn-image-registry/2046176460850335744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined standard test-suite filtering to additionally exclude tests marked disruptive and serial from standard runs, alongside existing exclusions. This prevents certain slow or stateful tests from running in routine executions, improving overall test stability and reducing time to feedback for typical test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->