### PR TITLE
OCPBUGS-86017: Extend image-registry single replica exception to s390x architecture

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -425,7 +425,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 					}
 				}
 				// Check for alternative architectures (ppc64le, s390x) with single replica
-				arch, err := getAltArchitecture(clientConfig)
+				arch, err := getArchitecture(clientConfig)
 				if err != nil {
 					logrus.WithError(err).Debug("failed to determine cluster architecture for image-registry exception")
 				} else if arch != "" {
@@ -484,9 +484,9 @@ func isVSphere(config *rest.Config) (bool, error) {
 	return infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType, nil
 }
 
-// getAltArchitecture checks if the cluster is running on an alternative architecture
+// getArchitecture checks if the cluster is running on an alternative architecture
 // (ppc64le or s390x) and returns the architecture name, or empty string if not found.
-func getAltArchitecture(config *rest.Config) (string, error) {
+func getArchitecture(config *rest.Config) (string, error) {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return "", err

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -424,16 +424,21 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 						return "https://issues.redhat.com/browse/OCPBUGS-22382"
 					}
 				}
-				ppc64le, err := isppc64le(clientConfig)
+				// Check for alternative architectures (ppc64le, s390x) with single replica
+				arch, err := getAltArchitecture(clientConfig)
 				if err != nil {
 					logrus.WithError(err).Debug("failed to determine cluster architecture for image-registry exception")
-				} else if ppc64le {
+				} else if arch != "" {
 					replicaCount, err := checkReplicas("openshift-image-registry", operator, clientConfig)
 					if err != nil {
-						logrus.WithError(err).Debug("failed to determine image-registry replica count for ppc64le exception")
-
+						logrus.WithError(err).Debugf("failed to determine image-registry replica count for %s exception", arch)
 					} else if replicaCount == 1 {
-						return "https://redhat.atlassian.net/browse/OCPBUGS-82160"
+						switch arch {
+						case platformidentification.ArchitecturePPC64le:
+							return "https://redhat.atlassian.net/browse/OCPBUGS-82160"
+						case platformidentification.ArchitectureS390:
+							return "https://redhat.atlassian.net/browse/OCPBUGS-86017"
+						}
 					}
 				}
 			}
@@ -479,21 +484,24 @@ func isVSphere(config *rest.Config) (bool, error) {
 	return infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType, nil
 }
 
-func isppc64le(config *rest.Config) (bool, error) {
+// getAltArchitecture checks if the cluster is running on an alternative architecture
+// (ppc64le or s390x) and returns the architecture name, or empty string if not found.
+func getAltArchitecture(config *rest.Config) (string, error) {
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return false, err
+		return "", err
 	}
 	nodes, err := client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return false, err
+		return "", err
 	}
 	for _, node := range nodes.Items {
-		if node.Status.NodeInfo.Architecture == "ppc64le" {
-			return true, nil
+		arch := node.Status.NodeInfo.Architecture
+		if arch == platformidentification.ArchitecturePPC64le || arch == platformidentification.ArchitectureS390 {
+			return arch, nil
 		}
 	}
-	return false, nil
+	return "", nil
 }
 
 func checkReplicas(namespace string, operator string, clientConfig *rest.Config) (int32, error) {


### PR DESCRIPTION
Hi Team, 

Can you PTAL on this PR. 

This commit extends the existing ppc64le single-replica image-registry exception to also cover s390x architecture. During upgrades from 4.22 to 5.0, clusters running on s390x with a single replica image-registry deployment experience temporary unavailability (NoReplicasAvailable) when the registry pod is restarted. This is a known limitation on alternative architectures due to the lack of redundancy with a single replica.

Changes:
- Replaced isppc64le() function with getAltArchitecture() to support multiple alternative architectures (ppc64le and s390x)
- Added s390x exception with bug ID OCPBUGS-86017
- Updated exception handling to use a switch statement for clarity
- Improved logging to include the detected architecture
- Used platformidentification constants for architecture names

Bug: https://redhat.atlassian.net/browse/OCPBUGS-86017
Related: https://redhat.atlassian.net/browse/OCPBUGS-82160 (ppc64le)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade operator handling for the image-registry so unavailable status outside upgrade windows correctly considers alternative architectures (ppc64le, s390x).
  * When architecture is detected, the operator returns architecture-specific guidance for single-replica registry cases.
  * When detection fails, emits debug logging to surface issues rather than silently falling back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->