### PR TITLE
OCPBUGS-85608: Fix for OCP E2E Flakiness - [sig-cli] oc adm release extract image-references [Suite:openshift/conformance/parallel]

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/test/e2e/framework"
 
-	"github.com/openshift/origin/test/extended/testdata"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -547,10 +546,23 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 	})
 
 	g.It("release extract image-references", func() {
-		expected := string(testdata.MustAsset("test/extended/testdata/cli/test-release-image-references.json"))
-		out, err := oc.Run("adm", "release", "extract").Args("--file", "image-references", "quay.io/openshift-release-dev/ocp-release:4.13.0-rc.0-x86_64").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.Equal(expected))
+		payloadImage, err := oc.AsAdmin().Run("get").Args("clusterversion", "version", "-o", "jsonpath={.status.desired.image}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get current payload image from clusterversion")
+		payloadImage = strings.TrimSpace(payloadImage)
+		o.Expect(payloadImage).NotTo(o.BeEmpty())
+		cleanup, regArgs, err := exutil.PrepareImagePullSecretAndCABundle(ocns)
+		if cleanup != nil {
+			defer cleanup()
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "PrepareImagePullSecretAndCABundle failed")
+		args := append([]string{"--file", "image-references"}, regArgs...)
+		args = append(args, payloadImage)
+		out, err := oc.AsAdmin().Run("adm", "release", "extract").Args(args...).Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "oc adm release extract failed with error")
+
+		o.Expect(out).To(o.ContainSubstring(`"kind": "ImageStream"`))
+		o.Expect(out).To(o.ContainSubstring(`"apiVersion": "image.openshift.io/v1"`))
+		o.Expect(out).To(o.MatchRegexp(`"name": ".*"`), "Output should contain a valid name field")
 	})
 
 	// TODO (soltysh): sync with Standa and figure out if we can get these


### PR DESCRIPTION
The test was brittle as it relied on a hardcoded OpenShift 4.13 image reference from a public registry (quay.io), leading to  "502 Bad Gateway" or "401 Unauthorized" errors. To resolve this, the test was refactored . It now retrieves the payload image directly from the cluster’s own clusterversion API, ensuring the test always targets the relevant version without hardcoded strings.

```
  Running Suite:  - /home/yshanmug/Documents/dev/forks/origin
  ===========================================================
  Random Seed: 1778741576 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-cli] oc adm release extract image-references
  github.com/openshift/origin/test/extended/cli/admin.go:548
    STEP: Creating a kubernetes client @ 05/14/26 12:22:57.853
  I0514 12:22:57.853527 3150154 discovery.go:214] Invalidating discovery information
  I0514 12:22:58.028819 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.051706 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.074976 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.098465 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.120808 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.143210 3150154 resource_usage_gatherer.go:386] Can't find any pods in namespace kube-system to grab metrics from
  I0514 12:22:58.143330 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-83-236.ap-south-1.compute.internal
    STEP: Creating a kubernetes client @ 05/14/26 12:22:58.143
  I0514 12:22:58.143383 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-51-10.ap-south-1.compute.internal
  I0514 12:22:58.143415 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-14-210.ap-south-1.compute.internal
  I0514 12:22:58.143438 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-58-11.ap-south-1.compute.internal
  I0514 12:22:58.143466 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-65-122.ap-south-1.compute.internal
  I0514 12:22:58.144361 3150154 discovery.go:214] Invalidating discovery information
    STEP: Creating a kubernetes client @ 05/14/26 12:22:58.144
  I0514 12:22:58.145317 3150154 discovery.go:214] Invalidating discovery information
  I0514 12:22:58.444537 3150154 resource_usage_gatherer.go:340] Closing worker for ip-10-0-0-196.ap-south-1.compute.internal
  I0514 12:22:58.713289 3150154 client.go:293] configPath is now "/tmp/configfile3416320880"
  I0514 12:22:58.713318 3150154 client.go:368] The user is now "e2e-test-oc-adm-ns-rrw85-user"
  I0514 12:22:58.713326 3150154 client.go:370] Creating project "e2e-test-oc-adm-ns-rrw85"
  I0514 12:22:58.799110 3150154 client.go:378] Waiting on permissions in project "e2e-test-oc-adm-ns-rrw85" ...
  I0514 12:22:58.894520 3150154 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0514 12:22:58.918142 3150154 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0514 12:22:59.063362 3150154 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0514 12:22:59.208054 3150154 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0514 12:22:59.352786 3150154 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0514 12:22:59.373710 3150154 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0514 12:22:59.393099 3150154 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0514 12:22:59.790808 3150154 client.go:469] Project "e2e-test-oc-adm-ns-rrw85" has been fully provisioned.
  I0514 12:23:03.350436 3150154 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-oc-adm-ns-rrw85-user}, err: <nil>
  I0514 12:23:03.376397 3150154 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-oc-adm-ns-rrw85}, err: <nil>
  I0514 12:23:03.403407 3150154 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~dw90g34ECLjsmcH44Exlf20eAbybFy0mS3kjdD58hTs}, err: <nil>
    STEP: Destroying namespace "e2e-test-oc-adm-ns-rrw85" for this suite. @ 05/14/26 12:23:03.403
    STEP: Collecting resource usage data @ 05/14/26 12:23:03.429
  I0514 12:23:03.429225 3150154 resource_usage_gatherer.go:512] Closed stop channel. Waiting for 6 workers
  I0514 12:23:03.429248 3150154 resource_usage_gatherer.go:520] Waitgroup finished.
  I0514 12:23:03.429329 3150154 framework.go:310] Printing summary: ResourceUsageSummary
  I0514 12:23:03.429397 3150154 framework.go:329] ResourceUsageSummary JSON
  {}

  I0514 12:23:03.429410 3150154 framework.go:330] Finished
  • [5.585 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 5.585 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-cli] oc adm release extract image-references [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 5584,
    "startTime": "2026-05-14 06:52:57.844579 UTC",
    "endTime": "2026-05-14 06:53:03.429570 UTC",
    "result": "passed",   
  }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made the release-extract image-references test environment-aware by reading the current payload image at runtime.
  * Ensures registry pull secret and CA bundle are prepared before running the extraction and surfaces preparation failures immediately.
  * Replaced strict fixture-based output equality with targeted assertions that the output contains expected ImageStream kind/apiVersion/name patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->