### PR TITLE
DNM: no-jira: fix egressfirewall test in aws dualstack jobs

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -43676,6 +43676,9 @@ spec:
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny
+    to:
+      cidrSelector: ::/0
 `)
 
 func testExtendedTestdataEgressFirewallOvnkEgressfirewallTestYamlBytes() ([]byte, error) {
@@ -43719,6 +43722,9 @@ spec:
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny
+    to:
+      cidrSelector: ::/0
 `)
 
 func testExtendedTestdataEgressFirewallOvnkEgressfirewallWildcardTestYamlBytes() ([]byte, error) {

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-test.yaml
@@ -27,3 +27,6 @@ spec:
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny
+    to:
+      cidrSelector: ::/0

--- a/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
+++ b/test/extended/testdata/egress-firewall/ovnk-egressfirewall-wildcard-test.yaml
@@ -24,3 +24,6 @@ spec:
   - type: Deny
     to:
       cidrSelector: 0.0.0.0/0
+  - type: Deny
+    to:
+      cidrSelector: ::/0


### PR DESCRIPTION
This is the duplicate of https://github.com/openshift/origin/pull/31147. I opened this to quickly test out the fix after regenerating the binddata.

Note: I do not intend to merge this (duplicate).

/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added IPv6 egress firewall denial rules to test configurations, extending firewall rule coverage across both IPv4 and IPv6 protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->