### PR TITLE
OCPNODE-4506, OCPNODE-4539: Migrate ContainerRuntimeConfig tests (OCP-45351, OCP-46313)

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -10,6 +10,7 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **kubelet_secret_pulled_images.go** - Tests kubelet credential verification for image pulls (`KubeletEnsureSecretPulledImages` feature gate). Covers multi-tenancy isolation, credential rotation, ImagePullPolicy behavior, credential verification policy (NeverVerify/AlwaysVerify), and registry availability scenarios. Requires `TechPreviewNoUpgrade` or `CustomNoUpgrade` FeatureSet.
 - **node_e2e/image_registry_config.go** - Container registry config change (OCP-44820) - Verifies search registry update triggers MCO rollout and lands on nodes [Disruptive]
 - **node_e2e/pdb_drain.go** - PodDisruptionBudget drain blocking (OCP-67564) - Tests that node drain is blocked when PDB has minAvailable=100% with empty selector [Disruptive] [Lifecycle:informing]
+- **node_e2e/container_runtime_config.go** - ContainerRuntimeConfig pidsLimit (OCP-45351) and overlaySize (OCP-46313) - Verifies CTRCFG settings are applied via MCO rollout and reflected on nodes [Disruptive]
 
 ### Suite: openshift/usernamespace
 

--- a/test/extended/node/node_e2e/container_runtime_config.go
+++ b/test/extended/node/node_e2e/container_runtime_config.go
@@ -1,0 +1,287 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
+	"github.com/openshift/origin/test/extended/imagepolicy"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/ptr"
+
+	nodeutils "github.com/openshift/origin/test/extended/node"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig", func() {
+	var (
+		oc = exutil.NewCLIWithoutNamespace("ctrcfg")
+	)
+
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to detect MicroShift cluster")
+		if isMicroShift {
+			g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
+		}
+	})
+
+	// Validates that ContainerRuntimeConfig pidsLimit setting is correctly applied
+	// by MCO to a single worker node and that manual crio.conf edits are overwritten.
+	//author: cmaurya@redhat.com
+	g.It("[OTP] Verify pidsLimit and MCO overwrite behavior [OCP-45351]", func() {
+		ctx := context.Background()
+		ctrcfgName := "set-pids-limit"
+		mcpName := "ctrcfg-pids"
+
+		g.By("Get a ready worker node")
+		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get ready schedulable worker nodes")
+		o.Expect(workers).NotTo(o.BeEmpty(), "No Ready worker nodes found")
+		workerNode := workers[0].Name
+
+		g.By("Make a manual change to crio.conf on worker node")
+		_, err = nodeutils.ExecOnNodeWithChroot(oc, workerNode,
+			"/bin/bash", "-c", `sed -i '/^\[crio\.runtime\]/a log_level = "debug"' /etc/crio/crio.conf`)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to edit crio.conf on node %s", workerNode)
+
+		g.By("Verify the manual crio.conf edit took effect")
+		editedConf, err := nodeutils.ExecOnNodeWithChroot(oc, workerNode, "cat", "/etc/crio/crio.conf")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read crio.conf on node %s", workerNode)
+		o.Expect(editedConf).To(o.ContainSubstring(`log_level = "debug"`),
+			"sed edit did not apply: expected log_level = debug in crio.conf")
+
+		createSingleNodeMCP(ctx, oc, mcpName, workerNode)
+
+		g.DeferCleanup(func() {
+			g.By("Cleanup: delete ContainerRuntimeConfig")
+			delErr := oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().Delete(
+				ctx, ctrcfgName, metav1.DeleteOptions{})
+			if !apierrors.IsNotFound(delErr) {
+				o.Expect(delErr).NotTo(o.HaveOccurred(),
+					"cleanup failed: could not delete ContainerRuntimeConfig %s", ctrcfgName)
+			}
+			cleanupSingleNodeMCP(ctx, oc, mcpName, workerNode)
+		})
+
+		initialSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, mcpName)
+
+		g.By("Create ContainerRuntimeConfig with pidsLimit 2048")
+		ctrcfg := &mcfgv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: ctrcfgName},
+			Spec: mcfgv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"machineconfiguration.openshift.io/pool": mcpName},
+				},
+				ContainerRuntimeConfig: &mcfgv1.ContainerRuntimeConfiguration{
+					PidsLimit: ptr.To[int64](2048),
+				},
+			},
+		}
+		_, err = oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+			ctx, ctrcfg, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ContainerRuntimeConfig")
+
+		g.By("Wait for custom MCP rollout to complete")
+		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, mcpName, initialSpec)
+		e2e.Logf("Worker node rolled out successfully")
+
+		g.By("Verify pidsLimit and conmon in crio config on worker node")
+		var crioConfig string
+		o.Eventually(func() error {
+			var execErr error
+			crioConfig, execErr = nodeutils.ExecOnNodeWithChroot(oc, workerNode,
+				"/bin/bash", "-c", "crio config 2>/dev/null")
+			return execErr
+		}, 30*time.Second, 5*time.Second).Should(o.Succeed(), "failed to get crio config on node %s", workerNode)
+		o.Expect(crioConfig).To(o.ContainSubstring("pids_limit = 2048"), "pidsLimit should be 2048")
+		o.Expect(crioConfig).To(o.ContainSubstring(`conmon = ""`), "conmon should be empty")
+		o.Expect(crioConfig).NotTo(o.ContainSubstring(`log_level = "debug"`),
+			"manual crio.conf edit should be overwritten by MCO")
+	})
+
+	// Validates that setting overlaySize in ContainerRuntimeConfig is applied to
+	// storage.conf on a single worker node and the overlay size is reflected inside a container.
+	//author: cmaurya@redhat.com
+	g.It("[OTP] Verify overlaySize is applied to node and container [OCP-46313]", func() {
+		oc.SetupProject()
+		ctx := context.Background()
+		ctrcfgName := "ctrcfg-46313"
+		mcpName := "ctrcfg-overlay"
+		overlaySize := "9G"
+
+		g.By("Get a ready worker node")
+		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get ready schedulable worker nodes")
+		o.Expect(workers).NotTo(o.BeEmpty(), "No Ready worker nodes found")
+		workerNode := workers[0].Name
+
+		createSingleNodeMCP(ctx, oc, mcpName, workerNode)
+
+		g.DeferCleanup(func() {
+			g.By("Cleanup: delete ContainerRuntimeConfig")
+			delErr := oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().Delete(
+				ctx, ctrcfgName, metav1.DeleteOptions{})
+			if !apierrors.IsNotFound(delErr) {
+				o.Expect(delErr).NotTo(o.HaveOccurred(),
+					"cleanup failed: could not delete ContainerRuntimeConfig %s", ctrcfgName)
+			}
+			cleanupSingleNodeMCP(ctx, oc, mcpName, workerNode)
+		})
+
+		initialSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, mcpName)
+
+		g.By("Create ContainerRuntimeConfig with overlaySize " + overlaySize)
+		quantity := resource.MustParse(overlaySize)
+		ctrcfg := &mcfgv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: ctrcfgName},
+			Spec: mcfgv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"machineconfiguration.openshift.io/pool": mcpName},
+				},
+				ContainerRuntimeConfig: &mcfgv1.ContainerRuntimeConfiguration{
+					OverlaySize: &quantity,
+				},
+			},
+		}
+		_, err = oc.MachineConfigurationClient().MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+			ctx, ctrcfg, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ContainerRuntimeConfig")
+
+		g.By("Wait for custom MCP rollout to complete")
+		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, mcpName, initialSpec)
+		e2e.Logf("Worker node rolled out successfully")
+
+		g.By("Check overlaySize takes effect in storage.conf on worker node")
+		storageConf, err := nodeutils.ExecOnNodeWithChroot(oc, workerNode,
+			"/bin/bash", "-c", "head -n 7 /etc/containers/storage.conf | grep size")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read storage.conf on node %s", workerNode)
+		e2e.Logf("storage.conf size line: %s", storageConf)
+		o.Expect(storageConf).To(o.ContainSubstring(overlaySize),
+			"storage.conf should contain size = %s", overlaySize)
+
+		g.By("Create a pod on the target node to verify overlay size inside container")
+		podName := "pod-46313"
+		ns := oc.Namespace()
+		err = oc.AsAdmin().WithoutNamespace().Run("run").Args(
+			podName, "-n", ns,
+			"--image=quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339",
+			"--restart=Never",
+			"--overrides", `{"spec":{"nodeName":"`+workerNode+`","securityContext":{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"`+podName+`","image":"quay.io/openshifttest/hello-openshift@sha256:56c354e7885051b6bb4263f9faa58b2c292d44790599b7dde0e49e7c466cf339","command":["/bin/bash","-c","sleep 100000000"],"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}`,
+		).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create pod")
+		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("pod", podName, "-n", ns, "--ignore-not-found").Execute()
+
+		g.By("Wait for pod to be running")
+		err = wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
+			phase, pollErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				"pod", podName, "-n", ns, "-o=jsonpath={.status.phase}").Output()
+			if pollErr != nil {
+				return false, nil
+			}
+			return phase == "Running", nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "pod did not reach Running state")
+
+		g.By("Check overlay filesystem size inside the container")
+		dfOutput, err := oc.AsAdmin().WithoutNamespace().Run("rsh").Args(
+			"-n", ns, podName, "/bin/bash", "-c", "df -h / | grep overlay").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to exec df inside pod")
+		e2e.Logf("overlay df output: %s", dfOutput)
+		fields := strings.Fields(dfOutput)
+		o.Expect(len(fields)).To(o.BeNumerically(">=", 2), "unexpected df output format: %s", dfOutput)
+		actualSize := strings.Split(strings.TrimSuffix(fields[1], "G"), ".")[0] + "G"
+		o.Expect(actualSize).To(o.Equal(overlaySize),
+			"overlay filesystem should show %s, got: %s", overlaySize, actualSize)
+	})
+})
+
+// createSingleNodeMCP creates a custom MachineConfigPool that targets exactly one worker node.
+// It labels the node to move it into the custom pool and waits until the pool reports 1 node.
+func createSingleNodeMCP(ctx context.Context, oc *exutil.CLI, mcpName, workerNode string) {
+	nodeLabel := "node-role.kubernetes.io/" + mcpName
+
+	g.By("Create a custom MachineConfigPool targeting a single worker node")
+	mcp := &mcfgv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   mcpName,
+			Labels: map[string]string{"machineconfiguration.openshift.io/pool": mcpName},
+		},
+		Spec: mcfgv1.MachineConfigPoolSpec{
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "machineconfiguration.openshift.io/role",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"worker", mcpName},
+					},
+				},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{nodeLabel: ""},
+			},
+		},
+	}
+	_, err := oc.MachineConfigurationClient().MachineconfigurationV1().MachineConfigPools().Create(ctx, mcp, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to create custom MachineConfigPool %s", mcpName)
+
+	g.By("Label worker node to move it into the custom MCP")
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nodeLabel))
+	_, err = oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, workerNode, types.MergePatchType, patch, metav1.PatchOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to label node %s", workerNode)
+
+	g.By("Wait for the custom MCP to report the node")
+	o.Eventually(func() int {
+		pool, getErr := oc.MachineConfigurationClient().MachineconfigurationV1().MachineConfigPools().Get(ctx, mcpName, metav1.GetOptions{})
+		if getErr != nil {
+			return 0
+		}
+		return int(pool.Status.MachineCount)
+	}, 2*time.Minute, 10*time.Second).Should(o.Equal(1), "custom MCP %s should have 1 node", mcpName)
+}
+
+// cleanupSingleNodeMCP removes the node label, waits for the node to transition back to the
+// worker pool config, and then deletes the custom MCP.
+func cleanupSingleNodeMCP(ctx context.Context, oc *exutil.CLI, mcpName, workerNode string) {
+	nodeLabel := "node-role.kubernetes.io/" + mcpName
+
+	g.By("Cleanup: remove node label to move node back to worker pool")
+	patch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nodeLabel))
+	_, err := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, workerNode, types.MergePatchType, patch, metav1.PatchOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Logf("WARNING: failed to remove label from node %s: %v", workerNode, err)
+	}
+
+	g.By("Cleanup: wait for node to transition back to worker config")
+	o.Eventually(func() bool {
+		node, getErr := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, workerNode, metav1.GetOptions{})
+		if getErr != nil {
+			e2e.Logf("Error getting node: %v", getErr)
+			return false
+		}
+		currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		isWorkerConfig := currentConfig != "" && !strings.Contains(currentConfig, mcpName) && currentConfig == desiredConfig
+		if !isWorkerConfig {
+			e2e.Logf("Node %s still transitioning: current=%s, desired=%s", workerNode, currentConfig, desiredConfig)
+		}
+		return isWorkerConfig
+	}, 15*time.Minute, 15*time.Second).Should(o.BeTrue(),
+		"node %s should transition back to worker pool config", workerNode)
+
+	g.By("Cleanup: delete custom MachineConfigPool")
+	delErr := oc.MachineConfigurationClient().MachineconfigurationV1().MachineConfigPools().Delete(ctx, mcpName, metav1.DeleteOptions{})
+	if !apierrors.IsNotFound(delErr) && delErr != nil {
+		e2e.Logf("WARNING: failed to delete MachineConfigPool %s: %v", mcpName, delErr)
+	}
+}


### PR DESCRIPTION
#### Summary

- Migrate ContainerRuntimeConfig tests (OCP-45351, OCP-46313) from openshift-tests-private to origin
- OCP-45351: Validates pidsLimit is applied via MCO and manual crio.conf edits are overwritten
- OCP-46313: Validates overlaySize is applied to storage.conf and reflected inside containers
- Tests use a custom single-node MCP for faster rollouts (~5 min each)

**Note:** Both tests exercise the same feature (ContainerRuntimeConfig) and share a common Describe block, so they are grouped in a single file (`container_runtime_config.go`).

#### Test Results
Both tests passed on a live OCP 4.22 cluster:
- OCP-45351: SUCCESS (276s)
- OCP-46313: SUCCESS (293s)

Here is the test case link: 
Test1: [Polarian-45351](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-45351)
Test2: [Polarian-46313](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-46313)

#### Test Results

```
##Test1

./openshift-tests run-test "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig [OTP] Verify pidsLimit and MCO overwrite behavior [OCP-45351] [Serial]"

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1779264791 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig [OTP] Verify pidsLimit and MCO overwrite behavior [OCP-45351]
  github.com/openshift/origin/test/extended/node/node_e2e/container_runtime_config.go:42
    STEP: Creating a kubernetes client @ 05/20/26 13:43:16.11
  I0520 13:43:16.111089   27968 discovery.go:214] Invalidating discovery information
  I0520 13:43:16.111811 27968 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0520 13:43:16.373456 27968 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Get a ready worker node @ 05/20/26 13:43:16.373
    STEP: Make a manual change to crio.conf on worker node @ 05/20/26 13:43:16.643
    STEP: Verify the manual crio.conf edit took effect @ 05/20/26 13:43:24.834
    STEP: Create a custom MachineConfigPool targeting a single worker node @ 05/20/26 13:43:28.085
    STEP: Label worker node to move it into the custom MCP @ 05/20/26 13:43:28.357
    STEP: Wait for the custom MCP to report the node @ 05/20/26 13:43:28.891
    STEP: Create ContainerRuntimeConfig with pidsLimit 2048 @ 05/20/26 13:43:39.814
    STEP: Wait for custom MCP rollout to complete @ 05/20/26 13:43:40.085
  I0520 13:43:40.085407 27968 imagepolicy.go:694] Waiting for pool ctrcfg-pids to complete
  I0520 13:46:14.464897 27968 container_runtime_config.go:97] Worker node rolled out successfully
    STEP: Verify pidsLimit and conmon in crio config on worker node @ 05/20/26 13:46:14.468
    STEP: Cleanup: delete ContainerRuntimeConfig @ 05/20/26 13:46:18.015
    STEP: Cleanup: remove node label to move node back to worker pool @ 05/20/26 13:46:18.29
    STEP: Cleanup: wait for node to transition back to worker config @ 05/20/26 13:46:18.836
  I0520 13:46:19.149965 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd
  I0520 13:46:34.737581 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:46:50.266219 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:47:05.898891 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:47:21.511628 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:47:37.043393 27968 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-pids-b07ba709db2b7e62a3f538c08a2814fd, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
    STEP: Cleanup: delete custom MachineConfigPool @ 05/20/26 13:47:52.573
  • [276.761 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 276.763 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

##Test2

./openshift-tests run-test "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig [OTP] Verify overlaySize is applied to node and container [OCP-46313] [Serial]"

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1779265202 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig [OTP] Verify overlaySize is applied to node and container [OCP-46313]
  github.com/openshift/origin/test/extended/node/node_e2e/container_runtime_config.go:116
    STEP: Creating a kubernetes client @ 05/20/26 13:50:07.513
  I0520 13:50:07.514841   29133 discovery.go:214] Invalidating discovery information
  I0520 13:50:07.515733 29133 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0520 13:50:07.774730 29133 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  I0520 13:50:11.125841 29133 client.go:293] configPath is now "/var/folders/gp/skdk64696bg1pfs3gmdnznv80000gn/T/configfile628642414"
  I0520 13:50:11.125919 29133 client.go:368] The user is now "e2e-test-ctrcfg-qqsx9-user"
  I0520 13:50:11.125938 29133 client.go:370] Creating project "e2e-test-ctrcfg-qqsx9"
  I0520 13:50:11.497335 29133 client.go:378] Waiting on permissions in project "e2e-test-ctrcfg-qqsx9" ...
  I0520 13:50:12.558851 29133 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0520 13:50:12.822731 29133 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0520 13:50:13.456884 29133 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0520 13:50:14.086652 29133 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0520 13:50:14.713630 29133 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0520 13:50:14.983908 29133 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0520 13:50:15.250016 29133 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0520 13:50:17.069646 29133 client.go:469] Project "e2e-test-ctrcfg-qqsx9" has been fully provisioned.
    STEP: Get a ready worker node @ 05/20/26 13:50:17.069
    STEP: Create a custom MachineConfigPool targeting a single worker node @ 05/20/26 13:50:17.643
    STEP: Label worker node to move it into the custom MCP @ 05/20/26 13:50:17.909
    STEP: Wait for the custom MCP to report the node @ 05/20/26 13:50:18.178
    STEP: Create ContainerRuntimeConfig with overlaySize 9G @ 05/20/26 13:50:28.968
    STEP: Wait for custom MCP rollout to complete @ 05/20/26 13:50:29.313
  I0520 13:50:29.313597 29133 imagepolicy.go:694] Waiting for pool ctrcfg-overlay to complete
  I0520 13:52:12.355749 29133 container_runtime_config.go:163] Worker node rolled out successfully
    STEP: Check overlaySize takes effect in storage.conf on worker node @ 05/20/26 13:52:12.355
  I0520 13:52:15.523091 29133 container_runtime_config.go:169] storage.conf size line: size = "9G"
    STEP: Create a pod to verify overlay size inside container @ 05/20/26 13:52:15.523
  pod/pod-46313 created
    STEP: Wait for pod to be running @ 05/20/26 13:52:16.414
    STEP: Check overlay filesystem size inside the container @ 05/20/26 13:52:22.375
  I0520 13:52:23.990998 29133 container_runtime_config.go:200] overlay df output: overlay         9.0G  8.0K  9.0G   1% /
  I0520 13:52:23.991173 29133 container_runtime_config.go:204] pod overlay size parsed: 9G
  pod "pod-46313" deleted from e2e-test-ctrcfg-qqsx9 namespace
  I0520 13:52:55.674802 29133 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-ctrcfg-qqsx9-user}, err: <nil>
  I0520 13:52:55.941430 29133 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-ctrcfg-qqsx9}, err: <nil>
  I0520 13:52:56.207489 29133 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~avDT_7-H8mdLlPotlvLOMQa93uCxM5wjgFfibXwsCMY}, err: <nil>
    STEP: Cleanup: delete ContainerRuntimeConfig @ 05/20/26 13:52:56.208
    STEP: Cleanup: remove node label to move node back to worker pool @ 05/20/26 13:52:56.474
    STEP: Cleanup: wait for node to transition back to worker config @ 05/20/26 13:52:56.999
  I0520 13:52:57.261038 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be
  I0520 13:53:12.787492 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:53:28.310448 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:53:43.838141 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:53:59.362282 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
  I0520 13:54:14.888999 29133 container_runtime_config.go:277] Node ip-10-0-3-101.us-east-2.compute.internal still transitioning: current=rendered-ctrcfg-overlay-cfb69ef9b1aa57a7c4b7e432e65ab0be, desired=rendered-worker-8fac0a2f831d6f24e84787c2f56f3bd3
    STEP: Cleanup: delete custom MachineConfigPool @ 05/20/26 13:54:30.878
    STEP: Destroying namespace "e2e-test-ctrcfg-qqsx9" for this suite. @ 05/20/26 13:55:00.309
  • [293.349 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 293.350 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test suite that validates applying and rolling out container runtime settings via machine configuration pools on worker nodes.
  * Confirms runtime values (pids limit, log level) are enforced and that system-managed updates take precedence over manual edits.
  * Verifies cleanup restores labels and configuration state after the test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->