### PR TITLE
OCPBUGS-85486: stage the creation of test pods to minimize etcd impact

### DIFF
--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -133,6 +133,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), podNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	time.Sleep(2 * time.Second)
 	klog.Infof("Starting deployment: %s", podNetworkToHostNetworkPollerDeployment.Name)
 	podNetworkToHostNetworkPollerDeployment.Spec.Replicas = &numNodes
 	podNetworkToHostNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
@@ -140,6 +141,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), podNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	time.Sleep(2 * time.Second)
 	klog.Infof("Starting deployment: %s", hostNetworkToPodNetworkPollerDeployment.Name)
 	hostNetworkToPodNetworkPollerDeployment.Spec.Replicas = &numNodes
 	hostNetworkToPodNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
@@ -147,6 +149,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	time.Sleep(2 * time.Second)
 	klog.Infof("Starting deployment: %s", hostNetworkToHostNetworkPollerDeployment.Name)
 	hostNetworkToHostNetworkPollerDeployment.Spec.Replicas = &numNodes
 	hostNetworkToHostNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
@@ -154,6 +157,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
 		return err
 	}
+	time.Sleep(2 * time.Second)
 	klog.Infof("Starting deployment: %s", podNetworkTargetDeployment.Name)
 	// force the image to use the "normal" global mapping.
 	originalAgnhost := k8simage.GetOriginalImageConfigs()[k8simage.Agnhost]
@@ -167,6 +171,7 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 		return err
 	}
 	pna.targetService = service
+	time.Sleep(2 * time.Second)
 	klog.Infof("Starting deployment: %s", hostNetworkTargetDeployment.Name)
 	hostNetworkTargetDeployment.Spec.Replicas = &numNodes
 	hostNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added timing adjustments between network deployment creation in network disruption tests to improve test stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->