### PR TITLE
OCPBUGS-85531: Fixed flakiness in OCP E2E tests -  oc debug image stream

### DIFF
--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/klog/v2"
 	admissionapi "k8s.io/pod-security-admission/api"
 
-	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -33,7 +33,6 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 	testDeployment := exutil.FixturePath("testdata", "test-deployment.yaml")
 	testReplicationController := exutil.FixturePath("testdata", "test-replication-controller.yaml")
 	helloPod := exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
-	imageStreamsCentos := exutil.FixturePath("..", "..", "examples", "image-streams", "image-streams-centos7.json")
 
 	g.It("deployment from a build [apigroup:image.openshift.io]", func() {
 		projectName, err := oc.Run("project").Args("-q").Output()
@@ -252,33 +251,41 @@ spec:
 	})
 
 	g.It("ensure it works with image streams [apigroup:image.openshift.io]", func() {
-		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		ctx := context.Background()
+		const (
+			targetIS        = "cli"
+			targetNS        = "openshift"
+			containerImage  = `{.spec.containers[0].image}`
+			digestPullMatch = `^.+@sha256:[a-f0-9]{64}$`
+		)
 
-		err = oc.Run("create").Args("-f", imageStreamsCentos).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		err = wait.Poll(cliInterval, cliTimeout, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "wildfly:latest").Execute()
-			return err == nil, nil
+		g.By("waiting for the internal ImageStreamTag to be available")
+		err := wait.PollUntilContextTimeout(ctx, cliInterval, cliTimeout, true, func(ctx context.Context) (bool, error) {
+			if err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS).Execute(); err != nil {
+				return false, nil
+			}
+			return true, nil
 		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		var out string
-		var resolvedImageMatcher = o.MatchRegexp("image:.*oc-debug-.*/wildfly@sha256")
-		if !hasImageRegistry {
-			resolvedImageMatcher = o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7")
+		if err != nil {
+			g.Skip(fmt.Sprintf("openshift/%s:latest not observed within %s: %v", targetIS, cliTimeout, err))
 		}
 
-		out, err = oc.Run("debug").Args("istag/wildfly:latest", "-o", "yaml").Output()
+		g.By("verifying oc debug works with istag")
+		img, err := oc.AsAdmin().Run("debug").Args(
+			fmt.Sprintf("istag/%s:latest", targetIS), "-n", targetNS, "-o", "jsonpath="+containerImage,
+		).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(resolvedImageMatcher)
+		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamTag by digest (any registry host)")
 
-		var sha string
-		sha, err = oc.Run("get").Args("istag/wildfly:latest", "--template", "{{ .image.metadata.name }}").Output()
+		g.By("verifying oc debug works with isimage (SHA-based lookup)")
+		sha, err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS, "--template", "{{ .image.metadata.name }}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		out, err = oc.Run("debug").Args(fmt.Sprintf("isimage/wildfly@%s", sha), "-o", "yaml").Output()
+
+		img, err = oc.AsAdmin().Run("debug").Args(
+			fmt.Sprintf("isimage/%s@%s", targetIS, strings.TrimSpace(sha)), "-n", targetNS, "-o", "jsonpath="+containerImage,
+		).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7"))
+		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamImage by digest (any registry host)")
 	})
 
 	g.It("ensure that the label is set for node debug", func() {


### PR DESCRIPTION
The original oc debug test was brittle due to its reliance on an external Wildfly fixture and deprecated polling methods. This dependency caused frequent failures. The fix switched to the guaranteed openshift/cli payload image and adopted PollUntilContextTimeout. 

Testing 
```
Will run 1 of 1 specs
  ------------------------------
  [sig-cli] oc debug ensure it works with image streams [apigroup:image.openshift.io]
  github.com/openshift/origin/test/extended/cli/debug.go:253
    STEP: Creating a kubernetes client @ 05/13/26 18:48:09.73
  I0513 18:48:09.731026 3032740 discovery.go:214] Invalidating discovery information
  I0513 18:48:10.134266 3032740 client.go:293] configPath is now "/tmp/configfile558432095"
  I0513 18:48:10.134298 3032740 client.go:368] The user is now "e2e-test-oc-debug-gsq4d-user"
  I0513 18:48:10.134306 3032740 client.go:370] Creating project "e2e-test-oc-debug-gsq4d"
  I0513 18:48:10.214464 3032740 client.go:378] Waiting on permissions in project "e2e-test-oc-debug-gsq4d" ...
  I0513 18:48:10.414529 3032740 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0513 18:48:10.444499 3032740 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0513 18:48:10.606831 3032740 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0513 18:48:10.769842 3032740 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0513 18:48:10.932852 3032740 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0513 18:48:10.965597 3032740 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0513 18:48:11.001155 3032740 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0513 18:48:11.421814 3032740 client.go:469] Project "e2e-test-oc-debug-gsq4d" has been fully provisioned.
    STEP: waiting for the internal ImageStreamTag to be available @ 05/13/26 18:48:11.425
  NAME         IMAGE REFERENCE                                                                                                                UPDATED
  cli:latest   registry.ci.openshift.org/ocp/4.22-2026-05-12-143123@sha256:76e1baa07b1a1193777c56ef46bb9e3d5de21e199fd4a2036f92d90195d0dbe5   8 hours ago
    STEP: verifying oc debug works with istag @ 05/13/26 18:48:11.645
    STEP: verifying oc debug works with isimage (SHA-based lookup) @ 05/13/26 18:48:11.823
  I0513 18:48:12.177401 3032740 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-oc-debug-gsq4d-user}, err: <nil>
  I0513 18:48:12.211936 3032740 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-oc-debug-gsq4d}, err: <nil>
  I0513 18:48:12.247106 3032740 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~8GPzSkkgYotZuR0GBF_qIkW0L9guT1B9HSKXCXl6sxg}, err: <nil>
    STEP: Destroying namespace "e2e-test-oc-debug-gsq4d" for this suite. @ 05/13/26 18:48:12.247
  • [2.558 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 2.558 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-cli] oc debug ensure it works with image streams [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 2558,
    "startTime": "2026-05-13 13:18:09.721839 UTC",
    "endTime": "2026-05-13 13:18:12.280265 UTC",
    "result": "passed",
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for the `oc debug` command with image streams, enhancing validation of image reference handling and test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->