### PR TITLE
CNTRLPLANE-3374: remove multus exception from monitor test

### DIFF
--- a/pkg/monitortests/authentication/nodefaultserviceaccountoperatortests/monitortest.go
+++ b/pkg/monitortests/authentication/nodefaultserviceaccountoperatortests/monitortest.go
@@ -45,9 +45,6 @@ func exceptionWithJira(prefix, jiraURL string) func(corev1.Pod) (string, bool) {
 // The following are current exceptions due to not being part of the core OpenShift
 // payload or have open PRs to resolve.
 var exceptions = []func(pod corev1.Pod) (string, bool){
-	// This exception is being kept as there is still an open PR for this ticket.
-	// TODO(ehearne-redhat): check back on this ticket to review progress.
-	exceptionWithJira("openshift-multus/multus-", "https://issues.redhat.com/browse/OCPBUGS-65631"),
 	exceptionWithJira("openshift-route-monitor-operator/blackbox-exporter-", "https://redhat.atlassian.net/browse/SREP-4724"),
 	exceptionWithJira("openshift-security/", "https://redhat.atlassian.net/browse/SREP-4725"),
 	// This one checks if it is a debug pod or not.


### PR DESCRIPTION
Since https://github.com/openshift/cluster-network-operator/pull/2961 is now merged, we can safely remove this exception from the list. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an exemption from service account validation, enabling stricter security checks across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->