### PR TITLE
MON-4581: Run CP tests everywhere

### DIFF
--- a/test/extended/prometheus/collection_profiles.go
+++ b/test/extended/prometheus/collection_profiles.go
@@ -63,9 +63,6 @@ var _ = g.Describe("[sig-instrumentation][OCPFeatureGate:MetricsCollectionProfil
 	tctx := context.Background()
 
 	g.BeforeAll(func() {
-		if !exutil.IsTechPreviewNoUpgrade(tctx, oc.AdminConfigClient()) {
-			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-		}
 		var err error
 		r.kclient, err = kubernetes.NewForConfig(oc.AdminConfig())
 		if err != nil {


### PR DESCRIPTION
These were restricted to TP only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified test initialization by removing conditional skip logic. Test suite now executes consistently across all supported cluster configurations without version-specific eligibility checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->