### PR TITLE
OCPBUGS-84510 : fix: remove the test exceptions for kubevirt-csi-node pods

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -130,7 +130,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/catalogd-controller-manager",
 		),
 		"openshift-cluster-csi-drivers": sets.NewString( // filed OCPBUGS-84510 to fix
-			"pods/kubevirt-csi-node",
 			"pods/nutanix-csi-controller",
 			"pods/nutanix-csi-node",
 		),


### PR DESCRIPTION
Remove kubevirt-csi-node pods from the existingViolations exception list in the terminationMessagePolicy monitor test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cluster monitoring exemptions to improve violation detection accuracy for container termination policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->