### PR TITLE
OCPBUGS-86611: Wait for namespace initialization before creating pod

### DIFF
--- a/test/extended/internalreleaseimage/helper.go
+++ b/test/extended/internalreleaseimage/helper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
@@ -12,6 +13,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
@@ -155,7 +157,7 @@ func (h *IRITestHelper) DeleteTestPod(namespace, name string) {
 	}
 }
 
-// CreateSimpleNamespace creates a basic namespace without waiting for service account secrets
+// CreateSimpleNamespace creates a basic namespace and waits for SCC annotations
 func (h *IRITestHelper) CreateSimpleNamespace() string {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -166,6 +168,18 @@ func (h *IRITestHelper) CreateSimpleNamespace() string {
 	createdNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create namespace")
 	e2e.Logf("Created namespace: %s", createdNs.Name)
+
+	// Wait for the namespace controller to set the SCC uid-range annotation,
+	// which is required by the admission controller before pods can be created.
+	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		updatedNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Get(ctx, createdNs.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		_, exists := updatedNs.Annotations["openshift.io/sa.scc.uid-range"]
+		return exists, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for namespace %s to get SCC uid-range annotation", createdNs.Name)
 
 	return createdNs.Name
 }


### PR DESCRIPTION
Fix timing issue by waiting for the `openshift.io/sa.scc.uid-range` annotation to be set by the namespace controller before creating the pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for namespace operations to ensure proper configuration state during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->