### PR TITLE
OCPBUGS-83580: Skip dev fuse test on runc runtime

### DIFF
--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -1,14 +1,12 @@
 package node
 
 import (
-	"context"
 	"path/filepath"
 	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 
@@ -115,13 +113,18 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		podName := "pod-devfuse"
 		ns := "devfuse-test"
 
-		g.By("Check if the default CRI-O runtime is runc")
-		ctrcfgList, err := oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().List(context.Background(), metav1.ListOptions{})
+		// Skip on runc: io.kubernetes.cri-o.Devices annotation is only in crun's allowed_annotations.
+		// We query crio config directly as ContainerRuntimeConfig API misses platform-default runc.
+		g.By("Skip if the default runtime is runc")
+		node, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+			"nodes", "-l", "node-role.kubernetes.io/worker", "-o=jsonpath={.items[0].metadata.name}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		for _, cfg := range ctrcfgList.Items {
-			if cfg.Spec.ContainerRuntimeConfig != nil && cfg.Spec.ContainerRuntimeConfig.DefaultRuntime == "runc" {
-				g.Skip("Skipping: not applicable to runc runtime")
-			}
+		o.Expect(node).NotTo(o.BeEmpty())
+		runtime, err := nodeutils.ExecOnNodeWithChroot(oc, node, "/bin/bash", "-c",
+			"crio status config 2>/dev/null | awk -F'\"' '/default_runtime/{print $2}'")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if strings.TrimSpace(runtime) == "runc" {
+			g.Skip("Skipping: not applicable to runc runtime")
 		}
 
 		g.By("Create a test namespace")


### PR DESCRIPTION
The io.kubernetes.cri-o.Devices annotation is only supported by crun. This will detect the actual runtime via crio status config on the node and skip when runc is there.

#### Bug

[OCPBUGS-83580](https://redhat.atlassian.net/browse/OCPBUGS-83580)

#### Follow-up PR

[#PR](https://github.com/openshift/origin/pull/30948)

#### Fix
Added a runtime check before test execution: query crio config on a worker node to detect the default runtime
Skip the test with a clear message when runc is the default runtime, since the /dev/fuse device annotation is not applicable

#### Testing
Tested on a fresh OCP 4.17 GCP cluster where the default runtime is runc.

```
➜  origin git:(fix-devfuse-runc-skip) ✗ oc debug node/$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}') -- chroot /host crio config 2>/dev/null | grep 'default_runtime'
# default_runtime is the _name_ of the OCI runtime to be used as the default.
# default_runtime = "runc"
# If no runtime handler is provided, the "default_runtime" will be used.

**Test skipping on runc as runtime**

➜  origin git:(fix-devfuse-runc-skip) ✗ ./openshift-tests run-test "[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987] [Suite:openshift/conformance/parallel]"

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1778134978 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111
    STEP: Creating a kubernetes client @ 05/07/26 11:53:05.357
  I0507 11:53:05.358716   88095 discovery.go:214] Invalidating discovery information
  I0507 11:53:05.360912 88095 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0507 11:53:05.678972 88095 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Skip if the default runtime is runc @ 05/07/26 11:53:05.679
    [SKIPPED] in [It] - github.com/openshift/origin/test/extended/node/node_e2e/node.go:126 @ 05/07/26 11:53:10.981
  S [SKIPPED] [5.663 seconds]
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [It] [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111

    [SKIPPED] Skipping: not applicable to runc runtime
    In [It] at: github.com/openshift/origin/test/extended/node/node_e2e/node.go:126 @ 05/07/26 11:53:10.981
  ------------------------------

  Ran 0 of 1 Specs in 5.664 seconds
  SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped

**Test getting pased on crun as runtime**

➜  origin git:(fix-devfuse-runc-skip) ✗ oc debug node/$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}') -- chroot /host crio config 2>/dev/null | grep 'default_runtime'
# default_runtime is the _name_ of the OCI runtime to be used as the default.
default_runtime = "crun"
# If no runtime handler is provided, the "default_runtime" will be used.

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1778135873 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] Allow dev fuse by default in CRI-O [OCP-70987]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:111
    STEP: Creating a kubernetes client @ 05/07/26 12:08:00.683
  I0507 12:08:00.684730   90487 discovery.go:214] Invalidating discovery information
  I0507 12:08:00.691999 90487 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0507 12:08:00.996333 90487 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Skip if the default runtime is runc @ 05/07/26 12:08:00.997
    STEP: Create a test namespace @ 05/07/26 12:08:06.911
  namespace/devfuse-test created
    STEP: Create a pod with dev fuse annotation @ 05/07/26 12:08:08.265
  pod/pod-devfuse created
    STEP: Wait for pod to be ready @ 05/07/26 12:08:10.062
    STEP: Check /dev/fuse is mounted inside the pod @ 05/07/26 12:08:16.221
  I0507 12:08:19.716678 90487 node.go:156] /dev/fuse mount output: File: /dev/fuse
    Size: 0             Blocks: 0          IO Block: 4096   character special file
  Device: 1000b0h/1048752d      Inode: 6           Links: 1     Device type: a,e5
  Access: (0666/crw-rw-rw-)  Uid: (    0/    root)   Gid: (    0/    root)
  Access: 2026-05-07 06:38:12.935627171 +0000
  Modify: 2026-05-07 06:38:12.935627171 +0000
  Change: 2026-05-07 06:38:12.935627171 +0000
   Birth: 2026-05-07 06:38:12.935627171 +0000
  namespace "devfuse-test" deleted
  • [58.651 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 58.660 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```
cc: @ngopalak-redhat 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CRI-O runtime test: now reads the runtime from a worker node’s CRI-O config (selects the first worker and parses/trims default_runtime) and skips only when the extracted value is exactly "runc", removing the previous MachineConfiguration API-based check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->