### PR TITLE
CORENET-7206: Register multus-cni OTE test extension binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -330,6 +330,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/olmv0-tests-ext.gz",
 	},
 	{
+		imageTag:   "multus-cni",
+		binaryPath: "/usr/bin/multus-cni-tests-ext.gz",
+	},
+	{
 		imageTag:   "ovn-kubernetes",
 		binaryPath: "/usr/bin/ovn-kubernetes-tests-ext.gz",
 	},


### PR DESCRIPTION
## Summary
- Register `multus-cni-tests-ext.gz` in the openshift-tests extension binary registry
- Companion to https://github.com/openshift/multus-cni/pull/303 which adds the OTE framework to multus-cni

## Test plan
- [ ] Verify CI builds successfully
- [ ] Use `/testwith openshift/multus-cni#303` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for testing the `multus-cni` extension to enhance test coverage and validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->