### PR TITLE
NO-JIRA: Add stephenfin to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -17,10 +17,11 @@ filters:
     - smg247
     - petr-muller
     - cpmeadors
-    - mkowalski 
+    - mkowalski
     - miyadav
     - jogeo
-    - xueqzhan 
+    - xueqzhan
+    - stephenfin
   "^\\.go.(mod|sum)$":
     labels:
     - "vendor-update"


### PR DESCRIPTION
Add stephenfin as platform team lead for openstack. This will avoid needing to ask for reviews for changes like https://github.com/openshift/origin/pull/31154.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership and reviewer assignment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->