### PR TITLE
NO-JIRA: Remove UserNamespacesSupport feature gate label from test

### DIFF
--- a/test/extended/node/nested_container.go
+++ b/test/extended/node/nested_container.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container", func() {
+var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] nested container", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("nested-podman", admissionapi.LevelBaseline)
 	g.It("should pass podman localsystem test in baseline mode",
 		func(ctx context.Context) {


### PR DESCRIPTION
## What this PR does
Backport of #31071 to release-4.23.

Removes the obsolete `[FeatureGate:UserNamespacesSupport]` label from the user namespace test suite.

## Why we need it
The UserNamespacesSupport feature gate was removed from openshift/api in https://github.com/openshift/api/pull/2762 because:
- The feature has been enabled by default since Kubernetes 1.33
- The feature gate is no longer needed

This PR updates the test label in the 4.23 branch to reflect that user namespaces are now a GA feature.

## Testing
The e2e-gcp-ovn-usernamespace CI job will validate that the test still runs successfully.

```
/test e2e-gcp-ovn-usernamespace
```

## Related
- Jira: [OCPBUGS-74525](https://issues.redhat.com/browse/OCPBUGS-74525)
- Jira Story: [OCPNODE-4450](https://redhat.atlassian.net/browse/OCPNODE-4450)
- openshift/api PR: https://github.com/openshift/api/pull/2762
- Main branch PR: https://github.com/openshift/origin/pull/31071