### PR TITLE
NO-JIRA: Fix flaky storage-admin e2e test

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -301,20 +301,21 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		o.Expect(out).To(o.ContainSubstring(`cannot list resource "rolebindings" in API group "rbac.authorization.k8s.io"`))
 
 		g.By("Test that scoped storage-admin now an admin in project foo")
-		o.Expect(oc.Run("new-project").Args("--skip-config-write=true", "--as=storage-adm2", "--as-group=system:authenticated:oauth", "--as-group=sytem:authenticated", "policy-can-i").Execute()).NotTo(o.HaveOccurred())
+		projectName := names.SimpleNameGenerator.GenerateName("policy-can-i-")
+		o.Expect(oc.Run("new-project").Args("--skip-config-write=true", "--as=storage-adm2", "--as-group=system:authenticated:oauth", "--as-group=system:authenticated", projectName).Execute()).NotTo(o.HaveOccurred())
 		defer func() {
-			oc.Run("delete").Args("project/policy-can-i").Execute()
+			oc.Run("delete").Args("project/" + projectName).Execute()
 		}()
 
-		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pod", "--all-namespaces").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace="+projectName, "--as=storage-adm2", "create", "pod", "--all-namespaces").Output()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("no"))
 
-		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pod").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace="+projectName, "--as=storage-adm2", "create", "pod").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("yes"))
 
-		out, err = oc.Run("auth", "can-i").Args("--namespace=policy-can-i", "--as=storage-adm2", "create", "pvc").Output()
+		out, err = oc.Run("auth", "can-i").Args("--namespace="+projectName, "--as=storage-adm2", "create", "pvc").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(out).To(o.HaveSuffix("yes"))
 	})


### PR DESCRIPTION
Use a unique project name derived from the test namespace and fix the "sytem" typo in --as-group.

This failure was seen in this job run: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_kubernetes/2653/pull-ci-openshift-kubernetes-master-e2e-aws-ovn-runc/2054927169104121856

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved CLI integration test isolation by using dynamically generated project names and ensuring reliable cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->