### PR TITLE
OCPBUGS-85628: Fix OCP e2e flakiness for oc image info

### DIFF
--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -15,7 +16,6 @@ import (
 	"k8s.io/klog/v2"
 	admissionapi "k8s.io/pod-security-admission/api"
 
-	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -33,7 +33,6 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 	testDeployment := exutil.FixturePath("testdata", "test-deployment.yaml")
 	testReplicationController := exutil.FixturePath("testdata", "test-replication-controller.yaml")
 	helloPod := exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
-	imageStreamsCentos := exutil.FixturePath("..", "..", "examples", "image-streams", "image-streams-centos7.json")
 
 	g.It("deployment from a build [apigroup:image.openshift.io]", func() {
 		projectName, err := oc.Run("project").Args("-q").Output()
@@ -252,33 +251,41 @@ spec:
 	})
 
 	g.It("ensure it works with image streams [apigroup:image.openshift.io]", func() {
-		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
-		o.Expect(err).NotTo(o.HaveOccurred())
+		ctx := context.Background()
+		const (
+			targetIS        = "cli"
+			targetNS        = "openshift"
+			containerImage  = `{.spec.containers[0].image}`
+			digestPullMatch = `^.+@sha256:[a-f0-9]{64}$`
+		)
 
-		err = oc.Run("create").Args("-f", imageStreamsCentos).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		err = wait.Poll(cliInterval, cliTimeout, func() (bool, error) {
-			err := oc.Run("get").Args("imagestreamtags", "wildfly:latest").Execute()
-			return err == nil, nil
+		g.By("waiting for the internal ImageStreamTag to be available")
+		err := wait.PollUntilContextTimeout(ctx, cliInterval, cliTimeout, true, func(ctx context.Context) (bool, error) {
+			if err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS).Execute(); err != nil {
+				return false, nil
+			}
+			return true, nil
 		})
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		var out string
-		var resolvedImageMatcher = o.MatchRegexp("image:.*oc-debug-.*/wildfly@sha256")
-		if !hasImageRegistry {
-			resolvedImageMatcher = o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7")
+		if err != nil {
+			g.Skip(fmt.Sprintf("openshift/%s:latest not observed within %s: %v", targetIS, cliTimeout, err))
 		}
 
-		out, err = oc.Run("debug").Args("istag/wildfly:latest", "-o", "yaml").Output()
+		g.By("verifying oc debug works with istag")
+		img, err := oc.AsAdmin().Run("debug").Args(
+			fmt.Sprintf("istag/%s:latest", targetIS), "-n", targetNS, "-o", "jsonpath="+containerImage,
+		).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(resolvedImageMatcher)
+		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamTag by digest (any registry host)")
 
-		var sha string
-		sha, err = oc.Run("get").Args("istag/wildfly:latest", "--template", "{{ .image.metadata.name }}").Output()
+		g.By("verifying oc debug works with isimage (SHA-based lookup)")
+		sha, err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS, "--template", "{{ .image.metadata.name }}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		out, err = oc.Run("debug").Args(fmt.Sprintf("isimage/wildfly@%s", sha), "-o", "yaml").Output()
+
+		img, err = oc.AsAdmin().Run("debug").Args(
+			fmt.Sprintf("isimage/%s@%s", targetIS, strings.TrimSpace(sha)), "-n", targetNS, "-o", "jsonpath="+containerImage,
+		).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(out).To(o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7"))
+		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamImage by digest (any registry host)")
 	})
 
 	g.It("ensure that the label is set for node debug", func() {

--- a/test/extended/cli/debug.go
+++ b/test/extended/cli/debug.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -16,6 +15,7 @@ import (
 	"k8s.io/klog/v2"
 	admissionapi "k8s.io/pod-security-admission/api"
 
+	configv1 "github.com/openshift/api/config/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
@@ -33,6 +33,7 @@ var _ = g.Describe("[sig-cli] oc debug", func() {
 	testDeployment := exutil.FixturePath("testdata", "test-deployment.yaml")
 	testReplicationController := exutil.FixturePath("testdata", "test-replication-controller.yaml")
 	helloPod := exutil.FixturePath("..", "..", "examples", "hello-openshift", "hello-pod.json")
+	imageStreamsCentos := exutil.FixturePath("..", "..", "examples", "image-streams", "image-streams-centos7.json")
 
 	g.It("deployment from a build [apigroup:image.openshift.io]", func() {
 		projectName, err := oc.Run("project").Args("-q").Output()
@@ -251,41 +252,33 @@ spec:
 	})
 
 	g.It("ensure it works with image streams [apigroup:image.openshift.io]", func() {
-		ctx := context.Background()
-		const (
-			targetIS        = "cli"
-			targetNS        = "openshift"
-			containerImage  = `{.spec.containers[0].image}`
-			digestPullMatch = `^.+@sha256:[a-f0-9]{64}$`
-		)
+		hasImageRegistry, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityImageRegistry)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		g.By("waiting for the internal ImageStreamTag to be available")
-		err := wait.PollUntilContextTimeout(ctx, cliInterval, cliTimeout, true, func(ctx context.Context) (bool, error) {
-			if err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS).Execute(); err != nil {
-				return false, nil
-			}
-			return true, nil
+		err = oc.Run("create").Args("-f", imageStreamsCentos).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = wait.Poll(cliInterval, cliTimeout, func() (bool, error) {
+			err := oc.Run("get").Args("imagestreamtags", "wildfly:latest").Execute()
+			return err == nil, nil
 		})
-		if err != nil {
-			g.Skip(fmt.Sprintf("openshift/%s:latest not observed within %s: %v", targetIS, cliTimeout, err))
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var out string
+		var resolvedImageMatcher = o.MatchRegexp("image:.*oc-debug-.*/wildfly@sha256")
+		if !hasImageRegistry {
+			resolvedImageMatcher = o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7")
 		}
 
-		g.By("verifying oc debug works with istag")
-		img, err := oc.AsAdmin().Run("debug").Args(
-			fmt.Sprintf("istag/%s:latest", targetIS), "-n", targetNS, "-o", "jsonpath="+containerImage,
-		).Output()
+		out, err = oc.Run("debug").Args("istag/wildfly:latest", "-o", "yaml").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamTag by digest (any registry host)")
+		o.Expect(out).To(resolvedImageMatcher)
 
-		g.By("verifying oc debug works with isimage (SHA-based lookup)")
-		sha, err := oc.AsAdmin().Run("get").Args("istag", targetIS+":latest", "-n", targetNS, "--template", "{{ .image.metadata.name }}").Output()
+		var sha string
+		sha, err = oc.Run("get").Args("istag/wildfly:latest", "--template", "{{ .image.metadata.name }}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		img, err = oc.AsAdmin().Run("debug").Args(
-			fmt.Sprintf("isimage/%s@%s", targetIS, strings.TrimSpace(sha)), "-n", targetNS, "-o", "jsonpath="+containerImage,
-		).Output()
+		out, err = oc.Run("debug").Args(fmt.Sprintf("isimage/wildfly@%s", sha), "-o", "yaml").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(strings.TrimSpace(img)).To(o.MatchRegexp(digestPullMatch), "debug pod should reference the ImageStreamImage by digest (any registry host)")
+		o.Expect(out).To(o.ContainSubstring("image: quay.io/wildfly/wildfly-centos7"))
 	})
 
 	g.It("ensure that the label is set for node debug", func() {

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -2,11 +2,11 @@ package images
 
 import (
 	"context"
+	"strings"
 
-	"github.com/MakeNowJust/heredoc"
 	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
 
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	admissionapi "k8s.io/pod-security-admission/api"
 
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -28,16 +28,42 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 
 	g.It("should display information about images [apigroup:image.openshift.io]", func() {
 		ns = oc.Namespace()
-		cli := e2epod.PodClientNS(oc.KubeFramework(), ns)
-		pod := cli.Create(context.TODO(), cliPodWithPullSecret(oc, heredoc.Docf(`
-			set -x
+		payloadImage, err := oc.AsAdmin().Run("get").Args("clusterversion", "version", "-o", "jsonpath={.status.desired.image}").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get current payload image from clusterversion")
+		payloadImage = strings.TrimSpace(payloadImage)
+		o.Expect(payloadImage).NotTo(o.BeEmpty())
 
-			# display info about an image on quay.io
-			oc image info quay.io/openshift-release-dev/ocp-release:4.18.3-x86_64
+		var out string
+		cleanup, regArgs, prepErr := exutil.PrepareImagePullSecretAndCABundle(oc)
+		if cleanup != nil {
+			defer cleanup()
+		}
 
-			# display info about an image in json format
-			oc image info quay.io/openshift-release-dev/ocp-release:4.18.3-x86_64 -o json
-		`)))
-		cli.WaitForSuccess(context.TODO(), pod.Name, podStartupTimeout)
+		if prepErr == nil {
+			args := append([]string{"info", payloadImage}, regArgs...)
+			out, err = oc.AsAdmin().Run("image").Args(args...).Output()
+		} else {
+			err = prepErr
+		}
+		if err != nil {
+			ctx := context.Background()
+			isHyperShift, hsErr := exutil.IsHypershift(ctx, oc.AdminConfigClient())
+			o.Expect(hsErr).NotTo(o.HaveOccurred())
+			if isHyperShift {
+				g.Skip("Skipping on HyperShift: runner requires external outbound access to registry")
+			}
+			o.Expect(err).NotTo(o.HaveOccurred(), "oc image info failed on a standard cluster")
+		}
+		o.Expect(out).To(o.ContainSubstring("Digest:"))
+		o.Expect(out).To(o.MatchRegexp(`Name:\s+.*`))
+
+		//Test the json output
+		if prepErr == nil {
+			argsJson := append([]string{"info", payloadImage, "-o", "json"}, regArgs...)
+			outJson, errJson := oc.AsAdmin().Run("image").Args(argsJson...).Output()
+			o.Expect(errJson).NotTo(o.HaveOccurred())
+			o.Expect(outJson).To(o.ContainSubstring(`"digest":`))
+			o.Expect(outJson).To(o.MatchRegexp(`"name":\s+.*`))
+		}
 	})
 })

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -39,12 +39,13 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 			defer cleanup()
 		}
 
-		if prepErr == nil {
-			args := append([]string{"info", payloadImage}, regArgs...)
-			out, err = oc.AsAdmin().Run("image").Args(args...).Output()
-		} else {
-			err = prepErr
+		if prepErr != nil {
+			o.Expect(prepErr).NotTo(o.HaveOccurred(), "Failed to prepare image pull secrets")
 		}
+
+		args := append([]string{"info", payloadImage}, regArgs...)
+		out, err = oc.AsAdmin().Run("image").Args(args...).Output()
+
 		if err != nil {
 			ctx := context.Background()
 			isHyperShift, hsErr := exutil.IsHypershift(ctx, oc.AdminConfigClient())

--- a/test/extended/images/info.go
+++ b/test/extended/images/info.go
@@ -59,12 +59,10 @@ var _ = g.Describe("[sig-imageregistry][Feature:ImageInfo] Image info", func() {
 		o.Expect(out).To(o.MatchRegexp(`Name:\s+.*`))
 
 		//Test the json output
-		if prepErr == nil {
-			argsJson := append([]string{"info", payloadImage, "-o", "json"}, regArgs...)
-			outJson, errJson := oc.AsAdmin().Run("image").Args(argsJson...).Output()
-			o.Expect(errJson).NotTo(o.HaveOccurred())
-			o.Expect(outJson).To(o.ContainSubstring(`"digest":`))
-			o.Expect(outJson).To(o.MatchRegexp(`"name":\s+.*`))
-		}
+		argsJson := append([]string{"info", payloadImage, "-o", "json"}, regArgs...)
+		outJson, errJson := oc.AsAdmin().Run("image").Args(argsJson...).Output()
+		o.Expect(errJson).NotTo(o.HaveOccurred())
+		o.Expect(outJson).To(o.ContainSubstring(`"digest":`))
+		o.Expect(outJson).To(o.MatchRegexp(`"name":\s+.*`))
 	})
 })


### PR DESCRIPTION
The original test was failing because it relied on a hardcoded OpenShift image from an external registry which in turn caused failures. To fix this, the test is made dynamic by having it pull the actual payload image used by the cluster instead of a static string. 
```
  Running Suite:  - /home/yshanmug/Documents/dev/forks/origin
  ===========================================================
  Random Seed: 1778754465 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-imageregistry][Feature:ImageInfo] Image info should display information about images [apigroup:image.openshift.io]
  github.com/openshift/origin/test/extended/images/info.go:29
    STEP: Creating a kubernetes client @ 05/14/26 15:57:46.813
  I0514 15:57:46.814111 3178848 discovery.go:214] Invalidating discovery information
  I0514 15:57:47.200100 3178848 client.go:293] configPath is now "/tmp/configfile2536781646"
  I0514 15:57:47.200127 3178848 client.go:368] The user is now "e2e-test-image-info-jgklq-user"
  I0514 15:57:47.200134 3178848 client.go:370] Creating project "e2e-test-image-info-jgklq"
  I0514 15:57:47.316662 3178848 client.go:378] Waiting on permissions in project "e2e-test-image-info-jgklq" ...
  I0514 15:57:47.423918 3178848 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0514 15:57:47.450521 3178848 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0514 15:57:47.601850 3178848 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0514 15:57:47.754459 3178848 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0514 15:57:47.907339 3178848 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0514 15:57:47.936330 3178848 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0514 15:57:47.966591 3178848 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0514 15:57:48.366676 3178848 client.go:469] Project "e2e-test-image-info-jgklq" has been fully provisioned.
  I0514 15:57:54.728997 3178848 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-image-info-jgklq-user}, err: <nil>
  I0514 15:57:54.758023 3178848 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-image-info-jgklq}, err: <nil>
  I0514 15:57:54.788177 3178848 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~3iSnmAnpnzBop07pu1EH9PkbCgEn1wv1ksK3DZEfLOM}, err: <nil>
    STEP: Destroying namespace "e2e-test-image-info-jgklq" for this suite. @ 05/14/26 15:57:54.788
  • [8.013 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 8.013 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-imageregistry][Feature:ImageInfo] Image info should display information about images [apigroup:image.openshift.io] [Suite:openshift/conformance/parallel]",
    "lifecycle": "blocking",
    "duration": 8013,
    "startTime": "2026-05-14 10:27:46.804783 UTC",
    "endTime": "2026-05-14 10:27:54.817784 UTC",
    "result": "passed",

  }

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced image-validation tests to detect the current cluster payload image, verify both human-readable and JSON outputs, handle registry authentication/certificate setup, defer cleanup when applicable, and skip gracefully when external outbound access is restricted.

---
**Note:** Internal testing improvements only; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->