### PR TITLE
TRT-2622: copy OTE attrs to junit properties

### DIFF
--- a/pkg/test/ginkgo/junit.go
+++ b/pkg/test/ginkgo/junit.go
@@ -18,31 +18,51 @@ import (
 	"github.com/openshift/origin/pkg/version"
 )
 
+// addPropertyIfPresent adds a test case property if the value is non-empty
+func addPropertyIfPresent(testCase *junitapi.JUnitTestCase, name, value string) {
+	if value != "" {
+		testCase.Properties = append(testCase.Properties, &junitapi.TestCaseProperty{
+			Name:  name,
+			Value: value,
+		})
+	}
+}
+
 // populateOTEMetadata adds OTE metadata attributes to a JUnit test case if available
 func populateOTEMetadata(testCase *junitapi.JUnitTestCase, extensionResult *extensions.ExtensionTestResult) {
 	if extensionResult == nil {
 		return
 	}
 
-	// Test source information
+	// Test source information - set attributes and properties
 	testCase.SourceImage = extensionResult.Source.SourceImage
+	addPropertyIfPresent(testCase, "source-image", extensionResult.Source.SourceImage)
+
 	testCase.SourceBinary = extensionResult.Source.SourceBinary
+	addPropertyIfPresent(testCase, "source-binary", extensionResult.Source.SourceBinary)
+
 	if extensionResult.Source.Source != nil {
 		testCase.SourceURL = extensionResult.Source.SourceURL
+		addPropertyIfPresent(testCase, "source-url", extensionResult.Source.SourceURL)
+
 		testCase.SourceCommit = extensionResult.Source.Commit
+		addPropertyIfPresent(testCase, "source-commit", extensionResult.Source.Commit)
 	}
 
-	// Set lifecycle attribute
+	// Set lifecycle attribute and property
 	testCase.Lifecycle = string(extensionResult.Lifecycle)
+	addPropertyIfPresent(testCase, "lifecycle", string(extensionResult.Lifecycle))
 
-	// Set start time attribute if available
+	// Set start time attribute and property if available
 	if extensionResult.StartTime != nil {
 		testCase.StartTime = time.Time(*extensionResult.StartTime).UTC().Format(time.RFC3339)
+		addPropertyIfPresent(testCase, "start-time", testCase.StartTime)
 	}
 
-	// Set end time attribute if available
+	// Set end time attribute and property if available
 	if extensionResult.EndTime != nil {
 		testCase.EndTime = time.Time(*extensionResult.EndTime).UTC().Format(time.RFC3339)
+		addPropertyIfPresent(testCase, "end-time", testCase.EndTime)
 	}
 }
 

--- a/pkg/test/ginkgo/junitapi/types.go
+++ b/pkg/test/ginkgo/junitapi/types.go
@@ -53,6 +53,14 @@ type TestSuiteProperty struct {
 	Value string `xml:"value,attr"`
 }
 
+// TestCaseProperty contains a mapping of a property name to a value
+type TestCaseProperty struct {
+	XMLName xml.Name `xml:"property"`
+
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
 // JUnitTestCase represents a jUnit test case
 type JUnitTestCase struct {
 	XMLName xml.Name `xml:"testcase"`
@@ -74,6 +82,9 @@ type JUnitTestCase struct {
 	SourceBinary string `xml:"source-binary,attr,omitempty"`
 	SourceURL    string `xml:"source-url,attr,omitempty"`
 	SourceCommit string `xml:"source-commit,attr,omitempty"`
+
+	// Properties holds test case properties as key-value pairs
+	Properties []*TestCaseProperty `xml:"properties>property,omitempty"`
 
 	// SkipMessage holds the reason why the test was skipped
 	SkipMessage *SkipMessage `xml:"skipped"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * JUnit test reports now record additional structured test-case properties: source-image, source-binary, source-url, source-commit, lifecycle, start-time, and end-time.
  * Properties are included only when values/timestamps are present, and omit the properties section when empty to keep reports concise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->