### PR TITLE
OCPBUGS-84255: Fix project name error during wait

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -214,7 +214,7 @@ func waitForNoEvent(w watch.Interface, skipProject string) {
 				project, ok := event.Object.(*projectv1.Project)
 				o.Expect(ok).To(o.BeTrue())
 				framework.Logf("got %#v %#v", event, project)
-				o.Expect(ok).To(o.Equal(skipProject))
+				o.Expect(project.Name).To(o.Equal(skipProject))
 
 				continue
 			case <-time.After(2 * time.Second):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed watch event filtering logic to correctly identify project names instead of incorrectly comparing type-cast results, ensuring stray events are properly excluded based on actual project identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->