### PR TITLE
OCPBUGS-84516: remove openshift-machine-config-operator exemption from terminationMessagePolicy monitor

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -156,7 +156,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/insights-runtime-extractor",
 			"pods/periodic-gathering",
 		),
-		"openshift-machine-config-operator": sets.NewString("containers[container-00]"), // filed OCPBUGS-84516 to fix
 		"openshift-metallb-system": sets.NewString( // filed OCPBUGS-84525 to fix
 			"pods/metallb-operator-controller-manager",
 			"pods/metallb-operator-webhook-server",


### PR DESCRIPTION
This removes' the MCO's exception for TRT-2084. The container policies were fixed in https://github.com/openshift/machine-config-operator/pull/5993.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compliance verification to properly identify containers with non-compliant configuration settings that were previously excluded from validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->