### PR TITLE
Tolerate network notready during upgrade

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -615,7 +615,7 @@ func NewUpgradePathologicalEventMatchers(kubeConfig *rest.Config, finalIntervals
 	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
 		name:               "NetworkNotReady",
 		messageReasonRegex: regexp.MustCompile(`^NetworkNotReady$`),
-		messageHumanRegex:  regexp.MustCompile(`network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file.*Has your network provider started\?`),
+		messageHumanRegex:  regexp.MustCompile(`network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: [Nn]o CNI configuration file.*Has your network provider started\?`),
 	})
 
 	// Allow FailedScheduling repeat events during node upgrades:

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_test.go
@@ -223,6 +223,32 @@ func TestAllowedRepeatedEvents(t *testing.T) {
 				Reason("SuccessfulCreate").Build(),
 			expectedAllowName: "PacemakerStatusCollectorCronJobEvents",
 		},
+		{
+			name: "NetworkNotReady with lowercase no from ocicni",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-multus",
+					monitorapi.LocatorPodKey:       "network-metrics-daemon-4snn9",
+					monitorapi.LocatorNodeKey:      "ip-10-0-124-97.us-west-1.compute.internal",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: no CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?").
+				Reason("NetworkNotReady").Build(),
+			expectedAllowName: "NetworkNotReady",
+		},
+		{
+			name: "NetworkNotReady with uppercase No",
+			locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: "openshift-network-diagnostics",
+					monitorapi.LocatorPodKey:       "network-check-target-pf5mx",
+					monitorapi.LocatorNodeKey:      "ip-10-0-80-8.us-west-1.compute.internal",
+				},
+			},
+			msg: monitorapi.NewMessage().HumanMessage("network is not ready: container runtime network not ready: NetworkReady=false reason:NetworkPluginNotReady message:Network plugin returns error: No CNI configuration file in /etc/kubernetes/cni/net.d/. Has your network provider started?").
+				Reason("NetworkNotReady").Build(),
+			expectedAllowName: "NetworkNotReady",
+		},
 	}
 	for _, test := range tests {
 		registry := NewUpgradePathologicalEventMatchers(nil, nil)

--- a/pkg/monitortests/node/watchnodes/monitortest.go
+++ b/pkg/monitortests/node/watchnodes/monitortest.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
@@ -49,9 +50,11 @@ func (*nodeWatcher) ConstructComputedIntervals(ctx context.Context, startingInte
 
 func (*nodeWatcher) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 
+	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
+
 	junits := []*junitapi.JUnitTestCase{}
-	junits = append(junits, unexpectedNodeNotReadyJunit(finalIntervals)...)
-	junits = append(junits, unreachableNodeTaint(finalIntervals)...)
+	junits = append(junits, unexpectedNodeNotReadyJunit(finalIntervals, isUpgrade)...)
+	junits = append(junits, unreachableNodeTaint(finalIntervals, isUpgrade)...)
 	junits = append(junits, nodeDiskPressure(finalIntervals)...)
 	return junits, nil
 }
@@ -65,10 +68,10 @@ func (*nodeWatcher) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
+func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals, isUpgrade bool) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] node-lifecycle detects unexpected not ready node"
 
-	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedReadyReason)
+	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedReadyReason, isUpgrade)
 	// failures during a run always fail the test suite
 	var tests []*junitapi.JUnitTestCase
 	if len(failures) > 0 {
@@ -87,9 +90,9 @@ func unexpectedNodeNotReadyJunit(finalIntervals monitorapi.Intervals) []*junitap
 	return tests
 }
 
-func unreachableNodeTaint(finalIntervals monitorapi.Intervals) []*junitapi.JUnitTestCase {
+func unreachableNodeTaint(finalIntervals monitorapi.Intervals, isUpgrade bool) []*junitapi.JUnitTestCase {
 	const testName = "[sig-node] node-lifecycle detects unreachable state on node"
-	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedUnreachableReason)
+	failures := reportUnexpectedNodeDownFailures(finalIntervals, monitorapi.NodeUnexpectedUnreachableReason, isUpgrade)
 
 	// failures during a run always fail the test suite
 	var tests []*junitapi.JUnitTestCase

--- a/pkg/monitortests/node/watchnodes/node.go
+++ b/pkg/monitortests/node/watchnodes/node.go
@@ -17,6 +17,17 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+// maxNetworkNotReadyDuration is the maximum duration a node can be NotReady
+// due to network and still be tolerated during upgrades. During an OVN-K
+// upgrade, the ovnkube-node daemonset pod is replaced and the CNI plugin
+// becomes briefly unavailable (config file removed, STATUS verb fails).
+// CRI-O detects this via continuous CNI STATUS monitoring and reports
+// NetworkReady=false to kubelet, which marks the node NotReady. The node
+// self-heals when the new ovnkube-node pod starts and restores CNI. This
+// typically takes 10-15 seconds. We tolerate up to 60 seconds to account
+// for slow environments while still catching prolonged outages.
+const maxNetworkNotReadyDuration = 60 * time.Second
+
 func startNodeMonitoring(ctx context.Context, m monitorapi.RecorderWriter, client kubernetes.Interface) {
 	nodeReadyFn := func(node, oldNode *corev1.Node) []monitorapi.Interval {
 		isCreate := false
@@ -167,11 +178,15 @@ func startNodeMonitoring(ctx context.Context, m monitorapi.RecorderWriter, clien
 
 			now := time.Now()
 			if isOldNodeReady && !isNewNodeReady && isConfigTheSame && !isNodeUnscheduable {
+				msg := monitorapi.NewMessage().Reason(monitorapi.NodeUnexpectedReadyReason).
+					HumanMessage("unexpected node not ready")
+				if isNotReadyDueToNetwork(node) {
+					msg = msg.WithAnnotation(monitorapi.AnnotationCause, "NetworkNotReady")
+				}
 				intervals = append(intervals,
 					monitorapi.NewInterval(monitorapi.SourceUnexpectedReady, monitorapi.Error).
 						Locator(monitorapi.NewLocator().NodeFromName(node.Name)).
-						Message(monitorapi.NewMessage().Reason(monitorapi.NodeUnexpectedReadyReason).
-							HumanMessage("unexpected node not ready")).
+						Message(msg).
 						Display().
 						Build(now, now))
 			}
@@ -345,6 +360,40 @@ func isNodeReady(node *corev1.Node) bool {
 	return isReady
 }
 
+// isNotReadyDueToNetwork returns true when the node went NotReady because
+// the CNI plugin is not ready (e.g. during an OVN-K daemonset rollout the
+// CNI config file is briefly removed).
+func isNotReadyDueToNetwork(node *corev1.Node) bool {
+	if c := findNodeCondition(node.Status.Conditions, corev1.NodeReady, 0); c != nil {
+		return c.Reason == "KubeletNotReady" && strings.Contains(c.Message, "NetworkReady=false")
+	}
+	return false
+}
+
+// nodeNotReadyDuration finds the NodeState span for the given node that
+// overlaps the event time and returns its duration. This uses the spans
+// constructed by nodestateanalyzer which pair NotReady/Ready transitions.
+func nodeNotReadyDuration(unexpectedEvent monitorapi.Interval, allIntervals monitorapi.Intervals) time.Duration {
+	nodeName := unexpectedEvent.Locator.Keys[monitorapi.LocatorNodeKey]
+	eventTime := unexpectedEvent.From
+
+	for _, interval := range allIntervals {
+		if interval.Source != monitorapi.SourceNodeState {
+			continue
+		}
+		if interval.Locator.Keys[monitorapi.LocatorNodeKey] != nodeName {
+			continue
+		}
+		if interval.Message.Reason != monitorapi.NodeNotReadyReason {
+			continue
+		}
+		if !eventTime.Before(interval.From) && !eventTime.After(interval.To) {
+			return interval.To.Sub(interval.From)
+		}
+	}
+	return 0
+}
+
 func doesNodeHaveUnreachableTaints(node *corev1.Node) bool {
 	if node == nil {
 		return false
@@ -358,7 +407,7 @@ func doesNodeHaveUnreachableTaints(node *corev1.Node) bool {
 	return false
 }
 
-func reportUnexpectedNodeDownFailures(intervals monitorapi.Intervals, targetedReason monitorapi.IntervalReason) []string {
+func reportUnexpectedNodeDownFailures(intervals monitorapi.Intervals, targetedReason monitorapi.IntervalReason, isUpgrade bool) []string {
 	// Get all the deleted machine phases
 	machineDeletePhases := intervals.Filter(func(eventInterval monitorapi.Interval) bool {
 		if eventInterval.Message.Reason != monitorapi.MachinePhase {
@@ -393,9 +442,20 @@ func reportUnexpectedNodeDownFailures(intervals monitorapi.Intervals, targetedRe
 
 		machineDeletingIntervals := machineNameToDeletePhases[machineNameForNode]
 
-		if !intervalStartDuring(unexpectedNodeUnready, machineDeletingIntervals) {
-			failures = append(failures, fmt.Sprintf("%v - %v at from: %v - to: %v", unexpectedNodeUnready.Locator.OldLocator(), unexpectedNodeUnready.Message.OldMessage(), unexpectedNodeUnready.From, unexpectedNodeUnready.To))
+		if intervalStartDuring(unexpectedNodeUnready, machineDeletingIntervals) {
+			continue
 		}
+		// During upgrades, OVN-K recreates the ovnkube-node daemonset pod.
+		// While the pod is being replaced, the CNI plugin is unavailable and
+		// CRI-O reports NetworkReady=false, causing the node to go NotReady.
+		// This is expected and transient -- tolerate it if the node recovered
+		// within maxNetworkNotReadyDuration.
+		if isUpgrade && unexpectedNodeUnready.Message.Annotations[monitorapi.AnnotationCause] == "NetworkNotReady" {
+			if nodeNotReadyDuration(unexpectedNodeUnready, intervals) <= maxNetworkNotReadyDuration {
+				continue
+			}
+		}
+		failures = append(failures, fmt.Sprintf("%v - %v at from: %v - to: %v", unexpectedNodeUnready.Locator.OldLocator(), unexpectedNodeUnready.Message.OldMessage(), unexpectedNodeUnready.From, unexpectedNodeUnready.To))
 	}
 
 	return failures

--- a/pkg/monitortests/node/watchnodes/node_test.go
+++ b/pkg/monitortests/node/watchnodes/node_test.go
@@ -325,7 +325,7 @@ func TestReportUnexpectedNodeDownFailures(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := reportUnexpectedNodeDownFailures(tc.rawIntervals, tc.unexpectedReason)
+			actual := reportUnexpectedNodeDownFailures(tc.rawIntervals, tc.unexpectedReason, false)
 			if len(actual) != len(tc.expected) {
 				t.Fatalf("mismatch of length from actual to expected")
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved network configuration error detection with case-insensitive pattern matching for more reliable network issue identification.

* **Improvements**
  * Enhanced node monitoring during cluster upgrades to automatically tolerate transient network-not-ready conditions lasting up to 60 seconds, reducing false failure alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->