### PR TITLE
OCPNODE-4535: Automate OCP-44820 change container registry config

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -8,6 +8,7 @@ This directory contains OpenShift end-to-end tests for node-related features.
 
 - **kubeletconfig_features.go** - Tests applying KubeletConfig to custom machine config pools, requires node reboots
 - **kubelet_secret_pulled_images.go** - Tests kubelet credential verification for image pulls (`KubeletEnsureSecretPulledImages` feature gate). Covers multi-tenancy isolation, credential rotation, ImagePullPolicy behavior, credential verification policy (NeverVerify/AlwaysVerify), and registry availability scenarios. Requires `TechPreviewNoUpgrade` or `CustomNoUpgrade` FeatureSet.
+- **node_e2e/image_registry_config.go** - Container registry config change (OCP-44820) - Verifies search registry update triggers MCO rollout and lands on nodes [Disruptive]
 
 ### Suite: openshift/usernamespace
 

--- a/test/extended/node/node_e2e/image_registry_config.go
+++ b/test/extended/node/node_e2e/image_registry_config.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	"github.com/openshift/origin/test/extended/imagepolicy"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	nodeutils "github.com/openshift/origin/test/extended/node"
+	exutil "github.com/openshift/origin/test/extended/util"
+	operator "github.com/openshift/origin/test/extended/util/operator"
+)
+
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config", func() {
+	var (
+		oc = exutil.NewCLIWithoutNamespace("imgcfg")
+	)
+
+	g.BeforeEach(func() {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to detect cluster type")
+		if isMicroShift {
+			g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
+		}
+	})
+
+	// Verifies that updating image.config.openshift.io/cluster with a new search
+	// registry triggers an MCO rollout and the change lands on nodes.
+	//author: cmaurya@redhat.com
+	g.It("[OTP] change container registry config [OCP-44820]", func() {
+		ctx := context.Background()
+		searchRegistry := "qe.quay.io"
+
+		g.By("Save the original image.config for later restore")
+		originalImageConfig, err := oc.AdminConfigClient().ConfigV1().Images().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get image.config.openshift.io/cluster")
+
+		initialWorkerSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, "worker")
+		initialMasterSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, "master")
+
+		g.DeferCleanup(func() {
+			e2e.Logf("Cleanup: restoring original image.config")
+			restoreErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				current, getErr := oc.AdminConfigClient().ConfigV1().Images().Get(ctx, "cluster", metav1.GetOptions{})
+				if getErr != nil {
+					return getErr
+				}
+				current.Spec.RegistrySources = originalImageConfig.Spec.RegistrySources
+				_, updateErr := oc.AdminConfigClient().ConfigV1().Images().Update(ctx, current, metav1.UpdateOptions{})
+				return updateErr
+			})
+			o.Expect(restoreErr).NotTo(o.HaveOccurred(),
+				"cleanup failed: could not restore original image.config")
+
+			cleanupWorkerSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, "worker")
+			cleanupMasterSpec := imagepolicy.GetMCPCurrentSpecConfigName(oc, "master")
+			imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "worker", cleanupWorkerSpec)
+			imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", cleanupMasterSpec)
+
+			e2e.Logf("Cleanup: waiting for all cluster operators to settle")
+			waitErr := operator.WaitForOperatorsToSettle(ctx, oc.AdminConfigClient(), 10)
+			o.Expect(waitErr).NotTo(o.HaveOccurred(),
+				"cluster operators did not settle after restore")
+		})
+
+		g.By("Update image.config to add search registry and allowed registries")
+		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			imageConfig, getErr := oc.AdminConfigClient().ConfigV1().Images().Get(ctx, "cluster", metav1.GetOptions{})
+			if getErr != nil {
+				return getErr
+			}
+			imageConfig.Spec.RegistrySources.AllowedRegistries = []string{
+				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,
+				"image-registry.openshift-image-registry.svc:5000",
+			}
+			imageConfig.Spec.RegistrySources.ContainerRuntimeSearchRegistries = []string{
+				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,
+			}
+			_, updateErr := oc.AdminConfigClient().ConfigV1().Images().Update(ctx, imageConfig, metav1.UpdateOptions{})
+			return updateErr
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to update image.config.openshift.io/cluster")
+
+		g.By("Wait for worker and master MCP rollout to complete")
+		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "worker", initialWorkerSpec)
+		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", initialMasterSpec)
+
+		g.By("Verify search registries config on a worker node")
+		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get ready schedulable worker nodes")
+		o.Expect(workers).NotTo(o.BeEmpty(), "no ready worker nodes found")
+
+		var registriesConf string
+		o.Eventually(func() error {
+			var execErr error
+			registriesConf, execErr = nodeutils.ExecOnNodeWithChroot(oc, workers[0].Name,
+				"cat", "/etc/containers/registries.conf.d/01-image-searchRegistries.conf")
+			if execErr != nil {
+				return execErr
+			}
+			if !strings.Contains(registriesConf, searchRegistry) {
+				return fmt.Errorf("search registry %s not yet in config", searchRegistry)
+			}
+			return nil
+		}, 30*time.Second, 5*time.Second).Should(o.Succeed(),
+			"search registry %s not found in registries config on node %s", searchRegistry, workers[0].Name)
+		e2e.Logf("Registries config on %s:\n%s", workers[0].Name, registriesConf)
+
+		g.By("Verify policy.json is updated with allowed registries")
+		policyJSON, err := nodeutils.ExecOnNodeWithChroot(oc, workers[0].Name,
+			"cat", "/etc/containers/policy.json")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read policy.json on node %s", workers[0].Name)
+		e2e.Logf("policy.json on %s:\n%s", workers[0].Name, policyJSON)
+		o.Expect(policyJSON).To(o.ContainSubstring(searchRegistry),
+			"policy.json should contain allowed registry %s", searchRegistry)
+	})
+})


### PR DESCRIPTION
## Summary

- Automates OCP-44820: verifies that updating `image.config.openshift.io/cluster` with `containerRuntimeSearchRegistries` and `allowedRegistries` triggers an MCO rollout and the change is reflected in `/etc/containers/registries.conf.d/01-image-searchRegistries.conf` on worker nodes.

Here is the test case link: [Polarian-44820](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-44820)

#### Test Results

It passed successfully while executing on a live OCP 4.22 cluster:

```
./openshift-tests run-test "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config [OTP] change container registry config [OCP-44820] [Serial]"

  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1779275320 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config [OTP] change container registry config [OCP-44820]
  github.com/openshift/origin/test/extended/node/node_e2e/image_registry_config.go:38
    STEP: Creating a kubernetes client @ 05/20/26 16:38:46.121
  I0520 16:38:46.122668   35591 discovery.go:214] Invalidating discovery information
  I0520 16:38:46.123434 35591 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0520 16:38:46.375865 35591 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Save the original image.config for later restore @ 05/20/26 16:38:46.376
    STEP: Update image.config to add search registry and allowed registries @ 05/20/26 16:38:47.144
    STEP: Wait for worker and master MCP rollout to complete @ 05/20/26 16:38:47.661
  I0520 16:38:47.661249 35591 imagepolicy.go:694] Waiting for pool worker to complete
  I0520 16:45:59.072363 35591 imagepolicy.go:694] Waiting for pool master to complete
    STEP: Verify search registries config on a worker node @ 05/20/26 16:55:34.137
  I0520 16:55:38.493948 35591 image_registry_config.go:115] Registries config on ip-10-0-3-101.us-east-2.compute.internal:
  unqualified-search-registries = ["registry.access.redhat.com", "docker.io", "quay.io", "qe.quay.io"]
  short-name-mode = ""
  additional-layer-store-auth-helper = ""
    STEP: Verify policy.json is updated with allowed registries @ 05/20/26 16:55:38.495
  I0520 16:55:41.506463 35591 image_registry_config.go:121] policy.json on ip-10-0-3-101.us-east-2.compute.internal:
  {
    "default": [
      {
        "type": "reject"
      }
    ],
    "transports": {
      "atomic": {
        "docker.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "image-registry.openshift-image-registry.svc:5000": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "qe.quay.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "quay.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "registry.access.redhat.com": [
          {
            "type": "insecureAcceptAnything"
          }
        ]
      },
      "docker": {
        "docker.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "image-registry.openshift-image-registry.svc:5000": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "qe.quay.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "quay.io": [
          {
            "type": "insecureAcceptAnything"
          }
        ],
        "registry.access.redhat.com": [
          {
            "type": "insecureAcceptAnything"
          }
        ]
      },
      "docker-daemon": {
        "": [
          {
            "type": "insecureAcceptAnything"
          }
        ]
      }
    }
  }
  I0520 16:55:41.514475 35591 image_registry_config.go:50] Cleanup: restoring original image.config
  I0520 16:55:42.548572 35591 imagepolicy.go:694] Waiting for pool worker to complete
  I0520 17:02:53.908652 35591 imagepolicy.go:694] Waiting for pool master to complete
  I0520 17:15:24.974045 35591 image_registry_config.go:68] Cleanup: waiting for all cluster operators to settle
  I0520 17:15:24.976861 35591 settle.go:38] Waiting for operators to settle
  • [2199.150 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 2199.152 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a disruptive long-running e2e suite "Image registry config" to verify a configured search registry is applied on ready, schedulable worker nodes.
  * Skips MicroShift clusters and when cluster-type detection fails.
  * Applies and restores cluster image registry settings with conflict-aware retries, waits for machine-config pool rollouts, optionally waits for cluster operators to settle, and logs warnings if restore/convergence/settle steps fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->