### PR TITLE
OPRUN-4569: test: remove OTE exceptions for OLM

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -356,15 +356,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23745"
 			}
-		case "olm":
-			if condition.Type == configv1.OperatorAvailable &&
-				condition.Status == configv1.ConditionFalse &&
-				// "OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
-				// "CatalogdDeploymentCatalogdControllerManager_Deploying"
-				// "CatalogdDeploymentCatalogdControllerManager_Deploying::OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
-				strings.HasSuffix(condition.Reason, "ControllerManager_Deploying") {
-				return "https://issues.redhat.com/browse/OCPBUGS-62517"
-			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
 				(condition.Reason == "APIServerDeployment_NoDeployment" ||
@@ -744,16 +735,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 		case "service-ca":
 			if reason == "_ManagedDeploymentsAvailable" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62633"
-			}
-		case "olm":
-			// CatalogdDeploymentCatalogdControllerManager_Deploying
-			// OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying
-			if strings.HasSuffix(reason, "ControllerManager_Deploying") {
-				return "https://issues.redhat.com/browse/OCPBUGS-62635"
-			}
-		case "operator-lifecycle-manager-packageserver":
-			if reason == "" {
-				return "https://issues.redhat.com/browse/OCPBUGS-63672"
 			}
 		}
 		return ""


### PR DESCRIPTION
Remove three exception callbacks that were suppressing test failures for now-fixed ClusterOperator condition false alarms in OLM components:

- OCPBUGS-62517: olm Available=False during rolling update — fixed by cluster-olm-operator PR #202 (2 replicas + PDB on HA topology)
- OCPBUGS-62635: olm Progressing=True during MCO upgrade window — fixed by same PR #202 (PDB prevents zero-pod rollout)
- OCPBUGS-63672: operator-lifecycle-manager-packageserver Progressing=True on empty reason during pod disruption — fixed by operator-framework-olm commit 3071726a6 (isAPIServiceBackendDisrupted returns RetryableError)

The operator-lifecycle-manager exception (OCPBUGS-65583) is intentionally kept; OLMv0 is in maintenance mode and the team decided not to change it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tightened cluster upgrade operator state-transition tests by removing legacy exception cases for OLM and packageserver, enforcing stricter validation of operator deployment states during upgrades.

* **Chores**
  * Cleaned up obsolete test accommodations and removed outdated exception handling from operator monitoring checks to improve test coverage, reliability, and detection of deployment regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->