### PR TITLE
OCPBUGS-79544: test: add monitortest to detect pods stuck in Pending state

### DIFF
--- a/pkg/monitortests/node/watchpods/monitortest.go
+++ b/pkg/monitortests/node/watchpods/monitortest.go
@@ -53,8 +53,10 @@ func (*podWatcher) ConstructComputedIntervals(ctx context.Context, startingInter
 }
 
 func (w *podWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	ret := stuckPendingPodsJunit(finalIntervals)
+
 	if w.podInformer == nil {
-		return nil, nil
+		return ret, nil
 	}
 
 	cacheFailures, err := checkCacheState(ctx, w.kubeClient, w.podInformer)
@@ -63,7 +65,6 @@ func (w *podWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, 
 	}
 
 	testName := "[sig-apimachinery] informers must match live results at the same resource version"
-	ret := []*junitapi.JUnitTestCase{}
 	if len(cacheFailures) > 0 {
 		ret = append(ret,
 			&junitapi.JUnitTestCase{

--- a/pkg/monitortests/node/watchpods/stuck_pending_pods.go
+++ b/pkg/monitortests/node/watchpods/stuck_pending_pods.go
@@ -1,0 +1,46 @@
+package watchpods
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+)
+
+func stuckPendingPodsJunit(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-node] pods should not be stuck in Pending state forever"
+
+	stuckPods := finalIntervals.Filter(func(interval monitorapi.Interval) bool {
+		return interval.Source == monitorapi.SourcePodState &&
+			interval.Message.Reason == "PodWasPending" &&
+			interval.Message.HumanMessage == "never completed"
+	})
+
+	var tests []*junitapi.JUnitTestCase
+	if len(stuckPods) > 0 {
+		var failures []string
+		for _, interval := range stuckPods {
+			pod := interval.Locator.Keys[monitorapi.LocatorPodKey]
+			namespace := interval.Locator.Keys[monitorapi.LocatorNamespaceKey]
+			failures = append(failures, fmt.Sprintf("ns/%s pod/%s was Pending from %s to %s and never completed",
+				namespace, pod, interval.From.UTC().Format("01-02T15:04:05Z"), interval.To.UTC().Format("01-02T15:04:05Z")))
+		}
+
+		tests = append(tests, &junitapi.JUnitTestCase{
+			Name:      testName,
+			SystemOut: strings.Join(failures, "\n"),
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("%d pod(s) were stuck in Pending state and never completed. "+
+					"This may indicate stuck image pulls or scheduling failures.\n\n%s",
+					len(failures), strings.Join(failures, "\n")),
+			},
+		})
+		// Also add a pass entry so this shows as a flake rather than a hard failure
+		// while we build confidence in this test.
+		tests = append(tests, &junitapi.JUnitTestCase{Name: testName})
+	} else {
+		tests = append(tests, &junitapi.JUnitTestCase{Name: testName})
+	}
+	return tests
+}

--- a/pkg/monitortests/node/watchpods/stuck_pending_pods_test.go
+++ b/pkg/monitortests/node/watchpods/stuck_pending_pods_test.go
@@ -1,0 +1,151 @@
+package watchpods
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func podLocator(namespace, name string) monitorapi.Locator {
+	return monitorapi.NewLocator().PodFromNames(namespace, name, "")
+}
+
+func TestStuckPendingPodsJunit(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name       string
+		intervals  monitorapi.Intervals
+		wantFail   bool
+		wantCount  int
+		wantSubstr string
+	}{
+		{
+			name:      "no intervals produces a pass",
+			intervals: monitorapi.Intervals{},
+			wantFail:  false,
+		},
+		{
+			name: "pod pending that completed is not a failure",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("openshift-etcd", "etcd-master-0")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("pod has been pending longer than a minute")).
+					Build(now.Add(-10*time.Minute), now.Add(-5*time.Minute)),
+			},
+			wantFail: false,
+		},
+		{
+			name: "single stuck pending pod is a failure",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("my-namespace", "stuck-pod")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("never completed")).
+					Build(now.Add(-30*time.Minute), now),
+			},
+			wantFail:   true,
+			wantCount:  1,
+			wantSubstr: "ns/my-namespace pod/stuck-pod",
+		},
+		{
+			name: "multiple stuck pending pods are reported",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("ns-a", "pod-a")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("never completed")).
+					Build(now.Add(-20*time.Minute), now),
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("ns-b", "pod-b")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("never completed")).
+					Build(now.Add(-15*time.Minute), now),
+			},
+			wantFail:  true,
+			wantCount: 2,
+		},
+		{
+			name: "different source is ignored",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Warning).
+					Locator(podLocator("ns", "pod")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("never completed")).
+					Build(now.Add(-10*time.Minute), now),
+			},
+			wantFail: false,
+		},
+		{
+			name: "different reason is ignored",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("ns", "pod")).
+					Message(monitorapi.NewMessage().Reason("NodeUpdate").HumanMessage("never completed")).
+					Build(now.Add(-10*time.Minute), now),
+			},
+			wantFail: false,
+		},
+		{
+			name: "stuck pod mixed with normal intervals",
+			intervals: monitorapi.Intervals{
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Info).
+					Locator(podLocator("ns-ok", "healthy-pod")).
+					Message(monitorapi.NewMessage().Reason("Created")).
+					Build(now.Add(-30*time.Minute), now.Add(-29*time.Minute)),
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("ns-stuck", "image-pull-stuck")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("never completed")).
+					Build(now.Add(-25*time.Minute), now),
+				monitorapi.NewInterval(monitorapi.SourcePodState, monitorapi.Warning).
+					Locator(podLocator("ns-ok", "slow-pod")).
+					Message(monitorapi.NewMessage().Reason("PodWasPending").HumanMessage("pod has been pending longer than a minute")).
+					Build(now.Add(-5*time.Minute), now.Add(-3*time.Minute)),
+			},
+			wantFail:   true,
+			wantCount:  1,
+			wantSubstr: "ns/ns-stuck pod/image-pull-stuck",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			junits := stuckPendingPodsJunit(tt.intervals)
+			require.NotEmpty(t, junits, "should always produce at least one JUnit test case")
+
+			if tt.wantFail {
+				// When failing, we expect a failure entry + a pass entry (flake pattern)
+				var failCase *junitapi.JUnitTestCase
+				for _, tc := range junits {
+					if tc.FailureOutput != nil {
+						failCase = tc
+						break
+					}
+				}
+				require.NotNil(t, failCase, "expected a failing test case")
+				assert.Contains(t, failCase.FailureOutput.Output, "stuck in Pending state")
+				if tt.wantSubstr != "" {
+					assert.Contains(t, failCase.FailureOutput.Output, tt.wantSubstr)
+				}
+				if tt.wantCount > 0 {
+					assert.Contains(t, failCase.FailureOutput.Output,
+						fmt.Sprintf("%d pod(s)", tt.wantCount))
+				}
+
+				// Verify the flake pattern: both a failure and a pass with the same test name
+				var hasPass bool
+				for _, tc := range junits {
+					if tc.FailureOutput == nil && tc.Name == failCase.Name {
+						hasPass = true
+					}
+				}
+				assert.True(t, hasPass, "expected a matching pass entry for flake pattern")
+			} else {
+				for _, tc := range junits {
+					assert.Nil(t, tc.FailureOutput, "expected no failure output for passing test")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a JUnit evaluation to the pod-lifecycle monitortest that scans intervals for pods with PodWasPending reason and "never completed" message, indicating pods that entered Pending and never left it. This reliably detects stuck image pulls and scheduling failures across all cluster configurations by leveraging already-collected interval data rather than brittle node-level inspection.

Assisted-by: Claude Code <https://claude.com/claude-code>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection and reporting for pods stuck in Pending state that never complete, including detailed per-pod failure summaries and counts.

* **Tests**
  * Added comprehensive tests for stuck-pending detection covering empty intervals, completed pods, single/multiple stuck pods, filtering cases, and ensuring paired passing entries for flake tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->