### PR TITLE
OCPNODE-4516: PDB configured with 100% minAvailable - Migrate - 67564

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -9,6 +9,7 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **kubeletconfig_features.go** - Tests applying KubeletConfig to custom machine config pools, requires node reboots
 - **kubelet_secret_pulled_images.go** - Tests kubelet credential verification for image pulls (`KubeletEnsureSecretPulledImages` feature gate). Covers multi-tenancy isolation, credential rotation, ImagePullPolicy behavior, credential verification policy (NeverVerify/AlwaysVerify), and registry availability scenarios. Requires `TechPreviewNoUpgrade` or `CustomNoUpgrade` FeatureSet.
 - **node_e2e/image_registry_config.go** - Container registry config change (OCP-44820) - Verifies search registry update triggers MCO rollout and lands on nodes [Disruptive]
+- **node_e2e/pdb_drain.go** - PodDisruptionBudget drain blocking (OCP-67564) - Tests that node drain is blocked when PDB has minAvailable=100% with empty selector [Disruptive] [Lifecycle:informing]
 
 ### Suite: openshift/usernamespace
 

--- a/test/extended/node/node_e2e/pdb_drain.go
+++ b/test/extended/node/node_e2e/pdb_drain.go
@@ -1,0 +1,200 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/utils/ptr"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/operator"
+)
+
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] PodDisruptionBudget", func() {
+	var (
+		oc = exutil.NewCLIWithoutNamespace("pdb-drain")
+	)
+
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Skipping test on MicroShift cluster")
+		}
+	})
+
+	//author: bgudi@redhat.com
+	g.It("[OTP] Node's drain should block when PodDisruptionBudget minAvailable equals 100 percentage and selector is empty [OCP-67564]", ote.Informing(), func() {
+		ctx := context.Background()
+
+		// Skip on SNO/External topologies where there might not be dedicated worker nodes
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster infrastructure")
+		if infra.Status.ControlPlaneTopology == "SingleReplica" || infra.Status.ControlPlaneTopology == "External" {
+			g.Skip("Skipping on SNO/External topology - requires dedicated worker nodes")
+		}
+
+		oc.SetupProject()
+		namespace := oc.Namespace()
+
+		g.By("Get a worker node to schedule pods on")
+		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get worker nodes")
+		o.Expect(workers).NotTo(o.BeEmpty(), "no ready schedulable worker nodes found")
+		workerNode := workers[0].Name
+		e2e.Logf("Selected worker node: %s", workerNode)
+
+		g.By("Create 6 pods on the selected worker node")
+		numPods := 6
+		podBaseName := "pdb-drain-test-pod"
+		for i := 0; i < numPods; i++ {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("%s-%d", podBaseName, i),
+					Namespace: namespace,
+					Labels: map[string]string{
+						"app": "pdb-drain-test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": workerNode,
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83",
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+							},
+						},
+					},
+				},
+			}
+			_, err = oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("failed to create pod %d", i))
+		}
+
+		g.By("Wait for all pods to be ready")
+		err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+			podList, pollErr := oc.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=pdb-drain-test",
+			})
+			if pollErr != nil {
+				e2e.Logf("Error getting pods: %v", pollErr)
+				return false, nil
+			}
+			readyPods := 0
+			for _, pod := range podList.Items {
+				for _, cond := range pod.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+						readyPods++
+						break
+					}
+				}
+			}
+			if readyPods == numPods {
+				e2e.Logf("All %d pods are ready", readyPods)
+				return true, nil
+			}
+			e2e.Logf("Waiting for pods to be ready: %d/%d", readyPods, numPods)
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "pods did not become ready")
+
+		g.By("Create PodDisruptionBudget with 100% minAvailable and empty selector")
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pdb-drain-test",
+				Namespace: namespace,
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				MinAvailable: &intstr.IntOrString{
+					Type:   intstr.String,
+					StrVal: "100%",
+				},
+				Selector: &metav1.LabelSelector{},
+			},
+		}
+		_, err = oc.KubeClient().PolicyV1().PodDisruptionBudgets(namespace).Create(ctx, pdb, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create PodDisruptionBudget")
+		g.DeferCleanup(oc.KubeClient().PolicyV1().PodDisruptionBudgets(namespace).Delete, ctx, "pdb-drain-test", metav1.DeleteOptions{})
+
+		g.By("Verify all test pods are on the selected worker node")
+		podList, err := oc.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=pdb-drain-test",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get pods")
+		podsOnWorker := 0
+		for _, pod := range podList.Items {
+			if pod.Spec.NodeName == workerNode {
+				podsOnWorker++
+			}
+		}
+		o.Expect(podsOnWorker).To(o.Equal(numPods), "not all pods are on the selected worker node")
+
+		g.By("Make sure that PDB's DisruptionAllowed condition is False")
+		var pdbStatus string
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(pollCtx context.Context) (bool, error) {
+			var pollErr error
+			pdbStatus, pollErr = oc.AsAdmin().WithoutNamespace().Run("get").Args("poddisruptionbudget", "pdb-drain-test", "-n", namespace, "-o=jsonpath={.status.conditions[?(@.type==\"DisruptionAllowed\")].status}").Output()
+			if pollErr != nil {
+				e2e.Logf("Error getting PDB status: %v", pollErr)
+				return false, nil
+			}
+			if pdbStatus != "" {
+				return true, nil
+			}
+			e2e.Logf("Waiting for PDB DisruptionAllowed condition to appear")
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "PDB DisruptionAllowed condition not found")
+		o.Expect(pdbStatus).Should(o.Equal("False"), "PDB DisruptionAllowed should be False")
+
+		g.By("Drain the selected worker node")
+		g.DeferCleanup(func() {
+			err := operator.WaitForOperatorsToSettle(ctx, oc.AdminConfigClient(), 10)
+			o.Expect(err).NotTo(o.HaveOccurred(), "cluster operators failed to return to available state after node drain")
+		})
+		g.DeferCleanup(oc.AsAdmin().WithoutNamespace().Run("adm").Args("uncordon", workerNode).Execute)
+
+		out, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("drain", workerNode, "--ignore-daemonsets", "--delete-emptydir-data", "--force", "--timeout=30s").Output()
+		o.Expect(err).To(o.HaveOccurred(), "drain operation should have been blocked but it wasn't")
+		o.Expect(strings.Contains(out, "Cannot evict pod as it would violate the pod's disruption budget")).Should(o.BeTrue(), "drain output missing PDB violation error message")
+		o.Expect(strings.Contains(out, "There are pending nodes to be drained")).Should(o.BeTrue(), "drain output missing pending nodes error message")
+
+		g.By("Verify that test pods remain on the node after failed drain")
+		podsAfterDrain, err := oc.KubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=pdb-drain-test",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get pods after drain attempt")
+		podsStillOnWorker := 0
+		for _, pod := range podsAfterDrain.Items {
+			if pod.Spec.NodeName == workerNode {
+				podsStillOnWorker++
+			}
+		}
+		o.Expect(podsStillOnWorker).To(o.Equal(numPods), "all test pods should still be on the worker node")
+	})
+})


### PR DESCRIPTION
Migrates testcase [OCP-67564](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-67564) from openshift-tests-private to origin.

   #### What this test validates

   This test verifies that node drain operations are correctly blocked when a PodDisruptionBudget (PDB) is configured with `minAvailable: 100%` and an empty selector (which applies to all pods in the
   namespace).

   The test:
   - Creates a deployment with 6 replicas
   - Creates a PDB with 100% minAvailable and empty selector
   - Attempts to drain a worker node
   - Verifies the drain is blocked with the expected error: "Cannot evict pod as it would violate the pod's disruption budget"
   - Confirms pods remain on the node after the failed drain attempt

   #### Implementation details

   - Resources (Deployment, PDB) are created inline in the test
   - Uses `g.DeferCleanup()` for proper Ginkgo-managed resource cleanup
   - Includes topology guards to skip on SNO/External clusters (requires dedicated worker nodes)
   - Helper functions return errors instead of asserting, with assertions in the main test

   #### Testing

   Tested successfully on OCP 4.22 cluster:

   ```bash
   ./openshift-tests run-test "[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] node's drain should block when PodDisruptionBudget minAvailable equals 100 percentage and selector is empty
   [Disruptive] [OCP-67564] [Serial]"
  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] node's drain should block when PodDisruptionBudget minAvailable equals 100 percentage and selector is empty [Disruptive] [OCP-67564]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:170
    STEP: Creating a kubernetes client @ 05/12/26 18:09:30.969
  I0512 18:09:30.970449 1575364 discovery.go:214] Invalidating discovery information
  I0512 18:09:30.971109 1575364 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0512 18:09:31.311301 1575364 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  I0512 18:09:36.863684 1575364 client.go:293] configPath is now "/tmp/configfile852360194"
  I0512 18:09:36.863726 1575364 client.go:368] The user is now "e2e-test-node-5r77j-user"
  I0512 18:09:36.863734 1575364 client.go:370] Creating project "e2e-test-node-5r77j"
  I0512 18:09:37.208074 1575364 client.go:378] Waiting on permissions in project "e2e-test-node-5r77j" ...
  I0512 18:09:39.468148 1575364 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0512 18:09:39.847683 1575364 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0512 18:09:40.630808 1575364 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0512 18:09:41.631735 1575364 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0512 18:09:42.249637 1575364 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0512 18:09:42.632416 1575364 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0512 18:09:43.012047 1575364 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0512 18:09:44.541813 1575364 client.go:469] Project "e2e-test-node-5r77j" has been fully provisioned.
    STEP: Create a deployment with 6 replicas @ 05/12/26 18:09:44.541
    STEP: Wait for deployment to be ready @ 05/12/26 18:09:44.798
  I0512 18:09:45.174059 1575364 node.go:245] Waiting for deployment, ready replicas: 0/6
  I0512 18:09:48.171823 1575364 node.go:245] Waiting for deployment, ready replicas: 4/6
  I0512 18:09:51.056030 1575364 node.go:242] Deployment is ready with 6 replicas
    STEP: Create PodDisruptionBudget with 100% minAvailable @ 05/12/26 18:09:51.056
    STEP: Get a single worker node @ 05/12/26 18:09:51.316
  I0512 18:09:51.924434 1575364 node_utils.go:750] Worker Node Name is ip-10-0-122-55.ec2.internal
  I0512 18:09:51.924513 1575364 node.go:270] Selected worker node: ip-10-0-122-55.ec2.internal
    STEP: Obtain the pods running on node ip-10-0-122-55.ec2.internal @ 05/12/26 18:09:51.924
    STEP: Make sure that PDB's DisruptionAllowed condition is False @ 05/12/26 18:09:54.23
    STEP: Drain the node ip-10-0-122-55.ec2.internal @ 05/12/26 18:09:55.013
  I0512 18:10:40.574192 1575364 client.go:1094] Error running oc --kubeconfig=/home/bgudi/Downloads/cluster/4.21/auth/kubeconfig adm drain ip-10-0-122-55.ec2.internal --ignore-daemonsets --delete-emptydir-data --timeout=30s:
  StdOut>
  node/ip-10-0-122-55.ec2.internal cordoned
  Warning: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-5f9pt, openshift-cluster-node-tuning-operator/tuned-wgjfr, openshift-dns/dns-default-l9dxp, openshift-dns/node-resolver-lx4j6, openshift-image-registry/node-ca-d8mcx, openshift-ingress-canary/ingress-canary-4zjbk, openshift-insights/insights-runtime-extractor-hcb6j, openshift-machine-config-operator/machine-config-daemon-xf5f4, openshift-monitoring/node-exporter-2497d, openshift-multus/multus-99wzl, openshift-multus/multus-additional-cni-plugins-g47p5, openshift-multus/network-metrics-daemon-q9zdn, openshift-network-diagnostics/network-check-target-xdldx, openshift-network-operator/iptables-alerter-2tz5k, openshift-ovn-kubernetes/ovnkube-node-m9fcz
  evicting pod openshift-network-console/networking-console-plugin-77b766d84f-phbjp
  evicting pod openshift-monitoring/alertmanager-main-0
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod openshift-ingress/router-default-5f887fc9-87j9j
  evicting pod openshift-image-registry/image-registry-7959dc7696-swqgf
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod openshift-monitoring/prometheus-operator-admission-webhook-fbcddc5f7-jgdjq
  evicting pod openshift-monitoring/prometheus-k8s-0
  evicting pod openshift-monitoring/monitoring-plugin-56ccf75868-tfznk
  evicting pod openshift-monitoring/thanos-querier-5cb4bdfbb5-966pg
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  pod/prometheus-operator-admission-webhook-fbcddc5f7-jgdjq evicted
  pod/monitoring-plugin-56ccf75868-tfznk evicted
  pod/networking-console-plugin-77b766d84f-phbjp evicted
  pod/thanos-querier-5cb4bdfbb5-966pg evicted
  pod/alertmanager-main-0 evicted
  pod/prometheus-k8s-0 evicted
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  pod/image-registry-7959dc7696-swqgf evicted
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  There are pending pods in node "ip-10-0-122-55.ec2.internal" when an error occurred: [error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded, error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s, error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s]
  pod/hello-openshift-8db55bd55-gwt6s
  pod/hello-openshift-8db55bd55-prg47
  pod/router-default-5f887fc9-87j9j
  error: unable to drain node "ip-10-0-122-55.ec2.internal" due to error: [error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded, error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s, error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s], continuing command...
  There are pending nodes to be drained:
   ip-10-0-122-55.ec2.internal
  error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s
  StdErr>
  node/ip-10-0-122-55.ec2.internal cordoned
  Warning: ignoring DaemonSet-managed Pods: openshift-cluster-csi-drivers/aws-ebs-csi-driver-node-5f9pt, openshift-cluster-node-tuning-operator/tuned-wgjfr, openshift-dns/dns-default-l9dxp, openshift-dns/node-resolver-lx4j6, openshift-image-registry/node-ca-d8mcx, openshift-ingress-canary/ingress-canary-4zjbk, openshift-insights/insights-runtime-extractor-hcb6j, openshift-machine-config-operator/machine-config-daemon-xf5f4, openshift-monitoring/node-exporter-2497d, openshift-multus/multus-99wzl, openshift-multus/multus-additional-cni-plugins-g47p5, openshift-multus/network-metrics-daemon-q9zdn, openshift-network-diagnostics/network-check-target-xdldx, openshift-network-operator/iptables-alerter-2tz5k, openshift-ovn-kubernetes/ovnkube-node-m9fcz
  evicting pod openshift-network-console/networking-console-plugin-77b766d84f-phbjp
  evicting pod openshift-monitoring/alertmanager-main-0
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod openshift-ingress/router-default-5f887fc9-87j9j
  evicting pod openshift-image-registry/image-registry-7959dc7696-swqgf
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod openshift-monitoring/prometheus-operator-admission-webhook-fbcddc5f7-jgdjq
  evicting pod openshift-monitoring/prometheus-k8s-0
  evicting pod openshift-monitoring/monitoring-plugin-56ccf75868-tfznk
  evicting pod openshift-monitoring/thanos-querier-5cb4bdfbb5-966pg
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  pod/prometheus-operator-admission-webhook-fbcddc5f7-jgdjq evicted
  pod/monitoring-plugin-56ccf75868-tfznk evicted
  pod/networking-console-plugin-77b766d84f-phbjp evicted
  pod/thanos-querier-5cb4bdfbb5-966pg evicted
  pod/alertmanager-main-0 evicted
  pod/prometheus-k8s-0 evicted
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
  pod/image-registry-7959dc7696-swqgf evicted
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-gwt6s
  evicting pod e2e-test-node-5r77j/hello-openshift-8db55bd55-prg47
  There are pending pods in node "ip-10-0-122-55.ec2.internal" when an error occurred: [error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded, error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s, error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s]
  pod/hello-openshift-8db55bd55-gwt6s
  pod/hello-openshift-8db55bd55-prg47
  pod/router-default-5f887fc9-87j9j
  error: unable to drain node "ip-10-0-122-55.ec2.internal" due to error: [error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded, error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s, error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s], continuing command...
  There are pending nodes to be drained:
   ip-10-0-122-55.ec2.internal
  error when waiting for pod "router-default-5f887fc9-87j9j" in namespace "openshift-ingress" to terminate: context deadline exceeded
  error when evicting pods/"hello-openshift-8db55bd55-gwt6s" -n "e2e-test-node-5r77j": global timeout reached: 30s
  error when evicting pods/"hello-openshift-8db55bd55-prg47" -n "e2e-test-node-5r77j": global timeout reached: 30s

    STEP: Verify that the pods were not drained from the node @ 05/12/26 18:10:40.574
  node/ip-10-0-122-55.ec2.internal uncordoned
  I0512 18:10:46.245171 1575364 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-node-5r77j-user}, err: <nil>
  I0512 18:10:46.486835 1575364 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-node-5r77j}, err: <nil>
  I0512 18:10:47.146367 1575364 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~Asr0jX2TaAo3ybwiQNkuEHsOhgX9YZ90sDxkPK5-_CA}, err: <nil>
    STEP: Destroying namespace "e2e-test-node-5r77j" for this suite. @ 05/12/26 18:10:47.146
  • [76.679 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 76.679 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying node drain is blocked when a PodDisruptionBudget requires 100% availability; confirms drain fails with expected PDB-related output and that pods on the drained node remain unchanged.
  * Added test helpers to reliably select a single worker node and to wait until cluster operators report Available, improving test stability and readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->