### PR TITLE
OCPNODE-4125: fix imagepolicy image config testcase

### DIFF
--- a/test/extended/imagepolicy/imagepolicy.go
+++ b/test/extended/imagepolicy/imagepolicy.go
@@ -26,6 +26,7 @@ const (
 	clusterImagePolicyKind                 = "ClusterImagePolicy"
 	imagePolicyKind                        = "ImagePolicy"
 	testSignedPolicyScope                  = "quay.io/openshifttest/busybox-testsigstoresigned@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f"
+	testSignedPolicyScopeRepo              = "quay.io/openshifttest/busybox-testsigstoresigned"
 	testPKISignedPolicyScope               = "quay.io/openshifttest/busybox-testsigstoresignedpki@sha256:c5439d7db88ab5423999530349d327b04279ad3161d7596d2126dfb5b02bfd1f"
 	registriesWorkerPoolMachineConfig      = "99-worker-generated-registries"
 	registriesMasterPoolMachineConfig      = "99-master-generated-registries"
@@ -95,8 +96,8 @@ var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Di
 	})
 
 	g.It("Should fail clusterimagepolicy signature validation when scope in allowedRegistries list does not skip signature verification", func() {
-		// Ensure allowedRegistries do not skip signature verification by adding testSignedPolicyScope to the list.
-		allowedRegistries := []string{"quay.io", "registry.redhat.io", "image-registry.openshift-image-registry.svc:5000", testSignedPolicyScope}
+		// Ensure allowedRegistries do not skip signature verification by adding testSignedPolicyScopeRepo to the list.
+		allowedRegistries := []string{"quay.io", "registry.redhat.io", "image-registry.openshift-image-registry.svc:5000", testSignedPolicyScopeRepo}
 		updateImageConfig(oc, allowedRegistries)
 		g.DeferCleanup(cleanupImageConfig, oc)
 
@@ -700,6 +701,9 @@ func WaitForMCPConfigSpecChangeAndUpdated(oc *exutil.CLI, pool string, initialSp
 			return false
 		}
 		if mcp.Status.Configuration.Name == initialSpecName {
+			return false
+		}
+		if mcp.Spec.Configuration.Name != mcp.Status.Configuration.Name {
 			return false
 		}
 		return machineconfighelper.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated)


### PR DESCRIPTION
- fix [failure](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-disruptive-longrunning-techpreview-1of2/2054789876368281600) appeared after api change: https://github.com/openshift/api/pull/2787
Test: 
```
[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:SigstoreImageVerification][Serial] Should fail clusterimagepolicy signature validation when scope in allowedRegistries list does not skip signature verification
```
- improve polling machine config pool by adding condition check spec.name == status.name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated image policy tests to use a repository-scoped image reference for signature verification checks.
  * Tightened the test polling condition so a pool is only considered updated when the configuration name equals the reported status name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->