### PR TITLE
OCPBUGS-83623: fix: add distruption tolerance for DualReplica (two-node) topology

### DIFF
--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -158,6 +158,11 @@ func createDisruptionJunit(
 		secondDetails, percentDetails = "added an additional 10s of grace for single node cluster", "added an additional 40% of grace for single node cluster"
 	}
 
+	if jobType.Topology == "dual" {
+		graceSeconds, gracePercent = 60, 1.4
+		secondDetails, percentDetails = "added an additional 60s of grace for dual replica cluster", "added an additional 40% of grace for dual replica cluster"
+	}
+
 	allowedSecsPlusGrace := allowedSecs + graceSeconds
 	allowedSecsPlusPercent := allowedSecs * gracePercent
 

--- a/pkg/monitortestlibrary/platformidentification/types.go
+++ b/pkg/monitortestlibrary/platformidentification/types.go
@@ -302,6 +302,8 @@ func GetJobType(ctx context.Context, clientConfig *rest.Config) (*JobType, error
 		topology = "single"
 	case configv1.ExternalTopologyMode:
 		topology = "external"
+	case configv1.DualReplicaTopologyMode:
+		topology = "dual"
 	}
 
 	return &JobType{


### PR DESCRIPTION
Single-replica operators on 2 node clusters experience ~53s of expected unavailability during NoExecuteTaintManager tests due to pod evition, rescheduling to the only othe control-plane node, and leader election. Add a 60s grace period for DualReplica topology, mirroring the existing SNO pattern, so this expected behaviour is not flagged as a test failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dual replica topology mode in platform identification.
  * Enabled specialized disruption test configurations for dual replica deployments with adjusted grace parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->