### PR TITLE
OCPNODE-4043: Fix NVIDIA DRA driver helm repo configuration

### DIFF
--- a/test/extended/node/dra/nvidia/README.md
+++ b/test/extended/node/dra/nvidia/README.md
@@ -121,7 +121,7 @@ The tests automatically install the DRA driver if needed. This section is for ma
 ### Step 1: Add NVIDIA Helm Repository
 
 ```bash
-helm repo add nvidia https://nvidia.github.io/gpu-operator
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia --force-update
 helm repo update
 ```
 
@@ -143,24 +143,24 @@ This label ensures the DRA kubelet plugin only runs on GPU nodes and works aroun
 
 ```bash
 # Create namespace
-oc create namespace nvidia-dra-driver-gpu
+oc create namespace nvidia-dra-driver
 
 # Grant SCC permissions
 oc adm policy add-scc-to-user privileged \
   -z nvidia-dra-driver-gpu-service-account-controller \
-  -n nvidia-dra-driver-gpu
+  -n nvidia-dra-driver
 oc adm policy add-scc-to-user privileged \
   -z nvidia-dra-driver-gpu-service-account-kubeletplugin \
-  -n nvidia-dra-driver-gpu
+  -n nvidia-dra-driver
 oc adm policy add-scc-to-user privileged \
   -z compute-domain-daemon-service-account \
-  -n nvidia-dra-driver-gpu
+  -n nvidia-dra-driver
 
 # Install via Helm (pinned to version used by tests)
 # Version can be overridden via NVIDIA_DRA_DRIVER_VERSION environment variable
 NVIDIA_DRA_DRIVER_VERSION=${NVIDIA_DRA_DRIVER_VERSION:-25.12.0}
-helm install nvidia-dra-driver-gpu nvidia/nvidia-dra-driver-gpu \
-  --namespace nvidia-dra-driver-gpu \
+helm install nvidia-dra-driver nvidia/nvidia-dra-driver-gpu \
+  --namespace nvidia-dra-driver \
   --version ${NVIDIA_DRA_DRIVER_VERSION} \
   --set nvidiaDriverRoot=/run/nvidia/driver \
   --set gpuResourcesEnabledOverride=true \
@@ -179,7 +179,7 @@ helm install nvidia-dra-driver-gpu nvidia/nvidia-dra-driver-gpu \
 
 ```bash
 # Check DRA driver pods
-oc get pods -n nvidia-dra-driver-gpu
+oc get pods -n nvidia-dra-driver
 # Expected: All pods should be Running
 
 # Verify ResourceSlices are published
@@ -191,8 +191,8 @@ oc get resourceslices
 
 ```bash
 # Uninstall DRA Driver
-helm uninstall nvidia-dra-driver-gpu -n nvidia-dra-driver-gpu --wait --timeout 5m
-oc delete namespace nvidia-dra-driver-gpu
+helm uninstall nvidia-dra-driver -n nvidia-dra-driver --wait --timeout 5m
+oc delete namespace nvidia-dra-driver
 
 # Remove SCC permissions
 oc delete clusterrolebinding \
@@ -230,13 +230,13 @@ oc delete clusterrolebinding \
 **Solution**:
 ```bash
 # Check DRA driver logs
-oc logs -n nvidia-dra-driver-gpu -l app.kubernetes.io/name=nvidia-dra-driver-gpu --all-containers
+oc logs -n nvidia-dra-driver -l app.kubernetes.io/name=nvidia-dra-driver-gpu --all-containers
 
 # Verify SCC permissions
 oc describe scc privileged | grep nvidia-dra-driver-gpu
 
 # Restart DRA driver if needed
-oc delete pod -n nvidia-dra-driver-gpu -l app.kubernetes.io/name=nvidia-dra-driver-gpu
+oc delete pod -n nvidia-dra-driver -l app.kubernetes.io/name=nvidia-dra-driver-gpu
 ```
 
 ## References

--- a/test/extended/node/dra/nvidia/prerequisites_installer.go
+++ b/test/extended/node/dra/nvidia/prerequisites_installer.go
@@ -23,8 +23,8 @@ const (
 	gpuOperatorNamespace = "nvidia-gpu-operator"
 
 	// DRA Driver constants
-	draDriverNamespace       = "nvidia-dra-driver-gpu"
-	draDriverRelease         = "nvidia-dra-driver-gpu"
+	draDriverNamespace       = "nvidia-dra-driver"
+	draDriverRelease         = "nvidia-dra-driver"
 	draDriverChart           = "nvidia/nvidia-dra-driver-gpu"
 	draDriverDefaultVersion  = "25.12.0"
 	draDriverControllerSA    = "nvidia-dra-driver-gpu-service-account-controller"
@@ -114,18 +114,27 @@ func (pi *PrerequisitesInstaller) ensureHelm(ctx context.Context) error {
 func (pi *PrerequisitesInstaller) addHelmRepoForDRADriver(ctx context.Context) error {
 	framework.Logf("Adding NVIDIA Helm repository for DRA driver")
 
-	// Add repo
-	cmd := exec.CommandContext(ctx, "helm", "repo", "add", "nvidia", "https://nvidia.github.io/gpu-operator")
+	// Add repo with force update to ensure we have the latest index
+	cmd := exec.CommandContext(ctx, "helm", "repo", "add", "nvidia", "https://helm.ngc.nvidia.com/nvidia", "--force-update")
 	output, err := cmd.CombinedOutput()
-	if err != nil && !strings.Contains(string(output), "already exists") {
+	if err != nil {
 		return fmt.Errorf("failed to add helm repo: %w\nOutput: %s", err, string(output))
 	}
 
-	// Update repo
-	cmd = exec.CommandContext(ctx, "helm", "repo", "update")
-	output, err = cmd.CombinedOutput()
+	// Update repo with retry logic (NVIDIA repo can be flaky)
+	var lastOutput []byte
+	var lastErr error
+	err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		cmd := exec.CommandContext(ctx, "helm", "repo", "update", "nvidia")
+		lastOutput, lastErr = cmd.CombinedOutput()
+		if lastErr != nil {
+			framework.Logf("Helm repo update failed: %v\nOutput: %s\nRetrying...", lastErr, string(lastOutput))
+			return false, nil
+		}
+		return true, nil
+	})
 	if err != nil {
-		return fmt.Errorf("failed to update helm repo: %w\nOutput: %s", err, string(output))
+		return fmt.Errorf("failed to update helm repo after retries: %w\nLast error: %v\nLast output: %s", err, lastErr, string(lastOutput))
 	}
 
 	framework.Logf("NVIDIA Helm repository added and updated")


### PR DESCRIPTION
- Fix Helm repo URL `helm.ngc.nvidia.com/nvidia`
- Add retry logic for flaky NVIDIA Helm repository updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Helm operations with automatic retry and per-attempt logging to reduce transient failures and surface final errors.
  * Updated NVIDIA Helm repository endpoint to the new official URL.
  * Standardized Helm release and namespace naming for the NVIDIA driver deployment.

* **Documentation**
  * Updated installation and troubleshooting docs to reflect the new repository endpoint and namespace/release naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->