### PR TITLE
OCPBUGS-86225: fix PDB AlwaysAllow test failure on IPv6-primary dualstack clusters

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -51170,6 +51170,7 @@ data:
   default.conf: |
     server {
         listen 8080;
+        listen [::]:8080;
         server_name  localhost;
         location / {
             root   /usr/share/nginx/html;

--- a/test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
+++ b/test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
@@ -68,6 +68,7 @@ data:
   default.conf: |
     server {
         listen 8080;
+        listen [::]:8080;
         server_name  localhost;
         location / {
             root   /usr/share/nginx/html;


### PR DESCRIPTION
The nginx config in the PDB test only had `listen 8080` which binds to IPv4 only. On dualstack clusters where IPv6 is the primary family, the kubelet probes readiness using the pod's IPv6 address. Since nginx was not listening on IPv6, the probe got connection refused and pods never became Ready, causing the test to time out.

Add `listen [::]:8080` so nginx accepts connections on both IPv4 and IPv6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test data updated to include an IPv6 listen directive for port 8080, ensuring test coverage for IPv6 connections alongside IPv4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->