### PR TITLE
NO-JIRA: Remove fixed bugs on CO conditions

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -379,10 +379,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					condition.Reason == "APIServices_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23746"
 			}
-		case "openshift-controller-manager":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && (condition.Reason == "OpenshiftControllerManagerStaticResources_SyncError") {
-				return "https://issues.redhat.com/browse/OCPBUGS-42870"
-			}
 		case "operator-lifecycle-manager-packageserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "ClusterServiceVersionNotSucceeded" {
 				return "https://issues.redhat.com/browse/OCPBUGS-23744"

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -701,8 +701,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 		switch co {
 		case "baremetal":
 			return "https://issues.redhat.com/browse/OCPBUGS-66101"
-		case "cluster-autoscaler":
-			return "https://issues.redhat.com/browse/OCPBUGS-65578"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "operator-lifecycle-manager":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -366,10 +366,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
-		case "machine-api":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {
-				return "https://issues.redhat.com/browse/OCPBUGS-44332"
-			}
 		case "monitoring":
 			if condition.Type == configv1.OperatorAvailable &&
 				(condition.Status == configv1.ConditionFalse &&

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -136,9 +136,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "network" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38684"
 			}
-			if operator == "machine-config" {
-				return "https://issues.redhat.com/browse/OCPBUGS-66209"
-			}
 			if operator == "authentication" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38675"
 			}
@@ -327,10 +324,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 					return "https://issues.redhat.com/browse/OCPBUGS-38676"
 				}
-			case "machine-config":
-				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-					return "https://issues.redhat.com/browse/OCPBUGS-66209"
-				}
 			case "kube-apiserver":
 				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 					return "https://issues.redhat.com/browse/OCPBUGS-38661"
@@ -376,10 +369,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "machine-api":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-44332"
-			}
-		case "machine-config":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-				return "https://issues.redhat.com/browse/OCPBUGS-66209"
 			}
 		case "monitoring":
 			if condition.Type == configv1.OperatorAvailable &&

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -414,10 +414,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					}
 				}
 			}
-		case "openshift-samples":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "APIServerServiceUnavailableError" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38679"
-			}
 		case "kube-apiserver":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 				if isSingleNode && condition.Reason == "NodeInstaller_InstallerPodFailed" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -707,8 +707,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "cloud-credential":
 			return "https://issues.redhat.com/browse/OCPBUGS-65580"
-		case "kube-scheduler":
-			return "https://issues.redhat.com/browse/OCPBUGS-65941"
 		case "marketplace":
 			return "https://issues.redhat.com/browse/OCPBUGS-65581"
 		case "operator-lifecycle-manager":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -142,9 +142,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "console" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
-			if operator == "cluster-autoscaler" {
-				return "https://issues.redhat.com/browse/OCPBUGS-42875"
-			}
 			return ""
 		}
 		return "We are not worried about other operator condition blips for stable-system tests yet."
@@ -339,10 +336,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-38675"
 			} else if checkAuthenticationAvailableExceptions(condition) {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056"
-			}
-		case "cluster-autoscaler":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "MissingDependency" {
-				return "https://issues.redhat.com/browse/OCPBUGS-42875"
 			}
 		case "cloud-controller-manager":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -133,9 +133,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "network" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38684"
 			}
-			if operator == "authentication" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38675"
-			}
 			if operator == "console" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
@@ -329,9 +326,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 
 		switch operator {
 		case "authentication":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-				return "https://issues.redhat.com/browse/OCPBUGS-38675"
-			} else if checkAuthenticationAvailableExceptions(condition) {
+			if checkAuthenticationAvailableExceptions(condition) {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056"
 			}
 		case "cloud-controller-manager":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -118,9 +118,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "cloud-controller-manager" && condition.Reason == "SyncingFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42837"
 			}
-			if operator == "cloud-credential" {
-				return "https://issues.redhat.com/browse/OCPBUGS-42872"
-			}
 			if operator == "ingress" {
 				return "https://issues.redhat.com/browse/OCPBUGS-45921"
 			}
@@ -340,12 +337,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "cloud-controller-manager":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42837"
-			}
-		case "cloud-credential":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
-				(condition.Reason == "CredentialsFailing" ||
-					condition.Reason == "StaticResourceReconcileFailed") {
-				return "https://issues.redhat.com/browse/OCPBUGS-42872"
 			}
 		case "console":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -707,8 +707,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "cloud-credential":
 			return "https://issues.redhat.com/browse/OCPBUGS-65580"
-		case "marketplace":
-			return "https://issues.redhat.com/browse/OCPBUGS-65581"
 		case "operator-lifecycle-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-65583"
 		case "openshift-samples":

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -705,8 +705,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return "https://issues.redhat.com/browse/OCPBUGS-65578"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
-		case "cloud-credential":
-			return "https://issues.redhat.com/browse/OCPBUGS-65580"
 		case "operator-lifecycle-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-65583"
 		case "openshift-samples":


### PR DESCRIPTION
In general the bugs are either fixed in 4.22 or earlier or their symptoms do not show in the testing.
See the verification in the commit messages.

They may impact the two-hop upgrade testing (for example 4.21->4.22->5.0) as the latest test binary is used in the first hops.
Those two hop upgrade testing do not block the OCP release.
Otherwise, we could do something similar to ignore the monitor-test like we do [here](https://github.com/openshift/release/blob/e14abc1a50acfe416cd477c45def141d7ac3ce67/ci-operator/step-registry/openshift/e2e/test/openshift-e2e-test-commands.sh#L300).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed legacy hardcoded exceptions from cluster version operator monitor tests, resulting in stricter validation of operator health, degradation status, and availability checks during cluster upgrade and maintenance operations.

* **Chores**
  * Eliminated obsolete exception mappings and legacy workaround rules to improve test framework maintainability and reduce accumulated technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->