### PR TITLE
OPRUN-4569: test: remove OLMv1 OTE exceptions; scope OLMv0 exceptions to SNO

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -355,15 +355,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
-		case "olm":
-			if condition.Type == configv1.OperatorAvailable &&
-				condition.Status == configv1.ConditionFalse &&
-				// "OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
-				// "CatalogdDeploymentCatalogdControllerManager_Deploying"
-				// "CatalogdDeploymentCatalogdControllerManager_Deploying::OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying"
-				strings.HasSuffix(condition.Reason, "ControllerManager_Deploying") {
-				return "https://issues.redhat.com/browse/OCPBUGS-62517"
-			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
 				if isTwoNode && condition.Reason == "APIServices_PreconditionNotReady" {
@@ -620,12 +611,14 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 	multiUpgrades := platformidentification.UpgradeNumberDuringCollection(events, time.Time{}, time.Time{}) > 1
 
 	isTwoNode := false
+	isSingleNode := false
 	if clientConfig != nil {
 		topology, err := getControlPlaneTopology(clientConfig)
 		if err != nil {
-			logrus.Warnf("Error checking for ControlPlaneTopology configuration for MCO co-progressing monitor (unable to apply two-node TNF exceptions): %v", err)
+			logrus.Warnf("Error checking for ControlPlaneTopology configuration for MCO co-progressing monitor (unable to apply topology exceptions): %v", err)
 		} else {
 			isTwoNode = topology == configv1.HighlyAvailableArbiterMode || topology == configv1.DualReplicaTopologyMode
+			isSingleNode = topology == configv1.SingleReplicaTopologyMode
 		}
 	}
 
@@ -777,8 +770,20 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "_ManagedDeploymentsAvailable" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62633"
 			}
+		case "olm":
+			// CatalogdDeploymentCatalogdControllerManager_Deploying
+			// OperatorcontrollerDeploymentOperatorControllerControllerManager_Deploying
+			// On HA, cluster-olm-operator PR #202 (2 replicas + PDB) prevents this.
+			// On SNO there is only one replica and the node reboot restarts all pods simultaneously.
+			if strings.HasSuffix(reason, "ControllerManager_Deploying") && isSingleNode {
+				return "https://issues.redhat.com/browse/OCPBUGS-62635"
+			}
 		case "operator-lifecycle-manager-packageserver":
-			if reason == "" {
+			// On HA, isAPIServiceBackendDisrupted() in operator-framework-olm detects terminating
+			// pods and returns RetryableError to prevent the CSV phase from changing to Failed.
+			// On SNO the OS-level node reboot kills all pods simultaneously so no terminating pod
+			// is ever observed; the detection does not fire and Progressing=True is still set.
+			if reason == "" && isSingleNode {
 				return "https://issues.redhat.com/browse/OCPBUGS-63672"
 			}
 		case "openshift-apiserver":


### PR DESCRIPTION
The OLMv1 fixes in cluster-olm-operator are now in release-5.0:
- PR https://github.com/openshift/origin/pull/202: 2 replicas + PDB on HA topology prevents Available=False and spurious Progressing=True during rolling updates (OCPBUGS-62517, OCPBUGS-62635)

Remove the OCPBUGS-62517 exception for olm Available=False entirely. The testUpgradeOperatorStateTransitions function already has a blanket SNO exemption, so single-node is covered.

For the Progressing-related exceptions, add clientConfig to testUpgradeOperatorProgressingStateTransitions so it can detect topology, then scope both remaining exceptions to SNO only:

- OCPBUGS-62635: olm Progressing=True during MCO window. On HA the 2-replica PDB fix prevents this; on SNO there is still 1 replica and the node reboot restarts all pods simultaneously. This had been removed, but is now restored since the issue still occurs under SNO.
- OCPBUGS-63672: operator-lifecycle-manager-packageserver Progressing=True on  empty reason. On HA, isAPIServiceBackendDisrupted() detects terminating pods and returns RetryableError. On SNO the OS-level reboot kills all pods at once so no terminating pod is observed and the detection does not fire.

The operator-lifecycle-manager exception (OCPBUGS-65583) is intentionally kept; OLMv0 is in maintenance mode.

Assisted-by: claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Operator state transition checks during upgrades now consider control-plane topology.
  * Progressing-state exceptions (including OLM and package server cases) are now limited to single-node deployments where appropriate, removing prior unconditional exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->