### PR TITLE
NO-JIRA: Improve graceful shutdown LB test output with more details of late requests

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
@@ -1,16 +1,53 @@
 package auditloganalyzer
 
 import (
+	"fmt"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 )
 
+type lateRequest struct {
+	auditID                  string
+	requestReceivedTimestamp time.Time
+	verb                     string
+	requestURI               string
+	username                 string
+	userAgent                string
+	sourceIPs                []string
+	responseCode             int32
+	annotationValue          string
+	// elapsedSinceShutdown is populated by correlating with GracefulAPIServerShutdown intervals.
+	// Negative duration means we could not determine.
+	elapsedSinceShutdown time.Duration
+}
+
+func (r lateRequest) String() string {
+	elapsed := "unknown"
+	if r.elapsedSinceShutdown >= 0 {
+		elapsed = fmt.Sprintf("%ds", int(r.elapsedSinceShutdown.Seconds()))
+	}
+	return fmt.Sprintf("auditID=%s time=%s elapsed-since-shutdown=%s verb=%s uri=%s user=%s sourceIPs=%s userAgent=%q responseCode=%d annotation=%s",
+		r.auditID,
+		r.requestReceivedTimestamp.UTC().Format(time.RFC3339),
+		elapsed,
+		r.verb,
+		r.requestURI,
+		r.username,
+		strings.Join(r.sourceIPs, ","),
+		r.userAgent,
+		r.responseCode,
+		r.annotationValue,
+	)
+}
+
 type lateRequestTracking struct {
-	lock     sync.Mutex
-	auditIDs []string
+	lock         sync.Mutex
+	lateRequests []lateRequest
 }
 
 func CheckForRequestsDuringShutdown() *lateRequestTracking {
@@ -33,6 +70,42 @@ func (l *lateRequestTracking) HandleAuditLogEvent(auditEvent *auditv1.Event, beg
 		if value_slice[0] == "loopback=true" {
 			return
 		}
-		l.auditIDs = append(l.auditIDs, string(auditEvent.AuditID))
+		var responseCode int32
+		if auditEvent.ResponseStatus != nil {
+			responseCode = auditEvent.ResponseStatus.Code
+		}
+		l.lateRequests = append(l.lateRequests, lateRequest{
+			auditID:                  string(auditEvent.AuditID),
+			requestReceivedTimestamp: auditEvent.RequestReceivedTimestamp.Time,
+			verb:                     auditEvent.Verb,
+			requestURI:               auditEvent.RequestURI,
+			username:                 auditEvent.User.Username,
+			userAgent:                auditEvent.UserAgent,
+			sourceIPs:                auditEvent.SourceIPs,
+			responseCode:             responseCode,
+			annotationValue:          value,
+			elapsedSinceShutdown:     -1, // unknown until correlated
+		})
+	}
+}
+
+// correlateWithShutdownIntervals matches each late request against GracefulAPIServerShutdown
+// intervals and computes how many seconds after shutdown start the request arrived.
+func (l *lateRequestTracking) correlateWithShutdownIntervals(finalIntervals monitorapi.Intervals) {
+	shutdownIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Message.Reason == monitorapi.GracefulAPIServerShutdown
+	})
+	if len(shutdownIntervals) == 0 {
+		return
+	}
+
+	for i := range l.lateRequests {
+		reqTime := l.lateRequests[i].requestReceivedTimestamp
+		for _, shutdown := range shutdownIntervals {
+			if !reqTime.Before(shutdown.From) && !reqTime.After(shutdown.To) {
+				l.lateRequests[i].elapsedSinceShutdown = reqTime.Sub(shutdown.From)
+				break
+			}
+		}
 	}
 }

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_requests_during_graceful_shutdown.go
@@ -99,6 +99,8 @@ func (l *lateRequestTracking) correlateWithShutdownIntervals(finalIntervals moni
 		return
 	}
 
+	l.lock.Lock()
+	defer l.lock.Unlock()
 	for i := range l.lateRequests {
 		reqTime := l.lateRequests[i].requestReceivedTimestamp
 		for _, shutdown := range shutdownIntervals {

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -391,13 +391,20 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 	}
 
 	testName = "[sig-api-machinery][Feature:APIServer] API LBs follow /readyz of kube-apiserver and stop sending requests before server shutdowns for external clients"
+	w.requestsDuringShutdownChecker.correlateWithShutdownIntervals(finalIntervals)
 	switch {
-	case len(w.requestsDuringShutdownChecker.auditIDs) > 0:
+	case len(w.requestsDuringShutdownChecker.lateRequests) > 0:
+		requestDetails := make([]string, 0, len(w.requestsDuringShutdownChecker.lateRequests))
+		for _, req := range w.requestsDuringShutdownChecker.lateRequests {
+			requestDetails = append(requestDetails, req.String())
+		}
 		ret = append(ret,
 			&junitapi.JUnitTestCase{
 				Name: testName,
 				FailureOutput: &junitapi.FailureOutput{
-					Output: fmt.Sprintf("The following requests arrived when apiserver was gracefully shutting down:\n%s\nmore details in audit log", strings.Join(w.requestsDuringShutdownChecker.auditIDs, "\n")),
+					Output: fmt.Sprintf("The following %d request(s) arrived when apiserver was gracefully shutting down:\n%s\nmore details in audit log",
+						len(requestDetails),
+						strings.Join(requestDetails, "\n")),
 				},
 			},
 		)


### PR DESCRIPTION
Enhance further by correlating with graceful shutdown intervals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Richer tracking of API server requests observed during graceful shutdown: captures full request details (audit metadata, requester, response status, annotations) and correlates each request to shutdown intervals to report elapsed time since shutdown start. Test reporting now surfaces formatted late-request details for clearer diagnostics and failure messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->