### PR TITLE
OCPSTRAT-3036: Disable kubectl kuberc commands test until oc is bumped to 1.36

### DIFF
--- a/pkg/test/filters/kube_rebase.go
+++ b/pkg/test/filters/kube_rebase.go
@@ -42,15 +42,16 @@ func (f *KubeRebaseTestsFilter) Filter(ctx context.Context, tests extensions.Ext
 
 	// TODO: this version along with below exclusions lists needs to be updated
 	// for the rebase in-progress.
-	if !strings.HasPrefix(serverVersion.Minor, "31") {
+	if !strings.HasPrefix(serverVersion.Minor, "36") {
 		return tests, nil
 	}
 
 	// Below list should only be filled in when we're trying to land k8s rebase.
 	// Don't pile them up!
 	exclusions := []string{
-		// affected by the available controller split https://github.com/kubernetes/kubernetes/pull/126149
-		`[sig-api-machinery] health handlers should contain necessary checks`,
+		// skipping the tests introduced in // https://github.com/kubernetes/kubernetes/pull/136643
+		// kuberc commands not registered in oc yet, will be re-enabled after oc is bumped to 1.36
+		`[sig-cli] kubectl kuberc commands`,
 	}
 
 	matches := make(extensions.ExtensionTestSpecs, 0, len(tests))


### PR DESCRIPTION
Skipping the `kubectl kuberc` tests introduced in // https://github.com/kubernetes/kubernetes/pull/136643.

Kuberc commands not registered in oc yet, will be re-enabled after oc is bumped to 1.36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes test compatibility from version 1.31 to 1.36, improving coverage for recent Kubernetes releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->