### PR TITLE
OCPBUGS-83580: Skip dev fuse test on runc runtime

### DIFF
--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	o "github.com/onsi/gomega"
 	nodeutils "github.com/openshift/origin/test/extended/node"
 	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -112,8 +114,17 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		podName := "pod-devfuse"
 		ns := "devfuse-test"
 
+		g.By("Check if the default CRI-O runtime is runc")
+		ctrcfgList, err := oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().List(context.Background(), metav1.ListOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, cfg := range ctrcfgList.Items {
+			if cfg.Spec.ContainerRuntimeConfig != nil && cfg.Spec.ContainerRuntimeConfig.DefaultRuntime == "runc" {
+				g.Skip("Skipping: not applicable to runc runtime")
+			}
+		}
+
 		g.By("Create a test namespace")
-		err := oc.AsAdmin().WithoutNamespace().Run("create").Args("namespace", ns).Execute()
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("namespace", ns).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("namespace", ns, "--ignore-not-found").Execute()
 


### PR DESCRIPTION
#### Bug

[OCPBUGS-83580](https://redhat.atlassian.net/browse/OCPBUGS-83580)

#### Follow-up PR

[#PR](https://github.com/openshift/origin/pull/30948)

#### Problem
The OCP-70987 test (Allow dev fuse by default in CRI-O) was failing across multiple CI platforms (AWS, GCP, vSphere, Metal+IPv6) with error: stat: cannot statx '/dev/fuse': **No such file or directory**

The test relies on the CRI-O annotation io.kubernetes.cri-o.Devices: "/dev/fuse" to mount /dev/fuse into the pod. However, this annotation is only supported by the crun runtime. When the default CRI-O runtime is runc, it does not include io.kubernetes.cri-o.Devices in its allowed_annotations, so CRI-O silently ignores the annotation and the pod starts without /dev/fuse mounted.

#### Root Cause
The test did not account for clusters using runc as the default CRI-O runtime. The /dev/fuse device annotation is a crun-specific feature, and running the test on runc nodes will always fail.

#### Fix
Added a runtime check before test execution: query crio config on a worker node to detect the default runtime
Skip the test with a clear message when runc is the default runtime, since the /dev/fuse device annotation is not applicable
Replaced the previous modprobe fuse workaround with this more targeted skip

#### Testing
Tested on a fresh OCP 4.22 GCP cluster (nightly 4.22.0-0.nightly-2026-04-26-170224):

crun (default): Test passed — /dev/fuse successfully mounted inside the pod
runc (via ContainerRuntimeConfig): Test correctly skipped with message: Skipping: not applicable to runc runtime

```
➜  origin git:(fix-devfuse-modprobe-fuse) ./openshift-tests run-test "[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987] [Suite:openshift/conformance/parallel]"

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1777308957 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111
    STEP: Creating a kubernetes client @ 04/27/26 22:26:01.05
  I0427 22:26:01.051091    5408 discovery.go:214] Invalidating discovery information
  I0427 22:26:01.056870 5408 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0427 22:26:01.427179 5408 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Check if the default CRI-O runtime is runc @ 04/27/26 22:26:01.427
    STEP: Create a test namespace @ 04/27/26 22:26:14.175
  namespace/devfuse-test created
    STEP: Create a pod with dev fuse annotation @ 04/27/26 22:26:14.891
  pod/pod-devfuse created
    STEP: Wait for pod to be ready @ 04/27/26 22:26:16.326
    STEP: Check /dev/fuse is mounted inside the pod @ 04/27/26 22:26:22.043
  I0427 22:26:23.463019 5408 node.go:152] /dev/fuse mount output: File: /dev/fuse
    Size: 0             Blocks: 0          IO Block: 4096   character special file
  Device: 1000feh/1048830d      Inode: 6           Links: 1     Device type: a,e5
  Access: (0666/crw-rw-rw-)  Uid: (    0/    root)   Gid: (    0/    root)
  Access: 2026-04-27 16:56:18.967382166 +0000
  Modify: 2026-04-27 16:56:18.967382166 +0000
  Change: 2026-04-27 16:56:18.968382164 +0000
   Birth: 2026-04-27 16:56:18.967382166 +0000
  namespace "devfuse-test" deleted
  • [67.736 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 67.737 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

**Test skipping on runc as runtime**

    STEP: Check if the default CRI-O runtime is runc @ 04/27/26 22:41:22.744
    [SKIPPED] in [It] - github.com/openshift/origin/test/extended/node/node_e2e/node.go:122 @ 04/27/26 22:41:28.02
  S [SKIPPED] [5.703 seconds]
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [It] [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111

    [SKIPPED] Skipping: not applicable to runc runtime
    In [It] at: github.com/openshift/origin/test/extended/node/node_e2e/node.go:122 @ 04/27/26 22:41:28.02
  ------------------------------

  Ran 0 of 1 Specs in 5.704 seconds
  SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened dev-fuse e2e preconditions: test now checks CRI-O's configured container runtime and skips when the default runtime is incompatible (e.g., runc).
  * Improved test setup order and error handling so namespace creation and precondition checks run in sequence, reducing false failures and making skips occur earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->