### PR TITLE
OCPBUGS-84519: Remove openshift-ovn-kubernetes terminationMessagePolicy exemption

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -160,9 +160,8 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/metallb-operator-controller-manager",
 			"pods/metallb-operator-webhook-server",
 		),
-		"openshift-marketplace":    sets.NewString("pods/podman"),                     // filed OCPBUGS-84517 to fix
-		"openshift-operators":      sets.NewString("pods/servicemesh-operator3"),      // filed OCPBUGS-84518 to fix
-		"openshift-ovn-kubernetes": sets.NewString("pods/ovnkube-upgrades-prepuller"), // filed OCPBUGS-84519 to fix
+		"openshift-marketplace": sets.NewString("pods/podman"),                // filed OCPBUGS-84517 to fix
+		"openshift-operators":   sets.NewString("pods/servicemesh-operator3"), // filed OCPBUGS-84518 to fix
 		"openshift-sriov-network-operator": sets.NewString( // filed OCPBUGS-84526 to fix
 			"pods/network-resources-injector",
 			"pods/operator-webhook",


### PR DESCRIPTION
Containers in openshift-ovn-kubernetes namespace now have terminationMessagePolicy set, exemption no longer needed.

Depends on: https://github.com/openshift/cluster-network-operator/pull/3004

Fixes: https://issues.redhat.com/browse/OCPBUGS-84519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated exemption from the policy enforcement list, so containers that were previously grandfathered will now be subject to strict termination-message validation. This removes a legacy exception and ensures consistent enforcement of termination message handling across cluster components, improving policy accuracy and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->