### PR TITLE
OCPBUGS-123611: Register cluster-baremetal-tests-ext in extension registry

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -230,6 +230,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-authentication-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-baremetal-operator",
+		binaryPath: "/usr/bin/cluster-baremetal-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-capi-operator",
 		binaryPath: "/usr/bin/cluster-capi-operator-tests-ext.gz",
 	},


### PR DESCRIPTION
Add cluster-baremetal-operator test extension binary to the payload extension registry. This allows baremetal E2E tests to run as part of the OpenShift test suite.

Binary path: /usr/bin/cluster-baremetal-tests-ext.gz
Source: openshift/cluster-baremetal-operator

Companion PR: https://github.com/openshift/cluster-baremetal-operator/pull/609

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added an external test binary for the cluster-baremetal-operator payload.
  * Enables running the bundled external test set for that payload.
  * Integrates these external tests into the standard automated test suites, improving validation and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->