### PR TITLE
OCPBUGS-85087: Allow OVN-Kubernetes CIDROverlap pathological events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -560,6 +560,16 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	newRemoveSigtermProtectionEventMatcher := newRemoveSigtermProtectionEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(newRemoveSigtermProtectionEventMatcher)
 
+	// OVN-Kuberentes EVPN e2e tests running in parallel incorrectly create
+	// multiple VTEP resources with the same CIDR. No further consequence other
+	// than the Events themselves. Will be fixed with OCPBUGS-84917
+	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
+		name:               "OVNKubernetesCIDRsOverlapWithVTEPsEvents",
+		messageReasonRegex: regexp.MustCompile(`^CIDROverlap$`),
+		messageHumanRegex:  regexp.MustCompile(`CIDRs overlap with VTEPs`),
+		jira:               "https://redhat.atlassian.net/browse/OCPBUGS-84917",
+	})
+
 	return registry
 }
 


### PR DESCRIPTION
OVN-Kubernetes EVPN e2e tests when running in parallel create multiple VTEP resources with the same CIDR. OVN-Kubernetes logs this through events with no further consequence other than reporting the wasteful resource use. When sufficient EVPN e2e tests run in parallel, monitoring pathological event tracker picks this up and fails the job.

https://redhat.atlassian.net/browse/OCPBUGS-85087 will fix the tests to share the same VTEP resource. Until then, add an exception for the event. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced network monitoring capabilities to detect overlaps between OVN Kubernetes cluster network configurations and VTEP virtual tunnel endpoint network configurations. This improvement provides better visibility into potential network configuration conflicts, enabling proactive identification and resolution of compatibility issues that could affect cluster stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->