### PR TITLE
SREP-4796: Allow CreateMustGather alert in conformance tests

### DIFF
--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -40,7 +40,8 @@ var AllowedAlertNames = []string{
 	"Watchdog",
 	"AlertmanagerReceiversNotConfigured",
 	"PrometheusRemoteWriteDesiredShards",
-	"KubeJobFailingSRE", // https://issues.redhat.com/browse/OCPBUGS-55635
+	"KubeJobFailingSRE",  // https://issues.redhat.com/browse/OCPBUGS-55635
+	"CreateMustGather",  // https://issues.redhat.com/browse/SREP-4796 - CAD meta-alert for must-gather collection
 
 	// indicates a problem in the external Telemeter service, presently very common, does not impact our ability to e2e test:
 	"TelemeterClientFailures",

--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -40,8 +40,8 @@ var AllowedAlertNames = []string{
 	"Watchdog",
 	"AlertmanagerReceiversNotConfigured",
 	"PrometheusRemoteWriteDesiredShards",
-	"KubeJobFailingSRE",  // https://issues.redhat.com/browse/OCPBUGS-55635
-	"CreateMustGather",  // https://issues.redhat.com/browse/SREP-4796 - CAD meta-alert for must-gather collection
+	"KubeJobFailingSRE", // https://issues.redhat.com/browse/OCPBUGS-55635
+	"CreateMustGather",  // https://issues.redhat.com/browse/SREP-4796
 
 	// indicates a problem in the external Telemeter service, presently very common, does not impact our ability to e2e test:
 	"TelemeterClientFailures",

--- a/pkg/monitortestlibrary/allowedalerts/types.go
+++ b/pkg/monitortestlibrary/allowedalerts/types.go
@@ -40,8 +40,8 @@ var AllowedAlertNames = []string{
 	"Watchdog",
 	"AlertmanagerReceiversNotConfigured",
 	"PrometheusRemoteWriteDesiredShards",
-	"KubeJobFailingSRE", // https://issues.redhat.com/browse/OCPBUGS-55635
-	"CreateMustGather",  // https://issues.redhat.com/browse/SREP-4796
+	"KubeJobFailingSRE",  // https://issues.redhat.com/browse/OCPBUGS-55635
+	"CreateMustGather.*", // https://issues.redhat.com/browse/SREP-4796
 
 	// indicates a problem in the external Telemeter service, presently very common, does not impact our ability to e2e test:
 	"TelemeterClientFailures",

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -3,6 +3,7 @@ package legacytestframeworkmonitortests
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -239,7 +240,7 @@ func runBackstopTest(
 func isSkippedAlert(alertName string) bool {
 	// Some alerts we always skip over in CI:
 	for _, a := range allowedalerts.AllowedAlertNames {
-		if a == alertName {
+		if matched, _ := regexp.MatchString("^"+a+"$", alertName); matched {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Add `CreateMustGather` to the `AllowedAlertNames` list so it does not fail the "shouldn't report any alerts in firing state" conformance test.

## Why

`CreateMustGather` is a managed-cluster-config meta-alert that fires when any other alert has been active for 15 minutes. It triggers CAD (configuration-anomaly-detection) to collect a must-gather for debugging. On CI clusters, transient alerts during cluster install settling trigger CreateMustGather, which persists after the underlying alert resolves and fails conformance testing.

This has caused the alert to be [reverted from MCC twice](https://github.com/openshift/managed-cluster-config/pull/2729).

## Context

- Jira: [SREP-4796](https://redhat.atlassian.net/browse/SREP-4796)
- CAD repo: https://github.com/openshift/configuration-anomaly-detection
- MCC revert PR: https://github.com/openshift/managed-cluster-config/pull/2729
- Original initiative: [SREP-4025](https://redhat.atlassian.net/browse/SREP-4025)

## Test plan

- CI conformance jobs should no longer fail when CreateMustGather fires during cluster settling
- The alert can then be re-added to MCC with an additional install-settling guard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes an additional alert type: CreateMustGather, expanding monitored alert coverage.

* **Bug Fixes / Behavior Change**
  * Improved alert matching for skip decisions to use pattern-based matching, ensuring alerts are correctly identified against the allowed list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->