### PR TITLE
CNTRLPLANE-3387: Update list of pending namespaces in the required-scc monitor test

### DIFF
--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -40,14 +40,10 @@ var nonStandardSCCNamespaces = map[string]sets.Set[string]{
 // namespacesWithPendingSCCPinning includes namespaces with workloads that have pending SCC pinning.
 var namespacesWithPendingSCCPinning = sets.NewString(
 	"openshift-cluster-csi-drivers",
-	"openshift-cluster-version",
 	"openshift-image-registry",
 	"openshift-ingress",
-	"openshift-ingress-canary",
-	"openshift-ingress-operator",
 	"openshift-insights",
 	"openshift-machine-api",
-	"openshift-monitoring",
 	// run-level namespaces
 	"openshift-cloud-controller-manager",
 	"openshift-cloud-controller-manager-operator",


### PR DESCRIPTION
Removing fixed namespaces from the pending list. This effectively means that the test will now be enforced on those as well by failing when a workload w/o SCC pinning is detected by the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined security constraint monitoring coverage for cluster namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->