### PR TITLE
OCPBUGS-78480: handle bookmark events in project watch tests

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -141,11 +141,17 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			time.Sleep(5 * time.Second)
 			fromNowWatch, err := bobProjectClient.Projects().Watch(ctx, metav1.ListOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
-			select {
-			case event := <-fromNowWatch.ResultChan():
-				g.Fail(fmt.Sprintf("unexpected event %s %#v", event.Type, event.Object))
+			for {
+				select {
+				case event := <-fromNowWatch.ResultChan():
+					if event.Type == watch.Bookmark {
+						continue
+					}
+					g.Fail(fmt.Sprintf("unexpected event %s %#v", event.Type, event.Object))
 
-			case <-time.After(2 * time.Second):
+				case <-time.After(2 * time.Second):
+					return
+				}
 			}
 		})
 	})
@@ -274,6 +280,9 @@ func waitForOnlyAdd(projectName string, w watch.Interface) {
 						return
 					}
 					g.Fail(fmt.Sprintf("got unexpected project ADD waiting for %s: %v", project.Name, event))
+				}
+				if event.Type == watch.Bookmark {
+					continue
 				}
 				if event.Type == watch.Modified {
 					// ignore modifications from other projects


### PR DESCRIPTION
The Kubernetes apiserver watch implementation sends bookmark events to signal completion of the initial list when SendInitialEvents=true (KEP-3157). This change updates tests to handle these bookmark events in preparation for enabling watch-list support for the project resource type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved watch-event handling in project tests to increase test reliability by filtering out bookmark events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->