### PR TITLE
OCPNODE-4536: Migrate OCP-55486 check no MountVolume.SetUp failed error in cronjob events

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -19,6 +19,7 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **image_volume.go** - Tests mounting container images as volumes in pods, including subPath and error handling
 - **node_swap.go** - Tests default kubelet swap settings (failSwapOn and swapBehavior) and rejection of user overrides
 - **zstd_chunked.go** - Tests building and running images with zstd:chunked compression format
+- **node_e2e/node.go** - Cronjob volume mount error check (OCP-55486) - Verifies that cronjob events do not contain MountVolume.SetUp failed errors for unregistered objects
 
 ## Directory Structure
 

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -163,6 +164,43 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		o.Expect(err).NotTo(o.HaveOccurred())
 		e2e.Logf("/dev/fuse mount output: %s", output)
 		o.Expect(output).To(o.ContainSubstring("fuse"), "dev fuse is not mounted inside pod")
+	})
+
+	//author: bgudi@redhat.com
+	g.It("[OTP][Late] Cronjob events should not contain MountVolume.SetUp failed errors [OCP-55486]", func() {
+		g.By("Check events in all cronjob namespaces for volume mount errors")
+		err := wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
+			allCronjobs, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("cronjob", "--all-namespaces", "-o=jsonpath={range .items[*]}{@.metadata.namespace}{\"\\n\"}{end}").Output()
+			if err != nil {
+				e2e.Logf("Error getting cronjobs: %v", err)
+				return false, nil
+			}
+			e2e.Logf("Cronjob namespaces: %v", allCronjobs)
+
+			for _, ns := range strings.Fields(allCronjobs) {
+				// Use jsonpath to get event messages directly instead of table output
+				events, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+					"events", "-n", ns, "-o=jsonpath={range .items[*]}{.message}{\"\\n\"}{end}",
+				).Output()
+				if err != nil {
+					e2e.Logf("Error getting events in namespace %s: %v", ns, err)
+					continue
+				}
+
+				// Check for the error pattern: MountVolume.SetUp failed for volume ... object ... not registered
+				errorPattern := regexp.MustCompile(`MountVolume\.SetUp failed for volume.*object.*not registered`)
+				matches := errorPattern.FindAllString(events, -1)
+				if len(matches) > 0 {
+					return false, fmt.Errorf("found mount error in namespace %s: %v", ns, matches[0])
+				}
+			}
+
+			// Keep polling until timeout - no errors found in this iteration
+			return false, nil
+		})
+		// Expect timeout (no errors found during the full polling window)
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(err.Error()).To(o.ContainSubstring("timed out"))
 	})
 })
 


### PR DESCRIPTION
## Description
Migrates test case [OCP-55486](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-55486) from openshift-tests-private to origin repository.

## Test Overview
This test validates that cronjob events do not contain volume mount errors related to unregistered objects. It checks for the error pattern:
`MountVolume.SetUp failed for volume ... object ... not registered`

## Test Steps
1. Get all cronjob namespaces in the cluster
2. Retrieve events from each cronjob namespace
3. Check for the error pattern using regex
4. Fail if any cronjob events contain the mount error

## Changes
- Add test to `test/extended/node/node_e2e/node.go`
- Add `regexp` import for pattern matching
- Document test in `test/extended/node/README.md`

## Related
- Relates: [OCP-55486](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-55486)
- Migrated from: openshift-tests-private

## Testing
```bash
./openshift-tests run-test "[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] check no MountVolume.SetUp failed error in cronjob events [OCP-55486]"
  Will run 1 of 1 specs
  ------------------------------
  [sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager [OTP] check no MountVolume.SetUp failed error in cronjob events [OCP-55486]
  github.com/openshift/origin/test/extended/node/node_e2e/node.go:172
    STEP: Creating a kubernetes client @ 05/18/26 15:40:21.077
  I0518 15:40:21.078257 2411148 discovery.go:214] Invalidating discovery information
  I0518 15:40:21.079068 2411148 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0518 15:40:21.319145 2411148 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Check events in all cronjob namespaces for volume mount errors @ 05/18/26 15:40:21.319
  I0518 15:40:23.637440 2411148 node.go:180] Cronjob namespaces: openshift-image-registry
  I0518 15:40:27.332787 2411148 node.go:180] Cronjob namespaces: openshift-image-registry
  I0518 15:40:32.313024 2411148 node.go:180] Cronjob namespaces: openshift-image-registry
  I0518 15:40:35.794789 2411148 node.go:180] Cronjob namespaces: openshift-image-registry
  • [16.646 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 16.647 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test that polls cronjob-related events across namespaces and fails if a MountVolume.SetUp failed error pattern is observed.

* **Documentation**
  * Added a Default Suite entry documenting the new cronjob event check in the test suite README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->