### PR TITLE
OCPBUGS-84257: fix openshift/network/third-party suite selecting zero tests

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -317,9 +317,9 @@ var staticSuites = []ginkgo.TestSuite{
 		The conformance testing suite for certified third-party CNI plugins.
 		`),
 		Qualifiers: []string{
-			`name.contains("[Suite:k8s]") && name.contains("[sig-network]") && 
-				(name.contains("[Conformance]") || 
-					(name.contains("NetworkPolicy") && !name.contains("named port")) || 
+			`source == "openshift:payload:hyperkube" && name.contains("[sig-network]") &&
+				(name.contains("[Conformance]") ||
+					(name.contains("NetworkPolicy") && !name.contains("named port")) ||
 					name.contains("[Feature:IPv6DualStack]"))`,
 		},
 	},

--- a/pkg/testsuites/suites_test.go
+++ b/pkg/testsuites/suites_test.go
@@ -5,13 +5,15 @@ import (
 	"testing"
 
 	"github.com/openshift-eng/openshift-tests-extension/pkg/extension/extensiontests"
+	"github.com/openshift/origin/pkg/test/ginkgo"
 )
 
 // TestSuiteQualifiersValidCEL validates that all CEL expressions in suite qualifiers
 // are syntactically valid
 func TestSuiteQualifiersValidCEL(t *testing.T) {
 	dummyTest := &extensiontests.ExtensionTestSpec{
-		Name: "[sig-test] Test a thing [Suite:openshift/conformance/parallel] [Early]",
+		Name:   "[sig-test] Test a thing [Suite:openshift/conformance/parallel] [Early]",
+		Source: "openshift:payload:origin",
 	}
 	dummySpecs := extensiontests.ExtensionTestSpecs{dummyTest}
 
@@ -48,4 +50,67 @@ func TestSuiteQualifiersValidCEL(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestThirdPartySuiteMatchesHyperkubeTests(t *testing.T) {
+	var thirdPartySuite *ginkgo.TestSuite
+	for i := range staticSuites {
+		if staticSuites[i].Name == "openshift/network/third-party" {
+			thirdPartySuite = &staticSuites[i]
+			break
+		}
+	}
+	if thirdPartySuite == nil {
+		t.Fatal("openshift/network/third-party suite not found")
+	}
+
+	candidateTests := extensiontests.ExtensionTestSpecs{
+		{
+			Name:   "[sig-network] NetworkPolicy API should support creating NetworkPolicy API operations [Conformance]",
+			Source: "openshift:payload:hyperkube",
+		},
+		{
+			Name:   "[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4] [Conformance]",
+			Source: "openshift:payload:hyperkube",
+		},
+		{
+			Name:   "[sig-network] NetworkPolicy should enforce policy based on Ports [Feature:IPv6DualStack]",
+			Source: "openshift:payload:hyperkube",
+		},
+		{
+			Name:   "[sig-network] NetworkPolicy named port should not match",
+			Source: "openshift:payload:hyperkube",
+		},
+		{
+			Name:   "[sig-storage] some storage test [Conformance]",
+			Source: "openshift:payload:hyperkube",
+		},
+		{
+			Name:   "[sig-network] some origin network test [Conformance]",
+			Source: "openshift:payload:origin",
+		},
+	}
+
+	filtered, err := candidateTests.Filter(thirdPartySuite.Qualifiers)
+	if err != nil {
+		t.Fatalf("failed to filter: %v", err)
+	}
+
+	expectedNames := map[string]bool{
+		"[sig-network] NetworkPolicy API should support creating NetworkPolicy API operations [Conformance]":                 true,
+		"[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4] [Conformance]": true,
+		"[sig-network] NetworkPolicy should enforce policy based on Ports [Feature:IPv6DualStack]":                           true,
+	}
+
+	if len(filtered) != len(expectedNames) {
+		t.Errorf("expected %d tests, got %d", len(expectedNames), len(filtered))
+		for _, s := range filtered {
+			t.Logf("  matched: %s", s.Name)
+		}
+	}
+	for _, s := range filtered {
+		if !expectedNames[s.Name] {
+			t.Errorf("unexpected test matched: %s", s.Name)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Fix the `openshift/network/third-party` suite CEL qualifier to use `source == "openshift:payload:hyperkube"` instead of `name.contains("[Suite:k8s]")`, which matches zero tests after the OTE migration
- Add a semantic test (`TestThirdPartySuiteMatchesHyperkubeTests`) verifying the qualifier correctly includes/excludes tests based on source, sig, and feature tags

## Root Cause

The OTE migration (commit c4895d7e85) converted the suite's `Matches` function to a CEL expression that still checks for `[Suite:k8s]` in test names. No tests carry that tag in the OTE framework — upstream k8s tests now use the `source` field (`"openshift:payload:hyperkube"`) to identify their origin.

Reproduced across 4.21.6, 4.21.12, 4.22-ec.5, and 5.0 nightly: zero tests have `[Suite:k8s]`, while 101 tests from `k8s-tests-ext` match the intended criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refined network-related suite qualification to target tests by their payload source (hyperkube), removing the previous name-based requirement.
  * Added a new automated test that verifies the third-party network suite filters and matches the expected hyperkube-sourced tests, and reports mismatches or filtering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->