### PR TITLE
OCPNODE-4538: Add e2e tests for DRA Partitionable Devices (KEP-4815)

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -509,6 +509,19 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout:                90 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
+	{
+		Name: "openshift/dra-example",
+		Description: templates.LongDesc(`
+		Tests that exercise Dynamic Resource Allocation (DRA) functionality
+		using the upstream dra-example-driver. Requires the driver to be
+		pre-installed on the cluster.
+		`),
+		Qualifiers: []string{
+			withStandardEarlyOrLateTests(`name.contains("[Suite:openshift/dra-example]") || name.contains("[Feature:DynamicResourceAllocation]")`),
+		},
+		Parallelism: 1,
+		TestTimeout: 60 * time.Minute,
+	},
 }
 
 func withExcludedTestsFilter(baseExpr string) string {

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -44,6 +44,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/node"
 	_ "github.com/openshift/origin/test/extended/node/dra/example"
 	_ "github.com/openshift/origin/test/extended/node/dra/nvidia"
+	_ "github.com/openshift/origin/test/extended/node/dra/partitionable"
 	_ "github.com/openshift/origin/test/extended/node/node_e2e"
 	_ "github.com/openshift/origin/test/extended/node_tuning"
 	_ "github.com/openshift/origin/test/extended/oauth"

--- a/test/extended/node/dra/common/counter_validator.go
+++ b/test/extended/node/dra/common/counter_validator.go
@@ -12,6 +12,12 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
+func (cv *CounterValidator) listOptions() metav1.ListOptions {
+	return metav1.ListOptions{
+		FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + cv.driverName,
+	}
+}
+
 // CounterValidator provides helpers for validating ResourceSlice counter
 // structures introduced by the DRAPartitionableDevices feature (KEP-4815).
 // It separates ResourceSlices into counter slices (SharedCounters only) and
@@ -31,19 +37,16 @@ func NewCounterValidator(client kubernetes.Interface, driverName string) *Counte
 }
 
 // GetResourceSlicesByType lists all ResourceSlices for the driver and separates
-// them into counter slices (have SharedCounters, no Devices) and device slices
-// (have Devices, may have ConsumesCounters).
+// them into counter slices (have SharedCounters but no Devices) and device slices
+// (have Devices, may have ConsumesCounters on individual devices).
 func (cv *CounterValidator) GetResourceSlicesByType(ctx context.Context) (counterSlices, deviceSlices []resourceapi.ResourceSlice, err error) {
-	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list ResourceSlices: %w", err)
 	}
 
 	for _, slice := range sliceList.Items {
-		if slice.Spec.Driver != cv.driverName {
-			continue
-		}
-		if len(slice.Spec.SharedCounters) > 0 {
+		if len(slice.Spec.SharedCounters) > 0 && len(slice.Spec.Devices) == 0 {
 			counterSlices = append(counterSlices, slice)
 		}
 		if len(slice.Spec.Devices) > 0 {
@@ -111,8 +114,10 @@ func (cv *CounterValidator) ValidateDeviceConsumesCounters(ctx context.Context) 
 	return nil
 }
 
-// CountPartitionDevices returns the number of devices whose names contain
-// "partition" across all device slices for the driver.
+// CountPartitionDevices returns the number of partition devices across all
+// device slices for the driver. The upstream dra-example-driver names partition
+// devices as "gpu-N-partition-M" when gpuPartitions > 0, so the substring
+// "partition" reliably identifies them within this driver's naming convention.
 func (cv *CounterValidator) CountPartitionDevices(ctx context.Context) (int, error) {
 	_, deviceSlices, err := cv.GetResourceSlicesByType(ctx)
 	if err != nil {
@@ -145,7 +150,7 @@ func (cv *CounterValidator) HasSharedCounters(ctx context.Context) bool {
 // taints would prevent regular test pods from being scheduled there. Falls
 // back to any node with devices if no untainted node is found.
 func (cv *CounterValidator) GetNodeWithDevices(ctx context.Context) (string, error) {
-	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
 	if err != nil {
 		return "", fmt.Errorf("failed to list ResourceSlices: %w", err)
 	}
@@ -167,7 +172,7 @@ func (cv *CounterValidator) GetNodeWithDevices(ctx context.Context) (string, err
 
 	var fallback string
 	for _, slice := range sliceList.Items {
-		if slice.Spec.Driver != cv.driverName || slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
+		if slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
 			continue
 		}
 		name := *slice.Spec.NodeName

--- a/test/extended/node/dra/common/counter_validator.go
+++ b/test/extended/node/dra/common/counter_validator.go
@@ -1,0 +1,186 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// CounterValidator provides helpers for validating ResourceSlice counter
+// structures introduced by the DRAPartitionableDevices feature (KEP-4815).
+// It separates ResourceSlices into counter slices (SharedCounters only) and
+// device slices (Devices with ConsumesCounters), matching the two-slice model
+// that partitionable drivers publish.
+type CounterValidator struct {
+	client     kubernetes.Interface
+	driverName string
+}
+
+// NewCounterValidator creates a validator for the given driver.
+func NewCounterValidator(client kubernetes.Interface, driverName string) *CounterValidator {
+	return &CounterValidator{
+		client:     client,
+		driverName: driverName,
+	}
+}
+
+// GetResourceSlicesByType lists all ResourceSlices for the driver and separates
+// them into counter slices (have SharedCounters, no Devices) and device slices
+// (have Devices, may have ConsumesCounters).
+func (cv *CounterValidator) GetResourceSlicesByType(ctx context.Context) (counterSlices, deviceSlices []resourceapi.ResourceSlice, err error) {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+
+	for _, slice := range sliceList.Items {
+		if slice.Spec.Driver != cv.driverName {
+			continue
+		}
+		if len(slice.Spec.SharedCounters) > 0 {
+			counterSlices = append(counterSlices, slice)
+		}
+		if len(slice.Spec.Devices) > 0 {
+			deviceSlices = append(deviceSlices, slice)
+		}
+	}
+	return counterSlices, deviceSlices, nil
+}
+
+// ValidateSharedCounters verifies that at least one counter slice exists and
+// that every CounterSet in those slices contains the expected counters with
+// non-zero values. Returns an error describing the first violation found.
+func (cv *CounterValidator) ValidateSharedCounters(ctx context.Context, expectedCounters []string) error {
+	counterSlices, _, err := cv.GetResourceSlicesByType(ctx)
+	if err != nil {
+		return err
+	}
+	if len(counterSlices) == 0 {
+		return fmt.Errorf("no ResourceSlices with SharedCounters found for driver %s", cv.driverName)
+	}
+
+	for _, slice := range counterSlices {
+		for _, cs := range slice.Spec.SharedCounters {
+			for _, name := range expectedCounters {
+				counter, exists := cs.Counters[name]
+				if !exists {
+					return fmt.Errorf("CounterSet %q in slice %s missing counter %q", cs.Name, slice.Name, name)
+				}
+				if counter.Value.IsZero() {
+					return fmt.Errorf("CounterSet %q counter %q has zero value", cs.Name, name)
+				}
+				framework.Logf("CounterSet %s: %s=%s", cs.Name, name, counter.Value.String())
+			}
+		}
+	}
+	framework.Logf("Validated SharedCounters across %d counter slice(s) for driver %s", len(counterSlices), cv.driverName)
+	return nil
+}
+
+// ValidateDeviceConsumesCounters verifies that every device in the driver's
+// device slices has at least one ConsumesCounters entry pointing to a named
+// CounterSet.
+func (cv *CounterValidator) ValidateDeviceConsumesCounters(ctx context.Context) error {
+	_, deviceSlices, err := cv.GetResourceSlicesByType(ctx)
+	if err != nil {
+		return err
+	}
+	if len(deviceSlices) == 0 {
+		return fmt.Errorf("no ResourceSlices with Devices found for driver %s", cv.driverName)
+	}
+
+	for _, slice := range deviceSlices {
+		for _, device := range slice.Spec.Devices {
+			if len(device.ConsumesCounters) == 0 {
+				return fmt.Errorf("device %s in slice %s has no ConsumesCounters", device.Name, slice.Name)
+			}
+			for _, cc := range device.ConsumesCounters {
+				if cc.CounterSet == "" {
+					return fmt.Errorf("device %s has ConsumesCounters with empty CounterSet name", device.Name)
+				}
+			}
+			framework.Logf("Device %s consumes from %d counter set(s)", device.Name, len(device.ConsumesCounters))
+		}
+	}
+	return nil
+}
+
+// CountPartitionDevices returns the number of devices whose names contain
+// "partition" across all device slices for the driver.
+func (cv *CounterValidator) CountPartitionDevices(ctx context.Context) (int, error) {
+	_, deviceSlices, err := cv.GetResourceSlicesByType(ctx)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, slice := range deviceSlices {
+		for _, device := range slice.Spec.Devices {
+			if strings.Contains(device.Name, "partition") {
+				count++
+			}
+		}
+	}
+	return count, nil
+}
+
+// HasSharedCounters returns true if the driver is publishing ResourceSlices
+// that contain SharedCounters.
+func (cv *CounterValidator) HasSharedCounters(ctx context.Context) bool {
+	counterSlices, _, err := cv.GetResourceSlicesByType(ctx)
+	if err != nil {
+		framework.Logf("Failed to check for SharedCounters: %v", err)
+		return false
+	}
+	return len(counterSlices) > 0
+}
+
+// GetNodeWithDevices returns the name of a schedulable worker node where the
+// driver is publishing devices. It avoids master/control-plane nodes whose
+// taints would prevent regular test pods from being scheduled there. Falls
+// back to any node with devices if no untainted node is found.
+func (cv *CounterValidator) GetNodeWithDevices(ctx context.Context) (string, error) {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+
+	nodeList, err := cv.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	taintedNodes := make(map[string]bool)
+	for _, node := range nodeList.Items {
+		for _, taint := range node.Spec.Taints {
+			if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
+				taintedNodes[node.Name] = true
+				break
+			}
+		}
+	}
+
+	var fallback string
+	for _, slice := range sliceList.Items {
+		if slice.Spec.Driver != cv.driverName || slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
+			continue
+		}
+		name := *slice.Spec.NodeName
+		if !taintedNodes[name] {
+			return name, nil
+		}
+		if fallback == "" {
+			fallback = name
+		}
+	}
+	if fallback != "" {
+		framework.Logf("Warning: no untainted node with devices found, falling back to tainted node %s", fallback)
+		return fallback, nil
+	}
+	return "", fmt.Errorf("no node found publishing devices for driver %s", cv.driverName)
+}

--- a/test/extended/node/dra/common/crud_helpers.go
+++ b/test/extended/node/dra/common/crud_helpers.go
@@ -3,90 +3,40 @@ package common
 import (
 	"context"
 
+	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/ptr"
+	"k8s.io/client-go/kubernetes"
 )
 
-var (
-	DeviceClassGVR = schema.GroupVersionResource{
-		Group:    "resource.k8s.io",
-		Version:  "v1",
-		Resource: "deviceclasses",
-	}
-	ResourceClaimGVR = schema.GroupVersionResource{
-		Group:    "resource.k8s.io",
-		Version:  "v1",
-		Resource: "resourceclaims",
-	}
-	ResourceClaimTemplateGVR = schema.GroupVersionResource{
-		Group:    "resource.k8s.io",
-		Version:  "v1",
-		Resource: "resourceclaimtemplates",
-	}
-)
-
-// ConvertToUnstructured converts a typed object to Unstructured
-func ConvertToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
-	unstructuredObj := &unstructured.Unstructured{}
-	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-	if err != nil {
-		return nil, err
-	}
-	unstructuredObj.Object = content
-	return unstructuredObj, nil
-}
-
-// CreateDeviceClass creates a DeviceClass
-func CreateDeviceClass(ctx context.Context, client dynamic.Interface, deviceClass interface{}) error {
-	unstructuredObj, err := ConvertToUnstructured(deviceClass)
-	if err != nil {
-		return err
-	}
-	_, err = client.Resource(DeviceClassGVR).Create(ctx, unstructuredObj, metav1.CreateOptions{})
+// CreateDeviceClass creates a DeviceClass using the typed client.
+func CreateDeviceClass(ctx context.Context, client kubernetes.Interface, deviceClass *resourceapi.DeviceClass) error {
+	_, err := client.ResourceV1().DeviceClasses().Create(ctx, deviceClass, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteDeviceClass deletes a DeviceClass
-func DeleteDeviceClass(ctx context.Context, client dynamic.Interface, name string) error {
-	return client.Resource(DeviceClassGVR).Delete(ctx, name, metav1.DeleteOptions{
-		GracePeriodSeconds: ptr.To[int64](0),
-	})
+func DeleteDeviceClass(ctx context.Context, client kubernetes.Interface, name string) error {
+	return client.ResourceV1().DeviceClasses().Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-// CreateResourceClaim creates a ResourceClaim
-func CreateResourceClaim(ctx context.Context, client dynamic.Interface, namespace string, claim interface{}) error {
-	unstructuredObj, err := ConvertToUnstructured(claim)
-	if err != nil {
-		return err
-	}
-	_, err = client.Resource(ResourceClaimGVR).Namespace(namespace).Create(ctx, unstructuredObj, metav1.CreateOptions{})
+// CreateResourceClaim creates a ResourceClaim using the typed client.
+func CreateResourceClaim(ctx context.Context, client kubernetes.Interface, namespace string, claim *resourceapi.ResourceClaim) error {
+	_, err := client.ResourceV1().ResourceClaims(namespace).Create(ctx, claim, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteResourceClaim deletes a ResourceClaim
-func DeleteResourceClaim(ctx context.Context, client dynamic.Interface, namespace, name string) error {
-	return client.Resource(ResourceClaimGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
-		GracePeriodSeconds: ptr.To[int64](0),
-	})
+func DeleteResourceClaim(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	return client.ResourceV1().ResourceClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
-// CreateResourceClaimTemplate creates a ResourceClaimTemplate
-func CreateResourceClaimTemplate(ctx context.Context, client dynamic.Interface, namespace string, template interface{}) error {
-	unstructuredObj, err := ConvertToUnstructured(template)
-	if err != nil {
-		return err
-	}
-	_, err = client.Resource(ResourceClaimTemplateGVR).Namespace(namespace).Create(ctx, unstructuredObj, metav1.CreateOptions{})
+// CreateResourceClaimTemplate creates a ResourceClaimTemplate using the typed client.
+func CreateResourceClaimTemplate(ctx context.Context, client kubernetes.Interface, namespace string, template *resourceapi.ResourceClaimTemplate) error {
+	_, err := client.ResourceV1().ResourceClaimTemplates(namespace).Create(ctx, template, metav1.CreateOptions{})
 	return err
 }
 
 // DeleteResourceClaimTemplate deletes a ResourceClaimTemplate
-func DeleteResourceClaimTemplate(ctx context.Context, client dynamic.Interface, namespace, name string) error {
-	return client.Resource(ResourceClaimTemplateGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{
-		GracePeriodSeconds: ptr.To[int64](0),
-	})
+func DeleteResourceClaimTemplate(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	return client.ResourceV1().ResourceClaimTemplates(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/test/extended/node/dra/example/device_validator.go
+++ b/test/extended/node/dra/example/device_validator.go
@@ -76,7 +76,9 @@ func (dv *DeviceValidator) ValidateDeviceAllocation(ctx context.Context, namespa
 func (dv *DeviceValidator) ValidateResourceSlice(ctx context.Context, nodeName string) (*resourceapi.ResourceSlice, error) {
 	framework.Logf("Validating ResourceSlice for node %s", nodeName)
 
-	sliceList, err := dv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	sliceList, err := dv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+		FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + exampleDriverName,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ResourceSlices: %w", err)
 	}
@@ -85,8 +87,7 @@ func (dv *DeviceValidator) ValidateResourceSlice(ctx context.Context, nodeName s
 	totalDevices := 0
 	for i := range sliceList.Items {
 		slice := &sliceList.Items[i]
-		if slice.Spec.NodeName != nil && *slice.Spec.NodeName == nodeName &&
-			slice.Spec.Driver == exampleDriverName {
+		if slice.Spec.NodeName != nil && *slice.Spec.NodeName == nodeName {
 			totalDevices += len(slice.Spec.Devices)
 			if nodeSlice == nil && len(slice.Spec.Devices) > 0 {
 				nodeSlice = slice
@@ -107,16 +108,16 @@ func (dv *DeviceValidator) ValidateResourceSlice(ctx context.Context, nodeName s
 func (dv *DeviceValidator) GetTotalDeviceCount(ctx context.Context) (int, error) {
 	framework.Logf("Counting total devices from %s driver via ResourceSlices", exampleDriverName)
 
-	sliceList, err := dv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{})
+	sliceList, err := dv.client.ResourceV1().ResourceSlices().List(ctx, metav1.ListOptions{
+		FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + exampleDriverName,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list ResourceSlices: %w", err)
 	}
 
 	totalDevices := 0
 	for _, slice := range sliceList.Items {
-		if slice.Spec.Driver == exampleDriverName {
-			totalDevices += len(slice.Spec.Devices)
-		}
+		totalDevices += len(slice.Spec.Devices)
 	}
 
 	framework.Logf("Found %d total device(s) from %s driver", totalDevices, exampleDriverName)

--- a/test/extended/node/dra/example/example_dra.go
+++ b/test/extended/node/dra/example/example_dra.go
@@ -14,7 +14,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -96,20 +95,20 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Creating DeviceClass for example driver")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err, "Failed to create DeviceClass")
 			defer func() {
-				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); err != nil {
+				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); err != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, err)
 				}
 			}()
 
 			g.By("Creating ResourceClaim requesting 1 device")
 			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claim)
 			framework.ExpectNoError(err, "Failed to create ResourceClaim")
 			defer func() {
-				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); err != nil {
+				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claimName); err != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, err)
 				}
 			}()
@@ -140,20 +139,20 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Creating DeviceClass")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); err != nil {
+				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); err != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, err)
 				}
 			}()
 
 			g.By("Creating ResourceClaim")
 			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); err != nil {
+				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claimName); err != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, err)
 				}
 			}()
@@ -180,17 +179,12 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Verifying ResourceClaim still exists but is not reserved")
 			err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
-				claimObj, getErr := oc.KubeFramework().DynamicClient.Resource(dracommon.ResourceClaimGVR).Namespace(oc.Namespace()).Get(ctx, claimName, metav1.GetOptions{})
+				claim, getErr := oc.KubeFramework().ClientSet.ResourceV1().ResourceClaims(oc.Namespace()).Get(ctx, claimName, metav1.GetOptions{})
 				if getErr != nil {
 					return false, getErr
 				}
-
-				reservedFor, found, nestErr := unstructured.NestedSlice(claimObj.Object, "status", "reservedFor")
-				if nestErr != nil {
-					return false, nestErr
-				}
-				if found && len(reservedFor) > 0 {
-					framework.Logf("ResourceClaim %s still has %d reservation(s), waiting for DRA controller to clear...", claimName, len(reservedFor))
+				if len(claim.Status.ReservedFor) > 0 {
+					framework.Logf("ResourceClaim %s still has %d reservation(s), waiting for DRA controller to clear...", claimName, len(claim.Status.ReservedFor))
 					return false, nil
 				}
 				return true, nil
@@ -216,20 +210,20 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Creating DeviceClass")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err = dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err = dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); err != nil {
+				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); err != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, err)
 				}
 			}()
 
 			g.By("Creating ResourceClaim requesting 2 devices")
 			claim := builder.BuildResourceClaim(claimName, deviceClassName, 2)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); err != nil {
+				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claimName); err != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, err)
 				}
 			}()
@@ -263,20 +257,20 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Creating DeviceClass")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); err != nil {
+				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); err != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, err)
 				}
 			}()
 
 			g.By("Creating shared ResourceClaim")
 			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); err != nil {
+				if err := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claimName); err != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, err)
 				}
 			}()
@@ -366,20 +360,20 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Creating DeviceClass")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); err != nil {
+				if err := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); err != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, err)
 				}
 			}()
 
 			g.By("Creating ResourceClaimTemplate")
 			template := builder.BuildResourceClaimTemplate(templateName, deviceClassName, 1)
-			err = dracommon.CreateResourceClaimTemplate(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), template)
+			err = dracommon.CreateResourceClaimTemplate(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), template)
 			framework.ExpectNoError(err)
 			defer func() {
-				if err := dracommon.DeleteResourceClaimTemplate(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), templateName); err != nil {
+				if err := dracommon.DeleteResourceClaimTemplate(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), templateName); err != nil {
 					framework.Logf("Warning: failed to delete ResourceClaimTemplate %s/%s: %v", oc.Namespace(), templateName, err)
 				}
 			}()
@@ -397,22 +391,19 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 			g.By("Verifying ResourceClaim was created from template")
 			claimPrefix := podName + "-device"
 
-			claimList, err := oc.KubeFramework().DynamicClient.Resource(dracommon.ResourceClaimGVR).Namespace(oc.Namespace()).List(ctx, metav1.ListOptions{})
+			claimList, err := oc.KubeFramework().ClientSet.ResourceV1().ResourceClaims(oc.Namespace()).List(ctx, metav1.ListOptions{})
 			framework.ExpectNoError(err, "Failed to list ResourceClaims")
 
 			var generatedClaimName string
-			var claimObj *unstructured.Unstructured
 			for _, claim := range claimList.Items {
-				if strings.HasPrefix(claim.GetName(), claimPrefix) {
-					generatedClaimName = claim.GetName()
-					claimObj = &claim
+				if strings.HasPrefix(claim.Name, claimPrefix) {
+					generatedClaimName = claim.Name
 					framework.Logf("Found template-generated ResourceClaim: %s (matches prefix: %s)", generatedClaimName, claimPrefix)
 					break
 				}
 			}
 
 			o.Expect(generatedClaimName).NotTo(o.BeEmpty(), "ResourceClaim with prefix %s should be auto-created from template", claimPrefix)
-			o.Expect(claimObj).NotTo(o.BeNil())
 			framework.Logf("ResourceClaim %s was successfully created from template", generatedClaimName)
 
 			g.By("Deleting pod and verifying claim cleanup")
@@ -424,7 +415,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-ex
 
 			g.By("Verifying auto-generated claim is deleted")
 			err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-				_, getErr := oc.KubeFramework().DynamicClient.Resource(dracommon.ResourceClaimGVR).Namespace(oc.Namespace()).Get(ctx, generatedClaimName, metav1.GetOptions{})
+				_, getErr := oc.KubeFramework().ClientSet.ResourceV1().ResourceClaims(oc.Namespace()).Get(ctx, generatedClaimName, metav1.GetOptions{})
 				if getErr != nil {
 					if errors.IsNotFound(getErr) {
 						framework.Logf("ResourceClaim %s was deleted as expected", generatedClaimName)

--- a/test/extended/node/dra/example/prerequisites_installer.go
+++ b/test/extended/node/dra/example/prerequisites_installer.go
@@ -56,8 +56,8 @@ func (pi *PrerequisitesInstaller) InstallAll(ctx context.Context) error {
 		return pi.WaitForDriver(ctx, 5*time.Minute)
 	}
 
-	if err := pi.ensureNamespaceGone(ctx); err != nil {
-		return fmt.Errorf("failed to ensure clean namespace state: %w", err)
+	if err := pi.cleanupStaleNamespace(ctx); err != nil {
+		return fmt.Errorf("failed to clean up stale namespace: %w", err)
 	}
 
 	if err := pi.cloneUpstreamRepo(ctx); err != nil {
@@ -131,12 +131,12 @@ func (pi *PrerequisitesInstaller) cloneUpstreamRepo(ctx context.Context) error {
 	return nil
 }
 
-// ensureNamespaceGone guarantees the driver namespace is fully deleted before
-// a fresh install begins. This handles the race where a previous run's cleanup
-// left the namespace in Terminating state (async GC of finalizers, Helm
-// release Secrets, or DaemonSet pods). It also runs a best-effort
-// helm uninstall to clear any stale release that would block re-creation.
-func (pi *PrerequisitesInstaller) ensureNamespaceGone(ctx context.Context) error {
+// cleanupStaleNamespace removes any leftover Helm release and namespace from a
+// previous test run, waiting for the namespace to fully terminate before
+// returning. This handles the race where a previous run's cleanup left the
+// namespace in Terminating state (async GC of finalizers, Helm release Secrets,
+// or DaemonSet pods).
+func (pi *PrerequisitesInstaller) cleanupStaleNamespace(ctx context.Context) error {
 	ns, err := pi.client.CoreV1().Namespaces().Get(ctx, driverNamespace, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil
@@ -148,9 +148,7 @@ func (pi *PrerequisitesInstaller) ensureNamespaceGone(ctx context.Context) error
 	framework.Logf("Namespace %s exists (phase=%s), cleaning up before fresh install...", driverNamespace, ns.Status.Phase)
 
 	if ns.Status.Phase != corev1.NamespaceTerminating {
-		cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
-			"--namespace", driverNamespace, "--wait", "--timeout", "2m")
-		output, helmErr := cmd.CombinedOutput()
+		output, helmErr := pi.helmUninstall(ctx, "2m")
 		if helmErr != nil && !strings.Contains(string(output), "not found") {
 			framework.Logf("Warning: helm uninstall during pre-cleanup: %v (output: %s)", helmErr, strings.TrimSpace(string(output)))
 		}
@@ -166,6 +164,10 @@ func (pi *PrerequisitesInstaller) ensureNamespaceGone(ctx context.Context) error
 		if errors.IsNotFound(getErr) {
 			framework.Logf("Namespace %s fully removed", driverNamespace)
 			return true, nil
+		}
+		if getErr != nil {
+			framework.Logf("Error checking namespace %s (will retry): %v", driverNamespace, getErr)
+			return false, nil
 		}
 		framework.Logf("Namespace %s still exists, waiting for GC...", driverNamespace)
 		return false, nil
@@ -248,6 +250,15 @@ func (pi *PrerequisitesInstaller) grantSCCPermissions(ctx context.Context) error
 	}
 	framework.Logf("SCC permissions granted to %s/%s", driverNamespace, driverServiceAccount)
 	return nil
+}
+
+// helmUninstall runs helm uninstall for the driver release with the given
+// timeout. It returns the combined output and any error so callers can decide
+// how to handle failures (fatal vs. best-effort).
+func (pi *PrerequisitesInstaller) helmUninstall(ctx context.Context, timeout string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
+		"--namespace", driverNamespace, "--wait", "--timeout", timeout)
+	return cmd.CombinedOutput()
 }
 
 // commonHelmArgs returns the base set of Helm arguments shared by install and
@@ -426,11 +437,7 @@ func (pi *PrerequisitesInstaller) IsDriverInstalled(ctx context.Context) bool {
 func (pi *PrerequisitesInstaller) UninstallAll(ctx context.Context) error {
 	framework.Logf("=== Cleaning up DRA Example Driver ===")
 
-	cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
-		"--namespace", driverNamespace,
-		"--wait",
-		"--timeout", "5m")
-	output, err := cmd.CombinedOutput()
+	output, err := pi.helmUninstall(ctx, "5m")
 	if err != nil && !strings.Contains(string(output), "not found") {
 		framework.Logf("Warning: helm uninstall failed: %v\nOutput: %s", err, string(output))
 	}
@@ -458,9 +465,7 @@ func (pi *PrerequisitesInstaller) UninstallAll(ctx context.Context) error {
 func (pi *PrerequisitesInstaller) RollbackMutations(ctx context.Context) {
 	framework.Logf("Rolling back DRA example driver cluster mutations (best-effort)...")
 
-	cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
-		"--namespace", driverNamespace, "--wait", "--timeout", "2m")
-	output, err := cmd.CombinedOutput()
+	output, err := pi.helmUninstall(ctx, "2m")
 	if err != nil && !strings.Contains(string(output), "not found") {
 		framework.Logf("Warning: helm uninstall during rollback: %v (output: %s)", err, strings.TrimSpace(string(output)))
 	}

--- a/test/extended/node/dra/example/prerequisites_installer.go
+++ b/test/extended/node/dra/example/prerequisites_installer.go
@@ -56,6 +56,10 @@ func (pi *PrerequisitesInstaller) InstallAll(ctx context.Context) error {
 		return pi.WaitForDriver(ctx, 5*time.Minute)
 	}
 
+	if err := pi.ensureNamespaceGone(ctx); err != nil {
+		return fmt.Errorf("failed to ensure clean namespace state: %w", err)
+	}
+
 	if err := pi.cloneUpstreamRepo(ctx); err != nil {
 		return fmt.Errorf("failed to clone upstream repo: %w", err)
 	}
@@ -91,6 +95,13 @@ func (pi *PrerequisitesInstaller) ensureHelm(ctx context.Context) error {
 		return fmt.Errorf("helm command not found or failed: %w\nOutput: %s", err, string(output))
 	}
 	framework.Logf("Helm version: %s", strings.TrimSpace(string(output)))
+
+	gitCmd := exec.CommandContext(ctx, "git", "version")
+	gitOutput, gitErr := gitCmd.CombinedOutput()
+	if gitErr != nil {
+		return fmt.Errorf("git command not found or failed: %w\nOutput: %s", gitErr, string(gitOutput))
+	}
+	framework.Logf("Git version: %s", strings.TrimSpace(string(gitOutput)))
 	return nil
 }
 
@@ -120,6 +131,47 @@ func (pi *PrerequisitesInstaller) cloneUpstreamRepo(ctx context.Context) error {
 	return nil
 }
 
+// ensureNamespaceGone guarantees the driver namespace is fully deleted before
+// a fresh install begins. This handles the race where a previous run's cleanup
+// left the namespace in Terminating state (async GC of finalizers, Helm
+// release Secrets, or DaemonSet pods). It also runs a best-effort
+// helm uninstall to clear any stale release that would block re-creation.
+func (pi *PrerequisitesInstaller) ensureNamespaceGone(ctx context.Context) error {
+	ns, err := pi.client.CoreV1().Namespaces().Get(ctx, driverNamespace, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check namespace %s: %w", driverNamespace, err)
+	}
+
+	framework.Logf("Namespace %s exists (phase=%s), cleaning up before fresh install...", driverNamespace, ns.Status.Phase)
+
+	if ns.Status.Phase != corev1.NamespaceTerminating {
+		cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
+			"--namespace", driverNamespace, "--wait", "--timeout", "2m")
+		output, helmErr := cmd.CombinedOutput()
+		if helmErr != nil && !strings.Contains(string(output), "not found") {
+			framework.Logf("Warning: helm uninstall during pre-cleanup: %v (output: %s)", helmErr, strings.TrimSpace(string(output)))
+		}
+
+		if delErr := pi.client.CoreV1().Namespaces().Delete(ctx, driverNamespace, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
+			framework.Logf("Warning: failed to delete namespace %s: %v", driverNamespace, delErr)
+		}
+	}
+
+	framework.Logf("Waiting for namespace %s to be fully removed...", driverNamespace)
+	return wait.PollUntilContextTimeout(ctx, 3*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, getErr := pi.client.CoreV1().Namespaces().Get(ctx, driverNamespace, metav1.GetOptions{})
+		if errors.IsNotFound(getErr) {
+			framework.Logf("Namespace %s fully removed", driverNamespace)
+			return true, nil
+		}
+		framework.Logf("Namespace %s still exists, waiting for GC...", driverNamespace)
+		return false, nil
+	})
+}
+
 func (pi *PrerequisitesInstaller) createNamespace(ctx context.Context) error {
 	requiredLabels := map[string]string{
 		"pod-security.kubernetes.io/enforce": "privileged",
@@ -146,6 +198,7 @@ func (pi *PrerequisitesInstaller) createNamespace(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get existing namespace %s: %w", driverNamespace, err)
 	}
+
 	needsUpdate := false
 	if existing.Labels == nil {
 		existing.Labels = make(map[string]string)
@@ -197,14 +250,10 @@ func (pi *PrerequisitesInstaller) grantSCCPermissions(ctx context.Context) error
 	return nil
 }
 
-func (pi *PrerequisitesInstaller) helmInstall(ctx context.Context) error {
-	chartPath := filepath.Join(pi.cloneDir, helmChartRelPath)
-
-	framework.Logf("Installing DRA example driver via Helm from %s", chartPath)
-
-	args := []string{
-		"install", driverRelease, chartPath,
-		"--namespace", driverNamespace,
+// commonHelmArgs returns the base set of Helm arguments shared by install and
+// upgrade operations (tolerations for master/control-plane nodes, wait, timeout).
+func commonHelmArgs() []string {
+	return []string{
 		"--set", "kubeletPlugin.tolerations[0].key=node-role.kubernetes.io/master",
 		"--set", "kubeletPlugin.tolerations[0].operator=Exists",
 		"--set", "kubeletPlugin.tolerations[0].effect=NoSchedule",
@@ -214,6 +263,15 @@ func (pi *PrerequisitesInstaller) helmInstall(ctx context.Context) error {
 		"--wait",
 		"--timeout", "5m",
 	}
+}
+
+func (pi *PrerequisitesInstaller) helmInstall(ctx context.Context) error {
+	chartPath := filepath.Join(pi.cloneDir, helmChartRelPath)
+
+	framework.Logf("Installing DRA example driver via Helm from %s", chartPath)
+
+	args := []string{"install", driverRelease, chartPath, "--namespace", driverNamespace}
+	args = append(args, commonHelmArgs()...)
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	output, err := cmd.CombinedOutput()
@@ -223,6 +281,48 @@ func (pi *PrerequisitesInstaller) helmInstall(ctx context.Context) error {
 
 	framework.Logf("DRA example driver Helm install succeeded")
 	return nil
+}
+
+// HelmUpgrade runs `helm upgrade` on the already-installed driver release with
+// additional --set overrides. Each element in setValues must be a "key=value"
+// string (e.g. "kubeletPlugin.gpuPartitions=4"). The base tolerations and
+// wait/timeout flags are always included.
+//
+// If the upstream repo has not been cloned yet (e.g. because another test
+// package performed the initial install), HelmUpgrade clones it automatically.
+func (pi *PrerequisitesInstaller) HelmUpgrade(ctx context.Context, setValues ...string) error {
+	chartPath, err := pi.resolveChartPath(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to resolve Helm chart path: %w", err)
+	}
+
+	args := []string{"upgrade", driverRelease, chartPath, "--namespace", driverNamespace}
+	args = append(args, commonHelmArgs()...)
+	for _, sv := range setValues {
+		args = append(args, "--set", sv)
+	}
+
+	framework.Logf("Running helm upgrade with extra values: %v", setValues)
+	cmd := exec.CommandContext(ctx, "helm", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("helm upgrade failed: %w\nOutput: %s", err, string(output))
+	}
+
+	framework.Logf("DRA example driver Helm upgrade succeeded")
+	return nil
+}
+
+// resolveChartPath returns the path to the Helm chart directory, cloning the
+// upstream repo if it hasn't been cloned yet by this installer instance.
+func (pi *PrerequisitesInstaller) resolveChartPath(ctx context.Context) (string, error) {
+	if pi.cloneDir != "" {
+		return filepath.Join(pi.cloneDir, helmChartRelPath), nil
+	}
+	if err := pi.cloneUpstreamRepo(ctx); err != nil {
+		return "", err
+	}
+	return filepath.Join(pi.cloneDir, helmChartRelPath), nil
 }
 
 // WaitForDriver waits for the driver to be ready and publishing devices
@@ -285,10 +385,15 @@ func (pi *PrerequisitesInstaller) waitForDaemonSet(ctx context.Context, timeout 
 	})
 }
 
-// IsDriverInstalled checks if the driver is already installed
+// IsDriverInstalled checks if the driver is already installed and healthy.
+// Returns false if the namespace is missing, terminating, or has no ready pods.
 func (pi *PrerequisitesInstaller) IsDriverInstalled(ctx context.Context) bool {
-	_, err := pi.client.CoreV1().Namespaces().Get(ctx, driverNamespace, metav1.GetOptions{})
+	ns, err := pi.client.CoreV1().Namespaces().Get(ctx, driverNamespace, metav1.GetOptions{})
 	if err != nil {
+		return false
+	}
+	if ns.Status.Phase == corev1.NamespaceTerminating {
+		framework.Logf("Namespace %s is terminating, driver not considered installed", driverNamespace)
 		return false
 	}
 
@@ -346,13 +451,23 @@ func (pi *PrerequisitesInstaller) UninstallAll(ctx context.Context) error {
 	return nil
 }
 
-// RollbackMutations performs best-effort cleanup after partial install failure
+// RollbackMutations performs best-effort cleanup after partial install failure.
+// It attempts helm uninstall first to properly remove Helm-managed resources
+// and their finalizers, preventing the namespace from getting stuck in
+// Terminating state on the next run.
 func (pi *PrerequisitesInstaller) RollbackMutations(ctx context.Context) {
 	framework.Logf("Rolling back DRA example driver cluster mutations (best-effort)...")
 
+	cmd := exec.CommandContext(ctx, "helm", "uninstall", driverRelease,
+		"--namespace", driverNamespace, "--wait", "--timeout", "2m")
+	output, err := cmd.CombinedOutput()
+	if err != nil && !strings.Contains(string(output), "not found") {
+		framework.Logf("Warning: helm uninstall during rollback: %v (output: %s)", err, strings.TrimSpace(string(output)))
+	}
+
 	pi.cleanupClusterResources(ctx)
 
-	err := pi.client.CoreV1().Namespaces().Delete(ctx, driverNamespace, metav1.DeleteOptions{})
+	err = pi.client.CoreV1().Namespaces().Delete(ctx, driverNamespace, metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		framework.Logf("Warning: failed to delete namespace %s during rollback: %v", driverNamespace, err)
 	}

--- a/test/extended/node/dra/partitionable/OWNERS
+++ b/test/extended/node/dra/partitionable/OWNERS
@@ -1,0 +1,17 @@
+approvers:
+  - sairameshv
+  - harche
+  - haircommander
+  - rphillips
+  - mrunalp
+
+reviewers:
+  - sairameshv
+  - harche
+  - haircommander
+  - rphillips
+  - mrunalp
+
+labels:
+  - sig/scheduling
+  - area/dra

--- a/test/extended/node/dra/partitionable/partitionable_dra.go
+++ b/test/extended/node/dra/partitionable/partitionable_dra.go
@@ -181,20 +181,25 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 
 			g.By("Creating DeviceClass for partitionable driver")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err, "Failed to create DeviceClass")
 			defer func() {
-				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); delErr != nil {
+				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); delErr != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, delErr)
 				}
 			}()
 
+			// Partitions are requested implicitly: with gpuPartitions enabled, the
+			// driver publishes both full-GPU and partition devices. The DRA scheduler
+			// allocates partition devices because they consume fewer shared counters.
+			// The assertion at the end of this test verifies the allocated devices
+			// are partitions (contain "partition" in their name), not full GPUs.
 			g.By("Creating ResourceClaim requesting 2 partition devices")
 			claim := builder.BuildResourceClaim(claimName, deviceClassName, 2)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claim)
 			framework.ExpectNoError(err, "Failed to create ResourceClaim")
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), claimName); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, delErr)
 				}
 			}()
@@ -219,7 +224,7 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 
 			g.By("Verifying allocated devices are partitions (not full GPUs)")
 			allocatedClaim, err := oc.KubeFramework().ClientSet.ResourceV1().ResourceClaims(oc.Namespace()).Get(ctx, claimName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "Failed to get ResourceClaim %s for partition verification", claimName)
 			for _, result := range allocatedClaim.Status.Allocation.Devices.Results {
 				o.Expect(result.Device).To(o.ContainSubstring("partition"),
 					"Expected partition device but got %q", result.Device)
@@ -241,10 +246,10 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 
 			g.By("Creating DeviceClass")
 			deviceClass := builder.BuildDeviceClass(deviceClassName)
-			err = dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			err = dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); delErr != nil {
+				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClassName); delErr != nil {
 					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, delErr)
 				}
 			}()
@@ -260,10 +265,10 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			// only allocate devices from ResourceSlices on the pinned node.
 			g.By(fmt.Sprintf("Creating ResourceClaim requesting %d devices to exhaust all counters on node %s", totalPartitionsPerNode, nodeName))
 			exhaustClaim := builder.BuildResourceClaim(exhaustClaimName, deviceClassName, totalPartitionsPerNode)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), exhaustClaim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), exhaustClaim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), exhaustClaimName); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), exhaustClaimName); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), exhaustClaimName, delErr)
 				}
 			}()
@@ -292,16 +297,18 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 
 			g.By("Creating overflow claim requesting 1 more device")
 			overflowClaim := builder.BuildResourceClaim(overflowClaimName, deviceClassName, 1)
-			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), overflowClaim)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), overflowClaimName); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaimName); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), overflowClaimName, delErr)
 				}
 			}()
 
 			g.By("Creating overflow pod pinned to same node — should be unschedulable")
 			overflowPod := builder.BuildPodWithClaim(overflowPodName, overflowClaimName, "")
+			// NodeSelector is load-bearing: counter exhaustion is per-node, not cluster-wide.
+			// Without it, the DRA scheduler could allocate from a different node's counters.
 			overflowPod.Spec.NodeSelector = map[string]string{
 				"kubernetes.io/hostname": nodeName,
 			}

--- a/test/extended/node/dra/partitionable/partitionable_dra.go
+++ b/test/extended/node/dra/partitionable/partitionable_dra.go
@@ -1,0 +1,341 @@
+package partitionable
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	dracommon "github.com/openshift/origin/test/extended/node/dra/common"
+	draexample "github.com/openshift/origin/test/extended/node/dra/example"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+)
+
+const (
+	// These must match the Helm values passed in BeforeAll. The upstream
+	// dra-example-driver defaults to numDevices=8; we override to 2 so
+	// the counter-exhaustion test can deterministically consume all
+	// partitions on a single node without requesting an excessive count.
+	// Upstream chart values:
+	//   https://github.com/kubernetes-sigs/dra-example-driver/blob/main/deployments/helm/dra-example-driver/values.yaml
+	numGPUs          = 2
+	partitionsPerGPU = 4
+
+	totalPartitionsPerNode = numGPUs * partitionsPerGPU
+)
+
+var (
+	prerequisitesOnce      sync.Once
+	prerequisitesInstalled bool
+	prerequisitesError     error
+	// cachedInstaller retains the PrerequisitesInstaller created during the
+	// first BeforeEach so that HelmUpgrade in AfterAll reuses its cloneDir
+	// instead of re-cloning the upstream repo.
+	cachedInstaller *draexample.PrerequisitesInstaller
+)
+
+var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Feature:DRAPartitionableDevices][Suite:openshift/dra-example][Serial][Skipped:Disconnected]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("dra-partitionable", admissionapi.LevelPrivileged)
+
+	var (
+		prereqInstaller  *draexample.PrerequisitesInstaller
+		counterValidator *dracommon.CounterValidator
+		builder          *dracommon.ResourceBuilder
+		validator        *draexample.DeviceValidator
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("Skipping DRA partitionable device tests on MicroShift cluster")
+		}
+
+		validator = draexample.NewDeviceValidator(oc.KubeFramework())
+		counterValidator = dracommon.NewCounterValidator(oc.KubeFramework().ClientSet, "gpu.example.com")
+		builder = dracommon.NewResourceBuilder(oc.Namespace(), dracommon.DriverConfig{
+			DriverName:       "gpu.example.com",
+			DefaultClass:     "gpu.example.com",
+			RequestName:      "device",
+			ContainerImage:   image.ShellImage(),
+			ContainerCommand: []string{"sh", "-c", "echo DRA partition device allocated && sleep infinity"},
+			LongRunCommand:   []string{"sh", "-c", "while true; do echo DRA partition active; sleep 60; done"},
+		})
+		if cachedInstaller == nil {
+			cachedInstaller = draexample.NewPrerequisitesInstaller(oc.KubeFramework())
+		}
+		prereqInstaller = cachedInstaller
+
+		prerequisitesOnce.Do(func() {
+			framework.Logf("Checking DRA example driver prerequisites for partitionable device tests")
+
+			if prereqInstaller.IsDriverInstalled(ctx) && validator.IsDriverPublishingDevices(ctx) {
+				framework.Logf("DRA example driver already installed and publishing devices")
+				prerequisitesInstalled = true
+				return
+			}
+
+			framework.Logf("Installing DRA example driver...")
+			if err := prereqInstaller.InstallAll(ctx); err != nil {
+				prerequisitesError = err
+				framework.Logf("ERROR: Failed to install DRA example driver: %v", err)
+				return
+			}
+
+			prerequisitesInstalled = true
+			framework.Logf("DRA example driver installation completed successfully")
+		})
+
+		if prerequisitesError != nil {
+			if strings.Contains(prerequisitesError.Error(), "not found or failed") {
+				g.Skip(fmt.Sprintf("Required tooling unavailable: %v", prerequisitesError))
+			}
+			g.Fail(fmt.Sprintf("DRA example driver prerequisites failed: %v", prerequisitesError))
+		}
+		if !prerequisitesInstalled {
+			g.Fail("DRA example driver prerequisites not installed")
+		}
+	})
+
+	g.Context("Partitionable Devices", g.Ordered, func() {
+		g.BeforeAll(func(ctx context.Context) {
+			framework.Logf("Upgrading DRA example driver with numDevices=%d, gpuPartitions=%d", numGPUs, partitionsPerGPU)
+			err := prereqInstaller.HelmUpgrade(ctx,
+				fmt.Sprintf("kubeletPlugin.numDevices=%d", numGPUs),
+				fmt.Sprintf("kubeletPlugin.gpuPartitions=%d", partitionsPerGPU),
+			)
+			framework.ExpectNoError(err, "Failed to helm upgrade driver with partitioning enabled")
+
+			framework.Logf("Waiting for driver to stabilize after upgrade...")
+			err = prereqInstaller.WaitForDriver(ctx, 5*time.Minute)
+			framework.ExpectNoError(err, "Driver failed to stabilize after helm upgrade")
+
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				return counterValidator.HasSharedCounters(ctx), nil
+			})
+			if err != nil {
+				g.Skip("DRAPartitionableDevices feature gate appears disabled — no SharedCounters published after upgrade")
+			}
+
+			framework.Logf("SharedCounters detected — DRAPartitionableDevices feature gate is active")
+		})
+
+		g.AfterAll(func(ctx context.Context) {
+			framework.Logf("Restoring DRA example driver to default mode (no partitions)")
+			err := prereqInstaller.HelmUpgrade(ctx,
+				"kubeletPlugin.numDevices=8",
+				"kubeletPlugin.gpuPartitions=0",
+			)
+			if err != nil {
+				framework.Logf("Warning: failed to restore driver to default mode: %v", err)
+				return
+			}
+			if waitErr := prereqInstaller.WaitForDriver(ctx, 5*time.Minute); waitErr != nil {
+				framework.Logf("Warning: driver did not stabilize after restore: %v", waitErr)
+				return
+			}
+			err = wait.PollUntilContextTimeout(ctx, 3*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+				return !counterValidator.HasSharedCounters(ctx), nil
+			})
+			if err != nil {
+				framework.Logf("Warning: SharedCounters still present after restoring non-partitioned mode")
+			}
+		})
+
+		g.It("should publish ResourceSlices with SharedCounters and ConsumesCounters", func(ctx context.Context) {
+			g.By("Validating SharedCounters in counter slices")
+			err := counterValidator.ValidateSharedCounters(ctx, []string{"memory", "compute"})
+			framework.ExpectNoError(err, "SharedCounters validation failed")
+
+			g.By("Validating Devices have ConsumesCounters in device slices")
+			err = counterValidator.ValidateDeviceConsumesCounters(ctx)
+			framework.ExpectNoError(err, "ConsumesCounters validation failed")
+
+			g.By("Verifying partition devices exist")
+			partitionCount, err := counterValidator.CountPartitionDevices(ctx)
+			framework.ExpectNoError(err, "Failed to count partition devices")
+			o.Expect(partitionCount).To(o.BeNumerically(">", 0),
+				"Expected partition devices after enabling gpuPartitions=%d", partitionsPerGPU)
+			framework.Logf("Found %d partition device(s) across all nodes", partitionCount)
+		})
+
+		g.It("should allocate partition device to pod via DRA", func(ctx context.Context) {
+			deviceClassName := "test-partitionable-" + oc.Namespace()
+			claimName := "test-partition-claim"
+			podName := "test-partition-pod"
+
+			g.By("Creating DeviceClass for partitionable driver")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err, "Failed to create DeviceClass")
+			defer func() {
+				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); delErr != nil {
+					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, delErr)
+				}
+			}()
+
+			g.By("Creating ResourceClaim requesting 2 partition devices")
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 2)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err, "Failed to create ResourceClaim")
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), claimName, delErr)
+				}
+			}()
+
+			g.By("Creating Pod using the partition claim")
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create pod")
+			defer func() {
+				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, podName, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), podName, delErr)
+				}
+			}()
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod with partition devices failed to start")
+
+			g.By("Validating device allocation shows 2 devices")
+			err = validator.ValidateDeviceAllocation(ctx, oc.Namespace(), claimName, 2)
+			framework.ExpectNoError(err, "Device allocation validation failed")
+
+			g.By("Verifying allocated devices are partitions (not full GPUs)")
+			allocatedClaim, err := oc.KubeFramework().ClientSet.ResourceV1().ResourceClaims(oc.Namespace()).Get(ctx, claimName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			for _, result := range allocatedClaim.Status.Allocation.Devices.Results {
+				o.Expect(result.Device).To(o.ContainSubstring("partition"),
+					"Expected partition device but got %q", result.Device)
+				framework.Logf("Allocated partition device: pool=%s, device=%s", result.Pool, result.Device)
+			}
+		})
+
+		g.It("should mark pod unschedulable when all counters are exhausted on a node", func(ctx context.Context) {
+			g.By("Finding a node where the driver publishes devices")
+			nodeName, err := counterValidator.GetNodeWithDevices(ctx)
+			framework.ExpectNoError(err, "Failed to find a node with published devices")
+			framework.Logf("Using node %s for counter exhaustion test", nodeName)
+
+			deviceClassName := "test-exhaustion-" + oc.Namespace()
+			exhaustClaimName := "test-exhaust-claim"
+			overflowClaimName := "test-overflow-claim"
+			exhaustPodName := "test-exhaust-pod"
+			overflowPodName := "test-overflow-pod"
+
+			g.By("Creating DeviceClass")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err = dracommon.CreateDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName); delErr != nil {
+					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, delErr)
+				}
+			}()
+
+			// With numGPUs=2 and partitionsPerGPU=4, each node has 8 partition
+			// devices plus 2 full-GPU devices. Requesting all 8 partitions
+			// exhausts every GPU's shared counters, leaving no capacity for
+			// additional allocations on this node.
+			//
+			// NodeSelector on the pod is sufficient to constrain device
+			// allocation: the DRA scheduler evaluates resource claims in
+			// the context of the pod's scheduling constraints, so it will
+			// only allocate devices from ResourceSlices on the pinned node.
+			g.By(fmt.Sprintf("Creating ResourceClaim requesting %d devices to exhaust all counters on node %s", totalPartitionsPerNode, nodeName))
+			exhaustClaim := builder.BuildResourceClaim(exhaustClaimName, deviceClassName, totalPartitionsPerNode)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), exhaustClaim)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), exhaustClaimName); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), exhaustClaimName, delErr)
+				}
+			}()
+
+			g.By("Creating pod pinned to target node to consume all partitions")
+			exhaustPod := builder.BuildLongRunningPodWithClaim(exhaustPodName, exhaustClaimName, "")
+			exhaustPod.Spec.NodeSelector = map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			}
+			exhaustPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, exhaustPod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				gracePeriod := int64(10)
+				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, exhaustPodName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); delErr != nil && !errors.IsNotFound(delErr) {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), exhaustPodName, delErr)
+				}
+			}()
+
+			g.By("Waiting for exhaustion pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, exhaustPod)
+			framework.ExpectNoError(err, "Exhaustion pod failed to start — scheduler may not support allocating %d partition devices", totalPartitionsPerNode)
+
+			g.By("Validating all partitions were allocated")
+			err = validator.ValidateDeviceAllocation(ctx, oc.Namespace(), exhaustClaimName, totalPartitionsPerNode)
+			framework.ExpectNoError(err)
+
+			g.By("Creating overflow claim requesting 1 more device")
+			overflowClaim := builder.BuildResourceClaim(overflowClaimName, deviceClassName, 1)
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), overflowClaim)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), overflowClaimName); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), overflowClaimName, delErr)
+				}
+			}()
+
+			g.By("Creating overflow pod pinned to same node — should be unschedulable")
+			overflowPod := builder.BuildPodWithClaim(overflowPodName, overflowClaimName, "")
+			overflowPod.Spec.NodeSelector = map[string]string{
+				"kubernetes.io/hostname": nodeName,
+			}
+			overflowPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, overflowPod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				gracePeriod := int64(10)
+				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, overflowPodName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); delErr != nil && !errors.IsNotFound(delErr) {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), overflowPodName, delErr)
+				}
+			}()
+
+			g.By("Verifying overflow pod stays Pending with Unschedulable condition")
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+				p, getErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, overflowPodName, metav1.GetOptions{})
+				if getErr != nil {
+					return false, getErr
+				}
+				if p.Status.Phase != corev1.PodPending {
+					return false, fmt.Errorf("expected overflow pod to stay Pending but got %s", p.Status.Phase)
+				}
+				for _, cond := range p.Status.Conditions {
+					if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
+						msg := strings.ToLower(cond.Message)
+						if strings.Contains(msg, "claim") || strings.Contains(msg, "insufficient") || strings.Contains(msg, "unresolvable") {
+							framework.Logf("Overflow pod correctly unschedulable: %s", cond.Message)
+							return true, nil
+						}
+					}
+				}
+				framework.Logf("Overflow pod is Pending but no DRA-related Unschedulable condition yet")
+				return false, nil
+			})
+			framework.ExpectNoError(err, "Overflow pod should be unschedulable when all counters are exhausted")
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Registers the `openshift/dra-example` test suite in `standard_suites.go` so all DRA example driver tests are runnable via `./openshift-tests run openshift/dra-example`
- Adds e2e tests for DRAPartitionableDevices (KEP-4815) using the upstream dra-example-driver with gpuPartitions enabled

**Architecture:**
- Reuses existing dra-example-driver install from [OCPNODE-4108](https://redhat.atlassian.net/browse/OCPNODE-4108)
- Helm upgrade enables partitioning (numDevices=2, gpuPartitions=4)
- Tests auto-skip when DRAPartitionableDevices feature gate is disabled
- AfterAll restores driver to default config

**CI Consolidation (companion openshift/release PR to follow):**
- Single consolidated Prow job will run both upstream + origin tests

## JIRA
https://issues.redhat.com/browse/OCPNODE-4538

## Verification on local OCP cluster

<details>
<summary>Downstream DRA tests -  8/8 passed</summary>

```
samaity@samaity-thinkpadt14sgen2i:~/Downstream/origin$ echo "=== DOWNSTREAM (8 tests) ==="
grep -E 'passed:|failed:|skipped:' /tmp/dra-suite-run.log | grep -iE 'DRA-Example|OCPFeatureGate:DRAPartitionable'
=== DOWNSTREAM (8 tests) ===
passed: (1m36s) 2026-07-21T07:40:07 "[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Feature:DRAPartitionableDevices][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Partitionable Devices should allocate partition device to pod via DRA"
passed: (49.2s) 2026-07-21T07:41:01 "[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-example][Serial][Skipped:Disconnected] ResourceClaimTemplate should create claim from template for pod"
passed: (51.8s) 2026-07-21T07:41:57 "[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Basic Device Allocation should handle pod deletion and resource cleanup"
passed: (19.8s) 2026-07-21T07:42:21 "[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Claim Sharing should allow multiple pods to share the same ResourceClaim"
passed: (17.5s) 2026-07-21T07:42:43 "[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Multi-Device Allocation should allocate multiple devices to single pod"
passed: (54.2s) 2026-07-21T07:43:42 "[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Feature:DRAPartitionableDevices][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Partitionable Devices should publish ResourceSlices with SharedCounters and ConsumesCounters"
passed: (1m2s) 2026-07-21T07:44:48 "[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Feature:DRAPartitionableDevices][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Partitionable Devices should mark pod unschedulable when all counters are exhausted on a node"
passed: (16.9s) 2026-07-21T07:45:09 "[sig-scheduling][Feature:DRA-Example][Suite:openshift/dra-example][Serial][Skipped:Disconnected] Basic Device Allocation should allocate single device to pod via DRA"
```

</details>

<details>
<summary>Upstream K8s DRA tests - 42/42 passed</summary>

```
samaity@samaity-thinkpadt14sgen2i:~/Downstream/origin$ echo "=== UPSTREAM (42 tests) ==="
grep -E 'passed:|failed:|skipped:' /tmp/dra-suite-run.log | grep 'DynamicResourceAllocation' | grep -v 'OCPFeatureGate'
=== UPSTREAM (42 tests) ===
passed: (1m9s) 2026-07-21T06:47:15 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on multiple nodes with node-local resources uses all resources"
passed: (58.6s) 2026-07-21T06:48:18 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports simple pod referencing inline resource claim"
passed: (1m4s) 2026-07-21T06:49:26 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports external claim referenced by multiple containers of multiple pods"
passed: (1m46s) 2026-07-21T06:51:16 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] [Beta] chooses the correct subrequest subject to constraints"
passed: (28.6s) 2026-07-21T06:51:48 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] DaemonSet with admin access [FeatureGate:DRAAdminAccess] [Beta]"
passed: (1m13s) 2026-07-21T06:53:06 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] failed update [KubeletMinVersion:1.33]"
passed: (1m54s) 2026-07-21T06:55:04 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] with multiple drivers using only drapbv1 [KubeletMinVersion:1.34] work"
passed: (58.2s) 2026-07-21T06:56:06 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports simple pod referencing external resource claim"
passed: (1m3s) 2026-07-21T06:57:13 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports inline claim referenced by multiple containers"
passed: (54.3s) 2026-07-21T06:58:12 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node runs a pod without a generated resource claim"
passed: (1m0s) 2026-07-21T06:59:16 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports sharing a claim concurrently"
passed: (57.5s) 2026-07-21T07:00:18 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node must deallocate after use"
passed: (1m24s) 2026-07-21T07:01:46 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPartitionableDevices] [Alpha] [Feature:OffByDefault] must consume and free up counters"
passed: (1m55s) 2026-07-21T07:03:46 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] with multiple drivers using drapbv1beta1 and drapbv1 work"
passed: (1m45s) 2026-07-21T07:05:35 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] [Beta] uses the config for the selected subrequest"
passed: (56.3s) 2026-07-21T07:06:36 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports init containers"
passed: (57.8s) 2026-07-21T07:07:38 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] deletes generated claims when pod is done"
passed: (1m2s) 2026-07-21T07:08:44 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] supports init containers with external claims"
passed: (28.4s) 2026-07-21T07:09:16 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must call NodePrepareResources even if not used by any container"
passed: (28.9s) 2026-07-21T07:09:49 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must unprepare resources for force-deleted pod"
passed: (1m59s) 2026-07-21T07:11:53 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] runs pod after driver starts"
passed: (1m21s) 2026-07-21T07:13:18 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] sequential update with pods replacing each other [KubeletMinVersion:1.33] [Slow]"
passed: (1m14s) 2026-07-21T07:14:36 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] does not delete generated claims when pod is restarting"
passed: (1m6s) 2026-07-21T07:15:46 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node with multiple claims allocation requests an already allocated and a new claim for a pod [KubeletMinVersion:1.35]"
passed: (1m1s) 2026-07-21T07:16:52 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports external claim referenced by multiple pods"
passed: (1m13s) 2026-07-21T07:18:09 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] rolling update [KubeletMinVersion:1.33]"
passed: (1m37s) 2026-07-21T07:19:50 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must retry NodePrepareResources"
passed: (49.4s) 2026-07-21T07:20:44 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must map configs and devices to the right containers"
passed: (1m46s) 2026-07-21T07:22:35 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] [Beta] filters config correctly for multiple devices"
passed: (1m12s) 2026-07-21T07:23:51 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must manage ResourceSlices"
passed: (43.4s) 2026-07-21T07:24:39 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] must not run a pod if a claim is not ready"
passed: (57.7s) 2026-07-21T07:25:41 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node retries pod scheduling after updating device class"
passed: (58.8s) 2026-07-21T07:26:44 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] removes reservation from claim when pod is done"
passed: (1m1s) 2026-07-21T07:27:49 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node retries pod scheduling after creating device class"
passed: (1m26s) 2026-07-21T07:29:19 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports reusing resources"
passed: (52.5s) 2026-07-21T07:30:16 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on multiple nodes with different ResourceSlices keeps pod pending because of CEL runtime errors"
passed: (21s) 2026-07-21T07:30:42 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] registers plugin"
passed: (1m42s) 2026-07-21T07:32:28 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] blocks new pod after force-delete [KubeletMinVersion:1.34]"
passed: (1m53s) 2026-07-21T07:34:26 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] with multiple drivers using only drapbv1beta1 work"
passed: (1m43s) 2026-07-21T07:36:12 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] [FeatureGate:DRAPrioritizedList] [Beta] selects the first subrequest that can be satisfied"
passed: (59.1s) 2026-07-21T07:37:16 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports claim and class parameters"
passed: (1m7s) 2026-07-21T07:38:27 "[sig-node] [DRA] kubelet [Feature:DynamicResourceAllocation] on single node supports extended resources together with ResourceClaim [Serial]"
```

</details>

## SUMMARY

Manually verified the tests on a OCP cluster built from commit 0c33a3f

**Test discovery:**

- 50 DRA tests discovered via `openshift-tests run openshift/dra-example --dry-run`
- 5 core DRA-Example tests (`[Feature:DRA-Example]`)
- 3 partitionable device tests (`[OCPFeatureGate:DRAPartitionableDevices]`)
- 42 upstream K8s DRA tests (`[Feature:DynamicResourceAllocation]`)

**Test execution:**

- `openshift-tests run openshift/dra-example` with all 50 DRA tests
- 50 pass, 0 flaky, 0 skip, 0 DRA failures
- Monitor tests (pod-lifecycle, ingress-availability, alert-summary, etc.) all clean with no cluster health regressions

**Cluster:**

-  OCP 5.0.0 / K8s 1.35.3, 6-node (3 master + 3 worker)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new built-in E2E suite for `DRAPartitionableDevices`, covering shared-counter validation, device allocation, and counter-exhaustion flows, with automatic driver upgrade/restore.
  * Registered required test modules via a side-effect import and added test ownership labeling.

* **Improvements**
  * Enhanced DRA example scheduling tests to use typed Kubernetes clients.
  * Improved driver prerequisites installation with stale-namespace cleanup and more robust Helm upgrade/uninstall handling.
  * Strengthened ResourceSlice/counter validation and driver-specific slice filtering.

* **Chores**
  * Refreshed DRA extended test CRUD helpers to use typed APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

