### PR TITLE
OCPBUGS-84520: remove openshift-catalogd exemption from terminationMessagePolicy monitor

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -126,9 +126,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 	// existingViolations is the list of violations already present, don't add to it once we start enforcing
 	existingViolations := map[string]sets.String{
 		"namespace": sets.NewString("<containerType>[<containerName>]"),
-		"openshift-catalogd": sets.NewString( // filed OCPBUGS-84520 to fix
-			"pods/catalogd-controller-manager",
-		),
 		"openshift-cluster-csi-drivers": sets.NewString( // filed OCPBUGS-84510 to fix
 			"pods/kubevirt-csi-node",
 			"pods/nutanix-csi-controller",


### PR DESCRIPTION
The catalogd deployment in openshift-catalogd now sets terminationMessagePolicy: FallbackToLogsOnError explicitly on its manager container in all active release branches (4.19+). The fix was confirmed in openshift/operator-framework-operator-controller across release-4.19 through main.

Remove the exemption that was added by [TRT-2084](https://redhat.atlassian.net/browse/TRT-2084) to allow the monitor test to enforce the policy again.

Fixes OCPBUGS-84520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a cluster version operator monitor test to remove a prior exception for catalogd controller-manager pods, enabling stricter detection and reporting of terminationMessagePolicy failures for affected containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->