### PR TITLE
OCPBUGS-59500: pathologicalevents: fix HPA FailedGetResourceMetric allowlist

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -408,9 +408,10 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
 		name: "PodAutoscalerFailedToGetCPUUtilization",
 		locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
-			monitorapi.LocatorNamespaceKey: regexp.MustCompile(`horizontalpodautoscaler`),
+			monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^(openshift-ingress|e2e-.*)$`),
 		},
-		messageHumanRegex: regexp.MustCompile(`failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API`),
+		messageReasonRegex: regexp.MustCompile(`^FailedGetResourceMetric$`),
+		messageHumanRegex:  regexp.MustCompile(`failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API`),
 	})
 
 	// Formerly bug: https://bugzilla.redhat.com/show_bug.cgi?id=2075204


### PR DESCRIPTION
The PodAutoscalerFailedToGetCPUUtilization matcher never matched real events because it treated horizontalpodautoscaler as the namespace key. Match openshift-ingress and e2e HPA conformance namespaces, and require FailedGetResourceMetric so Gateway API istiod HPAs stop failing the pathological events monitor during upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated pod autoscaler failure detection patterns to monitor expanded namespace coverage, including ingress and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->