### PR TITLE
SREP-4676: add exception for managed cluster namespaces

### DIFF
--- a/pkg/monitortests/authentication/nodefaultserviceaccountoperatortests/monitortest.go
+++ b/pkg/monitortests/authentication/nodefaultserviceaccountoperatortests/monitortest.go
@@ -48,6 +48,8 @@ var exceptions = []func(pod corev1.Pod) (string, bool){
 	// This exception is being kept as there is still an open PR for this ticket.
 	// TODO(ehearne-redhat): check back on this ticket to review progress.
 	exceptionWithJira("openshift-multus/multus-", "https://issues.redhat.com/browse/OCPBUGS-65631"),
+	exceptionWithJira("openshift-route-monitor-operator/blackbox-exporter-", "https://redhat.atlassian.net/browse/SREP-4724"),
+	exceptionWithJira("openshift-security/", "https://redhat.atlassian.net/browse/SREP-4725"),
 	// This one checks if it is a debug pod or not.
 	// debug pod does not run by default on an OpenShift cluster.
 	// debug pod has showed up in some e2e tests. In order to


### PR DESCRIPTION
Adding exception for the namespaces are only for managed clusters.

Each of the exception being tracked by JIRA card. Can remove them once the issue fixed in operators.

Fixes: [SREP-4676](https://redhat.atlassian.net/browse/SREP-4676)