### PR TITLE
Port 5 router cookie tests from openshift-tests-private

### DIFF
--- a/test/extended/router/cookies_otp.go
+++ b/test/extended/router/cookies_otp.go
@@ -89,7 +89,7 @@ var _ = g.Describe("[sig-network-edge] Network_Edge Component_Router [OTP]", fun
 		g.By("10.0: Curl the http route with the specified cookie for 10 times again, expect the requests are forwarded to the two servers")
 		_, result = repeatCmdOnClient(oc, curlCmd, expectOutput, 120, 10)
 		o.Expect(result[0] + result[1]).To(o.Equal(10))
-		o.Expect(result[0] * result[1] > 0).To(o.BeTrue())
+		o.Expect(result[0]*result[1] > 0).To(o.BeTrue())
 	})
 
 	g.It("[OTP] [OCP-12566] Cookie name should not use openshift prefix [apigroup:route.openshift.io]", func() {

--- a/test/extended/router/cookies_otp.go
+++ b/test/extended/router/cookies_otp.go
@@ -1,0 +1,253 @@
+package router
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = g.Describe("[sig-network-edge] Network_Edge Component_Router [OTP]", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLIWithPodSecurityLevel("route-cookies", admissionapi.LevelBaseline)
+
+	g.It("[OTP] [OCP-11903] haproxy cookies based sticky session for unsecure routes [apigroup:route.openshift.io]", func() {
+		var (
+			buildPruningBaseDir = exutil.FixturePath("testdata", "router")
+			customTemp          = filepath.Join(buildPruningBaseDir, "ingresscontroller-np.yaml")
+			clientPod           = filepath.Join(buildPruningBaseDir, "test-client-pod.yaml")
+			clientPodName       = "hello-pod"
+			clientPodLabel      = "app=hello-pod"
+			testPodSvc          = filepath.Join(buildPruningBaseDir, "web-server-deploy.yaml")
+			srvrcInfo           = "web-server-deploy"
+			unsecSvcName        = "service-unsecure"
+			cookie              = "/data/OCP-11903-cookie"
+
+			ingctrl = ingressControllerDescription{
+				name:      "otp11903",
+				namespace: "openshift-ingress-operator",
+				domain:    "",
+				template:  customTemp,
+			}
+		)
+
+		g.By("1.0 Create a custom ingresscontroller")
+		baseDomain := getBaseDomain(oc)
+		ingctrl.domain = ingctrl.name + "." + baseDomain
+		defer ingctrl.delete(oc)
+		ingctrl.create(oc)
+		ensureRouterDeployGenerationIs(oc, ingctrl.name, "1")
+
+		g.By("2.0: Prepare file for testing")
+		updateFilebySedCmd(testPodSvc, "replicas: 1", "replicas: 2")
+
+		g.By("3.0: Create a client pod and two server pods and the service")
+		ns := oc.Namespace()
+		err := oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", ns, "-f", clientPod).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		ensurePodWithLabelReady(oc, ns, clientPodLabel)
+		srvPodList := createResourceFromWebServer(oc, ns, testPodSvc, srvrcInfo)
+
+		g.By("4.0: Create a plain HTTP route")
+		routehost := "unsecure11903" + "." + ingctrl.domain
+		createRouteOTP(oc, ns, "http", unsecSvcName, unsecSvcName, []string{"--hostname=" + routehost})
+		ensureRouteIsAdmittedByIngressController(oc, ns, unsecSvcName, ingctrl.name)
+
+		g.By("5.0: Curl the http route, make sure the second server is hit")
+		routerpod := getOneNewRouterPodFromRollingUpdate(oc, ingctrl.name)
+		podIP := getPodv4Address(oc, routerpod, "openshift-ingress")
+		toDst := routehost + ":80:" + podIP
+		curlCmd := []string{"-n", ns, clientPodName, "--", "curl", "http://" + routehost, "-s", "-c", cookie, "--resolve", toDst, "--connect-timeout", "10"}
+		expectOutput := []string{"Hello-OpenShift " + srvPodList[1] + " http-8080"}
+		repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+
+		g.By("6.0: Curl the http route again, make sure the first server is hit")
+		curlCmd = []string{"-n", ns, clientPodName, "--", "curl", "http://" + routehost, "-s", "--resolve", toDst, "--connect-timeout", "10"}
+		expectOutput = []string{"Hello-OpenShift " + srvPodList[0] + " http-8080"}
+		repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+
+		g.By("7.0: Curl the http route with the specified cookie for 10 times, expect all are forwarded to the second server")
+		curlCmd = []string{"-n", ns, clientPodName, "--", "curl", "http://" + routehost, "-s", "-b", cookie, "--resolve", toDst, "--connect-timeout", "10"}
+		expectOutput = []string{"Hello-OpenShift " + srvPodList[0] + " http-8080", "Hello-OpenShift " + srvPodList[1] + " http-8080"}
+		_, result := repeatCmdOnClient(oc, curlCmd, expectOutput, 120, 10)
+		o.Expect(result[1]).To(o.Equal(10))
+
+		g.By(`8.0: Disable haproxy hash based sticky session for the route by adding 'disable cookies' annotation to it`)
+		setAnnotation(oc, ns, "route/"+unsecSvcName, "haproxy.router.openshift.io/disable_cookies=true")
+
+		g.By("9.0: Check the disable cookies configuration in haproxy")
+		backendStart := fmt.Sprintf(`backend be_http:%s:%s`, ns, unsecSvcName)
+		ensureHaproxyBlockConfigNotMatchRegexp(oc, routerpod, backendStart, []string{`cookie .+httponly`})
+
+		g.By("10.0: Curl the http route with the specified cookie for 10 times again, expect the requests are forwarded to the two servers")
+		_, result = repeatCmdOnClient(oc, curlCmd, expectOutput, 120, 10)
+		o.Expect(result[0] + result[1]).To(o.Equal(10))
+		o.Expect(result[0] * result[1] > 0).To(o.BeTrue())
+	})
+
+	g.It("[OTP] [OCP-12566] Cookie name should not use openshift prefix [apigroup:route.openshift.io]", func() {
+		if !isCanaryRouteAvailable(oc) {
+			g.Skip("Skip for the ingress canary route could not be available to the outside")
+		}
+
+		var (
+			buildPruningBaseDir = exutil.FixturePath("testdata", "router")
+			testPodSvc          = filepath.Join(buildPruningBaseDir, "web-server-deploy.yaml")
+			srvrcInfo           = "web-server-deploy"
+			unsecSvcName        = "service-unsecure"
+			fileDir             = "/tmp/OCP-12566-cookie"
+			cookie              = fileDir + "/cookie12566"
+			routeName           = "unsecureroute2"
+		)
+
+		g.By("1.0: Prepare file folder and file for testing")
+		defer os.RemoveAll(fileDir)
+		err := os.MkdirAll(fileDir, 0755)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("2.0: Create two server pods and the service")
+		ns := oc.Namespace()
+		updateFilebySedCmd(testPodSvc, "replicas: 1", "replicas: 2")
+		createResourceFromWebServer(oc, ns, testPodSvc, srvrcInfo)
+
+		g.By("3.0: Create a plain HTTP route")
+		routehost := "unsecure12566" + ".apps." + getBaseDomain(oc)
+		createRouteOTP(oc, ns, "http", routeName, unsecSvcName, []string{"--hostname=" + routehost})
+		ensureRouteIsAdmittedByIngressController(oc, ns, routeName, "default")
+
+		g.By("4.0: Curl the http route, make sure one server is hit")
+		curlCmd := fmt.Sprintf(`curl http://%s -s -c %s --connect-timeout 10`, routehost, cookie)
+		expectOutput := []string{"Hello-OpenShift"}
+		repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+
+		g.By("5.0: Check the cookies which should not contain a OPENSHIFT prefix or a md5 hash")
+		cmd := fmt.Sprintf(`cat %s`, cookie)
+		cookiesOutput, err := exec.Command("bash", "-c", cmd).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(string(cookiesOutput)).NotTo(o.ContainSubstring("OPENSHIFT"))
+		o.Expect(string(cookiesOutput)).NotTo(o.MatchRegexp(`\d+\.\d+\.\d+\.\d+`))
+	})
+
+	g.It("[OTP] [OCP-15872] can set cookie name for unsecure routes by annotation [apigroup:route.openshift.io]", func() {
+		if !isCanaryRouteAvailable(oc) {
+			g.Skip("Skip for the ingress canary route could not be available to the outside")
+		}
+
+		var (
+			buildPruningBaseDir = exutil.FixturePath("testdata", "router")
+			testPodSvc          = filepath.Join(buildPruningBaseDir, "web-server-deploy.yaml")
+			srvrcInfo           = "web-server-deploy"
+			unsecSvcName        = "service-unsecure"
+		)
+
+		g.By("1.0: Create two server pods and the service")
+		updateFilebySedCmd(testPodSvc, "replicas: 1", "replicas: 2")
+		ns := oc.Namespace()
+		srvPodList := createResourceFromWebServer(oc, ns, testPodSvc, srvrcInfo)
+
+		g.By("2.0: Create a plain HTTP route")
+		routehost := "unsecure15872" + ".apps." + getBaseDomain(oc)
+		createRouteOTP(oc, ns, "http", unsecSvcName, unsecSvcName, []string{"--hostname=" + routehost})
+		ensureRouteIsAdmittedByIngressController(oc, ns, unsecSvcName, "default")
+
+		g.By("3.0: Set a cookie name to the route by the annotation, and then ensure the change in haproxy")
+		setAnnotation(oc, ns, "route/"+unsecSvcName, "router.openshift.io/cookie_name=unsecure-cookie_1")
+		routerPod := getOneRouterPodNameByIC(oc, "default")
+		ensureHaproxyBlockConfigContains(oc, routerPod, "be_http:"+ns+":"+unsecSvcName, []string{"unsecure-cookie_1"})
+
+		g.By("4.0: Curl the http route, make sure the second server is hit and the cookie is set in the client side")
+		curlCmd := fmt.Sprintf(`curl http://%s -sv --connect-timeout 10`, routehost)
+		expectOutput := []string{"Hello-OpenShift " + srvPodList[1] + " http-8080"}
+		output, _ := repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(output).To(o.MatchRegexp(`(s|S)et-(c|C)ookie: unsecure-cookie_1=[0-9a-zA-Z]+`))
+	})
+
+	g.It("[OTP] [OCP-35547] cookie-same-site route annotation accepts None Lax or Strict attribute for edge routes [apigroup:route.openshift.io]", func() {
+		if !isCanaryRouteAvailable(oc) {
+			g.Skip("Skip for the ingress canary route could not be available to the outside")
+		}
+
+		var (
+			buildPruningBaseDir = exutil.FixturePath("testdata", "router")
+			testPodSvc          = filepath.Join(buildPruningBaseDir, "web-server-deploy.yaml")
+			srvrcInfo           = "web-server-deploy"
+			unsecSvcName        = "service-unsecure"
+		)
+
+		g.By("1.0: Create two server pods and the service")
+		ns := oc.Namespace()
+		createResourceFromWebServer(oc, ns, testPodSvc, srvrcInfo)
+
+		g.By("2.0: Create an edge route")
+		routehost := "edge35547" + ".apps." + getBaseDomain(oc)
+		createRouteOTP(oc, ns, "edge", "edge35547", unsecSvcName, []string{"--hostname=" + routehost})
+		ensureRouteIsAdmittedByIngressController(oc, ns, "edge35547", "default")
+
+		g.By("3.0: Curl the edge route, and check set-cookie header, expect getting SameSite=None")
+		curlCmd := fmt.Sprintf(`curl https://%s -sSkI  --connect-timeout 10`, routehost)
+		expectOutput := []string{"set-cookie:"}
+		result, _ := repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(result).To(o.ContainSubstring(`Secure; SameSite=None`))
+
+		g.By("4.0: Add Strict annotation to the edge route, and then ensure the change in haproxy")
+		setAnnotation(oc, ns, "route/edge35547", "router.openshift.io/cookie-same-site=Strict")
+		routerPod := getOneRouterPodNameByIC(oc, "default")
+		ensureHaproxyBlockConfigContains(oc, routerPod, "be_edge_http:"+ns+":edge35547", []string{"SameSite=Strict"})
+
+		g.By("5.0: Curl the edge route again, and check set-cookie header, expect getting SameSite=Strict")
+		result, _ = repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(result).To(o.ContainSubstring(`Secure; SameSite=Strict`))
+	})
+
+	g.It("[OTP] [OCP-35548] cookie-same-site route annotation accepts None Lax or Strict attribute for Reencrypt routes [apigroup:route.openshift.io]", func() {
+		if !isCanaryRouteAvailable(oc) {
+			g.Skip("Skip for the ingress canary route could not be available to the outside")
+		}
+
+		var (
+			buildPruningBaseDir = exutil.FixturePath("testdata", "router")
+			testPodSvc          = filepath.Join(buildPruningBaseDir, "web-server-signed-deploy.yaml")
+			srvrcInfo           = "web-server-deploy"
+			secsvcName          = "service-secure"
+		)
+
+		g.By("1.0: Create two server pods and the service")
+		ns := oc.Namespace()
+		createResourceFromWebServer(oc, ns, testPodSvc, srvrcInfo)
+
+		g.By("2.0: Create a reencrypt route")
+		routehost := "reen35548" + ".apps." + getBaseDomain(oc)
+		createRouteOTP(oc, ns, "reencrypt", "reen35548", secsvcName, []string{"--hostname=" + routehost})
+		ensureRouteIsAdmittedByIngressController(oc, ns, "reen35548", "default")
+
+		g.By("3.0: Curl the reencrypt route, and check set-cookie header, expect getting SameSite=None")
+		curlCmd := fmt.Sprintf(`curl https://%s -sSkI  --connect-timeout 10`, routehost)
+		expectOutput := []string{"set-cookie:"}
+		result, _ := repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(result).To(o.ContainSubstring(`Secure; SameSite=None`))
+
+		g.By("4.0: Add Lax annotation to the reencrypt route, and then ensure the change in haproxy")
+		setAnnotation(oc, ns, "route/reen35548", "router.openshift.io/cookie-same-site=Lax")
+		routerPod := getOneRouterPodNameByIC(oc, "default")
+		ensureHaproxyBlockConfigContains(oc, routerPod, "be_secure:"+ns+":reen35548", []string{"SameSite=Lax"})
+
+		g.By("5.0: Curl the reencrypt route again, and check set-cookie header, expect getting SameSite=Lax")
+		result, _ = repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(result).To(o.ContainSubstring(`Secure; SameSite=Lax`))
+
+		g.By("6.0: Add Strict annotation to the reencrypt route, and then ensure the change in haproxy")
+		setAnnotation(oc, ns, "route/reen35548", "router.openshift.io/cookie-same-site=Strict")
+		ensureHaproxyBlockConfigContains(oc, routerPod, "be_secure:"+ns+":reen35548", []string{"SameSite=Strict"})
+
+		g.By("7.0: Curl the reencrypt route for the 3rd time, and check set-cookie header, expect getting SameSite=Strict")
+		result, _ = repeatCmdOnClient(oc, curlCmd, expectOutput, 60, 1)
+		o.Expect(result).To(o.ContainSubstring(`Secure; SameSite=Strict`))
+	})
+})

--- a/test/extended/router/util_otp.go
+++ b/test/extended/router/util_otp.go
@@ -1,0 +1,450 @@
+package router
+
+import (
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	exutil "github.com/openshift/origin/test/extended/util"
+	compat_otp "github.com/openshift/origin/test/extended/util/compat_otp"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type ingressControllerDescription struct {
+	name      string
+	namespace string
+	domain    string
+	template  string
+}
+
+func (ingctrl *ingressControllerDescription) create(oc *exutil.CLI) {
+	availableWorkerNode, _ := exactNodeDetails(oc)
+	if availableWorkerNode < 1 {
+		g.Skip("Skipping as there is no enough worker nodes")
+	}
+	err := createResourceFromTemplate(oc, "--ignore-unknown-parameters=true", "-f", ingctrl.template, "-p", "NAME="+ingctrl.name, "NAMESPACE="+ingctrl.namespace, "DOMAIN="+ingctrl.domain)
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func (ingctrl *ingressControllerDescription) delete(oc *exutil.CLI) error {
+	return oc.AsAdmin().WithoutNamespace().Run("delete").Args("--ignore-not-found", "-n", ingctrl.namespace, "ingresscontroller", ingctrl.name).Execute()
+}
+
+func exactNodeDetails(oc *exutil.CLI) (int, string) {
+	linuxWorkerDetails, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "--selector=node-role.kubernetes.io/worker=,kubernetes.io/os=linux").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	nodeCount := int(strings.Count(linuxWorkerDetails, "Ready")) - (int(strings.Count(linuxWorkerDetails, "SchedulingDisabled")) + int(strings.Count(linuxWorkerDetails, "NotReady")))
+	e2e.Logf("Linux worker node details are:\n%v", linuxWorkerDetails)
+	e2e.Logf("Available linux worker node count is: %v", nodeCount)
+	return nodeCount, linuxWorkerDetails
+}
+
+func createResourceFromTemplate(oc *exutil.CLI, parameters ...string) error {
+	jsonCfg := parseToJSON(oc, parameters)
+	return oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", jsonCfg).Execute()
+}
+
+func parseToJSON(oc *exutil.CLI, parameters []string) string {
+	var jsonCfg string
+	err := wait.Poll(3*time.Second, 15*time.Second, func() (bool, error) {
+		output, err := oc.AsAdmin().Run("process").Args(parameters...).OutputToFile(getRandomString() + "-temp-resource.json")
+		if err != nil {
+			e2e.Logf("the err:%v, and try next round", err)
+			return false, nil
+		}
+		jsonCfg = output
+		return true, nil
+	})
+	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("fail to process %v", parameters))
+	e2e.Logf("the file of resource is %s", jsonCfg)
+	return jsonCfg
+}
+
+func getRandomString() string {
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	seed := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buffer := make([]byte, 8)
+	for index := range buffer {
+		buffer[index] = chars[seed.Intn(len(chars))]
+	}
+	return string(buffer)
+}
+
+func getBaseDomain(oc *exutil.CLI) string {
+	basedomain, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("dns.config/cluster", "-o=jsonpath={.spec.baseDomain}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("the base domain of the cluster: %v", basedomain)
+	return basedomain
+}
+
+func createRouteOTP(oc *exutil.CLI, ns, routeType, routeName, serviceName string, extraParas []string) {
+	if routeType == "http" {
+		cmd := []string{"-n", ns, "service", serviceName, "--name=" + routeName}
+		cmd = append(cmd, extraParas...)
+		_, err := oc.Run("expose").Args(cmd...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	} else {
+		cmd := []string{"-n", ns, "route", routeType, routeName, "--service=" + serviceName}
+		cmd = append(cmd, extraParas...)
+		_, err := oc.WithoutNamespace().Run("create").Args(cmd...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+}
+
+func setAnnotation(oc *exutil.CLI, ns, resource, annotation string) {
+	err := oc.Run("annotate").Args("-n", ns, resource, annotation, "--overwrite").Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func getOneRouterPodNameByIC(oc *exutil.CLI, icname string) string {
+	podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", "ingresscontroller.operator.openshift.io/deployment-ingresscontroller="+icname, "-o=jsonpath={.items[0].metadata.name}", "-n", "openshift-ingress").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("the result of router pod name: %v", podName)
+	return podName
+}
+
+func getOnePodNameByLabel(oc *exutil.CLI, ns, label string) string {
+	podName, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-l", label, "-o=jsonpath={.items[0].metadata.name}", "-n", ns).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("the one pod with label %v is %v", label, podName)
+	return podName
+}
+
+func getOneNewRouterPodFromRollingUpdate(oc *exutil.CLI, icName string) string {
+	ns := "openshift-ingress"
+	deployName := "deployment/router-" + icName
+	rsLabel := ""
+	re := regexp.MustCompile(`NewReplicaSet:\s+router-.+-([a-z0-9]+)\s+`)
+	waitErr := wait.PollImmediate(3*time.Second, 15*time.Second, func() (bool, error) {
+		output, _ := oc.AsAdmin().WithoutNamespace().Run("describe").Args(deployName, "-n", ns).Output()
+		hash := re.FindStringSubmatch(output)
+		if len(hash) > 1 {
+			rsLabel = "pod-template-hash=" + hash[1]
+			return true, nil
+		}
+		return false, nil
+	})
+	compat_otp.AssertWaitPollNoErr(waitErr, "reached max time allowed but NewReplicaSet not found")
+	e2e.Logf("the new ReplicaSet labels is %s", rsLabel)
+	err := waitForPodWithLabelReady(oc, ns, rsLabel)
+	if err != nil {
+		output, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", ns).Output()
+		e2e.Logf("All current router pods are:\n%v", output)
+	}
+	compat_otp.AssertWaitPollNoErr(err, "the new router pod failed to be ready within allowed time!")
+	return getOnePodNameByLabel(oc, ns, rsLabel)
+}
+
+func ensureRouterDeployGenerationIs(oc *exutil.CLI, icName, expectGeneration string) {
+	ns := "openshift-ingress"
+	deployName := "deployment/router-" + icName
+	actualGeneration := "0"
+
+	waitErr := wait.PollImmediate(3*time.Second, 30*time.Second, func() (bool, error) {
+		actualGeneration, _ = oc.AsAdmin().WithoutNamespace().Run("get").Args(deployName, "-n", ns, "-o=jsonpath={.metadata.generation}").Output()
+		e2e.Logf("Get the deployment generation is: %v", actualGeneration)
+		if actualGeneration == expectGeneration {
+			e2e.Logf("The router deployment generation is updated to %v", actualGeneration)
+			return true, nil
+		}
+		return false, nil
+	})
+	compat_otp.AssertWaitPollNoErr(waitErr, fmt.Sprintf("max time reached and the expected deployment generation is %v but got %v", expectGeneration, actualGeneration))
+}
+
+func waitForPodWithLabelReady(oc *exutil.CLI, ns, label string) error {
+	return wait.Poll(5*time.Second, 3*time.Minute, func() (bool, error) {
+		status, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", ns, "-l", label, `-ojsonpath={.items[*].status.conditions[?(@.type=="Ready")].status}`).Output()
+		e2e.Logf("the Ready status of pod is %v", status)
+		if err != nil || status == "" {
+			e2e.Logf("failed to get pod status: %v, retrying...", err)
+			return false, nil
+		}
+		if strings.Contains(status, "False") {
+			e2e.Logf("the pod Ready status not met; wanted True but got %v, retrying...", status)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+func ensurePodWithLabelReady(oc *exutil.CLI, ns, label string) {
+	err := waitForPodWithLabelReady(oc, ns, label)
+	if err != nil {
+		output, _ := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", ns, "-l", label).Output()
+		e2e.Logf("All pods with label %v are:\n%v", label, output)
+		logs, _ := oc.AsAdmin().WithoutNamespace().Run("logs").Args("-n", ns, "-l", label, "--tail=10").Output()
+		e2e.Logf("The logs of all labeled pods are:\n%v", logs)
+	}
+	compat_otp.AssertWaitPollNoErr(err, fmt.Sprintf("max time reached but the pods with label %v are not ready", label))
+}
+
+func createResourceFromFile(oc *exutil.CLI, ns, file string) {
+	err := oc.WithoutNamespace().Run("create").Args("-f", file, "-n", ns).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}
+
+func createResourceFromWebServer(oc *exutil.CLI, ns, file, srvrcInfo string) []string {
+	createResourceFromFile(oc, ns, file)
+	err := waitForPodWithLabelReady(oc, ns, "name="+srvrcInfo)
+	compat_otp.AssertWaitPollNoErr(err, "backend server pod failed to be ready state within allowed time!")
+	srvPodList := getPodListByLabel(oc, ns, "name="+srvrcInfo)
+	return srvPodList
+}
+
+func getPodListByLabel(oc *exutil.CLI, namespace string, label string) []string {
+	podNameAll, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", namespace, "pod", "-l", label, "-ojsonpath={.items..metadata.name}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	podList := strings.Split(podNameAll, " ")
+	e2e.Logf("The pod list is %v", podList)
+	return podList
+}
+
+func ensureRouteIsAdmittedByIngressController(oc *exutil.CLI, ns, routeName, icName string) {
+	jsonPath := fmt.Sprintf(`{.status.ingress[?(@.routerName=="%s")].conditions[?(@.type=="Admitted")].status}`, icName)
+	waitForOutputEquals(oc, ns, "route/"+routeName, jsonPath, "True")
+}
+
+func waitForOutputEquals(oc *exutil.CLI, ns, resourceName, jsonPath, expected string, args ...interface{}) {
+	waitDuration := 180 * time.Second
+	for _, arg := range args {
+		duration, ok := arg.(time.Duration)
+		if ok {
+			waitDuration = duration
+		}
+	}
+
+	waitErr := wait.PollImmediate(5*time.Second, waitDuration, func() (bool, error) {
+		output := getByJsonPath(oc, ns, resourceName, jsonPath)
+		if output == expected {
+			return true, nil
+		}
+		e2e.Logf("The output of jsonpath does NOT equal the expected string: %v, retrying...", expected)
+		return false, nil
+	})
+	compat_otp.AssertWaitPollNoErr(waitErr, "max time reached but cannot find the expected string")
+}
+
+func getByJsonPath(oc *exutil.CLI, ns, resource, jsonPath string) string {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ns, resource, "-o=jsonpath="+jsonPath).Output()
+	if err != nil {
+		e2e.Logf("the error is: %v", err.Error())
+	}
+	e2e.Logf("the output filtered by jsonpath is: %v", output)
+	return output
+}
+
+func ensureHaproxyBlockConfigContains(oc *exutil.CLI, routerPodName string, blockCfgStart string, searchList []string) string {
+	var (
+		haproxyCfg string
+		j          = 0
+	)
+
+	e2e.Logf("Polling and search haproxy config file")
+	waitErr := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+		haproxyCfg = getBlockConfig(oc, routerPodName, blockCfgStart)
+		for i := j; i < len(searchList); i++ {
+			if strings.Contains(haproxyCfg, searchList[i]) {
+				e2e.Logf("Found the given string %v in haproxy.config", searchList[i])
+				j++
+				if j == len(searchList) {
+					e2e.Logf("All the given strings are found in haproxy.config")
+					return true, nil
+				}
+			} else {
+				e2e.Logf("The given string %v is still not found in haproxy.config, retrying...", searchList[i])
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+
+	compat_otp.AssertWaitPollNoErr(waitErr, "Reached max time allowed but the given string was not found in haproxy.config")
+	e2e.Logf("The part of haproxy.config that matching \"%s\" is:\n%v", blockCfgStart, haproxyCfg)
+	return haproxyCfg
+}
+
+func ensureHaproxyBlockConfigNotMatchRegexp(oc *exutil.CLI, routerPodName string, blockCfgStart string, searchList []string) string {
+	var (
+		haproxyCfg string
+		j          = 0
+	)
+
+	e2e.Logf("Polling and search haproxy config file")
+	waitErr := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+		haproxyCfg = getBlockConfig(oc, routerPodName, blockCfgStart)
+		for i := j; i < len(searchList); i++ {
+			searchInfo := regexp.MustCompile(searchList[i]).FindStringSubmatch(haproxyCfg)
+			if len(searchInfo) == 0 {
+				e2e.Logf("Could not found the given string %v in haproxy.config as expected", searchList[i])
+				j++
+				if j == len(searchList) {
+					e2e.Logf("Could not found all given strings in haproxy.config as expected")
+					return true, nil
+				}
+			} else {
+				e2e.Logf("The given string %v is still present in haproxy.config, retrying...", searchList[i])
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+
+	compat_otp.AssertWaitPollNoErr(waitErr, "Reached max time allowed but given string is still present in haproxy.config")
+	e2e.Logf("The part of haproxy.config that matching \"%s\" is:\n%v", blockCfgStart, haproxyCfg)
+	return haproxyCfg
+}
+
+func getBlockConfig(oc *exutil.CLI, routerPodName, searchString string) string {
+	output, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args("-n", "openshift-ingress", routerPodName, "--", "bash", "-c", "cat haproxy.config").Output()
+	o.Expect(err).NotTo(o.HaveOccurred(), "get the content of haproxy.config failed")
+	result := ""
+	flag := 0
+	startIndex := 0
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, searchString) {
+			result = result + line + "\n"
+			flag = 1
+			startIndex = len(line) - len(strings.TrimLeft(line, " "))
+		} else if flag == 1 {
+			lineLen := len(line)
+			if lineLen == 0 {
+				result = result + "\n"
+			} else {
+				currentIndex := len(line) - len(strings.TrimLeft(line, " "))
+				if currentIndex > startIndex {
+					result = result + line + "\n"
+				} else {
+					flag = 2
+				}
+			}
+		} else if flag == 2 {
+			break
+		}
+	}
+	e2e.Logf("The block configuration in haproxy that matching \"%s\" is:\n%v", searchString, result)
+	return result
+}
+
+func getPodv4Address(oc *exutil.CLI, podName, namespace string) string {
+	podIPv4, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", podName, "-n", namespace, "-o=jsonpath={.status.podIP}").Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	e2e.Logf("IP of the %s pod in namespace %s is %q ", podName, namespace, podIPv4)
+	return podIPv4
+}
+
+func repeatCmdOnClient(oc *exutil.CLI, cmd, expectOutput interface{}, duration time.Duration, repeatTimes int) (string, []int) {
+	var (
+		clientType       = "Internal"
+		matchedTimesList = []int{}
+		successCurlCount = 0
+		matchedCount     = 0
+		expectOutputList = []string{}
+		output           = ""
+	)
+
+	cmdStr, ok := cmd.(string)
+	if ok {
+		clientType = "External"
+	}
+	cmdList, _ := cmd.([]string)
+
+	expStr, ok := expectOutput.(string)
+	if ok {
+		expectOutputList = append(expectOutputList, expStr)
+	}
+	expList, ok := expectOutput.([]string)
+	if ok {
+		expectOutputList = expList
+	}
+
+	for i := 0; i < len(expectOutputList); i++ {
+		matchedTimesList = append(matchedTimesList, 0)
+	}
+
+	e2e.Logf("Using client type: %v", clientType)
+	e2e.Logf("The cmdStr (used by External client) is '%v' and cmdList (used by Internal client) is %v", cmdStr, cmdList)
+	e2e.Logf("The expectOutputList is %v and initial matchedTimesList is %v", expectOutputList, matchedTimesList)
+
+	waitErr := wait.Poll(1*time.Second, duration*time.Second, func() (bool, error) {
+		isMatch := false
+		if clientType == "Internal" {
+			info, err := oc.AsAdmin().WithoutNamespace().Run("exec").Args(cmdList...).Output()
+			if err != nil {
+				e2e.Logf("The error is: %v", err.Error())
+				searchInfo := regexp.MustCompile(expectOutputList[0]).FindStringSubmatch(err.Error())
+				if len(searchInfo) > 0 {
+					e2e.Logf("The expected string is included in err: %v", err)
+					return true, nil
+				}
+				e2e.Logf("Failed to execute cmd and got err %v, retrying...", err.Error())
+				return false, nil
+			}
+			output = info
+		} else {
+			info, err := exec.Command("bash", "-c", cmdStr).CombinedOutput()
+			if err != nil {
+				e2e.Logf("The error is: %v", err.Error())
+				searchInfo := regexp.MustCompile(expectOutputList[0]).FindStringSubmatch(err.Error())
+				if len(searchInfo) > 0 {
+					e2e.Logf("The expected string is included in err: %v", err)
+					return true, nil
+				}
+				e2e.Logf("Failed to execute cmd and got err %v, retrying...", err.Error())
+				return false, nil
+			}
+			output = string(info)
+		}
+
+		successCurlCount++
+		e2e.Logf("Executed cmd for %v times on the client and got output: %s", successCurlCount, output)
+
+		for i := 0; i < len(expectOutputList); i++ {
+			searchInfo := regexp.MustCompile(expectOutputList[i]).FindStringSubmatch(output)
+			if len(searchInfo) > 0 {
+				isMatch = true
+				matchedCount++
+				matchedTimesList[i] = matchedTimesList[i] + 1
+				break
+			}
+		}
+
+		if isMatch {
+			e2e.Logf("Successfully executed cmd for %v times on the client, expecting %v times", matchedCount, repeatTimes)
+			if matchedCount == repeatTimes {
+				return true, nil
+			}
+			return false, nil
+		}
+		successCurlCount--
+		e2e.Logf("Failed to find a match in the output, retrying...")
+		return false, nil
+	})
+
+	e2e.Logf("The matchedTimesList is: %v", matchedTimesList)
+	compat_otp.AssertWaitPollNoErr(waitErr, "max time reached but can't execute the cmd successfully for the desired times")
+
+	return output, matchedTimesList
+}
+
+func isCanaryRouteAvailable(oc *exutil.CLI) bool {
+	routehost := getByJsonPath(oc, "openshift-ingress-canary", "route/canary", "{.status.ingress[0].host}")
+	curlCmd := fmt.Sprintf(`curl https://%s -skI --connect-timeout 10`, routehost)
+	_, matchedTimes := repeatCmdOnClient(oc, curlCmd, "200", 60, 1)
+	if matchedTimes[0] == 1 {
+		return true
+	}
+	return false
+}
+
+func updateFilebySedCmd(file, toBeReplaced, newContent string) {
+	sedCmd := fmt.Sprintf(`sed -i'' -e 's|%s|%s|g' %s`, toBeReplaced, newContent, file)
+	_, err := exec.Command("bash", "-c", sedCmd).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+}

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -479,10 +479,14 @@
 // test/extended/testdata/roles/policy-clusterroles.yaml
 // test/extended/testdata/roles/policy-roles.yaml
 // test/extended/testdata/router/ingress.yaml
+// test/extended/testdata/router/ingresscontroller-np.yaml
 // test/extended/testdata/router/reencrypt-serving-cert.yaml
 // test/extended/testdata/router/router-common.yaml
 // test/extended/testdata/router/router-http-echo-server.yaml
 // test/extended/testdata/router/router-metrics.yaml
+// test/extended/testdata/router/test-client-pod.yaml
+// test/extended/testdata/router/web-server-deploy.yaml
+// test/extended/testdata/router/web-server-signed-deploy.yaml
 // test/extended/testdata/run_policy/parallel-bc.yaml
 // test/extended/testdata/run_policy/serial-bc.yaml
 // test/extended/testdata/run_policy/serial-latest-only-bc.yaml
@@ -51660,6 +51664,44 @@ func testExtendedTestdataRouterIngressYaml() (*asset, error) {
 	return a, nil
 }
 
+var _testExtendedTestdataRouterIngresscontrollerNpYaml = []byte(`apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+- apiVersion: operator.openshift.io/v1
+  kind: IngressController
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    domain: ${DOMAIN}
+    replicas: 1
+    endpointPublishingStrategy:
+      type: NodePortService
+    routeAdmission:
+      namespaceOwnership: Strict
+      wildcardPolicy: WildcardsDisallowed
+parameters:
+- name: NAME
+- name: NAMESPACE
+  value: openshift-ingress-operator
+- name: DOMAIN
+`)
+
+func testExtendedTestdataRouterIngresscontrollerNpYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterIngresscontrollerNpYaml, nil
+}
+
+func testExtendedTestdataRouterIngresscontrollerNpYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterIngresscontrollerNpYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/ingresscontroller-np.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataRouterReencryptServingCertYaml = []byte(`apiVersion: v1
 kind: List
 items:
@@ -52090,6 +52132,229 @@ func testExtendedTestdataRouterRouterMetricsYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "test/extended/testdata/router/router-metrics.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterTestClientPodYaml = []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: hello-pod
+  name: hello-pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+    name: hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    ports:
+    - containerPort: 8080
+    - containerPort: 8443
+`)
+
+func testExtendedTestdataRouterTestClientPodYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterTestClientPodYaml, nil
+}
+
+func testExtendedTestdataRouterTestClientPodYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterTestClientPodYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/test-client-pod.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterWebServerDeployYaml = []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      app: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: web-server-deploy
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+- kind: Service
+  apiVersion: v1
+  metadata:
+      labels:
+          name: service-secure
+      name: service-secure
+  spec:
+      ports:
+         - name: https
+           protocol: TCP
+           port: 27443
+           targetPort: 8443
+      selector:
+        name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy`)
+
+func testExtendedTestdataRouterWebServerDeployYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterWebServerDeployYaml, nil
+}
+
+func testExtendedTestdataRouterWebServerDeployYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterWebServerDeployYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/web-server-deploy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _testExtendedTestdataRouterWebServerSignedDeployYaml = []byte(`apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: nginx-config
+  data:
+    nginx.conf: |
+      events {
+          worker_connections 1024;
+      }
+
+      http {
+          server {
+              listen		8080;
+              listen       [::]:8080;
+              location / {
+                  root /data/http;
+              }
+          }
+
+          server {
+              listen           	    8443 ssl http2 default;
+              listen           	    [::]:8443 ssl http2 default;
+              server_name      	    _;
+              ssl_certificate  	    certs/tls.crt;
+              ssl_certificate_key  	certs/tls.key;
+              location / {
+                  root /data/https-default;
+              }
+          }
+      }
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      name: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchExpressions:
+       - {key: name, operator: In, values: [web-server-deploy]}
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+          volumeMounts:
+          - name: service-secret
+            mountPath: /etc/nginx/certs/
+          - name: nginx-config
+            mountPath: /etc/nginx/
+        volumes:
+        - name: service-secret
+          secret:
+            secretName: service-secret
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+- kind: Service
+  apiVersion: v1
+  metadata:
+      annotations:
+          service.beta.openshift.io/serving-cert-secret-name: service-secret
+      labels:
+          name: service-secure
+      name: service-secure
+  spec:
+      ports:
+         - name: https
+           protocol: TCP
+           port: 27443
+           targetPort: 8443
+      selector:
+        name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy
+`)
+
+func testExtendedTestdataRouterWebServerSignedDeployYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataRouterWebServerSignedDeployYaml, nil
+}
+
+func testExtendedTestdataRouterWebServerSignedDeployYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataRouterWebServerSignedDeployYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/router/web-server-signed-deploy.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -56786,10 +57051,14 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/roles/policy-clusterroles.yaml":                                                  testExtendedTestdataRolesPolicyClusterrolesYaml,
 	"test/extended/testdata/roles/policy-roles.yaml":                                                         testExtendedTestdataRolesPolicyRolesYaml,
 	"test/extended/testdata/router/ingress.yaml":                                                             testExtendedTestdataRouterIngressYaml,
+	"test/extended/testdata/router/ingresscontroller-np.yaml":                                                testExtendedTestdataRouterIngresscontrollerNpYaml,
 	"test/extended/testdata/router/reencrypt-serving-cert.yaml":                                              testExtendedTestdataRouterReencryptServingCertYaml,
 	"test/extended/testdata/router/router-common.yaml":                                                       testExtendedTestdataRouterRouterCommonYaml,
 	"test/extended/testdata/router/router-http-echo-server.yaml":                                             testExtendedTestdataRouterRouterHttpEchoServerYaml,
 	"test/extended/testdata/router/router-metrics.yaml":                                                      testExtendedTestdataRouterRouterMetricsYaml,
+	"test/extended/testdata/router/test-client-pod.yaml":                                                     testExtendedTestdataRouterTestClientPodYaml,
+	"test/extended/testdata/router/web-server-deploy.yaml":                                                   testExtendedTestdataRouterWebServerDeployYaml,
+	"test/extended/testdata/router/web-server-signed-deploy.yaml":                                            testExtendedTestdataRouterWebServerSignedDeployYaml,
 	"test/extended/testdata/run_policy/parallel-bc.yaml":                                                     testExtendedTestdataRun_policyParallelBcYaml,
 	"test/extended/testdata/run_policy/serial-bc.yaml":                                                       testExtendedTestdataRun_policySerialBcYaml,
 	"test/extended/testdata/run_policy/serial-latest-only-bc.yaml":                                           testExtendedTestdataRun_policySerialLatestOnlyBcYaml,
@@ -57610,11 +57879,15 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"policy-roles.yaml":        {testExtendedTestdataRolesPolicyRolesYaml, map[string]*bintree{}},
 				}},
 				"router": {nil, map[string]*bintree{
-					"ingress.yaml":                 {testExtendedTestdataRouterIngressYaml, map[string]*bintree{}},
-					"reencrypt-serving-cert.yaml":  {testExtendedTestdataRouterReencryptServingCertYaml, map[string]*bintree{}},
-					"router-common.yaml":           {testExtendedTestdataRouterRouterCommonYaml, map[string]*bintree{}},
-					"router-http-echo-server.yaml": {testExtendedTestdataRouterRouterHttpEchoServerYaml, map[string]*bintree{}},
-					"router-metrics.yaml":          {testExtendedTestdataRouterRouterMetricsYaml, map[string]*bintree{}},
+					"ingress.yaml":                  {testExtendedTestdataRouterIngressYaml, map[string]*bintree{}},
+					"ingresscontroller-np.yaml":     {testExtendedTestdataRouterIngresscontrollerNpYaml, map[string]*bintree{}},
+					"reencrypt-serving-cert.yaml":   {testExtendedTestdataRouterReencryptServingCertYaml, map[string]*bintree{}},
+					"router-common.yaml":            {testExtendedTestdataRouterRouterCommonYaml, map[string]*bintree{}},
+					"router-http-echo-server.yaml":  {testExtendedTestdataRouterRouterHttpEchoServerYaml, map[string]*bintree{}},
+					"router-metrics.yaml":           {testExtendedTestdataRouterRouterMetricsYaml, map[string]*bintree{}},
+					"test-client-pod.yaml":          {testExtendedTestdataRouterTestClientPodYaml, map[string]*bintree{}},
+					"web-server-deploy.yaml":        {testExtendedTestdataRouterWebServerDeployYaml, map[string]*bintree{}},
+					"web-server-signed-deploy.yaml": {testExtendedTestdataRouterWebServerSignedDeployYaml, map[string]*bintree{}},
 				}},
 				"run_policy": {nil, map[string]*bintree{
 					"parallel-bc.yaml":           {testExtendedTestdataRun_policyParallelBcYaml, map[string]*bintree{}},

--- a/test/extended/testdata/router/ingresscontroller-np.yaml
+++ b/test/extended/testdata/router/ingresscontroller-np.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+objects:
+- apiVersion: operator.openshift.io/v1
+  kind: IngressController
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+  spec:
+    domain: ${DOMAIN}
+    replicas: 1
+    endpointPublishingStrategy:
+      type: NodePortService
+    routeAdmission:
+      namespaceOwnership: Strict
+      wildcardPolicy: WildcardsDisallowed
+parameters:
+- name: NAME
+- name: NAMESPACE
+  value: openshift-ingress-operator
+- name: DOMAIN

--- a/test/extended/testdata/router/test-client-pod.yaml
+++ b/test/extended/testdata/router/test-client-pod.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: hello-pod
+  name: hello-pod
+spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+    name: hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    ports:
+    - containerPort: 8080
+    - containerPort: 8443

--- a/test/extended/testdata/router/web-server-deploy.yaml
+++ b/test/extended/testdata/router/web-server-deploy.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      app: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        name: web-server-deploy
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+          ports:
+          - containerPort: 8080
+            name: http
+            protocol: TCP
+          - containerPort: 8443
+            name: https
+            protocol: TCP
+- kind: Service
+  apiVersion: v1
+  metadata:
+      labels:
+          name: service-secure
+      name: service-secure
+  spec:
+      ports:
+         - name: https
+           protocol: TCP
+           port: 27443
+           targetPort: 8443
+      selector:
+        name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy

--- a/test/extended/testdata/router/web-server-signed-deploy.yaml
+++ b/test/extended/testdata/router/web-server-signed-deploy.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: nginx-config
+  data:
+    nginx.conf: |
+      events {
+          worker_connections 1024;
+      }
+
+      http {
+          server {
+              listen		8080;
+              listen       [::]:8080;
+              location / {
+                  root /data/http;
+              }
+          }
+
+          server {
+              listen           	    8443 ssl http2 default;
+              listen           	    [::]:8443 ssl http2 default;
+              server_name      	    _;
+              ssl_certificate  	    certs/tls.crt;
+              ssl_certificate_key  	certs/tls.key;
+              location / {
+                  root /data/https-default;
+              }
+          }
+      }
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web-server-deploy
+    labels:
+      name: web-server-deploy
+  spec:
+    replicas: 1
+    selector:
+      matchExpressions:
+       - {key: name, operator: In, values: [web-server-deploy]}
+    template:
+      metadata:
+        labels:
+          name: web-server-deploy
+      spec:
+        containers:
+        - name: nginx
+          image: quay.io/openshifttest/nginx-alpine@sha256:cee6930776b92dc1e93b73f9e5965925d49cff3d2e91e1d071c2f0ff72cbca29
+          volumeMounts:
+          - name: service-secret
+            mountPath: /etc/nginx/certs/
+          - name: nginx-config
+            mountPath: /etc/nginx/
+        volumes:
+        - name: service-secret
+          secret:
+            secretName: service-secret
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+- kind: Service
+  apiVersion: v1
+  metadata:
+      annotations:
+          service.beta.openshift.io/serving-cert-secret-name: service-secret
+      labels:
+          name: service-secure
+      name: service-secure
+  spec:
+      ports:
+         - name: https
+           protocol: TCP
+           port: 27443
+           targetPort: 8443
+      selector:
+        name: web-server-deploy
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      name: service-unsecure
+    name: service-unsecure
+  spec:
+    ports:
+    - name: http
+      port: 27017
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: web-server-deploy


### PR DESCRIPTION
Testing a test porting agent, please be patient. 

Agent will respond to coderabbit feedback, ensure the tests appear to be running and passing, then respond to human feedback. 

Human feedback can request improvements or to skip porting a test entirely.

## Summary
- Ports 5 high-pass-rate router cookie tests from openshift-tests-private (OCP-11903, OCP-12566, OCP-15872, OCP-35547, OCP-35548)
- Tests cover HAProxy sticky sessions, cookie naming conventions, and SameSite attribute behavior for edge/reencrypt routes
- All tests have >98% pass rate over 760-790 runs in the last 60 days
- Adds helper utilities in `util_otp.go` and 4 fixture YAML files

## Test plan
- [ ] Verify `go build ./test/extended/router/` passes (verified locally)
- [ ] Verify `go vet ./test/extended/router/` passes (verified locally)
- [ ] CI presubmit passes
- [ ] Tests discoverable with `[OTP]` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for OTP cookie behavior: cookie-based sticky sessions, cookie naming, custom cookie names, and SameSite/Secure handling across route types.
* **Test Utilities**
  * Added helper utilities to create/manage ingress controllers, routes, and to inspect router behavior for end-to-end testing.
* **Test Data**
  * Added manifests and embedded test assets for web servers, signed HTTPS server, client pod, and a NodePort-configured ingress template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->