### PR TITLE
OCPBUGS-84846: Fix NetworkNotReady pathological event regex case mismatch

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -615,7 +615,7 @@ func NewUpgradePathologicalEventMatchers(kubeConfig *rest.Config, finalIntervals
 	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
 		name:               "NetworkNotReady",
 		messageReasonRegex: regexp.MustCompile(`^NetworkNotReady$`),
-		messageHumanRegex:  regexp.MustCompile(`network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file.*Has your network provider started\?`),
+		messageHumanRegex:  regexp.MustCompile(`network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: [Nn]o CNI configuration file.*Has your network provider started\?`),
 	})
 
 	// Allow FailedScheduling repeat events during node upgrades:

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -223,6 +223,32 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 				Reason("SuccessfulCreate").Build(),
 			expectedAllowName: "PacemakerStatusCollectorCronJobEvents",
 		},
+		{
+			name: "NetworkNotReady with lowercase no from ocicni",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-multus",
+					monitorapi.LocatorPodKey:       "network-metrics-daemon-4snn9",
+					monitorapi.LocatorNodeKey:      "ip-10-0-124-97.us-west-1.compute.internal",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: no CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?").
+				Reason("NetworkNotReady").Build(),
+			expectedAllowName: "NetworkNotReady",
+		},
+		{
+			name: "NetworkNotReady with uppercase No",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-network-diagnostics",
+					monitorapi.LocatorPodKey:       "network-check-target-pf5mx",
+					monitorapi.LocatorNodeKey:      "ip-10-0-80-8.us-west-1.compute.internal",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?").
+				Reason("NetworkNotReady").Build(),
+			expectedAllowName: "NetworkNotReady",
+		},
 	}
 	for _, test := range tests {
 		registry := NewUpgradePathologicalEventMatchers(nil, nil)


### PR DESCRIPTION
The NetworkNotReady allowlist regex used "No CNI configuration file" (capital N) but ocicni produces "no CNI configuration file" (lowercase n) probably it was changed one day. This case mismatch meant the allowlist never actually matched any event during upgrade jobs, causing intermittent test failures when the event count exceeded the threshold of 20.

Change the regex to match both cases with [Nn]o and add unit tests that verify both the lowercase (real ocicni error) and uppercase variants are correctly allowed.


Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error message pattern matching to handle case variations more robustly, improving detection reliability for network readiness conditions.

* **Tests**
  * Added comprehensive test coverage to validate error detection functionality works correctly across different message capitalization formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->