### PR TITLE
Contain exception OCPBUGS-65984 on two-node clusters

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -47,6 +47,7 @@ func checkAuthenticationAvailableExceptions(condition *configv1.ClusterOperatorS
 }
 
 func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topology configv1.TopologyMode) []*junitapi.JUnitTestCase {
+	isTwoNode := topology == configv1.HighlyAvailableArbiterMode || topology == configv1.DualReplicaTopologyMode
 	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, _ monitorapi.Interval) string {
 		if condition.Status == configv1.ConditionTrue {
 			if condition.Type == configv1.OperatorAvailable {
@@ -79,7 +80,7 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			if operator == "console" && condition.Reason == "Deployment_InsufficientReplicas" {
 				return "https://issues.redhat.com/browse/OCPBUGS-67134"
 			}
-			if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
+			if isTwoNode && operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
 			return ""
@@ -316,7 +317,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-25739"
 			}
 		case "kube-storage-version-migrator":
-			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
+			if isTwoNode && condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
 		case "monitoring":


### PR DESCRIPTION
See details in [1].

We should not merge this into 5.0 if the fix for HA is not backported to 4.22. The pull can be merged only when the symptom is still there for two-node clusters after 5.1 is cut.

/hold

[1]. https://redhat.atlassian.net/browse/OCPBUGS-65984?focusedCommentId=17095375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined validation of cluster operator state transitions for two-node topologies to ensure accurate testing of storage component stability during system operations and upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->