### PR TITLE
TRT-2669: Revert #31112 "NO-JIRA: Remove fixed bugs on CO conditions (2)"

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -130,6 +130,9 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, clien
 			if operator == "kube-scheduler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663"
 			}
+			if operator == "network" {
+				return "https://issues.redhat.com/browse/OCPBUGS-38684"
+			}
 			if operator == "console" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
@@ -354,6 +357,17 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "kube-storage-version-migrator":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
+			}
+		case "monitoring":
+			if condition.Type == configv1.OperatorAvailable &&
+				(condition.Status == configv1.ConditionFalse &&
+					(condition.Reason == "PlatformTasksFailed" ||
+						condition.Reason == "UpdatingAlertmanagerFailed" ||
+						condition.Reason == "UpdatingConsolePluginComponentsFailed" ||
+						condition.Reason == "UpdatingPrometheusK8SFailed" ||
+						condition.Reason == "UpdatingPrometheusOperatorFailed")) ||
+				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
+				return "https://issues.redhat.com/browse/OCPBUGS-23745"
 			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
@@ -748,6 +762,10 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "SyncLoopRefresh_InProgress" {
 				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
+		case "image-registry":
+			if reason == "NodeCADaemonUnavailable::Ready" || reason == "DeploymentNotCompleted" {
+				return "https://issues.redhat.com/browse/OCPBUGS-62626"
+			}
 		case "ingress":
 			if reason == "Reconciling" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62627"
@@ -758,7 +776,11 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			}
 		case "network":
 			if reason == "Deploying" || reason == "MachineConfig" {
-				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
+				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+			}
+		case "node-tuning":
+			if reason == "Reconciling" || reason == "ProfileProgressing" {
+				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -259,9 +259,15 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
-				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
+				return "https://issues.redhat.com/browse/OCPBUGS-62623"
+			case "image-registry":
+				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
-				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
+				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+			case "node-tuning":
+				return "https://issues.redhat.com/browse/OCPBUGS-62632"
+			case "storage":
+				return "https://issues.redhat.com/browse/OCPBUGS-62633"
 			default:
 				return ""
 			}


### PR DESCRIPTION
Reverts #31112 ; tracked by [TRT-2669](https://redhat.atlassian.net/browse/TRT-2669)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

This PR removed the `image-registry` operator from the exception list in the machine-scaling test's AfterEach assertion (`test/extended/machines/scale.go:280`). The image-registry operator's `node-ca` DaemonSet legitimately toggles `Progressing=True` for ~0.5s when nodes are added/removed during scaling. The underlying bug ([OCPBUGS-62626](https://issues.redhat.com/browse/OCPBUGS-62626)) is not actually fixed.

**Impact:** Payload `5.0.0-0.nightly-2026-05-20-101113` was [Rejected](https://amd64.ocp.releases.ci.openshift.org/releasestream/5.0.0-0.nightly/release/5.0.0-0.nightly-2026-05-20-101113). The `aws-ovn-serial-2of2` blocking job failed deterministically on both attempts:
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-serial-2of2/2057096534654193664
- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-ovn-serial-2of2/2057043060595888128

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

- `e2e-aws-ovn-serial` (the job that was broken)

CC: @hongkailiu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced cluster-operator monitoring exceptions to better tolerate expected states during stable and upgrade flows (network, monitoring, image-registry, node-tuning, olm, storage)
  * Added specific non-fatal/progressing allowances for network Degraded, monitoring update failures, image-registry progressing reasons, and node-tuning progressing states
  * Updated diagnostic issue references to OCPBUGS-62623/62626/62630/62632/62633 for clearer troubleshooting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->