### PR TITLE
NO-JIRA: Remove fixed bugs on CO conditions (2) - 2nd try

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -727,10 +727,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "Deploying" || reason == "MachineConfig" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			}
-		case "node-tuning":
-			if reason == "Reconciling" || reason == "ProfileProgressing" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved
 			// RouteControllerManager_DesiredStateNotYetAchieved

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -100,9 +100,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			if operator == "kube-scheduler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663"
 			}
-			if operator == "network" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38684"
-			}
 			if operator == "console" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -319,17 +319,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
-		case "monitoring":
-			if condition.Type == configv1.OperatorAvailable &&
-				(condition.Status == configv1.ConditionFalse &&
-					(condition.Reason == "PlatformTasksFailed" ||
-						condition.Reason == "UpdatingAlertmanagerFailed" ||
-						condition.Reason == "UpdatingConsolePluginComponentsFailed" ||
-						condition.Reason == "UpdatingPrometheusK8SFailed" ||
-						condition.Reason == "UpdatingPrometheusOperatorFailed")) ||
-				(condition.Status == configv1.ConditionUnknown && condition.Reason == "UpdatingPrometheusFailed") {
-				return "https://issues.redhat.com/browse/OCPBUGS-23745"
-			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
 				if isTwoNode && condition.Reason == "APIServices_PreconditionNotReady" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -711,10 +711,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if reason == "SyncLoopRefresh_InProgress" {
 				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
-		case "image-registry":
-			if reason == "NodeCADaemonUnavailable::Ready" || reason == "DeploymentNotCompleted" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62626"
-			}
 		case "ingress":
 			if reason == "Reconciling" {
 				return "https://issues.redhat.com/browse/OCPBUGS-62627"

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -718,7 +718,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			}
 		case "network":
 			if reason == "Deploying" || reason == "MachineConfig" {
-				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
 			}
 		case "openshift-controller-manager":
 			// _DesiredStateNotYetAchieved

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -269,8 +269,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
-			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -263,8 +263,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
 				return "https://issues.redhat.com/browse/OCPBUGS-62623"
-			case "image-registry":
-				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -270,7 +270,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "node-tuning":
 				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			case "storage":
-				return "https://issues.redhat.com/browse/OCPBUGS-62633"
+				return "https://issues.redhat.com/browse/OCPBUGS-62634"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -263,6 +263,8 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
 				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
+			case "image-registry":
+				return "https://redhat.atlassian.net/browse/OCPBUGS-86308"
 			case "network":
 				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -262,7 +262,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
 			case "dns":
-				return "https://issues.redhat.com/browse/OCPBUGS-62623"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
 			default:

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -264,7 +264,7 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			case "dns":
 				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
 			case "network":
-				return "https://issues.redhat.com/browse/OCPBUGS-62630"
+				return "https://redhat.atlassian.net/browse/OCPBUGS-85677"
 			default:
 				return ""
 			}

--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -267,8 +267,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 				return "https://issues.redhat.com/browse/OCPBUGS-62626"
 			case "network":
 				return "https://issues.redhat.com/browse/OCPBUGS-62630"
-			case "node-tuning":
-				return "https://issues.redhat.com/browse/OCPBUGS-62632"
 			default:
 				return ""
 			}


### PR DESCRIPTION
This is to redo https://github.com/openshift/origin/pull/31112 which is reverted by https://github.com/openshift/origin/pull/31201 because of [TRT-2669](https://redhat.atlassian.net/browse/TRT-2669).

Now https://redhat.atlassian.net/browse/OCPBUGS-86308 is added to address [TRT-2669](https://redhat.atlassian.net/browse/TRT-2669).

I did not reuse https://issues.redhat.com/browse/OCPBUGS-62626 because it turned out to be different cases:  OCPBUGS-86308 scale up vs OCPBUGS-62626 node reboot.

Comparing to https://github.com/openshift/origin/pull/31112, OCPBUGS-62635 is missing in this pull because it has been removed by https://github.com/openshift/origin/pull/30775 already.





I will do rebase after https://github.com/openshift/origin/pull/30775 gets in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened legacy operator exception handling to avoid incorrectly masking operator failures during normal and upgrade workflows.
* **Chores**
  * Standardized issue-tracker links by replacing older issue URLs with updated redhat.atlassian.net references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->