### PR TITLE
NO-JIRA: Remove fixed bugs on CO conditions (2)

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -704,10 +704,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "SyncLoopRefresh_InProgress" {
 				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
-		case "image-registry":
-			if reason == "NodeCADaemonUnavailable::Ready" || reason == "DeploymentNotCompleted" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62626"
-			}
 		case "ingress":
 			if reason == "Reconciling" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62627"

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -720,10 +720,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "Deploying" || reason == "MachineConfig" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			}
-		case "node-tuning":
-			if reason == "Reconciling" || reason == "ProfileProgressing" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved
 			// RouteControllerManager_DesiredStateNotYetAchieved

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -345,17 +345,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
-		case "monitoring":
-			if condition.Type == configv1.OperatorAvailable &&
-				(condition.Status == configv1.ConditionFalse &&
-					(condition.Reason == "PlatformTasksFailed" ||
-						condition.Reason == "UpdatingAlertmanagerFailed" ||
-						condition.Reason == "UpdatingConsolePluginComponentsFailed" ||
-						condition.Reason == "UpdatingPrometheusK8SFailed" ||
-						condition.Reason == "UpdatingPrometheusOperatorFailed")) ||
-				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
-				return "https://issues.redhat.com/browse/OCPBUGS-23745"
-			}
 		case "olm":
 			if condition.Type == configv1.OperatorAvailable &&
 				condition.Status == configv1.ConditionFalse &&

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -734,12 +734,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "_ManagedDeploymentsAvailable" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62633"
 			}
-		case "olm":
-			// CatalogdDeploymentCatalogdControllerManager_Deploying
-			// OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying
-			if strings.HasSuffix(reason, "ControllerManager_Deploying") {
-				return "https://issues.redhat.com/browse/OCPBUGS-62635"
-			}
 		case "operator-lifecycle-manager-packageserver":
 			if reason == "" {
 				return "https://issues.redhat.com/browse/OCPBUGS-63672"

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -130,9 +130,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "kube-scheduler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663"
 			}
-			if operator == "network" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38684"
-			}
 			if operator == "console" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -711,7 +711,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			}
 		case "network":
 			if reason == "Deploying" || reason == "MachineConfig" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
 			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -258,6 +258,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			switch co {
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
+			case "dns":
+				return "https://issues.redhat.com/browse/OCPBUGS-62623"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -259,7 +259,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
-				return "https://issues.redhat.com/browse/OCPBUGS-62623"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -258,8 +258,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			switch co {
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
-			case "dns":
-				return "https://issues.redhat.com/browse/OCPBUGS-62623"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -264,8 +264,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
-			case "node-tuning":
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -267,7 +267,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62633"
+				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -260,8 +260,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
 				return "https://issues.redhat.com/browse/OCPBUGS-62623"
-			case "image-registry":
-				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -266,8 +266,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -261,7 +261,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "dns":
 				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
 			case "network":
-				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
 			default:
 				return ""
 			}


### PR DESCRIPTION
Continue the effort in https://github.com/openshift/origin/pull/31081

In general the bugs are either fixed in 4.22 or earlier or their symptoms do not show in the testing.
See the verification in the commit messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened upgrade checks: removed several operator exemptions so they are now validated by default.
  * Reduced Progressing exceptions: fewer operators remain exempt during Progressing validation.
  * Scaling tests restricted exemptions: only the network operator remains exempt during scaling windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->