### PR TITLE
OCPBUGS-85363: Fixed flakiness of oc set image E2E tests

### DIFF
--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -2,17 +2,17 @@ package cli
 
 import (
 	"os"
-	"time"
+	"strings"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/klog/v2"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
 )
+
+const openshiftCLIImageStreamTag = "openshift/cli:latest"
 
 var _ = g.Describe("[sig-cli] oc set image", func() {
 	defer g.GinkgoRecover()
@@ -24,9 +24,17 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		oc               = exutil.NewCLIWithPodSecurityLevel("oc-set-image", admissionapi.LevelBaseline)
 	)
 
-	g.It("can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io][Skipped:Disconnected]", func() {
+	g.It("can set images for pods and deployments [apigroup:image.openshift.io][apigroup:apps.openshift.io]", func() {
+		payloadCLI, err := exutil.SearchLatestImage(oc, "cli")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		cliDigest := ""
+		if idx := strings.LastIndex(payloadCLI, "@sha256:"); idx >= 0 {
+			cliDigest = payloadCLI[idx+len("@sha256:"):]
+		}
+		o.Expect(cliDigest).NotTo(o.BeEmpty())
+
 		g.By("creating test deployment, pod, and image stream")
-		err := oc.Run("create").Args("-f", deploymentConfig).Execute()
+		err = oc.Run("create").Args("-f", deploymentConfig).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		file, err := writeObjectToFile(newHelloPod())
@@ -38,51 +46,46 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("create").Args("-f", imageStream).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("waiting for created resources to be ready for testing")
-		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "ruby:3.3-ubi8").Execute()
-			return err == nil, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
 		g.By("testing --local flag validation")
-		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.3-ubi8", "--local").Output()
+		out, err := oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--local").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
 
 		g.By("testing --dry-run=client with -o flags")
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag", "--dry-run=client").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag", "--dry-run=client").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("test-deployment-config"))
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config image updated (dry run)"))
 
-		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		out, err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag", "--dry-run=client", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deploymentconfig.apps.openshift.io/test-deployment-config"))
 
 		g.By("testing basic image updates")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		g.By("repeating basic image updates to ensure nothing changed")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		g.By("testing invalid image tags")
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:XYZ", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=istag").Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
-		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=ruby:XYZ", "--source=isimage").Execute()
+		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=isimage").Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
 		g.By("setting a different, valid image on deployment config")
@@ -109,30 +112,33 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("nginx:1.9.1"))
 
 		g.By("setting a different, valid image on multiple resources")
-		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("set").Args("image", "pods,dc", "*=ruby:3.3-ubi8", "--all", "--source=imagestreamtag").Execute()
-			if err != nil {
-				klog.Warningf("one of pods failed when setting image %v", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		err = oc.Run("set").Args("image", "pods,dc", "*="+openshiftCLIImageStreamTag, "--all", "--source=imagestreamtag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 	})
 
-	g.It("can set images for pods and deployments [apigroup:image.openshift.io][Skipped:Disconnected]", func() {
+	g.It("can set images for pods and deployments [apigroup:image.openshift.io]", func() {
+		payloadCLI, err := exutil.SearchLatestImage(oc, "cli")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		cliDigest := ""
+		if idx := strings.LastIndex(payloadCLI, "@sha256:"); idx >= 0 {
+			cliDigest = payloadCLI[idx+len("@sha256:"):]
+		}
+		o.Expect(cliDigest).NotTo(o.BeEmpty())
+
 		g.By("creating test deployment, pod, and image stream")
-		err := oc.Run("create").Args("-f", deployment).Execute()
+		err = oc.Run("create").Args("-f", deployment).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		file, err := writeObjectToFile(newHelloPod())
@@ -144,54 +150,49 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("create").Args("-f", imageStream).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("waiting for created resources to be ready for testing")
-		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "ruby:3.3-ubi8").Execute()
-			return err == nil, nil
-		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
 		g.By("testing --local flag validation")
-		out, err := oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.3-ubi8", "--local").Output()
+		out, err := oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--local").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("you must specify resources by --filename when --local is set."))
 
 		g.By("testing --dry-run=client with -o flags")
-		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag", "--dry-run=client").Output()
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag", "--dry-run=client").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("test-deployment"))
 		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment image updated (dry run)"))
 
-		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag", "--dry-run=client", "-o", "name").Output()
+		out, err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag", "--dry-run=client", "-o", "name").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("deployment.apps/test-deployment"))
 
 		g.By("testing basic image updates")
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		g.By("repeating basic image updates to ensure nothing changed")
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:3.3-ubi8", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		g.By("testing invalid image tags")
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:XYZ", "--source=istag").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=istag").Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
-		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=ruby:XYZ", "--source=isimage").Execute()
+		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=isimage").Execute()
 		o.Expect(err).To(o.HaveOccurred())
 
-		g.By("setting a different, valid image on deployment config")
+		g.By("setting a different, valid image on deployment")
 		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=nginx").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
@@ -215,24 +216,19 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		o.Expect(out).To(o.ContainSubstring("nginx:1.9.1"))
 
 		g.By("setting a different, valid image on multiple resources")
-		err = wait.PollImmediate(time.Second, 2*time.Minute, func() (bool, error) {
-			err := oc.Run("set").Args("image", "pods,deployments", "*=ruby:3.3-ubi8", "--all", "--source=imagestreamtag").Execute()
-			if err != nil {
-				klog.Warningf("one of pods failed when setting image %v", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		err = oc.Run("set").Args("image", "pods,deployments", "*="+openshiftCLIImageStreamTag, "--all", "--source=imagestreamtag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 
 		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/ruby@sha256:"))
+		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
+		o.Expect(out).To(o.ContainSubstring(cliDigest))
 	})
 })

--- a/test/extended/cli/setimage.go
+++ b/test/extended/cli/setimage.go
@@ -14,6 +14,20 @@ import (
 
 const openshiftCLIImageStreamTag = "openshift/cli:latest"
 
+// trimmedGetJSONPath runs oc get and returns stdout only (stderr is not merged), with jsonpath
+// quote wrappers removed. Client warnings must not be mixed into assertions.
+func trimmedGetJSONPath(oc *exutil.CLI, args ...string) (string, error) {
+	stdout, _, err := oc.Run("get").Args(args...).Outputs()
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(strings.TrimSpace(stdout), `'"`), nil
+}
+
+func expectResolvedCLIImage(image, cliDigest string) {
+	o.Expect(image).To(o.ContainSubstring("@sha256:" + cliDigest))
+}
+
 var _ = g.Describe("[sig-cli] oc set image", func() {
 	defer g.GinkgoRecover()
 
@@ -65,21 +79,17 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err := trimmedGetJSONPath(oc, "dc/test-deployment-config", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
 		g.By("repeating basic image updates to ensure nothing changed")
 		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "dc/test-deployment-config", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
 		g.By("testing invalid image tags")
 		err = oc.Run("set").Args("image", "dc/test-deployment-config", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=istag").Execute()
@@ -115,17 +125,13 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("set").Args("image", "pods,dc", "*="+openshiftCLIImageStreamTag, "--all", "--source=imagestreamtag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "pod/hello-openshift", "-o", "jsonpath={.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
-		out, err = oc.Run("get").Args("dc/test-deployment-config", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "dc/test-deployment-config", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 	})
 
 	g.It("can set images for pods and deployments [apigroup:image.openshift.io]", func() {
@@ -169,21 +175,17 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err := trimmedGetJSONPath(oc, "deployment/test-deployment", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
 		g.By("repeating basic image updates to ensure nothing changed")
 		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld="+openshiftCLIImageStreamTag, "--source=istag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "deployment/test-deployment", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
 		g.By("testing invalid image tags")
 		err = oc.Run("set").Args("image", "deployment/test-deployment", "ruby-helloworld=openshift/cli:notarealtagfortest", "--source=istag").Execute()
@@ -219,16 +221,12 @@ var _ = g.Describe("[sig-cli] oc set image", func() {
 		err = oc.Run("set").Args("image", "pods,deployments", "*="+openshiftCLIImageStreamTag, "--all", "--source=imagestreamtag").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		out, err = oc.Run("get").Args("pod/hello-openshift", "-o", "jsonpath='{.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "pod/hello-openshift", "-o", "jsonpath={.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 
-		out, err = oc.Run("get").Args("deployment/test-deployment", "-o", "jsonpath='{.spec.template.spec.containers[0].image}'").Output()
+		image, err = trimmedGetJSONPath(oc, "deployment/test-deployment", "-o", "jsonpath={.spec.template.spec.containers[0].image}")
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-"))
-		o.Expect(out).To(o.ContainSubstring("/cli@sha256:"))
-		o.Expect(out).To(o.ContainSubstring(cliDigest))
+		expectResolvedCLIImage(image, cliDigest)
 	})
 })

--- a/test/extended/util/search_latest_image.go
+++ b/test/extended/util/search_latest_image.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const openshiftPayloadImageNamespace = "openshift"
+
+// SearchLatestImage returns the resolved docker pull spec for imageName:latest in the openshift
+// namespace (payload imagestreams such as cli, tools, must-gather). The cluster serves the
+// architecture-appropriate image; callers must not hardcode digests.
+func SearchLatestImage(oc *CLI, imageName string) (string, error) {
+	if imageName == "" {
+		return "", fmt.Errorf("imageName is empty")
+	}
+	ctx := context.Background()
+	istag, err := oc.AdminImageClient().ImageV1().ImageStreamTags(openshiftPayloadImageNamespace).Get(ctx, imageName+":latest", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	ref := istag.Image.DockerImageReference
+	if ref == "" {
+		return "", fmt.Errorf("empty DockerImageReference for %s/%s:latest", openshiftPayloadImageNamespace, imageName)
+	}
+	return ref, nil
+}


### PR DESCRIPTION
oc set image e2e test fails consistently in CI due to a dependency on the ImageStream. The test attempts to use the ruby:3.3-ubi8 ImageStream, which must be imported from an external registry. If the Samples Operator is disabled, or external network access is restricted or slow the tests starts failing introducing flakiness in the tests. The test enters a retry loop waiting for the image metadata to populate and hits a 2-minute timeout

Modified the tests to use a Payload Image instead of a sample image. By switching to a payload-backed reference, the test eliminates external dependencies and avoids synchronization delays, and the flakiness will be removed.

**Testing**
**Before Fix**

imagestream.image.openshift.io/wildfly created
    STEP: waiting for created resources to be ready for testing @ 05/10/26 11:20:31.866
  I0510 11:20:33.025181 2599393 client.go:1094] Error running oc --namespace=e2e-test-oc-set-image-2j5qn --kubeconfig=/tmp/configfile1940459752 get imagestreamtags ruby:3.3-ubi8:
  StdOut>
  Error from server (NotFound): imagestreamtags.image.openshift.io "ruby:3.3-ubi8" not found
  StdErr>
  Error from server (NotFound): imagestreamtags.image.openshift.io "ruby:3.3-ubi8" not found

  Error from server (NotFound): imagestreamtags.image.openshift.io "ruby:3.3-ubi8" not found
  NAME            IMAGE REFERENCE                                                                                                                                             UPDATED
  ruby:3.3-ubi8   image-registry.openshift-image-registry.svc:5000/e2e-test-oc-set-image-2j5qn/ruby@sha256:0dab4f10d5038f00f4eaa6167ab75ec3dec9928ca2d9e77606ff39dfb4749854   2 seconds ago
    STEP: testing --local flag validation @ 05/10/26 11:20:35.013
  I0510 11:20:35.112917 2599393 client.go:1094] Error running oc --namespace=e2e-test-oc-set-image-2j5qn --k

**After Fix**

  imagestream.image.openshift.io/php created
  imagestream.image.openshift.io/postgresql created
  imagestream.image.openshift.io/python created
  imagestream.image.openshift.io/redis created
  imagestream.image.openshift.io/ruby created
  imagestream.image.openshift.io/wildfly created
    STEP: testing --local flag validation @ 05/11/26 15:00:18.288
  I0511 15:00:18.339969 2817270 client.go:1094] Error running oc --namespace=e2e-test-oc-set-image-wrwff --kubeconfig=/tmp/configfile1637928140 set image dc/test-deployment-config ruby-helloworld=openshift/cli:latest --local:
  StdOut>

As the new tests will work on air-gapped clusters as well, removed the skipped:disconnected in the test  
