### PR TITLE
Add CNO test extension binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -298,6 +298,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-storage-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-network-operator",
+		binaryPath: "/usr/bin/cluster-network-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-version-operator",
 		binaryPath: "/usr/bin/cluster-version-operator-tests.gz",
 	},


### PR DESCRIPTION
## Summary
- Register the `cluster-network-operator` OTE binary in openshift-tests so it can discover and run CNO-specific e2e tests from the payload.

Depends-On: https://github.com/openshift/cluster-network-operator/pull/3015

## Test plan
- [x] Verify openshift-tests discovers the CNO extension binary
- [x] Verify CNO e2e tests are listed and runnable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded external test binary discovery to include cluster network operator tests.
  * The additional test binary is now extracted and included in available external test listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->