### PR TITLE
OCPNODE-4055: Add comprehensive test suite for Additional Storage Support feature

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -13,46 +13,77 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **node_e2e/netns_cleanup.go** - Network namespace cleanup - Verifies kubelet/CRI-O properly deletes network namespace when a pod is deleted \[OTP\]
 - **node_e2e/pdb_drain.go** - PodDisruptionBudget drain blocking (OCP-67564) - Tests that node drain is blocked when PDB has minAvailable=100% with empty selector \[Disruptive\] \[Lifecycle:informing\]
 
-### Suite: openshift/conformance/parallel
-
-- **Additional Storage Support API Validation** - API validation tests for additionalArtifactStores, additionalImageStores, and additionalLayerStores CRI-O configuration
+- **Additional Storage Support** - Tests for additionalArtifactStores, additionalImageStores, and additionalLayerStores CRI-O configuration
   
   **Availability:**
   - **OCP 4.22:** TechPreview (requires TechPreviewNoUpgrade feature gate)
   - **OCP 4.23+/5.0+:** GA (Generally Available)
   
-  **Suite:** `openshift/conformance/parallel`  
+  **Suite:** `openshift/conformance/parallel` (API tests), `openshift/disruptive-longrunning` (E2E tests)  
   **Feature Tag:** `[Feature:AdditionalStorageSupport]`  
-  **Sig Tag:** `[sig-node]`  
-  **OCPFeatureGate:** `AdditionalStorageConfig`
+  **Sig Tag:** `[sig-node]`
   
-  **Test File:**
+  **Test Files:**
   - **additional_storage_api.go** - 13 API validation tests using DryRun (non-disruptive, parallel execution)
     - Combined Additional Stores (3 tests): invalid paths, max count enforcement, duplicate detection
     - Additional Layer Stores (8 tests): comprehensive path validation (empty, relative, spaces, special chars, length, max count, consecutive slashes, duplicates)
     - Additional Image Stores (1 smoke test): path validation wiring
     - Additional Artifact Stores (1 smoke test): path validation wiring
+  - **additional_storage_e2e.go** - 3 E2E tests with single-node MCP rollouts (disruptive, serial execution)
+    - Combined Stores - Configuration & Verification: validates all three storage types configure correctly
+    - Combined Stores - Functional Verification: tests layer/image/artifact stores functionality with prepopulated images and registry fallback
+    - Layer Stores - Comprehensive Lifecycle: stargz deployment, lazy pulling, store updates, maximum stores, CRC deletion cleanup, and fallback scenarios (standard OCI image, stopped stargz-store)
+  - **stargz_store_setup.go** - Helper for deploying/cleaning up stargz-store daemonset on worker nodes
   
   **Requirements:**
-  - AdditionalStorageConfig feature gate must be enabled
-  - API tests are non-disruptive (use DryRun)
-  - Run in parallel with other conformance tests
-  - Skip on MicroShift (no MachineConfig support)
-  - Skip on Microsoft Azure (known platform issues)
+  - TechPreviewNoUpgrade feature gate must be enabled (only for OCP 4.22)
+  - API tests: Non-disruptive, use DryRun, run in parallel (requires `OCPFeatureGate:AdditionalStorageConfig`)
+  - E2E tests: Serial and Disruptive, use single-node MCP for faster rollouts (~10-15 min vs ~25 min)
+  - Tests that pull external images are tagged [Skipped:Disconnected] for air-gapped environments
   
-  **Running API validation tests:**
+  **Test Environments:**
+  
+  These tests run in CI on multiple platforms via `disruptive-longrunning-techpreview` jobs:
+  - AWS (primary platform for Additional Storage Support E2E tests)
+  - Azure (E2E tests explicitly skip Azure via platform detection)
+  - GCP
+  - vSphere
+  - Metal IPI (IPv6 and dual-stack)
+  
+  **CI Job Configuration:**
+  - **Feature Set:** `TechPreviewNoUpgrade` (enables tech preview features)
+  - **Test Suite:** `openshift/disruptive-longrunning`
+  - **Interval:** Weekly (168h)
+  - **Sharding:** 2 shards to parallelize execution
+  - **Job definitions:** See `ci-operator/config/openshift/release/openshift-release-main__nightly-4.XX.yaml` in [openshift/release](https://github.com/openshift/release) repo
+  
+  **Running these tests:**
   ```bash
-  # Run only Additional Storage API validation tests (fast, non-disruptive)
-  ./openshift-tests run "openshift/conformance/parallel" --dry-run | \
-    grep "\[Feature:AdditionalStorageSupport\]" | \
-    ./openshift-tests run -f -
+  # Run API validation tests (fast, non-disruptive, parallel)
+  ./openshift-tests run "openshift/conformance/parallel" --dry-run | grep "\[Feature:AdditionalStorageSupport\]" | ./openshift-tests run -f -
+  
+  # Run E2E tests (slow, disruptive, triggers MCP rollouts)
+  ./openshift-tests run "openshift/disruptive-longrunning" --dry-run | grep "\[Feature:AdditionalStorageSupport\]" | ./openshift-tests run -f - --cluster-stability=Disruptive
+  
+  # Run all tests (API + E2E)
+  ./openshift-tests run "openshift/conformance/parallel" --dry-run | grep "\[Feature:AdditionalStorageSupport\]" | ./openshift-tests run -f - && \
+  ./openshift-tests run "openshift/disruptive-longrunning" --dry-run | grep "\[Feature:AdditionalStorageSupport\]" | ./openshift-tests run -f - --cluster-stability=Disruptive
   ```
   
-  **Test Coverage (13 tests, ~2-3 min total):**
-  - Path format validation (absolute paths, character restrictions, length limits)
-  - Count limits enforcement (5 for artifact/layer stores, 10 for image stores)
-  - Duplicate path detection within store types
-  - Combined store configurations with invalid paths
+  **Test Coverage:**
+  - **API Validation (13 tests, ~2-3 min total):**
+    - Path format validation (absolute paths, character restrictions, length limits)
+    - Count limits enforcement (5 for artifact/layer stores, 10 for image stores)
+    - Duplicate path detection within store types
+    - Combined store configurations with invalid paths
+  - **E2E Tests (3 tests, ~45-60 min total):**
+    - CRI-O storage.conf generation and verification on worker nodes
+    - MachineConfigOperator (MCO) configuration updates and single-node MCP rollouts
+    - Lazy pulling with eStargz images and stargz-store snapshotter
+    - Prepopulated image store functionality and registry fallback
+    - Artifact store read/write verification
+    - Layer store updates (2 stores, max 5 stores) and CRC deletion cleanup
+    - Fallback behavior: standard OCI images and stopped stargz-store service
 
 ### Suite: openshift/usernamespace
 
@@ -73,7 +104,9 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - Each file focuses on a specific node feature
 
 ### Utility Files
-- **node_utils.go** - Shared helper functions for node selection and kubelet configuration retrieval
+- **node_utils.go** - Shared helper functions for node selection, kubelet configuration retrieval, and Additional Storage Support skip/platform helpers
+- **node_mcp_helpers.go** - MCP lifecycle helpers: single-node MachineConfigPool creation/cleanup, directory management on nodes, pod creation/deletion, and MCP/CRC wait utilities
+- **stargz_store_setup.go** - Helper for deploying/cleaning up stargz-store daemonset on worker nodes for lazy pulling tests
 
 ### Test Data
 Test fixtures are referenced via `exutil.FixturePath` from:
@@ -124,6 +157,31 @@ Before submitting a PR that adds a test to the `openshift/disruptive-longrunning
 Useful links for `periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-disruptive-longrunning`:
 - [Previous runs (Sippy)](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.22/analysis?filters=%7B%22items%22%3A%5B%7B%22columnField%22%3A%22name%22%2C%22operatorValue%22%3A%22equals%22%2C%22value%22%3A%22periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-disruptive-longrunning%22%7D%5D%7D)
 - [Job history for latest runs (Prow)](https://prow.ci.openshift.org/job-history/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-disruptive-longrunning)
+
+### Adding TechPreview Tests to `openshift/disruptive-longrunning`
+
+For tests that require TechPreviewNoUpgrade feature gate (like Additional Storage Support in OCP 4.22), use the TechPreview variant of the disruptive-longrunning CI job:
+
+```
+# For OCP 4.22 TechPreview testing
+/payload-job periodic-ci-openshift-release-main-nightly-4.22-e2e-aws-disruptive-longrunning-techpreview
+
+# For OCP 4.23+ (GA), use standard job
+/payload-job periodic-ci-openshift-release-main-nightly-4.23-e2e-aws-disruptive-longrunning
+```
+
+**Available platform variants:**
+- `-e2e-aws-disruptive-longrunning-techpreview` (AWS - primary for storage tests)
+- `-e2e-azure-disruptive-longrunning-techpreview` (Azure)
+- `-e2e-gcp-disruptive-longrunning-techpreview` (GCP)
+- `-e2e-vsphere-disruptive-longrunning-techpreview` (vSphere)
+- `-e2e-metal-ipi-ovn-ipv6-disruptive-longrunning-techpreview` (Bare Metal IPv6)
+- `-e2e-metal-ipi-ovn-dual-disruptive-longrunning-techpreview` (Bare Metal dual-stack)
+
+**CI Job Configuration:**
+- Job definitions: `ci-operator/config/openshift/release/openshift-release-main__nightly-4.XX.yaml` in [openshift/release](https://github.com/openshift/release) repo
+- Feature Set: `TechPreviewNoUpgrade`
+- Test Suite: `openshift/disruptive-longrunning`
 
 ## Important Notes
 

--- a/test/extended/node/additional_storage_api.go
+++ b/test/extended/node/additional_storage_api.go
@@ -17,6 +17,7 @@ import (
 )
 
 // API validation tests - use DryRun to avoid triggering MCO reconciliation
+// Run in disruptive-longrunning suite to ensure TechPreview feature gate is enabled
 var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Suite:openshift/conformance/parallel] Additional Storage API Validation", func() {
 	defer g.GinkgoRecover()
 
@@ -31,7 +32,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 	// ========================================================================
 	g.Context("Combined Additional Stores", func() {
 		// Reject if any store type has invalid path
-		g.It("should reject if any store type has invalid path in combined config ", func(ctx context.Context) {
+		g.It("should reject if any store type has invalid path in combined config", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -71,7 +72,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Reject if layer stores exceed max while other stores are valid
-		g.It("should reject if layer stores exceed max even with valid image/artifact stores ", func(ctx context.Context) {
+		g.It("should reject if layer stores exceed max even with valid image/artifact stores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -112,7 +113,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Reject duplicate paths within same store type in combined config
-		g.It("should reject duplicate paths within same store type in combined config ", func(ctx context.Context) {
+		g.It("should reject duplicate paths within same store type in combined config", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -155,7 +156,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 	g.Context("Additional Layer Stores", func() {
 		// Should fail if additionalLayerStores path is empty
 		// Note: Go API returns "Required value" while YAML returns "at least 1 chars long"
-		g.It("should reject empty path for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject empty path for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -189,7 +190,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores path is not absolute
-		g.It("should reject relative path for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject relative path for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -221,7 +222,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores path contains spaces
-		g.It("should reject path with spaces for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject path with spaces for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -253,7 +254,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores path contains invalid characters
-		g.It("should reject path with invalid characters for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject path with invalid characters for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -280,11 +281,12 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
 			)
 			o.Expect(err).To(o.HaveOccurred(), "Expected API to reject path with invalid character '@'")
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
 			framework.Logf("Path with '@' correctly rejected: %v", err)
 		})
 
 		// Should fail if additionalLayerStores path is too long (>256 bytes)
-		g.It("should reject path exceeding 256 characters for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject path exceeding 256 characters for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -318,7 +320,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores exceeds maximum of 5 items
-		g.It("should reject more than 5 additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject more than 5 additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -353,7 +355,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores path contains consecutive forward slashes
-		g.It("should reject path with consecutive forward slashes for additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject path with consecutive forward slashes for additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -385,7 +387,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 		})
 
 		// Should fail if additionalLayerStores contains duplicate paths
-		g.It("should reject duplicate paths in additionalLayerStores ", func(ctx context.Context) {
+		g.It("should reject duplicate paths in additionalLayerStores", func(ctx context.Context) {
 			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
 			o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -450,6 +452,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
 			)
 			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
 			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
 		})
 	})
@@ -486,6 +489,7 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
 			)
 			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
 			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
 		})
 	})

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -1,0 +1,934 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
+// and run in the disruptive-longrunning suite.
+var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("additional-storage-e2e")
+
+	g.BeforeEach(func(ctx context.Context) {
+		skipUnlessAdditionalStorageConfigEnabled(ctx, oc)
+	})
+
+	// ========================================================================
+	// Combined Additional Stores E2E - Configuration and Node Verification
+	// ========================================================================
+	g.It("should configure all three storage types and verify node configuration", func(ctx context.Context) {
+		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// =====================================================================
+		// SETUP: Create single-node MachineConfigPool for faster rollouts
+		// =====================================================================
+		g.By("Getting worker node for test")
+		workerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(workerNodes).NotTo(o.BeEmpty(), "no worker nodes available")
+		testNode := workerNodes[0].Name
+
+		mcpName := "combined-all-test"
+		var mcpConfig *CustomMCPConfig
+		g.DeferCleanup(func() {
+			cleanupCtx := context.Background()
+			delErr := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(
+				cleanupCtx, "combined-all-test", metav1.DeleteOptions{})
+			if delErr != nil && !apierrors.IsNotFound(delErr) {
+				framework.Logf("Warning: failed to delete ContainerRuntimeConfig %s: %v", "combined-all-test", delErr)
+			}
+			cleanupSingleNodeMCP(cleanupCtx, mcpConfig)
+		})
+
+		g.By("Creating single-node MachineConfigPool for test isolation")
+		mcpConfig = createSingleNodeMCP(ctx, oc, mcpName, testNode)
+		framework.Logf("Custom MCP %s created, targeting node %s", mcpName, testNode)
+
+		// Get the node object for directory creation
+		testNodeObj, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Creating shared directories on test node")
+		allDirs := []string{
+			"/var/lib/combined-layers",
+			"/var/lib/combined-images",
+			"/var/lib/combined-artifacts",
+		}
+		err = createDirectoriesOnNodes(oc, []corev1.Node{*testNodeObj}, allDirs)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(cleanupDirectoriesOnNodes, oc, []corev1.Node{*testNodeObj}, allDirs)
+
+		g.By("Creating ContainerRuntimeConfig with all three storage types")
+		ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "combined-all-test",
+			},
+			Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machineconfiguration.openshift.io/pool": mcpName,
+					},
+				},
+				ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+					AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+						{Path: machineconfigv1.StorePath("/var/lib/combined-layers")},
+					},
+					AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+						{Path: machineconfigv1.StorePath("/var/lib/combined-images")},
+					},
+					AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+						{Path: machineconfigv1.StorePath("/var/lib/combined-artifacts")},
+					},
+				},
+			},
+		}
+
+		_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool rollout (single node)")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MachineConfigPool started updating")
+
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verifying storage.conf contains layer and image stores")
+		output, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(output).To(o.ContainSubstring("/var/lib/combined-layers"),
+			"storage.conf should contain layer store path on node %s", testNode)
+		o.Expect(output).To(o.ContainSubstring("/var/lib/combined-images"),
+			"storage.conf should contain image store path on node %s", testNode)
+
+		framework.Logf("Node %s: Layer and image stores verified in storage.conf", testNode)
+
+		g.By("Verifying CRI-O config contains artifact stores")
+		crioOutput, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/crio/crio.conf.d/01-ctrcfg-additionalArtifactStores")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		expectedArtifactConfig := `additional_artifact_stores = ["/var/lib/combined-artifacts"]`
+		o.Expect(crioOutput).To(o.ContainSubstring(expectedArtifactConfig),
+			"CRI-O config should contain artifact store on node %s", testNode)
+
+		framework.Logf("Node %s: Artifact stores verified in CRI-O config", testNode)
+
+		g.By("Verifying CRI-O is running")
+		crioStatus, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "crio")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(crioStatus)).To(o.Equal("active"))
+
+		framework.Logf("Test PASSED: All three storage types configured successfully")
+	})
+
+	// ========================================================================
+	// Combined Additional Stores E2E - Functional Verification
+	// ========================================================================
+	g.It("should functionally verify all three storage types work together", func(ctx context.Context) {
+		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// =====================================================================
+		// SETUP: Create single-node MachineConfigPool for faster rollouts
+		// =====================================================================
+		g.By("Getting worker node for test")
+		workerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(workerNodes).NotTo(o.BeEmpty(), "no worker nodes available")
+		testNode := workerNodes[0].Name
+
+		mcpName := "combined-func-test"
+		var mcpConfig *CustomMCPConfig
+		g.DeferCleanup(func() {
+			cleanupCtx := context.Background()
+			delErr := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(
+				cleanupCtx, "combined-func-test", metav1.DeleteOptions{})
+			if delErr != nil && !apierrors.IsNotFound(delErr) {
+				framework.Logf("Warning: failed to delete ContainerRuntimeConfig %s: %v", "combined-func-test", delErr)
+			}
+			cleanupSingleNodeMCP(cleanupCtx, mcpConfig)
+		})
+
+		g.By("Creating single-node MachineConfigPool for test isolation")
+		mcpConfig = createSingleNodeMCP(ctx, oc, mcpName, testNode)
+		framework.Logf("Custom MCP %s created, targeting node %s", mcpName, testNode)
+
+		// Get the node object for directory creation
+		testNodeObj, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		testNamespace := oc.Namespace()
+
+		// Phase 1: Pre-populate image store
+		g.By("Phase 1: Pre-populating additionalImageStores")
+		imageStorePath := "/var/lib/combined-imagestore"
+		allDirs := []string{imageStorePath}
+
+		// Also create artifact store directory
+		artifactStorePath := "/var/lib/combined-artifactstore"
+		allDirs = append(allDirs, artifactStorePath)
+
+		// Also create layer store directory
+		layerStorePath := "/var/lib/stargz-store/store"
+		allDirs = append(allDirs, layerStorePath)
+
+		err = createDirectoriesOnNodes(oc, []corev1.Node{*testNodeObj}, allDirs)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(cleanupDirectoriesOnNodes, oc, []corev1.Node{*testNodeObj}, allDirs)
+
+		// Pre-populate test image in image store
+		testImage := "quay.io/openshifttest/additional-storage-tests:test-6gb-standard-v2.0"
+		framework.Logf("Pre-populating image %s to %s on node %s", testImage, imageStorePath, testNode)
+
+		// Use podman --root to pull image to additional image store in containers/storage format
+		podmanCmd := fmt.Sprintf("podman --root %s pull %s", imageStorePath, testImage)
+		_, err = ExecOnNodeWithChroot(oc, testNode, "bash", "-c", podmanCmd)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify image exists using podman
+		verifyCmd := fmt.Sprintf("podman --root %s images --format '{{.Repository}}:{{.Tag}}'", imageStorePath)
+		lsOutput, err := ExecOnNodeWithChroot(oc, testNode, "bash", "-c", verifyCmd)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(lsOutput).To(o.ContainSubstring(testImage))
+		framework.Logf("Image pre-populated successfully: %s", lsOutput)
+
+		// Phase 2: Create ContainerRuntimeConfig with all three storage types
+		g.By("Phase 2: Creating ContainerRuntimeConfig with all three storage types")
+		ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "combined-func-test",
+			},
+			Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machineconfiguration.openshift.io/pool": mcpName,
+					},
+				},
+				ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+					AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+						{Path: machineconfigv1.StorePath(layerStorePath)},
+					},
+					AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+						{Path: machineconfigv1.StorePath(imageStorePath)},
+					},
+					AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+						{Path: machineconfigv1.StorePath(artifactStorePath)},
+					},
+				},
+			},
+		}
+
+		_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool rollout (single node)")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Phase 3: Verify storage configuration
+		g.By("Phase 3: Verifying storage.conf contains image stores")
+		storageConfOutput, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(storageConfOutput).To(o.ContainSubstring(imageStorePath))
+		framework.Logf("Image stores verified in storage.conf")
+
+		g.By("Verifying CRI-O config contains artifact stores")
+		crioOutput, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/crio/crio.conf.d/01-ctrcfg-additionalArtifactStores")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		expectedArtifactConfig := fmt.Sprintf(`additional_artifact_stores = ["%s"]`, artifactStorePath)
+		o.Expect(crioOutput).To(o.ContainSubstring(expectedArtifactConfig))
+		framework.Logf("Artifact stores verified in CRI-O config")
+
+		// =====================================================================
+		// Phase 4: Verify storage.conf contains layerstore path with :ref suffix
+		// =====================================================================
+		g.By("Phase 4: Verifying storage.conf contains stargz-store path with :ref suffix")
+		layerStoreConf, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// MCO automatically appends :ref suffix to all additionalLayerStores paths
+		expectedPathWithRef := layerStorePath + ":ref"
+		o.Expect(layerStoreConf).To(o.ContainSubstring("additionallayerstores"),
+			"storage.conf should contain additionallayerstores on node %s", testNode)
+		o.Expect(layerStoreConf).To(o.ContainSubstring(expectedPathWithRef),
+			"storage.conf should contain %s with :ref suffix on node %s", expectedPathWithRef, testNode)
+		framework.Logf("Node %s: storage.conf verified with path %s (MCO added :ref)", testNode, expectedPathWithRef)
+
+		g.By("Verifying CRI-O is active with new configuration")
+		crioStatus, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "crio")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(crioStatus)).To(o.Equal("active"))
+		framework.Logf("CRI-O is active")
+
+		// Phase 5: Test artifact store functionality
+		g.By("Phase 5: Testing additionalArtifactStores - verify path configured")
+
+		// Verify artifact store path in CRI-O config
+		crioConf, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/crio/crio.conf.d/01-ctrcfg-additionalArtifactStores")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(crioConf).To(o.ContainSubstring(artifactStorePath))
+		framework.Logf("Artifact store path verified in CRI-O config")
+
+		// Create a test artifact file
+		artifactTestFile := artifactStorePath + "/test-artifact.txt"
+		createArtifactCmd := fmt.Sprintf("echo 'test artifact content' > %s", artifactTestFile)
+		_, err = ExecOnNodeWithChroot(oc, testNode, "bash", "-c", createArtifactCmd)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify artifact file exists
+		artifactCheck, err := ExecOnNodeWithChroot(oc, testNode, "cat", artifactTestFile)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(artifactCheck).To(o.ContainSubstring("test artifact content"))
+		framework.Logf("Artifact store verified - can read/write artifacts")
+
+		// Phase 6: Test image store functionality - prepopulation and fallback
+		g.By("Phase 6a: Testing additionalImageStores - verify pre-populated image accessible")
+
+		// Check storage.conf has the image store path
+		storageConf, err := ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(storageConf).To(o.ContainSubstring(imageStorePath))
+		framework.Logf("Image store path verified in storage.conf")
+
+		// Test prepopulated image by creating a pod
+		g.By("Phase 6b: Creating pod using prepopulated image")
+		testPod1 := createTestPod("imagestore-prepop-pod", testNamespace, testImage, testNode)
+		startTime1 := time.Now()
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, testPod1, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForPodRunning(ctx, oc, testPod1.Name, 5*time.Minute)
+		if err != nil {
+			// Get pod logs to diagnose failure
+			logs, logErr := oc.AdminKubeClient().CoreV1().Pods(testNamespace).GetLogs(testPod1.Name, &corev1.PodLogOptions{}).DoRaw(ctx)
+			if logErr == nil {
+				framework.Logf("Pod logs: %s", string(logs))
+			}
+			// Get pod events and status
+			podObj, getErr := oc.AdminKubeClient().CoreV1().Pods(testNamespace).Get(ctx, testPod1.Name, metav1.GetOptions{})
+			if getErr == nil {
+				framework.Logf("Pod status: %+v", podObj.Status)
+				// Extract specific failure reason
+				if len(podObj.Status.ContainerStatuses) > 0 {
+					containerStatus := podObj.Status.ContainerStatuses[0]
+					if containerStatus.State.Waiting != nil {
+						o.Expect(err).NotTo(o.HaveOccurred(),
+							"Image store prepopulated pod failed - %s: %s (Image: %s)",
+							containerStatus.State.Waiting.Reason,
+							containerStatus.State.Waiting.Message,
+							testImage)
+					}
+				}
+			}
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "Image store prepopulated pod failed to start with image %s", testImage)
+		pod1Time := time.Since(startTime1)
+		framework.Logf("Pod using prepopulated image started in %v", pod1Time)
+
+		// Test fallback to registry
+		g.By("Phase 7: Testing fallback to registry when image removed from additional store")
+		err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Delete(ctx, testPod1.Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			_, err := oc.AdminKubeClient().CoreV1().Pods(testNamespace).Get(ctx, testPod1.Name, metav1.GetOptions{})
+			return apierrors.IsNotFound(err), nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Remove image from additional store
+		removeCmd := fmt.Sprintf("podman --root %s rmi %s", imageStorePath, testImage)
+		_, err = ExecOnNodeWithChroot(oc, testNode, "sh", "-c", removeCmd)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Removed image from additional store to test fallback")
+
+		// Create second pod - should fall back to registry
+		testPod2 := createTestPod("imagestore-fallback-pod", testNamespace, testImage, testNode)
+		startTime2 := time.Now()
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, testPod2, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(deletePodAndWait, ctx, oc, testNamespace, testPod2.Name)
+
+		err = waitForPodRunning(ctx, oc, testPod2.Name, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		pod2Time := time.Since(startTime2)
+		framework.Logf("Pod using registry fallback started in %v", pod2Time)
+
+		// Verify pod pulled from registry
+		var foundSuccessfullyPulled bool
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			events, _ := oc.AdminKubeClient().CoreV1().Events(testNamespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("involvedObject.name=%s", testPod2.Name),
+			})
+			for _, event := range events.Items {
+				if event.Reason == "Pulled" && strings.Contains(event.Message, "Successfully pulled") {
+					foundSuccessfullyPulled = true
+					framework.Logf("SUCCESS: Image pulled from registry - %s", event.Message)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(foundSuccessfullyPulled).To(o.BeTrue())
+		framework.Logf("Phase 7 PASSED: Fallback to registry works when image not in additional store")
+
+		// Clean up fallback test pod
+		deletePodAndWait(ctx, oc, testNamespace, testPod2.Name)
+
+		// Phase 8: Final verification
+		g.By("Phase 8: Final verification - all storage types functional")
+		framework.Logf("✓ Layer stores: :ref suffix verified in storage.conf")
+		framework.Logf("✓ Image stores: pre-populated images accessible")
+		framework.Logf("✓ Artifact stores: can read/write artifacts")
+
+		framework.Logf("Test PASSED: All storage types verified functionally")
+	})
+
+	// ========================================================================
+	// Additional Layer Stores E2E - Comprehensive Lifecycle
+	// ========================================================================
+	g.It("should perform comprehensive lifecycle for layerstores: deploy stargz, configure, verify lazy pulling, update stores, maximum stores, and fallback scenario", func(ctx context.Context) {
+		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// =====================================================================
+		// SETUP: Create single-node MachineConfigPool for faster rollouts
+		// =====================================================================
+		g.By("Getting worker node for test")
+		workerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(workerNodes).NotTo(o.BeEmpty(), "no worker nodes available")
+		testNode := workerNodes[0].Name
+
+		mcpName := "layer-test-mcp"
+		var mcpConfig *CustomMCPConfig
+		testNamespace := oc.Namespace()
+		pod1Name := "stargz-test-pod-1"
+		pod2Name := "stargz-test-pod-2"
+		g.DeferCleanup(func() {
+			cleanupCtx := context.Background()
+			delErr := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(
+				cleanupCtx, "stargz-comprehensive-test", metav1.DeleteOptions{})
+			if delErr != nil && !apierrors.IsNotFound(delErr) {
+				framework.Logf("Warning: failed to delete ContainerRuntimeConfig %s: %v", "stargz-comprehensive-test", delErr)
+			}
+			cleanupSingleNodeMCP(cleanupCtx, mcpConfig)
+		})
+
+		g.By("Creating single-node MachineConfigPool for test isolation")
+		mcpConfig = createSingleNodeMCP(ctx, oc, mcpName, testNode)
+		framework.Logf("Custom MCP %s created, targeting node %s", mcpName, testNode)
+
+		eStargzImage := "quay.io/openshifttest/additional-storage-tests:test-image-estargz"
+
+		// Clean up any cached eStargz images from previous test runs
+		// This prevents "layer not known" errors on reused test clusters
+		framework.Logf("Cleaning cached eStargz images from previous runs")
+		_, _ = ExecOnNodeWithChroot(oc, testNode, "crictl", "rmi", eStargzImage)
+
+		// =====================================================================
+		// PHASE 1: Deploy stargz-store
+		// =====================================================================
+		g.By("PHASE 1: Deploying stargz-store")
+		testLabel := fmt.Sprintf("node-role.kubernetes.io/%s", mcpName)
+		stargzSetup := NewStargzStoreSetup(oc, testLabel)
+		err = stargzSetup.Deploy(ctx)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(func() {
+			cleanupCtx := context.Background()
+			// Delete pods first to release image references
+			deletePodAndWait(cleanupCtx, oc, testNamespace, pod1Name)
+			deletePodAndWait(cleanupCtx, oc, testNamespace, pod2Name)
+			stargzSetup.Cleanup(context.Background())
+		})
+		framework.Logf("stargz-store deployed successfully")
+
+		g.By("Verifying stargz-store service is active on test node")
+		output, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "stargz-store")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(output)).To(o.Equal("active"))
+		framework.Logf("Node %s: stargz-store service active", testNode)
+
+		// =====================================================================
+		// PHASE 2: Create ContainerRuntimeConfig with stargz-store path
+		// =====================================================================
+		g.By("PHASE 2: Creating ContainerRuntimeConfig with stargz-store path")
+		ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "stargz-comprehensive-test",
+			},
+			Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machineconfiguration.openshift.io/pool": mcpName,
+					},
+				},
+				ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+					AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+						{Path: machineconfigv1.StorePath(stargzSetup.GetStorePath())},
+					},
+				},
+			},
+		}
+		_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+			ctx, ctrcfg, metav1.CreateOptions{},
+		)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("ContainerRuntimeConfig %s created with path: %s", ctrcfg.Name, stargzSetup.GetStorePath())
+
+		// =====================================================================
+		// PHASE 3: Verify MCP rollout (single node - faster)
+		// =====================================================================
+		g.By("PHASE 3: Waiting for MachineConfigPool rollout (single node)")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MachineConfigPool started updating")
+
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MachineConfigPool rollout completed")
+
+		g.By("Verifying test node is Ready")
+		nodeObj, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(isNodeInReadyState(nodeObj)).To(o.BeTrue(),
+			"Node %s should be Ready after MCP rollout", testNode)
+		framework.Logf("Node %s: Ready", testNode)
+
+		g.By("Re-verifying stargz-store service is active after MCP rollout")
+		stargzStatus, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "stargz-store")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(stargzStatus)).To(o.Equal("active"))
+		framework.Logf("Node %s: stargz-store service still active after MCP rollout", testNode)
+
+		// Verify FUSE mount exists
+		mountOutput, err := ExecOnNodeWithChroot(oc, testNode, "mount")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if !strings.Contains(mountOutput, "stargz-store") {
+			framework.Logf("WARNING: stargz-store service is active but FUSE mount not found!")
+			framework.Logf("Mount output:\n%s", mountOutput)
+			o.Expect(mountOutput).To(o.ContainSubstring("stargz-store"),
+				"stargz-store FUSE mount at %s should exist when service is active", stargzSetup.GetStorePath())
+		}
+		framework.Logf("Node %s: stargz-store FUSE mount verified", testNode)
+
+		// =====================================================================
+		// PHASE 4: Verify storage.conf contains path with :ref suffix (MCO added)
+		// =====================================================================
+		g.By("PHASE 4: Verifying storage.conf contains stargz-store path with :ref suffix")
+		output, err = ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// MCO automatically appends :ref suffix to all additionalLayerStores paths
+		expectedPathWithRef := fmt.Sprintf("%s:ref", stargzSetup.GetStorePath())
+		o.Expect(output).To(o.ContainSubstring("additionallayerstores"),
+			"storage.conf should contain additionallayerstores on node %s", testNode)
+		o.Expect(output).To(o.ContainSubstring(expectedPathWithRef),
+			"storage.conf should contain %s with :ref suffix on node %s", stargzSetup.GetStorePath(), testNode)
+		framework.Logf("Node %s: storage.conf verified with path %s (MCO added :ref)", testNode, expectedPathWithRef)
+
+		g.By("Verifying CRI-O is active with new configuration")
+		crioStatus, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "crio")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(crioStatus)).To(o.Equal("active"))
+		framework.Logf("CRI-O is active")
+
+		// =====================================================================
+		// PHASE 5: Create first pod with eStargz image
+		// =====================================================================
+		g.By("PHASE 5: Getting initial snapshot count in stargz-store")
+		initialSnapshots, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Initial snapshot count: %d", initialSnapshots)
+
+		g.By("Creating first pod with eStargz format image")
+		framework.Logf("Using eStargz image: %s", eStargzImage)
+		pod1 := createTestPod(pod1Name, testNamespace, eStargzImage, testNode)
+
+		startTime1 := time.Now()
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, pod1, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for first pod to be running")
+		err = waitForPodRunning(ctx, oc, pod1Name, 5*time.Minute)
+		if err != nil {
+			// Get pod logs and status to diagnose failure
+			logs, logErr := oc.AdminKubeClient().CoreV1().Pods(testNamespace).GetLogs(pod1Name, &corev1.PodLogOptions{}).DoRaw(ctx)
+			if logErr == nil {
+				framework.Logf("Pod %s logs: %s", pod1Name, string(logs))
+			}
+			podObj, getErr := oc.AdminKubeClient().CoreV1().Pods(testNamespace).Get(ctx, pod1Name, metav1.GetOptions{})
+			if getErr == nil {
+				framework.Logf("Pod %s status: %+v", pod1Name, podObj.Status)
+				// Extract specific failure reason
+				if len(podObj.Status.ContainerStatuses) > 0 {
+					containerStatus := podObj.Status.ContainerStatuses[0]
+					if containerStatus.State.Waiting != nil {
+						o.Expect(err).NotTo(o.HaveOccurred(),
+							"Pod failed to start - %s: %s (Image: %s)",
+							containerStatus.State.Waiting.Reason,
+							containerStatus.State.Waiting.Message,
+							eStargzImage)
+					}
+				}
+			}
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "Pod %s failed to start with eStargz image %s", pod1Name, eStargzImage)
+		pod1Duration := time.Since(startTime1)
+		framework.Logf("First pod %s started in %v (initial pull with lazy loading)", pod1Name, pod1Duration)
+
+		// =====================================================================
+		// PHASE 6: Verify snapshot created in layer store path
+		// =====================================================================
+		g.By("PHASE 6: Verifying snapshot is created in stargz-store")
+
+		// Poll for snapshots to be created instead of sleeping
+		var snapshotsAfterPod1 int
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+			count, countErr := getStargzSnapshotCount(oc, testNode)
+			if countErr != nil {
+				return false, countErr
+			}
+			snapshotsAfterPod1 = count
+			if snapshotsAfterPod1 > initialSnapshots {
+				framework.Logf("Snapshots created in stargz-store (lazy pulling verified)")
+				return true, nil
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "Snapshots should be created after pulling eStargz image")
+
+		// Verify stargz-store contains layer snapshots (check recursively since sha256 dirs are nested)
+		storeOutput, err := ExecOnNodeWithChroot(oc, testNode, "find", "/var/lib/stargz-store/store/", "-name", "sha256:*", "-type", "d")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if !strings.Contains(storeOutput, "sha256:") || snapshotsAfterPod1 == 0 {
+			// If verification fails, show detailed recursive listing for debugging
+			detailedOutput, detailErr := ExecOnNodeWithChroot(oc, testNode, "ls", "-lR", "/var/lib/stargz-store/store/")
+			if detailErr == nil {
+				framework.Logf("stargz-store detailed contents (verification failed):\n%s", detailedOutput)
+			}
+		} else {
+			framework.Logf("stargz-store verified: contains layer directories with sha256 digests")
+		}
+
+		o.Expect(storeOutput).To(o.ContainSubstring("sha256:"),
+			"stargz-store should contain layer directories with sha256 digests")
+
+		// =====================================================================
+		// PHASE 7: Create second pod with same image
+		// =====================================================================
+		g.By("PHASE 7: Creating second pod with same eStargz image")
+		pod2 := createTestPod(pod2Name, testNamespace, eStargzImage, testNode)
+
+		startTime2 := time.Now()
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, pod2, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for second pod to be running")
+		err = waitForPodRunning(ctx, oc, pod2Name, 3*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		pod2Duration := time.Since(startTime2)
+		framework.Logf("Second pod %s started in %v (using shared layers)", pod2Name, pod2Duration)
+
+		// Log performance comparison for informational purposes
+		g.By("Logging performance comparison with layer sharing")
+		speedup := float64(pod1Duration) / float64(pod2Duration)
+		framework.Logf("Performance comparison:")
+		framework.Logf("  - First pod (initial pull):  %v", pod1Duration)
+		framework.Logf("  - Second pod (layer sharing): %v", pod2Duration)
+		framework.Logf("  - Performance improvement: %.2fx faster with layer sharing", speedup)
+
+		// =====================================================================
+		// PHASE 8: Verify second pod used existing snapshot (no new layers)
+		// =====================================================================
+		g.By("PHASE 8: Verifying second pod used existing snapshot")
+		pod2Events, _ := oc.Run("describe").Args("pod", pod2Name).Output()
+		framework.Logf("Second pod events: %s", pod2Events)
+
+		snapshotsAfterPod2, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(snapshotsAfterPod2).To(o.Equal(snapshotsAfterPod1),
+			"Snapshot count should remain same when using shared layers")
+		framework.Logf("Layer sharing verified: second pod reused existing snapshots")
+
+		// =====================================================================
+		// PHASE 9: Verify through stargz-store and crio logs
+		// =====================================================================
+		g.By("PHASE 9: Verifying through stargz-store logs")
+		stargzLogs, _ := ExecOnNodeWithChroot(oc, testNode, "journalctl", "-u", "stargz-store", "--since", "5 minutes ago", "-n", "50")
+		framework.Logf("Recent stargz-store logs:\n%s", stargzLogs)
+
+		g.By("Verifying through CRI-O logs")
+		crioLogs, _ := ExecOnNodeWithChroot(oc, testNode, "journalctl", "-u", "crio", "--since", "5 minutes ago", "--grep", eStargzImage, "-n", "20")
+		framework.Logf("Recent CRI-O logs for image:\n%s", crioLogs)
+
+		// =====================================================================
+		// PHASE 10: Remove pods
+		// =====================================================================
+		g.By("PHASE 10: Removing test pods")
+		err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Delete(ctx, pod1Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForPodDeleted(ctx, oc, pod1Name, 2*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to wait for pod %s deletion", pod1Name)
+
+		err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Delete(ctx, pod2Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = waitForPodDeleted(ctx, oc, pod2Name, 2*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to wait for pod %s deletion", pod2Name)
+		framework.Logf("Test pods removed")
+
+		// =====================================================================
+		// PHASE 11: Create directories for additional layer stores
+		// =====================================================================
+		g.By("PHASE 11: Creating additional layer store directories for update testing")
+		testNodeObj, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, testNode, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		layerDirs := []string{"/var/lib/layerstore-1", "/var/lib/layerstore-2", "/var/lib/layerstore-3", "/var/lib/layerstore-4"}
+		err = createDirectoriesOnNodes(oc, []corev1.Node{*testNodeObj}, layerDirs)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		g.DeferCleanup(cleanupDirectoriesOnNodes, oc, []corev1.Node{*testNodeObj}, layerDirs)
+		framework.Logf("Created %d additional layer store directories", len(layerDirs))
+
+		// =====================================================================
+		// PHASE 12: Update CRC to add second layer store
+		// =====================================================================
+		g.By("PHASE 12: Updating ContainerRuntimeConfig to add second layer store")
+		currentCfg, err := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Get(ctx, ctrcfg.Name, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		currentCfg.Spec.ContainerRuntimeConfig.AdditionalLayerStores = []machineconfigv1.AdditionalLayerStore{
+			{Path: machineconfigv1.StorePath(stargzSetup.GetStorePath())},
+			{Path: machineconfigv1.StorePath("/var/lib/layerstore-1")},
+		}
+		_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Update(ctx, currentCfg, metav1.UpdateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Updated CRC to include 2 layer stores")
+
+		err = waitForContainerRuntimeConfigSuccess(ctx, mcClient, ctrcfg.Name, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool to start updating after adding second store")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool rollout to complete after update")
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MCP rollout completed with 2 layer stores")
+
+		g.By("Verifying both layer stores in storage.conf")
+		output, err = ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring(fmt.Sprintf("%s:ref", stargzSetup.GetStorePath())))
+		o.Expect(output).To(o.ContainSubstring("/var/lib/layerstore-1:ref"))
+		framework.Logf("Node %s: Both layer stores verified in storage.conf", testNode)
+
+		// =====================================================================
+		// PHASE 13: Update CRC to maximum 5 layer stores
+		// =====================================================================
+		g.By("PHASE 13: Updating ContainerRuntimeConfig to maximum 5 layer stores")
+		currentCfg, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Get(ctx, ctrcfg.Name, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		currentCfg.Spec.ContainerRuntimeConfig.AdditionalLayerStores = []machineconfigv1.AdditionalLayerStore{
+			{Path: machineconfigv1.StorePath(stargzSetup.GetStorePath())},
+			{Path: machineconfigv1.StorePath("/var/lib/layerstore-1")},
+			{Path: machineconfigv1.StorePath("/var/lib/layerstore-2")},
+			{Path: machineconfigv1.StorePath("/var/lib/layerstore-3")},
+			{Path: machineconfigv1.StorePath("/var/lib/layerstore-4")},
+		}
+		_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Update(ctx, currentCfg, metav1.UpdateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Updated CRC to include 5 layer stores (maximum)")
+
+		err = waitForContainerRuntimeConfigSuccess(ctx, mcClient, ctrcfg.Name, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool to start updating after adding to max stores")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for MachineConfigPool rollout to complete with max stores")
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MCP rollout completed with 5 layer stores (maximum)")
+
+		g.By("Verifying all 5 layer stores in storage.conf")
+		allLayerDirs := []string{stargzSetup.GetStorePath(), "/var/lib/layerstore-1", "/var/lib/layerstore-2", "/var/lib/layerstore-3", "/var/lib/layerstore-4"}
+		output, err = ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		for _, dir := range allLayerDirs {
+			expectedPathWithRef := fmt.Sprintf("%s:ref", dir)
+			o.Expect(output).To(o.ContainSubstring(expectedPathWithRef),
+				"storage.conf should contain %s on node %s", expectedPathWithRef, testNode)
+		}
+		framework.Logf("Node %s: All 5 layer stores verified in storage.conf", testNode)
+
+		// =====================================================================
+		// PHASE 14: Delete ContainerRuntimeConfig
+		// =====================================================================
+		g.By("PHASE 14: Deleting ContainerRuntimeConfig")
+		err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(ctx, ctrcfg.Name, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("ContainerRuntimeConfig %s deleted", ctrcfg.Name)
+
+		g.By("Waiting for MachineConfigPool to start updating after deletion")
+		err = waitForMCPToStartUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MachineConfigPool started updating after CRC deletion")
+
+		g.By("Waiting for MachineConfigPool rollout to complete after deletion")
+		err = waitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("MachineConfigPool rollout completed after deletion")
+
+		// =====================================================================
+		// PHASE 15: Verify storage.conf cleanup (path removed)
+		// =====================================================================
+		g.By("PHASE 15: Verifying storage.conf cleanup after CRC deletion")
+		output, err = ExecOnNodeWithChroot(oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.ContainSubstring(stargzSetup.GetStorePath()),
+			"storage.conf should not contain stargz-store path after ContainerRuntimeConfig deletion on node %s",
+			testNode)
+		framework.Logf("Node %s: stargz-store path removed from storage.conf", testNode)
+
+		// =====================================================================
+		// PHASE 16: Test fallback with standard OCI image (non-eStargz)
+		// =====================================================================
+		g.By("PHASE 16: Testing fallback with standard OCI image (non-eStargz)")
+		standardImage := "quay.io/openshifttest/additional-storage-tests:test-6gb-standard-v2.0"
+		framework.Logf("Using standard OCI image (non-eStargz): %s", standardImage)
+
+		snapshotsBeforeFallback, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Snapshots before standard image test: %d", snapshotsBeforeFallback)
+
+		fallbackPodName := "fallback-standard-oci-pod"
+		fallbackPod := createTestPod(fallbackPodName, testNamespace, standardImage, testNode)
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, fallbackPod, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForPodRunning(ctx, oc, fallbackPodName, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Pod started successfully with standard OCI image")
+
+		snapshotsAfterFallback, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		snapshotDiff := snapshotsAfterFallback - snapshotsBeforeFallback
+		framework.Logf("Snapshots after standard image: %d (diff: %d)", snapshotsAfterFallback, snapshotDiff)
+
+		o.Expect(snapshotDiff).To(o.BeNumerically("<=", 1),
+			"Standard OCI image should not create significant stargz snapshots (fallback to standard pull)")
+
+		deletePodAndWait(ctx, oc, testNamespace, fallbackPodName)
+		framework.Logf("16. Standard OCI image fallback: YES")
+
+		// =====================================================================
+		// PHASE 17: Stop stargz-store and test eStargz fallback
+		// =====================================================================
+		g.By("PHASE 17: Stopping stargz-store service")
+		_, err = ExecOnNodeWithChroot(oc, testNode, "systemctl", "stop", "stargz-store")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("stargz-store service stopped")
+
+		statusOutput, err := ExecOnNodeWithChroot(oc, testNode, "systemctl", "is-active", "stargz-store")
+		framework.Logf("stargz-store status: %s", strings.TrimSpace(statusOutput))
+		o.Expect(strings.TrimSpace(statusOutput)).NotTo(o.Equal("active"))
+
+		g.By("PHASE 18: Testing eStargz image fallback when stargz-store is stopped")
+		// Use a different eStargz image to test cold-start fallback (not cached)
+		fallbackEStargzImage := "quay.io/openshifttest/additional-storage-tests:test-image-estargz-v1.0"
+		framework.Logf("Using different eStargz image for fallback test: %s", fallbackEStargzImage)
+
+		snapshotsBeforeStop, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		fallbackPod2Name := "fallback-estargz-stopped-pod"
+		fallbackPod2 := createTestPod(fallbackPod2Name, testNamespace, fallbackEStargzImage, testNode)
+		_, err = oc.AdminKubeClient().CoreV1().Pods(testNamespace).Create(ctx, fallbackPod2, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = waitForPodRunning(ctx, oc, fallbackPod2Name, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Pod running successfully with stargz-store stopped (fallback to standard pull)")
+
+		snapshotsAfterStop, err := getStargzSnapshotCount(oc, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		snapshotDiffAfterStop := snapshotsAfterStop - snapshotsBeforeStop
+		framework.Logf("Snapshots after stargz stopped: %d (diff: %d)", snapshotsAfterStop, snapshotDiffAfterStop)
+
+		o.Expect(snapshotDiffAfterStop).To(o.BeNumerically("<=", 1),
+			"eStargz image should fallback to standard pull when stargz-store is stopped")
+
+		deletePodAndWait(ctx, oc, testNamespace, fallbackPod2Name)
+
+		// Restart stargz-store for cleanup
+		g.By("Restarting stargz-store service for cleanup")
+		_, err = ExecOnNodeWithChroot(oc, testNode, "systemctl", "start", "stargz-store")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("stargz-store service restarted")
+
+		// Final Summary
+		framework.Logf("========================================")
+		framework.Logf("COMPREHENSIVE TEST RESULTS SUMMARY ")
+		framework.Logf("========================================")
+		framework.Logf("1. stargz-store deployed: YES")
+		framework.Logf("2. stargz-store service active: YES")
+		framework.Logf("3. ContainerRuntimeConfig applied (1 store): YES")
+		framework.Logf("4. MCO/MCP rollout completed: YES")
+		framework.Logf("5. storage.conf updated with :ref: YES")
+		framework.Logf("6. CRI-O active: YES")
+		framework.Logf("7. All nodes Ready: YES")
+		framework.Logf("8. First pod with eStargz created: YES")
+		framework.Logf("9. Snapshots created (lazy pull): YES")
+		framework.Logf("10. Second pod layer sharing: VERIFIED")
+		framework.Logf("11. stargz-store logs verified: YES")
+		framework.Logf("12. CRI-O logs verified: YES")
+		framework.Logf("13. Pods removed: YES")
+		framework.Logf("14. CRC updated to 2 layer stores: YES")
+		framework.Logf("15. MCP rollout with 2 stores: YES")
+		framework.Logf("16. CRC updated to 5 layer stores max: YES")
+		framework.Logf("17. MCP rollout with 5 stores: YES")
+		framework.Logf("18. All 5 stores verified in storage.conf: YES")
+		framework.Logf("19. CRC deleted: YES")
+		framework.Logf("20. storage.conf cleanup: YES")
+		framework.Logf("22. stargz-store stopped fallback: YES")
+		framework.Logf("23. eStargz fallback to standard pull: YES")
+		framework.Logf("========================================")
+		framework.Logf("Image: %s", eStargzImage)
+		framework.Logf("Test Node: %s", testNode)
+		framework.Logf("========================================")
+		framework.Logf("Test PASSED: Comprehensive additionalLayerStores E2E with fallback verification complete")
+	})
+
+})

--- a/test/extended/node/node_mcp_helpers.go
+++ b/test/extended/node/node_mcp_helpers.go
@@ -1,0 +1,242 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	corev1 "k8s.io/api/core/v1"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var standardNodeRoles = map[string]bool{
+	"worker":        true,
+	"control-plane": true,
+	"master":        true,
+}
+
+func NodeHasCustomRole(node corev1.Node) (string, bool) {
+	const prefix = "node-role.kubernetes.io/"
+	for label := range node.Labels {
+		if strings.HasPrefix(label, prefix) {
+			role := strings.TrimPrefix(label, prefix)
+			if !standardNodeRoles[role] {
+				return role, true
+			}
+		}
+	}
+	return "", false
+}
+
+func EnsureNodeHasNoCustomRole(ctx context.Context, oc *exutil.CLI, nodeName string) error {
+	node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get node %s: %w", nodeName, err)
+	}
+	if role, found := NodeHasCustomRole(*node); found {
+		return fmt.Errorf("node %s already has custom role %q; another test's MCP cleanup may not have completed", nodeName, role)
+	}
+	return nil
+}
+
+// CustomMCPConfig holds the configuration for a custom MachineConfigPool setup.
+// This is returned by CreateCustomMCPForNode and should be passed to CleanupCustomMCP.
+type CustomMCPConfig struct {
+	// Name is the name of the custom MachineConfigPool
+	Name string
+	// NodeName is the name of the node labeled and added to the MCP
+	NodeName string
+	// MCClient is the machine config client for MCP operations
+	MCClient *machineconfigclient.Clientset
+	// KubeClient is the Kubernetes client for node operations
+	KubeClient *exutil.CLI
+}
+
+// CreateCustomMCPForNode creates a custom MachineConfigPool and labels a node to join it.
+// It returns a CustomMCPConfig that should be passed to CleanupCustomMCP for cleanup.
+// This is useful for tests that need to apply custom KubeletConfigs to specific nodes
+// without affecting the entire worker pool.
+//
+// The function performs the following steps:
+// 1. Labels the specified node with "node-role.kubernetes.io/<mcpName>"
+// 2. Creates a custom MachineConfigPool that targets nodes with that label
+// 3. Waits for the MCP to become ready (up to 5 minutes)
+//
+// Example usage:
+//
+//	mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+//	o.Expect(err).NotTo(o.HaveOccurred())
+//
+//	mcpConfig, err := CreateCustomMCPForNode(ctx, oc, mcClient, "my-test-pool", nodeName)
+//	o.Expect(err).NotTo(o.HaveOccurred())
+//	defer CleanupCustomMCP(context.Background(), mcpConfig)
+//
+//	// Now you can create KubeletConfigs targeting this MCP
+//	// The node will apply configs without affecting other workers
+func CreateCustomMCPForNode(ctx context.Context, oc *exutil.CLI, mcClient *machineconfigclient.Clientset, mcpName, nodeName string) (*CustomMCPConfig, error) {
+	config := &CustomMCPConfig{
+		Name:       mcpName,
+		NodeName:   nodeName,
+		MCClient:   mcClient,
+		KubeClient: oc,
+	}
+
+	if err := EnsureNodeHasNoCustomRole(ctx, oc, nodeName); err != nil {
+		return nil, err
+	}
+
+	nodeLabel := fmt.Sprintf("node-role.kubernetes.io/%s", mcpName)
+
+	framework.Logf("Labeling node %s with %s", nodeName, nodeLabel)
+	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nodeLabel))
+	_, err := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to label node %s: %w", nodeName, err)
+	}
+
+	// Step 2: Create custom MachineConfigPool
+	framework.Logf("Creating custom MachineConfigPool %s", mcpName)
+	mcp := &machineconfigv1.MachineConfigPool{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "machineconfiguration.openshift.io/v1",
+			Kind:       "MachineConfigPool",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcpName,
+			Labels: map[string]string{
+				"machineconfiguration.openshift.io/pool": mcpName,
+			},
+		},
+		Spec: machineconfigv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "machineconfiguration.openshift.io/role",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", mcpName},
+					},
+				},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					nodeLabel: "",
+				},
+			},
+		},
+	}
+
+	_, err = mcClient.MachineconfigurationV1().MachineConfigPools().Create(ctx, mcp, metav1.CreateOptions{})
+	if err != nil {
+		// Cleanup the node label if MCP creation fails
+		framework.Logf("MCP creation failed, removing node label")
+		unlabelPatchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nodeLabel))
+		_, _ = oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, unlabelPatchData, metav1.PatchOptions{})
+		return nil, fmt.Errorf("failed to create MachineConfigPool %s: %w", mcpName, err)
+	}
+
+	// Step 3: Wait for MCP to become ready
+	framework.Logf("Waiting for custom MachineConfigPool %s to be ready", mcpName)
+	err = WaitForMCP(ctx, mcClient, mcpName, 5*time.Minute)
+	if err != nil {
+		return config, fmt.Errorf("MachineConfigPool %s did not become ready: %w", mcpName, err)
+	}
+
+	framework.Logf("Custom MachineConfigPool %s created successfully", mcpName)
+	return config, nil
+}
+
+// CleanupCustomMCP removes the custom MachineConfigPool and unlabels the node,
+// returning it to the worker pool. It should be called in a defer or cleanup
+// handler after CreateCustomMCPForNode.
+//
+// The function performs the following steps:
+// 1. Removes the custom node label from the node
+// 2. Waits for the node to transition back to the worker pool (up to 7 minutes)
+// 3. Deletes the custom MachineConfigPool
+// 4. Waits for the worker MCP to stabilize (up to 10 minutes)
+//
+// This function is idempotent and safe to call multiple times. It handles
+// NotFound errors gracefully, making it safe to use even if resources were
+// already cleaned up.
+//
+// Example usage:
+//
+//	mcpConfig, err := CreateCustomMCPForNode(ctx, oc, mcClient, "my-test-pool", nodeName)
+//	o.Expect(err).NotTo(o.HaveOccurred())
+//	defer func() {
+//		err := CleanupCustomMCP(context.Background(), mcpConfig)
+//		if err != nil {
+//			framework.Logf("Warning: cleanup had errors: %v", err)
+//		}
+//	}()
+func CleanupCustomMCP(ctx context.Context, config *CustomMCPConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	nodeLabel := fmt.Sprintf("node-role.kubernetes.io/%s", config.Name)
+	var cleanupErrors []error
+
+	// Step 1: Remove node label
+	framework.Logf("Removing node label %s from node %s", nodeLabel, config.NodeName)
+	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nodeLabel))
+	_, err := config.KubeClient.AdminKubeClient().CoreV1().Nodes().Patch(ctx, config.NodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to remove label from node %s: %w", config.NodeName, err))
+	}
+
+	// Step 2: Wait for node to transition back to worker pool
+	if err == nil || apierrors.IsNotFound(err) {
+		framework.Logf("Waiting for node %s to transition back to worker pool", config.NodeName)
+		transitionErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 7*time.Minute, true, func(ctx context.Context) (bool, error) {
+			node, getErr := config.KubeClient.AdminKubeClient().CoreV1().Nodes().Get(ctx, config.NodeName, metav1.GetOptions{})
+			if apierrors.IsNotFound(getErr) {
+				// Node was deleted, consider it transitioned
+				return true, nil
+			}
+			if getErr != nil {
+				return false, nil
+			}
+			currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+			desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+			isWorkerConfig := currentConfig != "" && !strings.Contains(currentConfig, config.Name) && currentConfig == desiredConfig
+			return isWorkerConfig, nil
+		})
+		if transitionErr != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("node %s did not transition back to worker pool: %w", config.NodeName, transitionErr))
+		}
+	}
+
+	// Step 3: Delete the custom MachineConfigPool
+	framework.Logf("Deleting custom MachineConfigPool %s", config.Name)
+	deleteErr := config.MCClient.MachineconfigurationV1().MachineConfigPools().Delete(ctx, config.Name, metav1.DeleteOptions{})
+	if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		cleanupErrors = append(cleanupErrors, fmt.Errorf("failed to delete MachineConfigPool %s: %w", config.Name, deleteErr))
+	}
+
+	// Step 4: Wait for worker MCP to stabilize
+	if deleteErr == nil || apierrors.IsNotFound(deleteErr) {
+		framework.Logf("Waiting for worker MCP to stabilize after custom MCP deletion")
+		waitErr := WaitForMCP(ctx, config.MCClient, "worker", 10*time.Minute)
+		if waitErr != nil && !apierrors.IsNotFound(waitErr) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("worker MCP did not stabilize: %w", waitErr))
+		}
+	}
+
+	if len(cleanupErrors) > 0 {
+		return fmt.Errorf("cleanup completed with errors: %v", cleanupErrors)
+	}
+
+	framework.Logf("Custom MachineConfigPool %s cleaned up successfully", config.Name)
+	return nil
+}

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"time"
 
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,9 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/test/e2e/framework"
-
-	g "github.com/onsi/ginkgo/v2"
-	o "github.com/onsi/gomega"
 
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -265,6 +265,7 @@ func isTransientNetworkError(err error) bool {
 
 // waitForNodeToBeReady waits for a node to become Ready
 func waitForNodeToBeReady(ctx context.Context, oc *exutil.CLI, nodeName string) {
+	g.GinkgoHelper()
 	o.Eventually(func() bool {
 		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
@@ -529,6 +530,137 @@ func waitForHyperConvergedReady(ctx context.Context, oc *exutil.CLI) error {
 		}
 		framework.Logf("Waiting for HyperConverged to become Available...")
 		return false, nil
+	})
+}
+
+func waitForMCPToStartUpdating(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration) error {
+	framework.Logf("Waiting for MCP %s to start updating (timeout: %v)...", poolName, timeout)
+
+	// First get current rendered config to detect change
+	initialMCP, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	initialConfig := initialMCP.Status.Configuration.Name
+	framework.Logf("Initial rendered config: %s", initialConfig)
+
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		// Check if config changed or MCP is updating
+		configChanged := mcp.Status.Configuration.Name != initialConfig
+		updating := false
+		for _, condition := range mcp.Status.Conditions {
+			if condition.Type == "Updating" && condition.Status == corev1.ConditionTrue {
+				updating = true
+				break
+			}
+		}
+
+		if configChanged || updating {
+			framework.Logf("MCP %s started updating: configChanged=%v, updating=%v, newConfig=%s",
+				poolName, configChanged, updating, mcp.Status.Configuration.Name)
+			return true, nil
+		}
+
+		framework.Logf("MCP %s not yet updating, waiting for MCO to process config change...", poolName)
+		return false, nil
+	})
+}
+
+// WaitForMCP waits for a MachineConfigPool to be ready (not updating, updated, and all machines ready).
+// By default it returns an error immediately if the MCP becomes degraded.
+func WaitForMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration, opts ...func(*waitMCPOptions)) error {
+	options := waitMCPOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	framework.Logf("Waiting for MCP %s to be ready (timeout: %v)...", poolName, timeout)
+
+	poolSeen := false
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Only treat NotFound as success when draining a pool we have previously observed.
+				// A typo in poolName must not pass silently on the first poll.
+				if poolSeen && options.machineCount != nil && *options.machineCount == 0 {
+					framework.Logf("MachineConfigPool %s no longer exists after draining to 0 machines", poolName)
+					return true, nil
+				}
+			}
+			return false, err
+		}
+		poolSeen = true
+
+		updating := false
+		degraded := false
+		renderDegraded := false
+		ready := false
+
+		for _, condition := range mcp.Status.Conditions {
+			switch condition.Type {
+			case machineconfigv1.MachineConfigPoolUpdating:
+				if condition.Status == corev1.ConditionTrue {
+					updating = true
+				}
+			case machineconfigv1.MachineConfigPoolDegraded:
+				if condition.Status == corev1.ConditionTrue {
+					degraded = true
+				}
+			case machineconfigv1.MachineConfigPoolRenderDegraded:
+				if condition.Status == corev1.ConditionTrue {
+					renderDegraded = true
+				}
+			case machineconfigv1.MachineConfigPoolUpdated:
+				if condition.Status == corev1.ConditionTrue {
+					ready = true
+				}
+			}
+		}
+
+		if !options.allowDegraded {
+			if degraded {
+				return false, fmt.Errorf("MachineConfigPool %s is degraded", poolName)
+			}
+			if renderDegraded {
+				return false, fmt.Errorf("MachineConfigPool %s render is degraded", poolName)
+			}
+		}
+
+		// Drained pool: all nodes removed and conditions stable before cleanup continues.
+		if options.machineCount != nil && *options.machineCount == 0 {
+			isDrained := mcp.Status.MachineCount == 0 &&
+				mcp.Status.ReadyMachineCount == 0 &&
+				!updating && !degraded && !renderDegraded
+			if isDrained {
+				framework.Logf("MachineConfigPool %s drained: 0 machines, not updating/degraded", poolName)
+				return true, nil
+			}
+			framework.Logf("MachineConfigPool %s waiting to drain: updating=%v degraded=%v renderDegraded=%v machines=%d/%d",
+				poolName, updating, degraded, renderDegraded, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+			return false, nil
+		}
+
+		isReady := !updating && !degraded && !renderDegraded && ready &&
+			mcp.Status.MachineCount > 0 && mcp.Status.ReadyMachineCount == mcp.Status.MachineCount
+		if options.machineCount != nil {
+			isReady = isReady && mcp.Status.MachineCount == *options.machineCount
+		}
+
+		if isReady {
+			framework.Logf("MachineConfigPool %s is ready: %d/%d machines ready",
+				poolName, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+		} else {
+			framework.Logf("MachineConfigPool %s not ready yet: updating=%v degraded=%v renderDegraded=%v updated=%v machines=%d/%d",
+				poolName, updating, degraded, renderDegraded, ready, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+		}
+
+		return isReady, nil
 	})
 }
 
@@ -821,6 +953,7 @@ func ensureDropInDirectoryExists(ctx context.Context, oc *exutil.CLI, dirPath st
 
 // GetFirstReadyWorkerNode returns the name of the first Ready worker node in the cluster.
 func GetFirstReadyWorkerNode(oc *exutil.CLI) string {
+	g.GinkgoHelper()
 	nodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
 		"nodes", "-l", "node-role.kubernetes.io/worker",
 		"-o=jsonpath={.items[*].metadata.name}",
@@ -840,6 +973,227 @@ func GetFirstReadyWorkerNode(oc *exutil.CLI) string {
 	}
 	o.Expect(false).To(o.BeTrue(), "no Ready worker node found among %v", workers)
 	return "" // unreachable; satisfies compiler
+}
+
+// createDirectoriesOnNodes creates specified directories on the given nodes
+func createDirectoriesOnNodes(oc *exutil.CLI, nodes []corev1.Node, dirs []string) error {
+	for _, node := range nodes {
+		for _, dir := range dirs {
+			_, err := ExecOnNodeWithChroot(oc, node.Name, "mkdir", "-p", dir)
+			if err != nil {
+				return fmt.Errorf("failed to create directory %s on node %s: %v", dir, node.Name, err)
+			}
+			framework.Logf("Node %s: directory %s created", node.Name, dir)
+		}
+	}
+	return nil
+}
+
+// cleanupDirectoriesOnNodes removes specified directories from the given nodes
+func cleanupDirectoriesOnNodes(oc *exutil.CLI, nodes []corev1.Node, dirs []string) {
+	for _, node := range nodes {
+		for _, dir := range dirs {
+			_, err := ExecOnNodeWithChroot(oc, node.Name, "rm", "-rf", dir)
+			if err != nil {
+				framework.Logf("Warning: failed to cleanup directory %s on node %s: %v", dir, node.Name, err)
+			}
+		}
+	}
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func createTestPod(name, namespace, image, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Tolerations: []corev1.Toleration{
+				{
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:    int64Ptr(1000),
+				RunAsNonRoot: boolPtr(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "test",
+					Image:   image,
+					Command: []string{"sleep", "3600"},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: boolPtr(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: boolPtr(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}
+
+func waitForContainerRuntimeConfigSuccess(ctx context.Context, mcClient *machineconfigclient.Clientset, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		ctrcfg, err := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if ctrcfg.Status.ObservedGeneration != ctrcfg.Generation {
+			return false, nil
+		}
+
+		for _, condition := range ctrcfg.Status.Conditions {
+			if condition.Type == machineconfigv1.ContainerRuntimeConfigSuccess &&
+				condition.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+			if condition.Type == machineconfigv1.ContainerRuntimeConfigFailure &&
+				condition.Status == corev1.ConditionTrue {
+				return false, fmt.Errorf("ContainerRuntimeConfig failed: %s", condition.Message)
+			}
+		}
+		return false, nil
+	})
+}
+
+func waitForPodRunning(ctx context.Context, oc *exutil.CLI, podName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pod, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("Error getting pod %s: %v", podName, err)
+			return false, nil
+		}
+
+		framework.Logf("Pod %s status: Phase=%s, ContainerStatuses=%d", podName, pod.Status.Phase, len(pod.Status.ContainerStatuses))
+
+		// Check if pod is in Running phase
+		if pod.Status.Phase == corev1.PodRunning {
+			return true, nil
+		}
+
+		// Also consider pod as running if all containers are running, even if phase hasn't updated
+		if len(pod.Status.ContainerStatuses) > 0 {
+			allRunning := true
+			for _, cs := range pod.Status.ContainerStatuses {
+				if cs.State.Running == nil {
+					allRunning = false
+					framework.Logf("Container %s not yet running: %+v", cs.Name, cs.State)
+					break
+				}
+			}
+			if allRunning {
+				framework.Logf("All containers running, considering pod as running")
+				return true, nil
+			}
+		}
+
+		return false, nil
+	})
+}
+
+func waitForPodDeleted(ctx context.Context, oc *exutil.CLI, podName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+// createSingleNodeMCP creates a custom MachineConfigPool targeting a single worker node.
+// This is a wrapper around CreateCustomMCPForNode from node_mcp_helpers.go.
+// Returns the CustomMCPConfig that should be passed to cleanupSingleNodeMCP for cleanup.
+func createSingleNodeMCP(ctx context.Context, oc *exutil.CLI, mcpName, workerNode string) *CustomMCPConfig {
+	mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to create machine config client")
+
+	mcpConfig, err := CreateCustomMCPForNode(ctx, oc, mcClient, mcpName, workerNode)
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to create custom MCP")
+
+	return mcpConfig
+}
+
+// cleanupSingleNodeMCP removes the node label, waits for the node to transition back to the
+// worker pool config, and then deletes the custom MCP.
+// It uses the shared helper from node_mcp_helpers.go.
+func cleanupSingleNodeMCP(ctx context.Context, mcpConfig *CustomMCPConfig) {
+	if mcpConfig == nil {
+		return
+	}
+
+	err := CleanupCustomMCP(ctx, mcpConfig)
+	if err != nil {
+		framework.Logf("WARNING: cleanup had errors: %v", err)
+	}
+}
+
+// skipUnlessAdditionalStorageConfigEnabled verifies test prerequisites including platform check.
+// It performs the following checks in order:
+//  1. MicroShift cluster detection (skips - MachineConfig not available)
+//  2. Microsoft Azure platform detection (skips)
+//  3. AdditionalStorageConfig feature gate verification (skips if not enabled)
+func skipUnlessAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) {
+	// Skip on MicroShift - MachineConfig resources are not available
+	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+	if err != nil {
+		framework.Logf("Failed to detect MicroShift cluster: %v", err)
+		g.Skip("Cannot verify cluster type")
+	}
+	if isMicroShift {
+		g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
+	}
+
+	// Skip on Microsoft
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Failed to get Infrastructure resource: %v", err)
+		g.Skip("Cannot verify platform type")
+	}
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.AzurePlatformType {
+		g.Skip("Skipping test on Microsoft Azure cluster")
+	}
+
+	// Verify AdditionalStorageConfig feature gate is enabled
+	g.By("Verifying AdditionalStorageConfig feature gate is enabled")
+	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Failed to get FeatureGate resource: %v", err)
+		g.Skip("Cannot verify AdditionalStorageConfig feature gate requirement")
+	}
+
+	for _, fg := range fgs.Status.FeatureGates {
+		for _, enabledFG := range fg.Enabled {
+			if enabledFG.Name == "AdditionalStorageConfig" {
+				return // All prerequisites met, continue with test
+			}
+		}
+	}
+
+	g.Skip("Skipping test - AdditionalStorageConfig feature gate is not enabled")
 }
 
 // CalculateEventTimeDiff calculates the time difference between two Kubernetes events.
@@ -904,44 +1258,4 @@ func CheckNetNsCleaned(oc *exutil.CLI, nodeName, netNsPath string) error {
 	}
 	// No error means file still exists
 	return fmt.Errorf("NetNS file still exists at %s", netNsPath)
-}
-
-func skipUnlessAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) {
-	// Skip on MicroShift - MachineConfig resources are not available
-	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
-	if err != nil {
-		framework.Logf("Failed to detect MicroShift cluster: %v", err)
-		g.Skip("Cannot verify cluster type")
-	}
-	if isMicroShift {
-		g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
-	}
-
-	// Skip on Microsoft
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		framework.Logf("Failed to get Infrastructure resource: %v", err)
-		g.Skip("Cannot verify platform type")
-	}
-	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.AzurePlatformType {
-		g.Skip("Skipping test on Microsoft Azure cluster")
-	}
-
-	// Verify AdditionalStorageConfig feature gate is enabled
-	g.By("Verifying AdditionalStorageConfig feature gate is enabled")
-	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
-		framework.Logf("Failed to get FeatureGate resource: %v", err)
-		g.Skip("Cannot verify AdditionalStorageConfig feature gate requirement")
-	}
-
-	for _, fg := range fgs.Status.FeatureGates {
-		for _, enabledFG := range fg.Enabled {
-			if enabledFG.Name == "AdditionalStorageConfig" {
-				return // All prerequisites met, continue with test
-			}
-		}
-	}
-
-	g.Skip("Skipping test - AdditionalStorageConfig feature gate is not enabled")
 }

--- a/test/extended/node/stargz_store_setup.go
+++ b/test/extended/node/stargz_store_setup.go
@@ -1,0 +1,520 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	stargzStoreNamespace      = "stargz-store"
+	stargzStoreDaemonSetName  = "stargz-store-installer"
+	stargzStoreServiceAccount = "stargz-store-installer"
+	stargzStoreVersion        = "v0.18.2"
+	stargzStorePath           = "/var/lib/stargz-store/store"
+)
+
+// StargzStoreSetup manages the lifecycle of stargz-store on cluster nodes
+type StargzStoreSetup struct {
+	oc              *exutil.CLI
+	namespace       string
+	deployed        bool
+	targetNodeLabel string // Node label selector for DaemonSet (e.g., "node-role.kubernetes.io/worker")
+}
+
+// NewStargzStoreSetup creates a new StargzStoreSetup instance
+// targetNodeLabel specifies which nodes to deploy stargz-store to (e.g., "node-role.kubernetes.io/worker")
+func NewStargzStoreSetup(oc *exutil.CLI, targetNodeLabel string) *StargzStoreSetup {
+	return &StargzStoreSetup{
+		oc:              oc,
+		namespace:       stargzStoreNamespace,
+		deployed:        false,
+		targetNodeLabel: targetNodeLabel,
+	}
+}
+
+// Deploy installs stargz-store on target nodes using YAML
+func (s *StargzStoreSetup) Deploy(ctx context.Context) error {
+	framework.Logf("Deploying stargz-store using YAML approach...")
+
+	// Generate YAML with dynamic node label
+	yaml := s.generateYAML()
+
+	// Write YAML to temp file
+	tmpFile, err := os.CreateTemp("", "stargz-store-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(yaml); err != nil {
+		return fmt.Errorf("failed to write YAML: %w", err)
+	}
+	tmpFile.Close()
+
+	framework.Logf("Created YAML file: %s", tmpFile.Name())
+
+	// Apply YAML using oc
+	cmd := exec.Command("oc", "apply", "-f", tmpFile.Name())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apply YAML: %w\nOutput: %s", err, string(output))
+	}
+	framework.Logf("Applied YAML successfully:\n%s", string(output))
+
+	// Grant privileged SCC (YAML can't do this automatically)
+	framework.Logf("Granting privileged SCC to serviceaccount...")
+	if err := s.grantPrivilegedSCC(ctx); err != nil {
+		return fmt.Errorf("failed to grant privileged SCC: %w", err)
+	}
+
+	// Mark as deployed
+	s.deployed = true
+
+	// Wait for DaemonSet to be ready
+	framework.Logf("Waiting for DaemonSet to be ready...")
+	if err := s.waitForDaemonSetReady(ctx, 10*time.Minute); err != nil {
+		return fmt.Errorf("daemonset not ready: %w", err)
+	}
+
+	framework.Logf("stargz-store deployed successfully")
+	return nil
+}
+
+// generateYAML creates the stargz-store YAML with dynamic node label
+func (s *StargzStoreSetup) generateYAML() string {
+	// This YAML is based on the manual setup script that works
+	yaml := fmt.Sprintf(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: %s
+  labels:
+    app: stargz-store
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+    security.openshift.io/scc.podSecurityLabelSync: "false"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: %s
+  namespace: %s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stargz-store-config
+  namespace: %s
+data:
+  config.toml: |
+    # Stargz-store configuration for CRI-O
+    [[resolver.host."quay.io".mirrors]]
+    host = "quay.io"
+
+    [[resolver.host."docker.io".mirrors]]
+    host = "registry-1.docker.io"
+
+    [[resolver.host."gcr.io".mirrors]]
+    host = "gcr.io"
+
+    [[resolver.host."ghcr.io".mirrors]]
+    host = "ghcr.io"
+
+    [[resolver.host."registry.redhat.io".mirrors]]
+    host = "registry.redhat.io"
+
+  stargz-store.service: |
+    [Unit]
+    Description=stargz store
+    After=network.target
+    Before=crio.service
+
+    [Service]
+    Type=notify
+    Environment=HOME=/root
+    ExecStart=/usr/local/bin/stargz-store --log-level=debug --config=/etc/stargz-store/config.toml /var/lib/stargz-store/store
+    ExecStopPost=umount /var/lib/stargz-store/store
+    Restart=always
+    RestartSec=1
+
+    [Install]
+    WantedBy=multi-user.target
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  selector:
+    matchLabels:
+      app: stargz-store-installer
+  template:
+    metadata:
+      labels:
+        app: stargz-store-installer
+    spec:
+      serviceAccountName: %s
+      nodeSelector:
+        %s: ""
+      hostPID: true
+      hostNetwork: true
+      tolerations:
+      - operator: Exists
+      containers:
+      - name: installer
+        image: registry.access.redhat.com/ubi9/ubi:latest
+        securityContext:
+          privileged: true
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "=== Stargz-store Installer ==="
+          echo "Node: $(hostname)"
+
+          # Check if already installed and running
+          if nsenter -t 1 -m -u -i -n -p -- systemctl is-active stargz-store &>/dev/null; then
+            echo "stargz-store already running on this node"
+            nsenter -t 1 -m -u -i -n -p -- mount | grep stargz || true
+            echo "Sleeping to keep pod running..."
+            sleep infinity
+          fi
+
+          echo "Installing stargz-store..."
+
+          # Unlock ostree for modifications
+          echo "Unlocking ostree..."
+          nsenter -t 1 -m -u -i -n -p -- ostree admin unlock --hotfix || echo "ostree unlock failed or already unlocked"
+
+          # Download stargz-snapshotter release
+          echo "Downloading stargz-snapshotter %s..."
+          curl -L -o /tmp/stargz.tar.gz \
+            https://github.com/containerd/stargz-snapshotter/releases/download/%s/stargz-snapshotter-%s-linux-amd64.tar.gz
+
+          # Extract to host
+          echo "Extracting binary to /usr/local/bin..."
+          tar -xzf /tmp/stargz.tar.gz -C /tmp/
+          cp /tmp/stargz-store /host/usr/local/bin/
+          chmod +x /host/usr/local/bin/stargz-store
+
+          # Verify binary
+          echo "Verifying binary..."
+          nsenter -t 1 -m -u -i -n -p -- /usr/local/bin/stargz-store --version || echo "Version check skipped"
+
+          # Create directories
+          echo "Creating directories..."
+          mkdir -p /host/etc/stargz-store
+          mkdir -p /host/var/lib/stargz-store/store
+
+          # Copy config file
+          echo "Copying config.toml..."
+          cp /config/config.toml /host/etc/stargz-store/config.toml
+
+          # Copy service file
+          echo "Copying systemd service..."
+          cp /config/stargz-store.service /host/etc/systemd/system/stargz-store.service
+
+          # Reload systemd and enable service
+          echo "Enabling stargz-store service..."
+          nsenter -t 1 -m -u -i -n -p -- systemctl daemon-reload
+          nsenter -t 1 -m -u -i -n -p -- systemctl enable stargz-store
+          nsenter -t 1 -m -u -i -n -p -- systemctl start stargz-store
+
+          # Wait for service to be ready
+          echo "Waiting for stargz-store to be ready..."
+          sleep 5
+
+          # Verify service is running
+          echo "Verifying stargz-store service..."
+          nsenter -t 1 -m -u -i -n -p -- systemctl status stargz-store --no-pager || true
+
+          # Verify FUSE mount
+          echo "Verifying FUSE mount..."
+          nsenter -t 1 -m -u -i -n -p -- mount | grep stargz || echo "WARNING: stargz mount not found"
+
+          # Restart CRI-O to pick up the new layer store
+          echo "Restarting CRI-O..."
+          nsenter -t 1 -m -u -i -n -p -- systemctl restart crio
+
+          echo "=== Setup complete! ==="
+          echo "stargz-store is now running on $(hostname)"
+
+          # Keep pod running
+          sleep infinity
+        volumeMounts:
+        - name: host-root
+          mountPath: /host
+        - name: config
+          mountPath: /config
+          readOnly: true
+      volumes:
+      - name: host-root
+        hostPath:
+          path: /
+          type: Directory
+      - name: config
+        configMap:
+          name: stargz-store-config
+`, s.namespace, stargzStoreServiceAccount, s.namespace, s.namespace,
+		stargzStoreDaemonSetName, s.namespace, stargzStoreServiceAccount,
+		s.targetNodeLabel, stargzStoreVersion, stargzStoreVersion, stargzStoreVersion)
+
+	return yaml
+}
+
+// grantPrivilegedSCC grants privileged SCC to the stargz-store serviceaccount
+func (s *StargzStoreSetup) grantPrivilegedSCC(ctx context.Context) error {
+	// Get the privileged SCC
+	scc, err := s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get privileged SCC: %w", err)
+	}
+
+	// Check if serviceaccount already has access
+	saName := fmt.Sprintf("system:serviceaccount:%s:%s", s.namespace, stargzStoreServiceAccount)
+	for _, user := range scc.Users {
+		if user == saName {
+			framework.Logf("ServiceAccount %s already has privileged SCC", saName)
+			return nil
+		}
+	}
+
+	// Add serviceaccount to privileged SCC
+	scc.Users = append(scc.Users, saName)
+	_, err = s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Update(ctx, scc, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update privileged SCC: %w", err)
+	}
+
+	framework.Logf("Granted privileged SCC to %s", saName)
+	return nil
+}
+
+// waitForDaemonSetReady waits for the DaemonSet to have all pods ready
+func (s *StargzStoreSetup) waitForDaemonSetReady(ctx context.Context, timeout time.Duration) error {
+	framework.Logf("Waiting for stargz-store DaemonSet to be ready (timeout: %v)...", timeout)
+
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		ds, err := s.oc.AdminKubeClient().AppsV1().DaemonSets(s.namespace).Get(ctx, stargzStoreDaemonSetName, metav1.GetOptions{})
+		if err != nil {
+			framework.Logf("Failed to get DaemonSet: %v", err)
+			return false, nil
+		}
+
+		desired := ds.Status.DesiredNumberScheduled
+		ready := ds.Status.NumberReady
+		available := ds.Status.NumberAvailable
+		updated := ds.Status.UpdatedNumberScheduled
+
+		framework.Logf("DaemonSet status: desired=%d, ready=%d, available=%d, updated=%d",
+			desired, ready, available, updated)
+
+		// Check if all pods are ready
+		if desired > 0 && ready == desired && available == desired {
+			framework.Logf("DaemonSet is ready: %d/%d pods ready", ready, desired)
+			return true, nil
+		}
+
+		// Get pod details for debugging
+		pods, err := s.oc.AdminKubeClient().CoreV1().Pods(s.namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=stargz-store-installer",
+		})
+		if err == nil && len(pods.Items) > 0 {
+			framework.Logf("DEBUG: DaemonSet pods status:")
+			for _, pod := range pods.Items {
+				framework.Logf("  Pod %s on node %s: Phase=%s, Ready=%v",
+					pod.Name, pod.Spec.NodeName, pod.Status.Phase, isPodReady(&pod))
+
+				// Show container status for debugging
+				for _, cs := range pod.Status.ContainerStatuses {
+					if cs.State.Waiting != nil {
+						framework.Logf("    Container %s: Waiting - %s: %s",
+							cs.Name, cs.State.Waiting.Reason, cs.State.Waiting.Message)
+					} else if cs.State.Terminated != nil {
+						framework.Logf("    Container %s: Terminated - %s (exit %d): %s",
+							cs.Name, cs.State.Terminated.Reason, cs.State.Terminated.ExitCode, cs.State.Terminated.Message)
+					} else if cs.State.Running != nil {
+						framework.Logf("    Container %s: Running, Ready=%v", cs.Name, cs.Ready)
+					}
+				}
+			}
+		}
+
+		return false, nil
+	})
+}
+
+// isPodReady returns true if a pod is ready
+func isPodReady(pod *corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// GetStorePath returns the stargz-store path for ContainerRuntimeConfig
+func (s *StargzStoreSetup) GetStorePath() string {
+	return stargzStorePath
+}
+
+// IsDeployed returns true if stargz-store has been deployed
+func (s *StargzStoreSetup) IsDeployed() bool {
+	return s.deployed
+}
+
+// Cleanup removes stargz-store from the cluster
+func (s *StargzStoreSetup) Cleanup(ctx context.Context) error {
+	if !s.deployed {
+		framework.Logf("stargz-store was not deployed, skipping cleanup")
+		return nil
+	}
+
+	framework.Logf("Cleaning up stargz-store...")
+
+	// Delete namespace (this cascades to all resources)
+	cmd := exec.Command("oc", "delete", "namespace", s.namespace, "--ignore-not-found=true")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		framework.Logf("Warning: failed to delete namespace: %v\nOutput: %s", err, string(output))
+	} else {
+		framework.Logf("Deleted namespace %s", s.namespace)
+
+		// Wait for namespace to be fully deleted
+		framework.Logf("Waiting for namespace %s to be fully deleted...", s.namespace)
+		wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			_, err := s.oc.AdminKubeClient().CoreV1().Namespaces().Get(ctx, s.namespace, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, nil
+		})
+	}
+
+	// Remove from privileged SCC
+	saName := fmt.Sprintf("system:serviceaccount:%s:%s", s.namespace, stargzStoreServiceAccount)
+	scc, err := s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Get(ctx, "privileged", metav1.GetOptions{})
+	if err == nil {
+		var newUsers []string
+		removed := false
+		for _, user := range scc.Users {
+			if user != saName {
+				newUsers = append(newUsers, user)
+			} else {
+				removed = true
+			}
+		}
+		if removed {
+			scc.Users = newUsers
+			_, err = s.oc.AdminSecurityClient().SecurityV1().SecurityContextConstraints().Update(ctx, scc, metav1.UpdateOptions{})
+			if err != nil {
+				framework.Logf("Warning: failed to remove SA from privileged SCC: %v", err)
+			} else {
+				framework.Logf("Removed %s from privileged SCC", saName)
+			}
+		}
+	}
+
+	// Stop and disable stargz-store service on nodes
+	nodes, err := getNodesByLabel(ctx, s.oc, s.targetNodeLabel)
+	if err == nil {
+		for _, node := range nodes {
+			framework.Logf("Stopping stargz-store on node %s", node.Name)
+			_, err := ExecOnNodeWithChroot(s.oc, node.Name, "systemctl", "stop", "stargz-store")
+			if err != nil {
+				framework.Logf("Warning: failed to stop stargz-store on %s: %v", node.Name, err)
+			}
+
+			_, err = ExecOnNodeWithChroot(s.oc, node.Name, "systemctl", "disable", "stargz-store")
+			if err != nil {
+				framework.Logf("Warning: failed to disable stargz-store on %s: %v", node.Name, err)
+			}
+
+			// Unmount any stale FUSE mounts
+			_, err = ExecOnNodeWithChroot(s.oc, node.Name, "umount", "-l", "/var/lib/stargz-store/store")
+			if err != nil {
+				framework.Logf("Info: no stargz-store mount to unmount on %s (expected if already cleaned)", node.Name)
+			} else {
+				framework.Logf("Unmounted stargz-store FUSE mount on %s", node.Name)
+			}
+
+			// Clean up snapshot metadata (but not the binary/config - those persist)
+			_, err = ExecOnNodeWithChroot(s.oc, node.Name, "rm", "-rf", "/var/lib/stargz-store/store/*")
+			if err != nil {
+				framework.Logf("Warning: failed to clean stargz-store snapshots on %s: %v", node.Name, err)
+			}
+
+			// Restart CRI-O to remove stargz-store from layer stores
+			_, err = ExecOnNodeWithChroot(s.oc, node.Name, "systemctl", "restart", "crio")
+			if err != nil {
+				framework.Logf("Warning: failed to restart crio on %s: %v", node.Name, err)
+			}
+		}
+	}
+
+	s.deployed = false
+	framework.Logf("stargz-store cleanup complete")
+	return nil
+}
+
+// getStargzSnapshotCount counts the number of snapshots in stargz-store
+func getStargzSnapshotCount(oc *exutil.CLI, nodeName string) (int, error) {
+	// List contents of stargz-store to count snapshots/layers
+	output, err := ExecOnNodeWithChroot(oc, nodeName, "find", "/var/lib/stargz-store/store", "-type", "d", "-mindepth", "1")
+	if err != nil {
+		return 0, fmt.Errorf("failed to count snapshots: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	count := 0
+	for _, line := range lines {
+		if line != "" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+// deletePodAndWait deletes a pod and waits for it to be gone
+func deletePodAndWait(ctx context.Context, oc *exutil.CLI, namespace, podName string) {
+	err := oc.AdminKubeClient().CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		framework.Logf("Warning: failed to delete pod %s/%s: %v", namespace, podName, err)
+		return
+	}
+	if apierrors.IsNotFound(err) {
+		framework.Logf("Pod %s/%s already deleted", namespace, podName)
+		return
+	}
+	framework.Logf("Deleting pod %s/%s", namespace, podName)
+
+	// Wait for pod to be deleted
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := oc.AdminKubeClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		framework.Logf("Warning: timeout waiting for pod %s/%s deletion: %v", namespace, podName, err)
+	} else {
+		framework.Logf("Pod %s/%s deleted successfully", namespace, podName)
+	}
+}

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -76,6 +76,11 @@ var (
 
 		// used by cluster-image-registry-operator e2e tests (S3/Minio endpoint test)
 		"quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z": -1,
+
+		// used by Additional Storage Support tests
+		"quay.io/openshifttest/additional-storage-tests:test-6gb-standard-v2.0":  -1,
+		"quay.io/openshifttest/additional-storage-tests:test-image-estargz":      -1,
+		"quay.io/openshifttest/additional-storage-tests:test-image-estargz-v1.0": -1,
 	}
 )
 

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -6,6 +6,9 @@ quay.io/keycloak/keycloak:25.0 quay.io/openshift/community-e2e-images:e2e-quay-i
 quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E
 quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z quay.io/openshift/community-e2e-images:e2e-quay-io-minio-minio-RELEASE-2025-09-07T16-13-09Z-vEhi3VtwtVplkeun
 quay.io/olmtest/webhook-operator:v0.0.5 quay.io/openshift/community-e2e-images:e2e-quay-io-olmtest-webhook-operator-v0-0-5--2OhUsk-Xv-pLaTI
+quay.io/openshifttest/additional-storage-tests:test-6gb-standard-v2.0 quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-additional-storage-tests-test-6gb-standard-v2-0-UZiDUGNF5THsMB_J
+quay.io/openshifttest/additional-storage-tests:test-image-estargz quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-additional-storage-tests-test-image-estargz-e3fnjn5t9ghuNnFi
+quay.io/openshifttest/additional-storage-tests:test-image-estargz-v1.0 quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-additional-storage-tests-test-image-estargz-v1-0-bnvbpqNZfD6z2RRR
 quay.io/openshifttest/ldap:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-ldap-1-2-O3f5zPgtmWzEtasv
 quay.io/redhat-developer/nfs-server:1.1 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-nfs-server-1-1-dlXGfzrk5aNo8EjC
 quay.io/redhat-developer/test-build-roots2i:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-test-build-roots2i-1-2-gLJ7WcnS2TSllJ32


### PR DESCRIPTION
# Additional Storage Support - Comprehensive Test Suite

  This adds API validation and E2E tests for the Additional Storage Configurations feature (TechPreviewNoUpgrade):
  - **additionalArtifactStores** (max 5 stores)
  - **additionalImageStores** (max 10 stores)
  - **additionalLayerStores** (max 5 stores, supports `:ref` suffix)
  - **Combined storage configurations**

 ## Test Organization

  Tests are consolidated into 2 files for maintainability:
  
  ### API Validation Tests (`additional_storage_api.go`)
  **13 tests** in `openshift/conformance/parallel` suite (non-disruptive, uses DryRun):
  - **Combined Additional Stores** (3 tests)
    - Invalid path validation in mixed configurations
    - Max count enforcement with valid other stores
    - Duplicate path detection across store types
  - **Additional Layer Stores** (8 tests) 
    - Empty path, relative path, path with spaces
    - Invalid characters, path length (max 256 chars)
    - Max count (5 stores), consecutive slashes, duplicates
  - **Additional Image Stores** (1 smoke test)
    - Path validation wiring verification
  - **Additional Artifact Stores** (1 smoke test)
    - Path validation wiring verification 
  
  ### E2E Tests (`additional_storage_e2e.go`)
  **4 tests** in `openshift/disruptive-longrunning` suite (triggers MCP rollouts):
    - Validates all three storage types configure correctly
    - Verifies storage.conf and CRI-O config on worker nodes
  - **Combined Stores - Functional Verification**
    - Tests layer stores (stargz lazy pulling with eStargz images)
    - Tests image stores (prepopulated image access)
    - Tests artifact stores (OCI artifact read/write)
  - **Layer Stores - Comprehensive Lifecycle**
    - Deploy stargz-store, configure stores, verify lazy pulling
    - Update stores, test maximum stores, validate storage.conf
  - **Layer Stores - Fallback Behavior**
    - Standard pull for non-eStargz images
    - Fallback when stargz-store is stopped

## Implementation Details

  - **Single-node MCP approach**: All E2E tests use `createSingleNodeMCP()` for faster rollouts (~10-15 min vs ~25 min)
  - **No multi-node iteration**: Tests operate on single test node only (SNO compatible)
  - **Inline verification**: Direct node checks instead of looping over worker nodes
  - **DryRun for API tests**: Zero MCO impact for validation tests

## Multi-Architecture Support

  Test images published to [quay.io/openshifttest/additional-storage-tests](http://quay.io/openshifttest/additional-storage-tests):
  - `test-6gb-standard-v2.0` - 6GB standard format image (amd64, arm64, ppc64le, s390x)
 Images are multi-architecture manifest lists supporting OpenShift CI mirroring to [quay.io/openshift/community-e2e-images](http://quay.io/openshift/community-e2e-images).

## Testing
Ran tests locally as longrunning testsuite would take time
Additional Storage E2E Tests should configure all three storage types and verify node configuration - [PASS](https://drive.google.com/file/d/1v7AmBYUGd0uDxo-XClJQoLhnpdxMM-IT/view?usp=sharing)
Additional Storage E2E Tests should functionally verify all three storage types work together - [PASS](https://drive.google.com/file/d/1YeUtb5-U7x48svtIbeNYoEB3gHIzg_A4/view?usp=sharing)
Additional Storage E2E Tests should perform comprehensive lifecycle for layerstores: deploy stargz, configure, verify lazy pulling, update stores, maximum stores, and fallback scenario - [PASS](https://drive.google.com/file/d/1R-eIOaOVGdWFezjw463gpPV4SDVLKNJG/view?usp=sharing)
 