### PR TITLE
OCPBUGS-63307: Move imagepolicy test to disruptive long-running suite

### DIFF
--- a/test/extended/imagepolicy/imagepolicy.go
+++ b/test/extended/imagepolicy/imagepolicy.go
@@ -44,7 +44,7 @@ const (
 	invalidEmailPKIClusterImagePolicyName  = "invalid-email-pki-cluster-image-policy"
 )
 
-var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][Serial]", g.Ordered, func() {
+var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:SigstoreImageVerification][Serial]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                       = exutil.NewCLIWithoutNamespace("cluster-image-policy")
@@ -150,7 +150,7 @@ var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerification][
 	})
 })
 
-var _ = g.Describe("[sig-imagepolicy][OCPFeatureGate:SigstoreImageVerificationPKI][Serial][Skipped:Disconnected]", g.Ordered, func() {
+var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:SigstoreImageVerificationPKI][Serial][Skipped:Disconnected]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                       = exutil.NewCLIWithoutNamespace("cluster-image-policy")


### PR DESCRIPTION
SigstoreImageVerification and SigstoreImageVerificationPKI in distuptive long-running test suite which does not monitor `events should not repeat pathologically`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite metadata to improve test categorization and organization for image policy test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->