### PR TITLE
OCPBUGS-84809: Disable particular CSI tests if CSI driver is removed

### DIFF
--- a/pkg/clioptions/clusterdiscovery/cluster.go
+++ b/pkg/clioptions/clusterdiscovery/cluster.go
@@ -92,6 +92,8 @@ type ClusterConfiguration struct {
 	EnabledFeatureGates sets.Set[string] `json:"-"`
 	// DisabledFeatureGates contains the set of disabled feature gates in the cluster
 	DisabledFeatureGates sets.Set[string] `json:"-"`
+	// DisabledCSIDrivers contains list of CSI drivers which has been disabled in the cluster
+	DisabledCSIDrivers sets.Set[string] `json:"-"`
 }
 
 func (c *ClusterConfiguration) ToJSONString() string {
@@ -110,6 +112,7 @@ type ClusterState struct {
 	Masters              *corev1.NodeList
 	NonMasters           *corev1.NodeList
 	NetworkSpec          *operatorv1.NetworkSpec
+	DisabledCSIDrivers   sets.Set[string]
 	ControlPlaneTopology *configv1.TopologyMode
 	OptionalCapabilities []configv1.ClusterVersionCapability
 	Version              *configv1.ClusterVersion
@@ -196,6 +199,21 @@ func discoverFeatureGates(configClient configclient.Interface, clusterVersion *c
 	return enabled, disabled, nil
 }
 
+func discoverRemovedCSIDrivers(operatorClient operatorclient.Interface) (sets.Set[string], error) {
+	ctx := context.Background()
+	csidrivers, err := operatorClient.OperatorV1().ClusterCSIDrivers().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return sets.New[string](), err
+	}
+	csidriversSet := sets.New[string]()
+	for _, csidriver := range csidrivers.Items {
+		if csidriver.Spec.ManagementState == operatorv1.Removed {
+			csidriversSet.Insert(string(csidriver.Name))
+		}
+	}
+	return csidriversSet, nil
+}
+
 // DiscoverClusterState creates a ClusterState based on a live cluster
 func DiscoverClusterState(clientConfig *rest.Config) (*ClusterState, error) {
 	coreClient, err := clientset.NewForConfig(clientConfig)
@@ -258,6 +276,12 @@ func DiscoverClusterState(clientConfig *rest.Config) (*ClusterState, error) {
 	}
 	state.Version = clusterVersion
 	state.OptionalCapabilities = clusterVersion.Status.Capabilities.EnabledCapabilities
+
+	removedCSIDrivers, err := discoverRemovedCSIDrivers(operatorClient)
+	if err != nil {
+		return nil, err
+	}
+	state.DisabledCSIDrivers = removedCSIDrivers
 
 	// Discover available API groups
 	state.APIGroups, err = discoverAPIGroups(coreClient)
@@ -397,6 +421,7 @@ func LoadConfig(state *ClusterState) (*ClusterConfiguration, error) {
 	config.APIGroups = state.APIGroups
 	config.EnabledFeatureGates = state.EnabledFeatureGates
 	config.DisabledFeatureGates = state.DisabledFeatureGates
+	config.DisabledCSIDrivers = state.DisabledCSIDrivers
 
 	return config, nil
 }

--- a/pkg/test/filters/cluster_state.go
+++ b/pkg/test/filters/cluster_state.go
@@ -141,6 +141,15 @@ func (f *ClusterStateFilter) matchTest(name string) bool {
 		return false
 	}
 
+	if f.config.DisabledCSIDrivers != nil {
+		for _, csidriver := range f.config.DisabledCSIDrivers.UnsortedList() {
+			if strings.Contains(name, fmt.Sprintf("External Storage [Driver: %s]", csidriver)) {
+				logrus.WithField("test", name).WithField("csidriver", csidriver).Debug("Skipping test")
+				return false
+			}
+		}
+	}
+
 	// Apply feature gate filtering - keep this last
 	featureGates := []string{}
 	matches = featureGateRegex.FindAllStringSubmatch(name, -1)

--- a/pkg/test/filters/cluster_state_test.go
+++ b/pkg/test/filters/cluster_state_test.go
@@ -13,6 +13,103 @@ import (
 	"github.com/openshift/origin/pkg/test/extensions"
 )
 
+// realisticExternalCSITestName returns a spec name shaped like upstream kubernetes external
+// CSI tests: framework.Describe joins string fragments with a single space (see
+// k8s.io/kubernetes/test/e2e/framework/ginkgowrapper.go registerInSuite), and
+// k8s.io/kubernetes/test/e2e/storage/external/external.go registers
+// framework.Describe("External Storage", "[Driver: <name>]", ...).
+// Ginkgo full names include nested container text; they always contain this substring
+// when the driver matches.
+func realisticExternalCSITestName(driver string) string {
+	return "External Storage [Driver: " + driver + "] [Testpattern: Dynamic PV (default fs)] volume should allow exec of files on the volume"
+}
+
+func TestClusterStateFilterDisabledCSIDrivers(t *testing.T) {
+	const (
+		azureDriver = "disk.csi.azure.com"
+		awsDriver   = "ebs.csi.aws.com"
+	)
+
+	baseConfig := func() *clusterdiscovery.ClusterConfiguration {
+		return &clusterdiscovery.ClusterConfiguration{
+			ProviderName:         "aws",
+			NetworkPlugin:        "OVNKubernetes",
+			HasIPv4:              true,
+			HasIPv6:              false,
+			EnabledFeatureGates:  sets.New[string](),
+			DisabledFeatureGates: sets.New[string](),
+			APIGroups:            sets.New[string](),
+		}
+	}
+
+	tests := []struct {
+		name string
+		// disabledDriverNames: when empty (nil or len 0), ClusterConfiguration.DisabledCSIDrivers is
+		// left unset (nil). When non-empty, set to sets.New(names...). For this filter, nil and a
+		// non-nil empty set behave the same (no CSI names skipped); empty slice here models
+		// "nothing disabled" without assigning the field.
+		disabledDriverNames []string
+		inputNames          []string
+		wantNames           []string
+	}{
+		{
+			name:                "filters when driver management state is removed",
+			disabledDriverNames: []string{azureDriver},
+			inputNames: []string{
+				realisticExternalCSITestName(azureDriver),
+				realisticExternalCSITestName(awsDriver),
+				"openshift/conformance unrelated test",
+			},
+			wantNames: []string{
+				realisticExternalCSITestName(awsDriver),
+				"openshift/conformance unrelated test",
+			},
+		},
+		{
+			name:                "no removed CSI drivers does not filter",
+			disabledDriverNames: nil,
+			inputNames:          []string{realisticExternalCSITestName(azureDriver)},
+			wantNames:           []string{realisticExternalCSITestName(azureDriver)},
+		},
+		{
+			name:                "multiple removed drivers",
+			disabledDriverNames: []string{azureDriver, awsDriver},
+			inputNames: []string{
+				realisticExternalCSITestName(azureDriver),
+				realisticExternalCSITestName(awsDriver),
+			},
+			wantNames: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			if len(tt.disabledDriverNames) > 0 {
+				cfg.DisabledCSIDrivers = sets.New(tt.disabledDriverNames...)
+			}
+
+			filter := NewClusterStateFilter(cfg)
+			specs := make(extensions.ExtensionTestSpecs, 0, len(tt.inputNames))
+			for _, n := range tt.inputNames {
+				specs = append(specs, &extensions.ExtensionTestSpec{
+					ExtensionTestSpec: &extensiontests.ExtensionTestSpec{Name: n},
+				})
+			}
+
+			out, err := filter.Filter(context.Background(), specs)
+			require.NoError(t, err)
+			require.Len(t, out, len(tt.wantNames))
+
+			got := make([]string, len(out))
+			for i, spec := range out {
+				got[i] = spec.Name
+			}
+			assert.Equal(t, tt.wantNames, got)
+		})
+	}
+}
+
 func TestClusterStateFilter(t *testing.T) {
 	config := &clusterdiscovery.ClusterConfiguration{
 		ProviderName:         "aws",

--- a/test/extended/storage/driver_configuration.go
+++ b/test/extended/storage/driver_configuration.go
@@ -11,6 +11,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	opv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -80,6 +81,10 @@ var _ = g.Describe("[sig-storage][FeatureGate:VSphereDriverConfiguration][Serial
 
 		originalClusterCSIDriver, err := oc.AdminOperatorClient().OperatorV1().ClusterCSIDrivers().Get(ctx, providerName, metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if originalClusterCSIDriver.Spec.ManagementState == operatorv1.Removed {
+			g.Skip("CSI driver is not configured")
+		}
 
 		originalDriverConfigSpec = originalClusterCSIDriver.Spec.DriverConfig.DeepCopy()
 		e2e.Logf("Storing original driverConfig of ClusterCSIDriver")


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-84809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster discovery now detects and tracks CSI drivers marked as removed/disabled.
  * Test runner skips storage subtests when a CSI driver is reported as removed.

* **Tests**
  * Added tests covering filtering of tests when one or more CSI drivers are disabled.
  * Verifies disabled-driver specs are excluded while unrelated specs remain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->