### PR TITLE
NO-JIRA: Tolerate events during the vSphere CSI driver removal test

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1113,8 +1113,23 @@ func newTopologyAwareHintsDisabledDuringTaintTestsPathologicalEventMatcher(final
 // The tests change clusterCSIDriver object and have to rollout new pods to load new configuration.
 func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
 	configurationTestIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "snapshot options in clusterCSIDriver")
+		if eventInterval.Source != monitorapi.SourceE2ETest {
+			return false
+		}
+		testNames := []string{
+			// Snapshot configuration changes result in the DaemonSet + Deployment update + rollout,
+			// which generates a lot of "Create / Update / Delete" events.
+			"snapshot options in clusterCSIDriver",
+			// vSphere CSI driver removal test  results in the DaemonSet + Deployment removal + re-creation,
+			// with a subsequent rollout.
+			"vSphere CSI Driver Operator Removal",
+		}
+		for _, testName := range testNames {
+			if strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], testName) {
+				return true
+			}
+		}
+		return false
 	})
 	for i := range configurationTestIntervals {
 		configurationTestIntervals[i].To = configurationTestIntervals[i].To.Add(time.Minute * 10)

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -33,6 +33,17 @@ type upgradeWindowHolder struct {
 	endInterval   *monitorapi.Interval
 }
 
+// intervalOverlapsE2ETest reports whether eventInterval overlaps with an e2e test  whose name contains given substring.
+func intervalOverlapsE2ETest(e2eIntervals monitorapi.Intervals, eventInterval monitorapi.Interval, testNameSubstring string) bool {
+	for _, overlap := range utility.FindOverlap(e2eIntervals, eventInterval) {
+		name, ok := monitorapi.E2ETestFromLocator(overlap.Locator)
+		if ok && strings.Contains(name, testNameSubstring) {
+			return true
+		}
+	}
+	return false
+}
+
 func checkAuthenticationAvailableExceptions(condition *configv1.ClusterOperatorStatusCondition) bool {
 	if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
 		switch condition.Reason {
@@ -47,7 +58,8 @@ func checkAuthenticationAvailableExceptions(condition *configv1.ClusterOperatorS
 }
 
 func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topology configv1.TopologyMode) []*junitapi.JUnitTestCase {
-	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, _ monitorapi.Interval) string {
+	e2eEventIntervals := operatorstateanalyzer.E2ETestEventIntervals(events)
+	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, eventInterval monitorapi.Interval) string {
 		if condition.Status == configv1.ConditionTrue {
 			if condition.Type == configv1.OperatorAvailable {
 				return fmt.Sprintf("%s=%s is the happy case", condition.Type, condition.Status)
@@ -60,6 +72,12 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 
 		// For the non-upgrade case, if any operator has Available=False, fail the test.
 		if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
+			if operator == "storage" &&
+				intervalOverlapsE2ETest(e2eEventIntervals, eventInterval, "vSphere CSI Driver Operator Removal") {
+				// This tests removes the vSphere CSI driver operator and adds it back. As result, the storage operator may report Available=False for a short period of time.
+				// [sig-storage][platform:vsphere] vSphere CSI Driver Operator Removal should successfully remove and restore storage resources [Suite:openshift/conformance/serial]
+				return "storage operator may report Available=False while \"vSphere CSI Driver Operator Removal\" e2e test runs"
+			}
 			if operator == "authentication" {
 				if checkAuthenticationAvailableExceptions(condition) {
 					return "https://issues.redhat.com/browse/OCPBUGS-20056"


### PR DESCRIPTION
Test "vSphere CSI Driver Operator Removal" un-installs the CSI driver + installs it back. I.e. a DaemonSet and two Deployment are deleted + re-created with many events like "Created pod: vmware-vsphere-csi-driver-node-tkl25"

See https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/337 that adds the test + [a rehearsal result](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-vmware-vsphere-csi-driver-operator-337-nightly-5.0-e2e-vsphere-ovn-serial/2051332952062693376)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened detection of vSphere CSI-related E2E test intervals to include additional configuration and operator-removal scenarios, improving recognition of relevant test overlaps.
  * Added interval-overlap detection and a storage-specific exception path to better handle upgrade/test timing edge cases in monitoring tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->