### PR TITLE
OCPBUGS-82501: Fix AWS DualStack CI jobs consistently encounter 2 EgressFirewall Test Failures

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43673,9 +43673,12 @@ spec:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/control-plane: ''
-  - type: Deny
+  - type: Deny        # IPv4 default deny-all
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny        # IPv6 default deny-all
+    to:
+      cidrSelector: ::/0
 `)
 
 func testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYamlBytes() ([]byte, error) {
@@ -43716,10 +43719,12 @@ spec:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/control-plane: ''
-  - type: Deny
+  - type: Deny        # IPv4 default deny-all
     to:
       cidrSelector: 0.0.0.0/0
-`)
+  - type: Deny        # IPv6 default deny-all
+    to:
+      cidrSelector: ::/0`)
 
 func testExtendedTestdataEgressFirewallOvnkEgressfirewallWildcardTestYamlBytes() ([]byte, error) {
 	return _testExtendedTestdataEgressFirewallOvnkEgressfirewallWildcardTestYaml, nil

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -24,6 +24,9 @@ spec:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/control-plane: ''
-  - type: Deny
+  - type: Deny        # IPv4 default deny-all
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny        # IPv6 default deny-all
+    to:
+      cidrSelector: ::/0

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
@@ -21,6 +21,9 @@ spec:
       nodeSelector:
         matchLabels:
           node-role.kubernetes.io/control-plane: ''
-  - type: Deny
+  - type: Deny        # IPv4 default deny-all
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny        # IPv6 default deny-all
+    to:
+      cidrSelector: ::/0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced egress firewall tests with explicit DNS resolution checks and verbose connectivity diagnostics (nslookup, detailed curl traces, resolved remote IPs, HTTP codes).
  * Updated test assertions to explicitly distinguish expected success and failure for different domains.
  * Test data updated to make deny-all behavior explicit for both IPv4 and IPv6, improving dual-stack coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->