### PR TITLE
CNTRLPLANE-3238: pathological events: bump KMS ScalingReplicaSet threshold to 120

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1391,7 +1391,7 @@ func kmsEncryptionTestsDetected(finalIntervals monitorapi.Intervals) bool {
 // in openshift-apiserver and openshift-oauth-apiserver during KMS encryption tests.
 // KMS encryption tests trigger multiple kube-apiserver rollouts (encrypt/decrypt cycles)
 // that cascade into these namespaces, generating ScalingReplicaSet events.
-// Observed: 58-82 times per run; threshold set to 100 with headroom.
+// Observed: 58-106 times per run; threshold set to 120 with headroom.
 func newKMSEncryptionTestScalingReplicaSetMatcher() EventMatcher {
 	return &SimplePathologicalEventMatcher{
 		name: "APIServerScalingReplicaSetDuringKMSEncryption",
@@ -1400,7 +1400,7 @@ func newKMSEncryptionTestScalingReplicaSetMatcher() EventMatcher {
 			monitorapi.LocatorDeploymentKey: regexp.MustCompile(`^apiserver$`),
 		},
 		messageReasonRegex:      regexp.MustCompile(`^ScalingReplicaSet$`),
-		repeatThresholdOverride: 100,
+		repeatThresholdOverride: 120,
 	}
 }
 


### PR DESCRIPTION
The KMS encryption tests trigger cascading rollouts across openshift-apiserver and openshift-oauth-apiserver. The previous threshold of 100 was exceeded in CI (observed 106 events), causing spurious pathological event failures. Bump to 120 to provide adequate headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased tolerance for repeated scaling-related events during KMS-encryption test rollouts to reduce false failures from higher observed repeat counts.
  * Updated validation thresholds and explanatory notes to reflect the new allowance, improving test stability for affected control-plane components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->