### PR TITLE
[release-4.21] OCPBUGS-88295, OCPBUGS-88297, OCPBUGS-82146, OCPBUGS-78330, OCPBUGS-85550, OCPBUGS-88324, OCPBUGS-88322, OCPBUGS-88320: Backport noOLM Gateway API test coverage and upgrade tests

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift/origin/test/e2e/upgrade/manifestdelete"
 	mc "github.com/openshift/origin/test/extended/machine_config"
 	"github.com/openshift/origin/test/extended/prometheus"
+	"github.com/openshift/origin/test/extended/router"
 	"github.com/openshift/origin/test/extended/util/disruption"
 	"github.com/openshift/origin/test/extended/util/operator"
 )
@@ -69,6 +70,7 @@ func AllTests() []upgrades.Test {
 		&prometheus.ImagePullsAreFast{},
 		&prometheus.MetricsAvailableAfterUpgradeTest{},
 		&dns.UpgradeTest{},
+		&router.GatewayAPIUpgradeTest{},
 	}
 }
 

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -278,7 +278,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Istio CR if it exists")
 	// This should get cleaned up by the CIO, but this is here just in case of failure
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "istio", istioName).Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete Istio CR %q: %v", istioName, err)
 	}
 
@@ -288,7 +288,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Sail Operator subscription")
 	// This doesn't get deleted by the CIO, so must manually clean up
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName).Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
 	}
 
@@ -296,7 +296,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// Delete CSV using label selector to handle any version (e.g., servicemeshoperator3.v3.2.0)
 	labelSelector := fmt.Sprintf("operators.coreos.com/%s", serviceMeshOperatorName)
 	err = t.oc.Run("delete").Args("csv", "-n", expectedSubscriptionNamespace, "-l", labelSelector, "--ignore-not-found=true").Execute()
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "the server doesn't have a resource type") {
 		e2e.Failf("Failed to delete CSV with label %q: %v", labelSelector, err)
 	}
 

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -279,7 +279,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// This should get cleaned up by the CIO, but this is here just in case of failure
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "istio", istioName).Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete Istio CR %q: %v", istioName, err)
+		e2e.Failf("Failed to delete Istio CR %q: %v", istioName, err)
 	}
 
 	g.By("Waiting for istiod pods to be deleted")
@@ -289,7 +289,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	// This doesn't get deleted by the CIO, so must manually clean up
 	err = t.oc.Run("delete").Args("--ignore-not-found=true", "subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName).Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
+		e2e.Failf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
 	}
 
 	g.By("Deleting Sail Operator CSV by label selector")
@@ -297,7 +297,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	labelSelector := fmt.Sprintf("operators.coreos.com/%s", serviceMeshOperatorName)
 	err = t.oc.Run("delete").Args("csv", "-n", expectedSubscriptionNamespace, "-l", labelSelector, "--ignore-not-found=true").Execute()
 	if err != nil {
-		e2e.Logf("Failed to delete CSV with label %q: %v", labelSelector, err)
+		e2e.Failf("Failed to delete CSV with label %q: %v", labelSelector, err)
 	}
 
 	g.By("Deleting OLM-managed Istio CRDs to clean up migration state")
@@ -313,7 +313,7 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 			if strings.HasSuffix(crd.Name, "istio.io") {
 				err := t.oc.Run("delete").Args("--ignore-not-found=true", "crd", crd.Name).Execute()
 				if err != nil {
-					e2e.Logf("Failed to delete CRD %q: %v", crd.Name, err)
+					e2e.Failf("Failed to delete CRD %q: %v", crd.Name, err)
 				}
 			}
 		}

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -1,0 +1,310 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// GatewayAPIUpgradeTest verifies that Gateway API resources work during upgrade,
+// whether using OLM-based or CIO-based (NO-OLM) provisioning
+type GatewayAPIUpgradeTest struct {
+	oc                    *exutil.CLI
+	namespace             string
+	gatewayName           string
+	routeName             string
+	hostname              string
+	startedWithNoOLM      bool // tracks if GatewayAPIWithoutOLM was enabled at start
+	loadBalancerSupported bool
+	managedDNS            bool
+}
+
+func (t *GatewayAPIUpgradeTest) Name() string {
+	return "gateway-api-upgrade"
+}
+
+func (t *GatewayAPIUpgradeTest) DisplayName() string {
+	return "[sig-network-edge][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API functionality during upgrade"
+}
+
+// Setup creates Gateway and HTTPRoute resources and tests connectivity
+func (t *GatewayAPIUpgradeTest) Setup(ctx context.Context, f *e2e.Framework) {
+	g.By("Setting up Gateway API upgrade test")
+
+	t.oc = exutil.NewCLIWithFramework(f).AsAdmin()
+	t.namespace = f.Namespace.Name
+	t.gatewayName = "upgrade-test-gateway"
+	t.routeName = "test-httproute"
+
+	// Check platform support and get capabilities (LoadBalancer, DNS)
+	t.loadBalancerSupported, t.managedDNS = checkPlatformSupportAndGetCapabilities(t.oc)
+
+	g.By("Checking if GatewayAPIWithoutOLM feature gate is enabled before upgrade")
+	t.startedWithNoOLM = isNoOLMFeatureGateEnabled(t.oc)
+
+	// Skip on clusters missing OLM/Marketplace capabilities if starting with OLM mode
+	if !t.startedWithNoOLM {
+		exutil.SkipIfMissingCapabilities(t.oc, olmCapabilities...)
+	}
+
+	if t.startedWithNoOLM {
+		e2e.Logf("Starting with GatewayAPIWithoutOLM enabled (NO-OLM mode)")
+	} else {
+		e2e.Logf("Starting with OLM-based Gateway API provisioning")
+	}
+
+	g.By("Creating default GatewayClass to trigger Gateway API installation")
+	gatewayClassControllerName := "openshift.io/gateway-controller/v1"
+	gatewayClass := buildGatewayClass(gatewayClassName, gatewayClassControllerName)
+	_, err := t.oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		e2e.Failf("Failed to create GatewayClass %q: %v", gatewayClassName, err)
+	}
+
+	g.By("Waiting for GatewayClass to be accepted")
+	err = checkGatewayClassCondition(t.oc, gatewayClassName, string(gatewayv1.GatewayClassConditionStatusAccepted), metav1.ConditionTrue)
+	o.Expect(err).NotTo(o.HaveOccurred(), "GatewayClass %q was not accepted", gatewayClassName)
+
+	g.By("Getting the default domain")
+	defaultIngressDomain, err := getDefaultIngressClusterDomainName(t.oc, time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to find default domain name")
+	customDomain := strings.Replace(defaultIngressDomain, "apps.", "gw-upgrade.", 1)
+	t.hostname = "test-upgrade." + customDomain
+
+	g.By("Creating Gateway")
+	_, err = createAndCheckGateway(t.oc, t.gatewayName, gatewayClassName, customDomain, t.loadBalancerSupported)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create Gateway")
+
+	g.By("Verify the gateway's LoadBalancer service and DNSRecords")
+	if t.loadBalancerSupported {
+		assertGatewayLoadbalancerReady(t.oc, t.gatewayName, t.gatewayName+"-openshift-default")
+	}
+
+	if t.managedDNS {
+		assertDNSRecordStatus(t.oc, t.gatewayName)
+	}
+
+	if !t.startedWithNoOLM {
+		g.By("Validating OLM-based provisioning before upgrade")
+		validateOLMBasedOSSM(t.oc, 20*time.Minute)
+		e2e.Logf("GatewayAPI resources successfully created with OLM-based provisioning")
+	} else {
+		g.By("Validating CIO-based (NO-OLM) provisioning before upgrade")
+		t.validateCIOProvisioning(ctx, false) // false = no migration occurred
+		e2e.Logf("GatewayAPI resources successfully created with CIO-based (NO-OLM) provisioning")
+	}
+
+	g.By("Creating HTTPRoute with backend")
+	backendName := "echo-backend-" + t.gatewayName
+	createHttpRoute(t.oc, t.gatewayName, t.routeName, t.hostname, backendName)
+
+	g.By("Waiting for HTTPRoute to be accepted")
+	_, err = assertHttpRouteSuccessful(t.oc, t.gatewayName, t.routeName)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if t.loadBalancerSupported && t.managedDNS {
+		g.By("Verifying HTTP connectivity before upgrade")
+		assertHttpRouteConnection(t.hostname)
+		e2e.Logf("HTTPRoute connectivity verified before upgrade")
+	}
+}
+
+// Test validates that resources continue working during upgrade and validates provisioning method
+func (t *GatewayAPIUpgradeTest) Test(ctx context.Context, f *e2e.Framework, done <-chan struct{}, _ upgrades.UpgradeType) {
+	g.By("Validating Gateway API resources remain functional after upgrade")
+
+	// Block until upgrade completes
+	g.By("Waiting for upgrade to complete")
+	<-done
+
+	g.By("Verifying Gateway still exists and is programmed")
+	_, err := checkGatewayStatus(t.oc, t.gatewayName, ingressNamespace, t.loadBalancerSupported)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Gateway should remain programmed")
+
+	g.By("Checking if GatewayAPIWithoutOLM feature gate is enabled after upgrade")
+	endsWithNoOLM := isNoOLMFeatureGateEnabled(t.oc)
+
+	// Determine if migration happened: started with OLM, ended with NO-OLM
+	migrationOccurred := !t.startedWithNoOLM && endsWithNoOLM
+	if migrationOccurred {
+		e2e.Logf("Migration detected: started with OLM, ended with NO-OLM")
+	} else {
+		e2e.Logf("No migration occurred (started with NO-OLM=%v, ended with NO-OLM=%v)", t.startedWithNoOLM, endsWithNoOLM)
+	}
+
+	if endsWithNoOLM {
+		g.By("GatewayAPIWithoutOLM is enabled - validating CIO-based (NO-OLM) provisioning")
+		t.validateCIOProvisioning(ctx, migrationOccurred)
+	} else {
+		g.By("GatewayAPIWithoutOLM is disabled - validating OLM-based provisioning")
+		// A shorter timeout here is because the resources should already exist post-upgrade state.
+		validateOLMBasedOSSM(t.oc, 2*time.Minute)
+	}
+
+	g.By("Verifying HTTPRoute still exists and is accepted after upgrade")
+	_, err = assertHttpRouteSuccessful(t.oc, t.gatewayName, t.routeName)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	if t.loadBalancerSupported && t.managedDNS {
+		g.By("Verifying HTTP connectivity after upgrade")
+		assertHttpRouteConnection(t.hostname)
+	}
+
+	if migrationOccurred {
+		e2e.Logf("Gateway API successfully migrated from OLM to CIO (NO-OLM) during upgrade")
+	} else if endsWithNoOLM {
+		e2e.Logf("Gateway API using CIO-based (NO-OLM) provisioning - no migration occurred")
+	} else {
+		e2e.Logf("Gateway API remains on OLM-based provisioning after upgrade")
+	}
+}
+
+// validateCIOProvisioning validates that Gateway API is using CIO-based (NO-OLM) provisioning
+// If migrationOccurred is true, validates the migration from OLM to CIO Sail Library
+func (t *GatewayAPIUpgradeTest) validateCIOProvisioning(ctx context.Context, migrationOccurred bool) {
+	g.By("Verifying Istiod control plane is running")
+	err := checkIstiodRunning(t.oc, 2*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Verifying CIO has taken ownership via GatewayClass")
+	// Check GatewayClass has CIO sail library finalizer
+	err = checkGatewayClassFinalizer(t.oc, gatewayClassName, "openshift.io/ingress-operator-sail-finalizer")
+	o.Expect(err).NotTo(o.HaveOccurred(), "GatewayClass should have CIO sail library finalizer")
+
+	// Check GatewayClass has required CIO conditions
+	err = checkGatewayClassCondition(t.oc, gatewayClassName, gatewayClassControllerInstalledConditionType, metav1.ConditionTrue)
+	o.Expect(err).NotTo(o.HaveOccurred(), "GatewayClass should have ControllerInstalled condition")
+
+	err = checkGatewayClassCondition(t.oc, gatewayClassName, gatewayClassCRDsReadyConditionType, metav1.ConditionTrue)
+	o.Expect(err).NotTo(o.HaveOccurred(), "GatewayClass should have CRDsReady condition")
+
+	g.By("Verifying istiod deployment is managed by sail library")
+	err = checkIstiodManagedBySailLibrary(t.oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Istiod should be managed by sail library")
+
+	if migrationOccurred {
+		g.By("Verifying Istio CRDs remain managed by OLM after migration")
+		// When migrating from OLM, CRDs were installed by OLM and should remain OLM-managed
+		err = assertIstioCRDsOwnedByOLM(t.oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Istio CRDs should remain OLM-managed after migration")
+
+		g.By("Verifying OLM subscription still exists after migration")
+		// The OLM Subscription for Sail Operator should still exist (it's not removed during migration)
+		_, err = t.oc.Run("get").Args("subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName, "-o", "name").Output()
+		o.Expect(err).NotTo(o.HaveOccurred(), "Sail Operator subscription should still exist after migration")
+
+		g.By("Verifying Istio CR was removed during migration")
+		out, err := t.oc.Run("get").Args("--ignore-not-found=true", "istio", istioName, "-o", "name").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(out)).To(o.BeEmpty(), "Istio CR %q should not exist", istioName)
+
+		e2e.Logf("Successfully validated OLM to NO-OLM migration")
+	} else {
+		g.By("Verifying Istio CRDs are managed by CIO")
+		// When using CIO from the start, CRDs are CIO-managed
+		err := assertIstioCRDsOwnedByCIO(t.oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Istio CRDs should be CIO-managed when using NO-OLM from the start")
+
+		g.By("Verifying CIO-managed resources")
+
+		out, err := t.oc.Run("get").Args("--ignore-not-found=true", "istio", istioName, "-o", "name").Output()
+		if err != nil && strings.Contains(err.Error(), "the server doesn't have a resource type") {
+			e2e.Logf("Istio CRD does not exist on the cluster, confirming Istio CR %q is absent", istioName)
+		} else {
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(strings.TrimSpace(out)).To(o.BeEmpty(), "Istio CR %q should not exist when using CIO-based provisioning", istioName)
+		}
+		e2e.Logf("Successfully validated CIO-based (NO-OLM) provisioning")
+	}
+}
+
+// Teardown cleans up Gateway API resources, Istio CR, and OSSM subscription
+// This runs even if the test fails, ensuring complete cleanup
+func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) {
+	g.By("Deleting the Gateway")
+	err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(ctx, t.gatewayName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Logf("Failed to delete Gateway %q: %v", t.gatewayName, err)
+	}
+
+	// Wait for Gateway to be fully deleted before removing GatewayClass
+	// This prevents orphaned resources if the controller (defined by GatewayClass) is removed
+	// before Istiod completes cleanup
+	g.By("Waiting for Gateway to be fully deleted")
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
+		_, err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Get(ctx, t.gatewayName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			e2e.Logf("Gateway %q successfully deleted", t.gatewayName)
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		e2e.Logf("Gateway %q still exists after 2 minutes, continuing cleanup anyway", t.gatewayName)
+	}
+
+	g.By("Deleting the GatewayClass")
+	err = t.oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Logf("Failed to delete GatewayClass %q: %v", gatewayClassName, err)
+	}
+
+	g.By("Deleting the Istio CR if it exists")
+	// This should get cleaned up by the CIO, but this is here just in case of failure
+	err = t.oc.Run("delete").Args("--ignore-not-found=true", "istio", istioName).Execute()
+	if err != nil {
+		e2e.Logf("Failed to delete Istio CR %q: %v", istioName, err)
+	}
+
+	g.By("Waiting for istiod pods to be deleted")
+	waitForIstiodPodDeletion(t.oc)
+
+	g.By("Deleting the Sail Operator subscription")
+	// This doesn't get deleted by the CIO, so must manually clean up
+	err = t.oc.Run("delete").Args("--ignore-not-found=true", "subscription", "-n", expectedSubscriptionNamespace, expectedSubscriptionName).Execute()
+	if err != nil {
+		e2e.Logf("Failed to delete Subscription %q: %v", expectedSubscriptionName, err)
+	}
+
+	g.By("Deleting Sail Operator CSV by label selector")
+	// Delete CSV using label selector to handle any version (e.g., servicemeshoperator3.v3.2.0)
+	labelSelector := fmt.Sprintf("operators.coreos.com/%s", serviceMeshOperatorName)
+	err = t.oc.Run("delete").Args("csv", "-n", expectedSubscriptionNamespace, "-l", labelSelector, "--ignore-not-found=true").Execute()
+	if err != nil {
+		e2e.Logf("Failed to delete CSV with label %q: %v", labelSelector, err)
+	}
+
+	g.By("Deleting OLM-managed Istio CRDs to clean up migration state")
+	// Delete Istio CRDs so subsequent NO-OLM tests don't see OLM-managed CRDs
+	// Use LabelSelector to only delete OLM-managed CRDs and suffix check as additional safety
+	crdList, err := t.oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().List(ctx, metav1.ListOptions{
+		LabelSelector: "olm.managed=true",
+	})
+	if err != nil {
+		e2e.Logf("Failed to list OLM-managed CRDs: %v", err)
+	} else {
+		for _, crd := range crdList.Items {
+			if strings.HasSuffix(crd.Name, "istio.io") {
+				err := t.oc.Run("delete").Args("--ignore-not-found=true", "crd", crd.Name).Execute()
+				if err != nil {
+					e2e.Logf("Failed to delete CRD %q: %v", crd.Name, err)
+				}
+			}
+		}
+	}
+
+	e2e.Logf("Gateway API resources, Istio CR, OSSM subscription, CSV, and Istio CRDs successfully cleaned up")
+}

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -13,7 +13,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -262,29 +261,18 @@ func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) 
 	g.By("Deleting the Gateway")
 	err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(ctx, t.gatewayName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		e2e.Logf("Failed to delete Gateway %q: %v", t.gatewayName, err)
+		e2e.Failf("Failed to delete Gateway %q: %v", t.gatewayName, err)
 	}
 
-	// Wait for Gateway to be fully deleted before removing GatewayClass
-	// This prevents orphaned resources if the controller (defined by GatewayClass) is removed
-	// before Istiod completes cleanup
-	g.By("Waiting for Gateway to be fully deleted")
-	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
-		_, err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Get(ctx, t.gatewayName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			e2e.Logf("Gateway %q successfully deleted", t.gatewayName)
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		e2e.Logf("Gateway %q still exists after 2 minutes, continuing cleanup anyway", t.gatewayName)
+	g.By("Waiting for gateway deployment to be deleted")
+	if err := waitForGatewayDeploymentDeletion(t.oc, t.gatewayName); err != nil {
+		e2e.Failf("Gateway deployment for %q was not cleaned up: %v", t.gatewayName, err)
 	}
 
 	g.By("Deleting the GatewayClass")
 	err = t.oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(ctx, gatewayClassName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
-		e2e.Logf("Failed to delete GatewayClass %q: %v", gatewayClassName, err)
+		e2e.Failf("Failed to delete GatewayClass %q: %v", gatewayClassName, err)
 	}
 
 	g.By("Deleting the Istio CR if it exists")

--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -30,6 +30,7 @@ type GatewayAPIUpgradeTest struct {
 	startedWithNoOLM      bool // tracks if GatewayAPIWithoutOLM was enabled at start
 	loadBalancerSupported bool
 	managedDNS            bool
+	precheckErr           error // error from Skip() to surface in Setup()
 }
 
 func (t *GatewayAPIUpgradeTest) Name() string {
@@ -40,25 +41,48 @@ func (t *GatewayAPIUpgradeTest) DisplayName() string {
 	return "[sig-network-edge][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API functionality during upgrade"
 }
 
+// Skip checks if this upgrade test should be skipped. This is called by the
+// disruption framework before Setup.
+func (t *GatewayAPIUpgradeTest) Skip(_ upgrades.UpgradeContext) bool {
+	oc := exutil.NewCLIForMonitorTest("gateway-api-upgrade-skip").AsAdmin()
+
+	t.precheckErr = nil
+	noOLM, err := isNoOLMFeatureGateEnabled(oc)
+	if err != nil {
+		t.precheckErr = fmt.Errorf("failed to check GatewayAPIWithoutOLM feature gate: %w", err)
+		return false
+	}
+
+	skip, reason, err := shouldSkipGatewayAPITests(oc, noOLM)
+	if err != nil {
+		t.precheckErr = fmt.Errorf("failed to check Gateway API skip conditions: %w", err)
+		return false
+	}
+	if skip {
+		g.By(fmt.Sprintf("skipping test: %s", reason))
+		return true
+	}
+
+	return false
+}
+
 // Setup creates Gateway and HTTPRoute resources and tests connectivity
 func (t *GatewayAPIUpgradeTest) Setup(ctx context.Context, f *e2e.Framework) {
 	g.By("Setting up Gateway API upgrade test")
+	o.Expect(t.precheckErr).NotTo(o.HaveOccurred(), "Skip() precheck failed: could not determine if Gateway API upgrade test should run")
 
 	t.oc = exutil.NewCLIWithFramework(f).AsAdmin()
 	t.namespace = f.Namespace.Name
 	t.gatewayName = "upgrade-test-gateway"
 	t.routeName = "test-httproute"
 
-	// Check platform support and get capabilities (LoadBalancer, DNS)
-	t.loadBalancerSupported, t.managedDNS = checkPlatformSupportAndGetCapabilities(t.oc)
+	// Get platform capabilities (skip checks already handled by Skip())
+	t.loadBalancerSupported, t.managedDNS = getPlatformCapabilities(t.oc)
 
 	g.By("Checking if GatewayAPIWithoutOLM feature gate is enabled before upgrade")
-	t.startedWithNoOLM = isNoOLMFeatureGateEnabled(t.oc)
-
-	// Skip on clusters missing OLM/Marketplace capabilities if starting with OLM mode
-	if !t.startedWithNoOLM {
-		exutil.SkipIfMissingCapabilities(t.oc, olmCapabilities...)
-	}
+	var noOLMErr error
+	t.startedWithNoOLM, noOLMErr = isNoOLMFeatureGateEnabled(t.oc)
+	o.Expect(noOLMErr).NotTo(o.HaveOccurred())
 
 	if t.startedWithNoOLM {
 		e2e.Logf("Starting with GatewayAPIWithoutOLM enabled (NO-OLM mode)")
@@ -135,7 +159,8 @@ func (t *GatewayAPIUpgradeTest) Test(ctx context.Context, f *e2e.Framework, done
 	o.Expect(err).NotTo(o.HaveOccurred(), "Gateway should remain programmed")
 
 	g.By("Checking if GatewayAPIWithoutOLM feature gate is enabled after upgrade")
-	endsWithNoOLM := isNoOLMFeatureGateEnabled(t.oc)
+	endsWithNoOLM, err := isNoOLMFeatureGateEnabled(t.oc)
+	o.Expect(err).NotTo(o.HaveOccurred())
 
 	// Determine if migration happened: started with OLM, ended with NO-OLM
 	migrationOccurred := !t.startedWithNoOLM && endsWithNoOLM

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -19,6 +19,7 @@ import (
 	operatoringressv1 "github.com/openshift/api/operatoringress/v1"
 
 	exutil "github.com/openshift/origin/test/extended/util"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -58,6 +59,8 @@ const (
 	expectedSubscriptionSource = "redhat-operators"
 	// The expected OSSM operator namespace.
 	expectedSubscriptionNamespace = "openshift-operators"
+	// The expected OSSM operator deployment name.
+	deploymentOSSMName = "servicemesh-operator3"
 
 	gatewayClassCRDsReadyConditionType           = "CRDsReady"
 	gatewayClassControllerInstalledConditionType = "ControllerInstalled"
@@ -106,7 +109,6 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 	defer g.GinkgoRecover()
 	var (
 		oc                    = exutil.NewCLIWithPodSecurityLevel("gatewayapi-controller", admissionapi.LevelBaseline)
-		csvName               string
 		err                   error
 		gateways              []string
 		infPoolCRD            = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/main/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
@@ -116,20 +118,10 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 	const (
 		// gatewayClassControllerName is the name that must be used to create a supported gatewayClass.
-		gatewayClassControllerName = "openshift.io/gateway-controller/v1"
-		//OSSM Deployment Pod Name
-		deploymentOSSMName          = "servicemesh-operator3"
+		gatewayClassControllerName  = "openshift.io/gateway-controller/v1"
 		openshiftOperatorsNamespace = "openshift-operators"
 	)
 	g.BeforeEach(func() {
-		isokd, err := isOKD(oc)
-		if err != nil {
-			e2e.Failf("Failed to get clusterversion to determine if release is OKD: %v", err)
-		}
-		if isokd {
-			g.Skip("Skipping on OKD cluster as OSSM is not available as a community operator")
-		}
-
 		// Check platform support and get capabilities (LoadBalancer, DNS)
 		loadBalancerSupported, managedDNS = checkPlatformSupportAndGetCapabilities(oc)
 
@@ -265,9 +257,9 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		errCheck := checkGatewayClassCondition(oc, gatewayClassName, string(gatewayapiv1.GatewayClassConditionStatusAccepted), metav1.ConditionTrue)
 		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q was not installed and accepted", gatewayClassName)
 
-		g.By("Ensure the istiod Deployment is present and managed by helm")
-		errCheck = checkIstiodExists(oc, ingressNamespace, istiodDeployment)
-		o.Expect(errCheck).NotTo(o.HaveOccurred(), "istiod deployment %s does not exist", istiodDeployment)
+		g.By("Ensure the istiod Deployment is present and running")
+		errCheck = checkIstiodRunning(oc, 5*time.Minute)
+		o.Expect(errCheck).NotTo(o.HaveOccurred(), "istiod deployment %s is not running", istiodDeployment)
 
 		g.By("Check the corresponding Istio CRDs are managed by CIO")
 		err := assertIstioCRDsOwnedByCIO(oc)
@@ -282,22 +274,8 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q was not installed and accepted", gatewayClassName)
 
 		g.By("Confirm the istiod Deployment contains the correct managed label")
-		waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
-			istiod, err := oc.AdminKubeClient().AppsV1().Deployments(ingressNamespace).Get(context, istiodDeployment, metav1.GetOptions{})
-			if err != nil {
-				e2e.Logf("Failed to get istiod deployment %q: %v; retrying...", istiodDeployment, err)
-				return false, nil
-			}
-			labels := istiod.ObjectMeta.Labels
-			e2e.Logf("the labels are %s", labels)
-			if value, ok := labels["managed-by"]; ok && value == "sail-library" {
-				e2e.Logf("The istiod deployment %q is managed by the sail library and has no sail-operator dependencies", istiodDeployment)
-				return true, nil
-			}
-			e2e.Logf("The istiod deployment %q does not have the label, retrying...", istiodDeployment)
-			return false, nil
-		})
-		o.Expect(waitErr).NotTo(o.HaveOccurred(), "Timed out looking for the label in deployment %q", istiodDeployment)
+		err := checkIstiodManagedBySailLibrary(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 	})
 
@@ -308,72 +286,8 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 			g.Skip("Skip this test since it requires OLM resources")
 		}
 
-		//check the catalogSource
-		g.By("Check OLM catalogSource, subscription, CSV and Pod")
-		waitCatalogErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 20*time.Minute, false, func(context context.Context) (bool, error) {
-			catalog, err := oc.AsAdmin().Run("get").Args("-n", "openshift-marketplace", "catalogsource", expectedSubscriptionSource, "-o=jsonpath={.status.connectionState.lastObservedState}").Output()
-			if err != nil {
-				e2e.Logf("Failed to get CatalogSource %q: %v; retrying...", expectedSubscriptionSource, err)
-				return false, nil
-			}
-			if catalog != "READY" {
-				e2e.Logf("CatalogSource %q is not in ready state, retrying...", expectedSubscriptionSource)
-				return false, nil
-			}
-			e2e.Logf("CatalogSource %q is ready!", expectedSubscriptionSource)
-			return true, nil
-		})
-		o.Expect(waitCatalogErr).NotTo(o.HaveOccurred(), "Timed out waiting for CatalogSource %q to become ready", expectedSubscriptionSource)
-
-		// check Subscription
-		waitVersionErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 20*time.Minute, false, func(context context.Context) (bool, error) {
-			csvName, err = oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "subscription", expectedSubscriptionName, "-o=jsonpath={.status.installedCSV}").Output()
-			if err != nil {
-				e2e.Logf("Failed to get Subscription %q: %v; retrying...", expectedSubscriptionName, err)
-				return false, nil
-			}
-			if csvName == "" {
-				e2e.Logf("Subscription %q doesn't have installed CSV, retrying...", expectedSubscriptionName)
-				return false, nil
-			}
-			e2e.Logf("Subscription %q has installed CSV: %s", expectedSubscriptionName, csvName)
-			return true, nil
-		})
-		o.Expect(waitVersionErr).NotTo(o.HaveOccurred(), "Timed out waiting for the ClusterServiceVersion to install")
-
-		waitCSVErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 20*time.Minute, false, func(context context.Context) (bool, error) {
-			csvStatus, err := oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "clusterserviceversion", csvName, "-o=jsonpath={.status.phase}").Output()
-			if err != nil {
-				e2e.Logf("Failed to get ClusterServiceVersion %q: %v; retrying...", csvName, err)
-				return false, nil
-			}
-			if csvStatus != "Succeeded" {
-				e2e.Logf("Cluster Service Version %q is not successful, retrying...", csvName)
-				return false, nil
-			}
-			e2e.Logf("Cluster Service Version %q has succeeded!", csvName)
-			return true, nil
-		})
-		o.Expect(waitCSVErr).NotTo(o.HaveOccurred(), "Cluster Service Version %s never reached succeeded status", csvName)
-
-		// get OSSM Operator deployment
-		waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 20*time.Minute, false, func(context context.Context) (bool, error) {
-			deployOSSM, err := oc.AdminKubeClient().AppsV1().Deployments(expectedSubscriptionNamespace).Get(context, "servicemesh-operator3", metav1.GetOptions{})
-			if err != nil {
-				e2e.Logf("Failed to get OSSM operator deployment %q: %v; retrying...", deploymentOSSMName, err)
-				return false, nil
-			}
-			if deployOSSM.Status.ReadyReplicas < 1 {
-				e2e.Logf("OSSM operator deployment %q is not ready, retrying...", deploymentOSSMName)
-				return false, nil
-			}
-			e2e.Logf("OSSM operator deployment %q is ready", deploymentOSSMName)
-			return true, nil
-		})
-		o.Expect(waitErr).NotTo(o.HaveOccurred(), "OSSM Operator deployment %q did not successfully deploy its pod", deploymentOSSMName)
-
-		g.By("Confirm that Istio CR is created and in healthy state")
-		waitForIstioHealthy(oc)
+		// Validate OSSM is installed via OLM
+		validateOLMBasedOSSM(oc, 20*time.Minute)
 	})
 
 	g.It("Ensure default gatewayclass is accepted", func() {
@@ -427,11 +341,11 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		if !isNoOLMFeatureGateEnabled(oc) {
 			g.By("Confirm that ISTIO CR is created and in healthy state")
-			waitForIstioHealthy(oc)
+			waitForIstioHealthy(oc, 20*time.Minute)
 		}
 
 		g.By("Confirm that the istiod deployment still exists")
-		errIstio := checkIstiodExists(oc, ingressNamespace, istiodDeployment)
+		_, errIstio := checkIstiodExists(oc, 5*time.Minute)
 		o.Expect(errIstio).NotTo(o.HaveOccurred(), "istiod deployment %s does not exist", istiodDeployment)
 
 	})
@@ -636,6 +550,14 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 // checkPlatformSupportAndGetCapabilities verifies the platform is supported and returns
 // platform capabilities for LoadBalancer services and managed DNS.
 func checkPlatformSupportAndGetCapabilities(oc *exutil.CLI) (loadBalancerSupported bool, managedDNS bool) {
+	// Skip on OKD since OSSM is not available as a community operator
+	// TODO: Determine if we can enable and start testing OKD with Sail Library
+	isokd, err := isOKD(oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get clusterversion to determine if release is OKD")
+	if isokd {
+		g.Skip("Skipping on OKD cluster as OSSM is not available as a community operator")
+	}
+
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred())
 	o.Expect(infra).NotTo(o.BeNil())
@@ -702,8 +624,7 @@ func isNoOLMFeatureGateEnabled(oc *exutil.CLI) bool {
 	return false
 }
 
-func waitForIstioHealthy(oc *exutil.CLI) {
-	timeout := 20 * time.Minute
+func waitForIstioHealthy(oc *exutil.CLI, timeout time.Duration) {
 	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Second, timeout, false, func(context context.Context) (bool, error) {
 		istioStatus, errIstio := oc.AsAdmin().Run("get").Args("istio", istioName, "-o=jsonpath={.status.state}").Output()
 		if errIstio != nil {
@@ -882,17 +803,32 @@ func createHttpRoute(oc *exutil.CLI, gwName, routeName, hostname, backendRefname
 		e2e.Failf("Unable to create httpRoute, no gateway available during route assertion %v", errGwStatus)
 	}
 
-	// Create the backend (service and pod) needed for the route to have resolvedRefs=true.
-	// The httproute, service, and pod are cleaned up when the namespace is automatically deleted.
-	// buildEchoPod builds a pod that listens on port 8080.
-	// Use regular user to create pod, service and httproute.
-	echoPod := buildEchoPod(backendRefname, namespace)
-	_, echoPodErr := oc.KubeClient().CoreV1().Pods(namespace).Create(context.TODO(), echoPod, metav1.CreateOptions{})
-	o.Expect(echoPodErr).NotTo(o.HaveOccurred())
+	// Create the backend (deployment and service) needed for the route to have resolvedRefs=true.
+	// The httproute, service, and deployment are cleaned up when the namespace is automatically deleted.
+	// buildEchoDeployment builds a deployment that listens on port 8080.
+	// Use admin client to create deployment, service and httproute.
+	echoDeployment := buildEchoDeployment(backendRefname, namespace)
+	_, deployErr := oc.AdminKubeClient().AppsV1().Deployments(namespace).Create(context.TODO(), echoDeployment, metav1.CreateOptions{})
+	o.Expect(deployErr).NotTo(o.HaveOccurred())
+
+	// Wait for deployment to be ready
+	deployReadyErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 2*time.Minute, false, func(context context.Context) (bool, error) {
+		dep, err := oc.AdminKubeClient().AppsV1().Deployments(namespace).Get(context, backendRefname, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		if dep.Status.ReadyReplicas > 0 {
+			e2e.Logf("Deployment %s is ready with %d replicas", backendRefname, dep.Status.ReadyReplicas)
+			return true, nil
+		}
+		e2e.Logf("Waiting for deployment %s to be ready...", backendRefname)
+		return false, nil
+	})
+	o.Expect(deployReadyErr).NotTo(o.HaveOccurred(), "Deployment %s never became ready", backendRefname)
 
 	// buildEchoService builds a service that targets port 8080.
-	echoService := buildEchoService(echoPod.Name, namespace, echoPod.ObjectMeta.Labels)
-	_, echoServiceErr := oc.KubeClient().CoreV1().Services(namespace).Create(context.Background(), echoService, metav1.CreateOptions{})
+	echoService := buildEchoService(backendRefname, namespace, echoDeployment.Spec.Template.ObjectMeta.Labels)
+	_, echoServiceErr := oc.AdminKubeClient().CoreV1().Services(namespace).Create(context.Background(), echoService, metav1.CreateOptions{})
 	o.Expect(echoServiceErr).NotTo(o.HaveOccurred())
 
 	// Create the HTTPRoute
@@ -963,6 +899,27 @@ func buildEchoPod(name, namespace string) *corev1.Pod {
 						},
 					},
 				},
+			},
+		},
+	}
+}
+
+// buildEchoDeployment returns a deployment for an socat-based echo server.
+func buildEchoDeployment(name, namespace string) *appsv1.Deployment {
+	pod := buildEchoPod(name, namespace)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: pod.ObjectMeta.Labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: pod.ObjectMeta,
+				Spec:       pod.Spec,
 			},
 		},
 	}
@@ -1361,17 +1318,140 @@ func waitForIstiodPodDeletion(oc *exutil.CLI) {
 	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
 }
 
-func checkIstiodExists(oc *exutil.CLI, namespace string, name string) error {
-	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
-		istiod, err := oc.AdminKubeClient().AppsV1().Deployments(namespace).Get(context, name, metav1.GetOptions{})
+// validateOLMBasedOSSM validates that Gateway API is using OLM-based provisioning.
+func validateOLMBasedOSSM(oc *exutil.CLI, timeout time.Duration) {
+	pollInterval := 5 * time.Second
+
+	//check the catalogSource
+	g.By("Check OLM catalogSource, subscription, CSV and Deployment")
+	waitCatalogErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, false, func(context context.Context) (bool, error) {
+		catalog, err := oc.AsAdmin().Run("get").Args("-n", "openshift-marketplace", "catalogsource", expectedSubscriptionSource, "-o=jsonpath={.status.connectionState.lastObservedState}").Output()
 		if err != nil {
-			e2e.Logf("Failed to get istiod deployment %q: %v; retrying...", name, err)
+			e2e.Logf("Failed to get CatalogSource %q: %v; retrying...", expectedSubscriptionSource, err)
+			return false, nil
+		}
+		if catalog != "READY" {
+			e2e.Logf("CatalogSource %q is not in ready state, retrying...", expectedSubscriptionSource)
+			return false, nil
+		}
+		e2e.Logf("CatalogSource %q is ready!", expectedSubscriptionSource)
+		return true, nil
+	})
+	o.Expect(waitCatalogErr).NotTo(o.HaveOccurred(), "Timed out waiting for CatalogSource %q to become ready", expectedSubscriptionSource)
+
+	// check Subscription
+	var csvName string
+	var err error
+	waitVersionErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, false, func(context context.Context) (bool, error) {
+		csvName, err = oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "subscription", expectedSubscriptionName, "-o=jsonpath={.status.installedCSV}").Output()
+		if err != nil {
+			e2e.Logf("Failed to get Subscription %q: %v; retrying...", expectedSubscriptionName, err)
+			return false, nil
+		}
+		if csvName == "" {
+			e2e.Logf("Subscription %q doesn't have installed CSV, retrying...", expectedSubscriptionName)
+			return false, nil
+		}
+		e2e.Logf("Subscription %q has installed CSV: %s", expectedSubscriptionName, csvName)
+		return true, nil
+	})
+	o.Expect(waitVersionErr).NotTo(o.HaveOccurred(), "Timed out waiting for the ClusterServiceVersion to install")
+
+	waitCSVErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, false, func(context context.Context) (bool, error) {
+		csvStatus, err := oc.AsAdmin().Run("get").Args("-n", expectedSubscriptionNamespace, "clusterserviceversion", csvName, "-o=jsonpath={.status.phase}").Output()
+		if err != nil {
+			e2e.Logf("Failed to get ClusterServiceVersion %q: %v; retrying...", csvName, err)
+			return false, nil
+		}
+		if csvStatus != "Succeeded" {
+			e2e.Logf("Cluster Service Version %q is not successful, retrying...", csvName)
+			return false, nil
+		}
+		e2e.Logf("Cluster Service Version %q has succeeded!", csvName)
+		return true, nil
+	})
+	o.Expect(waitCSVErr).NotTo(o.HaveOccurred(), "Cluster Service Version %s never reached succeeded status", csvName)
+
+	// get OSSM Operator deployment
+	waitErr := wait.PollUntilContextTimeout(context.Background(), pollInterval, timeout, false, func(context context.Context) (bool, error) {
+		deployOSSM, err := oc.AdminKubeClient().AppsV1().Deployments(expectedSubscriptionNamespace).Get(context, deploymentOSSMName, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Failed to get OSSM operator deployment %q: %v; retrying...", deploymentOSSMName, err)
+			return false, nil
+		}
+		if deployOSSM.Status.ReadyReplicas < 1 {
+			e2e.Logf("OSSM operator deployment %q is not ready, retrying...", deploymentOSSMName)
+			return false, nil
+		}
+		e2e.Logf("OSSM operator deployment %q is ready", deploymentOSSMName)
+		return true, nil
+	})
+	o.Expect(waitErr).NotTo(o.HaveOccurred(), "OSSM Operator deployment %q did not successfully deploy its pod", deploymentOSSMName)
+
+	g.By("Confirm that Istio CR is created and in healthy state")
+	waitForIstioHealthy(oc, timeout)
+
+	g.By("Verifying Istiod control plane is running")
+	err = checkIstiodRunning(oc, timeout)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	g.By("Verifying Istio CRDs are managed by OLM")
+	err = assertIstioCRDsOwnedByOLM(oc)
+	o.Expect(err).NotTo(o.HaveOccurred(), "Istio CRDs should be OLM-managed")
+}
+
+func checkIstiodExists(oc *exutil.CLI, timeout time.Duration) (*appsv1.Deployment, error) {
+	var deployment *appsv1.Deployment
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, timeout, false, func(context context.Context) (bool, error) {
+		istiod, err := oc.AdminKubeClient().AppsV1().Deployments(ingressNamespace).Get(context, istiodDeployment, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Failed to get istiod deployment %q: %v; retrying...", istiodDeployment, err)
 			return false, nil
 		}
 		e2e.Logf("Successfully found the istiod Deployment: %s", istiod)
+		deployment = istiod
 		return true, nil
 	})
-	o.Expect(waitErr).NotTo(o.HaveOccurred(), "Timed out looking for the deployment %q", name)
+	if waitErr != nil {
+		return nil, fmt.Errorf("timed out looking for the deployment %q: %w", istiodDeployment, waitErr)
+	}
+	return deployment, nil
+}
+
+// checkIstiodRunning verifies that at least one istiod pod is ready
+func checkIstiodRunning(oc *exutil.CLI, timeout time.Duration) error {
+	ctx := context.Background()
+
+	// Wait for Istiod deployment to exist
+	deployment, err := checkIstiodExists(oc, timeout)
+	if err != nil {
+		return err
+	}
+
+	// Verify at least one istiod pod is ready
+	err = wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		pods, err := oc.AdminKubeClient().CoreV1().Pods(ingressNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(deployment.Spec.Selector),
+		})
+		if err != nil {
+			return false, nil
+		}
+		if len(pods.Items) < 1 {
+			e2e.Logf("Waiting for istiod pods to be created...")
+			return false, nil
+		}
+		for _, pod := range pods.Items {
+			if podConditionStatus(&pod, corev1.PodReady) == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		e2e.Logf("Waiting for at least one istiod pod to be ready...")
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("at least one istiod pod should be ready: %w", err)
+	}
+
 	return nil
 }
 
@@ -1435,7 +1515,8 @@ func checkGatewayClassFinalizer(oc *exutil.CLI, name string, expectedFinalizer s
 	return nil
 }
 
-func assertIstioCRDsOwnedByCIO(oc *exutil.CLI) error {
+// assertIstioCRDsHaveLabel verifies that all Istio CRDs have the specified label with expected value
+func assertIstioCRDsHaveLabel(oc *exutil.CLI, labelKey string, expectedValue string, owner string) error {
 	crdList, err := oc.AdminApiextensionsClient().ApiextensionsV1().CustomResourceDefinitions().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list CRDs: %w", err)
@@ -1445,16 +1526,47 @@ func assertIstioCRDsOwnedByCIO(oc *exutil.CLI) error {
 	for _, crd := range crdList.Items {
 		if strings.HasSuffix(crd.Name, "istio.io") {
 			istioFound = true
-			if value, ok := crd.Labels["ingress.operator.openshift.io/owned"]; ok && value == "true" {
-				e2e.Logf("CRD %s has the specific label value: %s", crd.Name, value)
+			if value, ok := crd.Labels[labelKey]; ok && value == expectedValue {
+				e2e.Logf("CRD %s has label %s=%s", crd.Name, labelKey, value)
 				continue
 			}
-			return fmt.Errorf("CRD %s is not managed by CIO", crd.Name)
+			return fmt.Errorf("CRD %s is not managed by %s (expected label %s=%s)", crd.Name, owner, labelKey, expectedValue)
 		}
 	}
 
 	if !istioFound {
-		return fmt.Errorf("There are no istio.io CRDs found")
+		return fmt.Errorf("no istio.io CRDs found")
+	}
+	return nil
+}
+
+func assertIstioCRDsOwnedByCIO(oc *exutil.CLI) error {
+	return assertIstioCRDsHaveLabel(oc, "ingress.operator.openshift.io/owned", "true", "CIO")
+}
+
+func assertIstioCRDsOwnedByOLM(oc *exutil.CLI) error {
+	return assertIstioCRDsHaveLabel(oc, "olm.managed", "true", "OLM")
+}
+
+// checkIstiodManagedBySailLibrary verifies that the istiod deployment has the managed-by: sail-library label
+func checkIstiodManagedBySailLibrary(oc *exutil.CLI) error {
+	waitErr := wait.PollUntilContextTimeout(context.Background(), 1*time.Second, 5*time.Minute, false, func(context context.Context) (bool, error) {
+		istiod, err := oc.AdminKubeClient().AppsV1().Deployments(ingressNamespace).Get(context, istiodDeployment, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Failed to get istiod deployment %q: %v; retrying...", istiodDeployment, err)
+			return false, nil
+		}
+		labels := istiod.ObjectMeta.Labels
+		e2e.Logf("istiod deployment labels: %s", labels)
+		if value, ok := labels["managed-by"]; ok && value == "sail-library" {
+			e2e.Logf("The istiod deployment %q is managed by the sail library", istiodDeployment)
+			return true, nil
+		}
+		e2e.Logf("The istiod deployment %q does not have managed-by=sail-library label, retrying...", istiodDeployment)
+		return false, nil
+	})
+	if waitErr != nil {
+		return fmt.Errorf("timed out waiting for istiod deployment to have managed-by=sail-library label: %w", waitErr)
 	}
 	return nil
 }

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -105,12 +105,11 @@ var (
 	}
 )
 
-var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", g.Ordered, g.Serial, func() {
+var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feature:Router][apigroup:gateway.networking.k8s.io]", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                    = exutil.NewCLIWithPodSecurityLevel("gatewayapi-controller", admissionapi.LevelBaseline)
 		err                   error
-		gateways              []string
 		infPoolCRD            = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/main/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 		managedDNS            bool
 		loadBalancerSupported bool
@@ -145,13 +144,6 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		if !checkAllTestsDone(oc) {
 			e2e.Logf("Skipping cleanup while not all GatewayAPIController tests are done")
 		} else {
-			g.By("Deleting the gateways")
-
-			for _, name := range gateways {
-				err = oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
-				o.Expect(err).NotTo(o.HaveOccurred(), "Gateway %s could not be deleted", name)
-			}
-
 			g.By("Deleting the GatewayClass")
 
 			if err := oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(context.Background(), gatewayClassName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
@@ -365,7 +357,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create the default Gateway")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, defaultDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "failed to create Gateway")
 
@@ -394,7 +386,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create a custom Gateway for the HTTPRoute")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, customDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "Failed to create Gateway")
 
@@ -510,7 +502,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		g.By("Create a custom Gateway")
 		gw := names.SimpleNameGenerator.GenerateName("gateway-")
-		gateways = append(gateways, gw)
+		defer deleteGatewayAndWaitForCleanup(oc, gw)
 		_, gwerr := createAndCheckGateway(oc, gw, gatewayClassName, customDomain, loadBalancerSupported)
 		o.Expect(gwerr).NotTo(o.HaveOccurred(), "Failed to create Gateway")
 
@@ -1357,6 +1349,40 @@ func waitForIstiodPodDeletion(oc *exutil.CLI) {
 		g.Expect(err).NotTo(o.HaveOccurred())
 		g.Expect(podsList.Items).Should(o.BeEmpty())
 	}).WithTimeout(10 * time.Minute).WithPolling(10 * time.Second).Should(o.Succeed())
+}
+
+// waitForGatewayDeploymentDeletion waits for a Gateway's deployment to be
+// deleted. The deployment is cascade-deleted by GC after the Gateway is
+// removed, but this is asynchronous. Must complete before removing the
+// GatewayClass or istiod to prevent gateway pods from crash-looping.
+func waitForGatewayDeploymentDeletion(oc *exutil.CLI, gatewayName string) error {
+	deploymentName := gatewayName + "-" + gatewayClassName
+	e2e.Logf("Waiting for gateway deployment %q in namespace %q to be deleted", deploymentName, ingressNamespace)
+	return wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := oc.AdminKubeClient().AppsV1().Deployments(ingressNamespace).Get(ctx, deploymentName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			e2e.Logf("Gateway deployment %q has been deleted", deploymentName)
+			return true, nil
+		}
+		if err != nil {
+			e2e.Logf("Error checking gateway deployment %q: %v, retrying...", deploymentName, err)
+			return false, nil
+		}
+		e2e.Logf("Gateway deployment %q still exists, waiting for GC cascade deletion...", deploymentName)
+		return false, nil
+	})
+}
+
+// deleteGatewayAndWaitForCleanup deletes a Gateway and waits for its proxy deployment to be removed by GC.
+func deleteGatewayAndWaitForCleanup(oc *exutil.CLI, gatewayName string) {
+	e2e.Logf("Deleting Gateway %q", gatewayName)
+	err := oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(context.Background(), gatewayName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Failf("Failed to delete Gateway %q: %v", gatewayName, err)
+	}
+	if err := waitForGatewayDeploymentDeletion(oc, gatewayName); err != nil {
+		e2e.Failf("Failed: Gateway deployment for %q was not deleted: %v", gatewayName, err)
+	}
 }
 
 // validateOLMBasedOSSM validates that Gateway API is using OLM-based provisioning.

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -114,6 +114,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		infPoolCRD            = "https://raw.githubusercontent.com/kubernetes-sigs/gateway-api-inference-extension/main/config/crd/bases/inference.networking.k8s.io_inferencepools.yaml"
 		managedDNS            bool
 		loadBalancerSupported bool
+		noOLM                 bool
 	)
 
 	const (
@@ -122,16 +123,16 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		openshiftOperatorsNamespace = "openshift-operators"
 	)
 	g.BeforeEach(func() {
-		// Check platform support and get capabilities (LoadBalancer, DNS)
-		loadBalancerSupported, managedDNS = checkPlatformSupportAndGetCapabilities(oc)
+		noOLM, err = isNoOLMFeatureGateEnabled(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
 
-		if !isNoOLMFeatureGateEnabled(oc) {
-			// GatewayAPIController without GatewayAPIWithoutOLM featuregate
-			// relies on OSSM OLM operator.
-			// Skipping on clusters which don't have capabilities required
-			// to install an OLM operator.
-			exutil.SkipIfMissingCapabilities(oc, olmCapabilities...)
+		// Check platform support, capabilities, and skip conditions
+		skip, reason, err := shouldSkipGatewayAPITests(oc, noOLM)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if skip {
+			g.Skip(reason)
 		}
+		loadBalancerSupported, managedDNS = getPlatformCapabilities(oc)
 		// create the default gatewayClass
 		gatewayClass := buildGatewayClass(gatewayClassName, gatewayClassControllerName)
 		_, err = oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Create(context.TODO(), gatewayClass, metav1.CreateOptions{})
@@ -156,7 +157,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 			if err := oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Delete(context.Background(), gatewayClassName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 				e2e.Failf("Failed to delete GatewayClass %q", gatewayClassName)
 			}
-			if isNoOLMFeatureGateEnabled(oc) {
+			if noOLM {
 				g.By("Waiting for the istiod pod to be deleted")
 				waitForIstiodPodDeletion(oc)
 			} else {
@@ -282,7 +283,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 	g.It("Ensure OSSM and OLM related resources are created after creating GatewayClass", func() {
 		defer markTestDone(oc, ossmAndOLMResourcesCreated)
 		// these will fail since no OLM Resources will be available
-		if isNoOLMFeatureGateEnabled(oc) {
+		if noOLM {
 			g.Skip("Skip this test since it requires OLM resources")
 		}
 
@@ -312,7 +313,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		errCheck := checkGatewayClassCondition(oc, customGatewayClassName, string(gatewayapiv1.GatewayClassConditionStatusAccepted), metav1.ConditionTrue)
 		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q was not installed and accepted", gwc.Name)
 
-		if isNoOLMFeatureGateEnabled(oc) {
+		if noOLM {
 			g.By("Check the GatewayClass conditions")
 			errCheck = checkGatewayClassCondition(oc, customGatewayClassName, gatewayClassControllerInstalledConditionType, metav1.ConditionTrue)
 			o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q does not have the ControllerInstalled condition", customGatewayClassName)
@@ -339,7 +340,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		defaultCheck := checkGatewayClassCondition(oc, gatewayClassName, string(gatewayapiv1.GatewayClassConditionStatusAccepted), metav1.ConditionTrue)
 		o.Expect(defaultCheck).NotTo(o.HaveOccurred())
 
-		if !isNoOLMFeatureGateEnabled(oc) {
+		if !noOLM {
 			g.By("Confirm that ISTIO CR is created and in healthy state")
 			waitForIstioHealthy(oc, 20*time.Minute)
 		}
@@ -481,7 +482,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		g.By(fmt.Sprintf("Wait until the istiod deployment in %s namespace is automatically created successfully", ingressNamespace))
 		pollWaitDeploymentCreated(oc, ingressNamespace, istiodDeployment, deployment.CreationTimestamp)
 
-		if !isNoOLMFeatureGateEnabled(oc) {
+		if !noOLM {
 			// delete the istio and check if it is restored
 			g.By(fmt.Sprintf("Try to delete the istio %s", istioName))
 			istioOriginalCreatedTimestamp, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("-n", ingressNamespace, "istio/"+istioName, `-o=jsonpath={.metadata.creationTimestamp}`).Output()
@@ -547,44 +548,80 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 	})
 })
 
-// checkPlatformSupportAndGetCapabilities verifies the platform is supported and returns
-// platform capabilities for LoadBalancer services and managed DNS.
-func checkPlatformSupportAndGetCapabilities(oc *exutil.CLI) (loadBalancerSupported bool, managedDNS bool) {
-	// Skip on OKD since OSSM is not available as a community operator
+// shouldSkipGatewayAPITests checks if Gateway API tests should be skipped on this cluster.
+// It returns (skip bool, reason string, err error). An error indicates a failure to
+// determine skip status and should be treated as a test failure, not a skip.
+// This function avoids calling g.Skip() or o.Expect() so it is safe to call from
+// upgrade test Skip() methods that run outside of Ginkgo leaf nodes.
+func shouldSkipGatewayAPITests(oc *exutil.CLI, noOLM bool) (bool, string, error) {
 	// TODO: Determine if we can enable and start testing OKD with Sail Library
 	isokd, err := isOKD(oc)
-	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get clusterversion to determine if release is OKD")
+	if err != nil {
+		return false, "", fmt.Errorf("failed to determine if release is OKD: %v", err)
+	}
 	if isokd {
-		g.Skip("Skipping on OKD cluster as OSSM is not available as a community operator")
+		return true, "Skipping on OKD cluster as OSSM is not available as a community operator", nil
 	}
 
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
-	o.Expect(infra).NotTo(o.BeNil())
+	if err != nil {
+		return false, "", fmt.Errorf("failed to get infrastructure: %v", err)
+	}
 
-	o.Expect(infra.Status.PlatformStatus).NotTo(o.BeNil())
+	if infra.Status.PlatformStatus == nil {
+		return false, "", fmt.Errorf("infrastructure PlatformStatus is nil")
+	}
 	platformType := infra.Status.PlatformStatus.Type
-	o.Expect(platformType).NotTo(o.BeEmpty())
 	switch platformType {
+	case configv1.AWSPlatformType,
+		configv1.AzurePlatformType,
+		configv1.GCPPlatformType,
+		configv1.IBMCloudPlatformType,
+		configv1.VSpherePlatformType,
+		configv1.BareMetalPlatformType,
+		configv1.EquinixMetalPlatformType:
+		// supported
+	default:
+		return true, fmt.Sprintf("Skipping on unsupported platform type %q", platformType), nil
+	}
+
+	ipv6, err := isIPv6OrDualStack(oc)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to check IPv6/dual-stack: %v", err)
+	}
+	if ipv6 {
+		return true, "Skipping Gateway API tests on IPv6/dual-stack cluster", nil
+	}
+
+	if !noOLM {
+		enabled, err := exutil.AllCapabilitiesEnabled(oc, olmCapabilities...)
+		if err != nil {
+			return false, "", fmt.Errorf("failed to check OLM capabilities: %v", err)
+		}
+		if !enabled {
+			return true, "Skipping: OLM/Marketplace capabilities are not enabled and GatewayAPIWithoutOLM is not enabled", nil
+		}
+	}
+
+	return false, "", nil
+}
+
+// getPlatformCapabilities returns platform capabilities for LoadBalancer services and managed DNS.
+func getPlatformCapabilities(oc *exutil.CLI) (loadBalancerSupported bool, managedDNS bool) {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(infra.Status.PlatformStatus).NotTo(o.BeNil())
+
+	switch infra.Status.PlatformStatus.Type {
 	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType, configv1.IBMCloudPlatformType:
-		// Cloud platforms with native LoadBalancer support
 		loadBalancerSupported = true
 	case configv1.VSpherePlatformType, configv1.BareMetalPlatformType, configv1.EquinixMetalPlatformType:
-		// Platforms without native LoadBalancer support (may have MetalLB or similar)
 		loadBalancerSupported = false
-	default:
-		g.Skip(fmt.Sprintf("Skipping on unsupported platform type %q", platformType))
 	}
 
-	// Check if DNS is managed (has public or private zones configured)
 	managedDNS = isDNSManaged(oc)
 
-	// Skip Gateway API tests on IPv6 or dual-stack clusters (any platform)
-	if isIPv6OrDualStack(oc) {
-		g.Skip("Skipping Gateway API tests on IPv6/dual-stack cluster")
-	}
-
-	e2e.Logf("Platform: %s, LoadBalancer supported: %t, DNS managed: %t", platformType, loadBalancerSupported, managedDNS)
+	e2e.Logf("Platform: %s, LoadBalancer supported: %t, DNS managed: %t", infra.Status.PlatformStatus.Type, loadBalancerSupported, managedDNS)
 	return loadBalancerSupported, managedDNS
 }
 
@@ -598,30 +635,34 @@ func isDNSManaged(oc *exutil.CLI) bool {
 
 // isIPv6OrDualStack checks if the cluster is using IPv6 or dual-stack networking.
 // Returns true if any ServiceNetwork CIDR is IPv6 (indicates IPv6-only or dual-stack).
-func isIPv6OrDualStack(oc *exutil.CLI) bool {
+func isIPv6OrDualStack(oc *exutil.CLI) (bool, error) {
 	networkConfig, err := oc.AdminOperatorClient().OperatorV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get network config")
+	if err != nil {
+		return false, fmt.Errorf("failed to get network config: %v", err)
+	}
 
 	for _, cidr := range networkConfig.Spec.ServiceNetwork {
 		if utilnet.IsIPv6CIDRString(cidr) {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
-func isNoOLMFeatureGateEnabled(oc *exutil.CLI) bool {
+func isNoOLMFeatureGateEnabled(oc *exutil.CLI) (bool, error) {
 	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred(), "Error getting cluster FeatureGates.")
+	if err != nil {
+		return false, fmt.Errorf("failed to get cluster FeatureGates: %v", err)
+	}
 	for _, fg := range fgs.Status.FeatureGates {
 		for _, enabledFG := range fg.Enabled {
 			if enabledFG.Name == "GatewayAPIWithoutOLM" {
 				e2e.Logf("GatewayAPIWithoutOLM featuregate is enabled")
-				return true
+				return true, nil
 			}
 		}
 	}
-	return false
+	return false, nil
 }
 
 func waitForIstioHealthy(oc *exutil.CLI, timeout time.Duration) {

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/util/retry"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -1111,14 +1112,19 @@ func annotationKeyForTest(testName string) string {
 // These annotations are used to determine whether it is safe to clean up the
 // gatewayclass and other shared resources.
 func markTestDone(oc *exutil.CLI, testName string) {
-	gwc, err := oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Get(context.Background(), gatewayClassName, metav1.GetOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred())
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		gwc, err := oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Get(context.Background(), gatewayClassName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
 
-	if gwc.Annotations == nil {
-		gwc.Annotations = map[string]string{}
-	}
-	gwc.Annotations[annotationKeyForTest(testName)] = ""
-	_, err = oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Update(context.Background(), gwc, metav1.UpdateOptions{})
+		if gwc.Annotations == nil {
+			gwc.Annotations = map[string]string{}
+		}
+		gwc.Annotations[annotationKeyForTest(testName)] = ""
+		_, err = oc.AdminGatewayApiClient().GatewayV1().GatewayClasses().Update(context.Background(), gwc, metav1.UpdateOptions{})
+		return err
+	})
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 


### PR DESCRIPTION
## Summary

Backport of Gateway API noOLM (Sail Library) test coverage and upgrade tests to release-4.21, as part of the Sail Library backport ([NE-2286](https://issues.redhat.com/browse/NE-2286)). This provides full test coverage for the `GatewayAPIWithoutOLM` feature gate, including OLM-to-Sail-Library migration upgrade testing, test flake fixes, and parallel worker cleanup fixes.

Depends on https://github.com/openshift/origin/pull/31139

## Cherry-picked PRs

| PR | Title | Type |
|----|-------|------|
| [#30897](https://github.com/openshift/origin/pull/30897) | [NE-2561](https://redhat.atlassian.net/browse/NE-2561): Add Gateway API OLM to noOLM migration upgrade test | Feature |
| [#30964](https://github.com/openshift/origin/pull/30964) | [OCPBUGS-81751](https://issues.redhat.com/browse/OCPBUGS-81751): Fix GatewayClass update conflict in markTestDone | Bug fix |
| [#31000](https://github.com/openshift/origin/pull/31000) | [OCPBUGS-83267](https://issues.redhat.com/browse/OCPBUGS-83267): Use upgrades.Skippable for Gateway API upgrade test skip logic | Bug fix |
| [#31023](https://github.com/openshift/origin/pull/31023) | [OCPBUGS-83281](https://issues.redhat.com/browse/OCPBUGS-83281): Fix Gateway cleanup in parallel e2e test workers | Bug fix |

## Early CI Test Results (GatewayAPIWithoutOLM FG Disabled)

This PR backports the Gateway API upgrade test and bug fixes to release-4.21. The `GatewayAPIWithoutOLM` feature gate is **disabled** on this branch, so all default CI jobs test the existing OLM-based Gateway API path only. To validate the noOLM (Sail Library) path, we run `/testwith` including https://github.com/openshift/cluster-ingress-operator/pull/1462 and https://github.com/openshift/api/pull/2865, which enable the feature gate.

### OLM Tests (FG Disabled)

These tests run with the `GatewayAPIWithoutOLM` feature gate disabled, so Gateway API uses the existing OLM-based installation path. They confirm the backported test code does not regress existing behavior.

- **OLM non-upgrade** — Pre-submit e2e jobs test fresh OLM-based install and Gateway API functionality
- **OLM-to-OLM upgrade** — Pre-submit upgrade job + payload upgrade jobs validate OLM-based upgrades are not regressed across platforms

#### Pre-submits

Pre-submits are passing, including the `e2e-gcp-ovn-upgrade` job which runs the Gateway API upgrade test against the OLM-based path.

[Full PR test history](https://prow.ci.openshift.org/pr-history?org=openshift&repo=origin&pr=31232)

#### Payload Upgrade Jobs

Additional upgrade coverage across platforms beyond what pre-submits test.

```
/payload-job periodic-ci-openshift-release-main-ci-4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-rt-upgrade
/payload-job periodic-ci-openshift-release-main-ci-4.21-e2e-aws-ovn-upgrade-out-of-change
/payload-job periodic-ci-openshift-release-main-ci-4.21-e2e-azure-ovn-upgrade
/payload-job periodic-ci-openshift-release-main-ci-4.21-e2e-vsphere-ovn-upgrade
/payload-job periodic-ci-openshift-release-main-nightly-4.21-e2e-metal-ipi-ovn-upgrade
/payload-job periodic-ci-openshift-release-main-nightly-4.21-e2e-metal-ipi-upgrade-ovn-ipv6
/payload-job periodic-ci-openshift-release-main-ci-4.21-e2e-aws-upgrade-ovn-single-node
/payload-job periodic-ci-openshift-release-main-nightly-4.21-e2e-aws-ovn-upgrade-fips
```

[Example Payload run](https://pr-payload-tests.ci.openshift.org/runs/ci/b5bbf0d0-604c-11f1-8aeb-16c9b905159d-0)

| Job | Result | Failure Reason | Prow Link |
|-----|--------|----------------|-----------|
| e2e-azure-ovn-upgrade | :white_check_mark: PASS | — | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-ci-4.21-e2e-azure-ovn-upgrade/2062619577589698560) |
| e2e-vsphere-ovn-upgrade | :white_check_mark: PASS | — | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-ci-4.21-e2e-vsphere-ovn-upgrade/2062619578164318208) |
| e2e-metal-ipi-ovn-upgrade | :white_check_mark: PASS | — | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-nightly-4.21-e2e-metal-ipi-ovn-upgrade/2062619578688606208) |
| e2e-metal-ipi-upgrade-ovn-ipv6 | :white_check_mark: PASS | — | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-nightly-4.21-e2e-metal-ipi-upgrade-ovn-ipv6/2062619579183534080) |
| e2e-gcp-ovn-rt-upgrade | :warning: FLAKE | Timed out waiting for node count (5) to equal machine count (6) — machine never joined cluster | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-ci-4.21-upgrade-from-stable-4.20-e2e-gcp-ovn-rt-upgrade/2062619576528539648) |
| e2e-aws-ovn-upgrade-out-of-change | :x: FAIL | Expected failure from backporting the `GatewayAPIWithoutOLM` feature gate (https://github.com/openshift/api/pull/2864) — latest candidate includes the FG but previous candidate predates it, so the test sees a missing FG post-upgrade. Will self-resolve once both candidates include the API change. | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-ci-4.21-e2e-aws-ovn-upgrade-out-of-change/2062619577057021952) |
| e2e-aws-upgrade-ovn-single-node | :warning: FLAKE | No JUnit results generated — install/setup failure before tests ran | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-ci-4.21-e2e-aws-upgrade-ovn-single-node/2062619579728793600) |
| e2e-aws-ovn-upgrade-fips | :warning: FLAKE | Pre-existing monitor failures: `required-scc-annotation-checker` across many namespaces (etcd, kube-apiserver, dns, multus, ovn-kubernetes, etc.) and `terminationMessagePolicy` on istiod/servicemesh pods — not related to this PR | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31232-nightly-4.21-e2e-aws-ovn-upgrade-fips/2062619580253081600) |

### noOLM Tests (FG Enabled via /testwith with CIO https://github.com/openshift/cluster-ingress-operator/pull/1462 + API https://github.com/openshift/api/pull/2865)

> **Note:** https://github.com/openshift/cluster-ingress-operator/pull/1462 is identical to https://github.com/openshift/cluster-ingress-operator/pull/1442 (the actual backport PR) plus one commit that removes the `release.openshift.io/feature-set` annotation from the Sail Library RBAC manifests, allowing the noOLM path to run under the Default feature set. https://github.com/openshift/api/pull/2865 promotes the `GatewayAPIWithoutOLM` feature gate to Default.

These tests include the CIO and API PRs that enable the `GatewayAPIWithoutOLM` feature gate, so Gateway API uses the Sail Library installation path instead of OLM.

- **noOLM non-upgrade** — `e2e-gcp-ovn` validates fresh install with Sail Library
- **OLM-to-noOLM upgrade** — `e2e-gcp-ovn-upgrade` validates migration from OLM to Sail Library during upgrade

```
/testwith openshift/origin/release-4.21/e2e-gcp-ovn openshift/cluster-ingress-operator#1462 openshift/api#2865
/testwith openshift/origin/release-4.21/e2e-gcp-ovn-upgrade openshift/cluster-ingress-operator#1462 openshift/api#2865
```

| Job | Result | Prow Link |
|-----|--------|-----------|
| e2e-gcp-ovn | :white_check_mark: PASS | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-31232-openshift-cluster-ingress-operator-1462-openshift-api-2865-e2e-gcp-ovn/2062619729226371072) |
| e2e-gcp-ovn-upgrade | :white_check_mark: PASS | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-31232-openshift-cluster-ingress-operator-1462-openshift-api-2865-e2e-gcp-ovn-upgrade/2062619892422545408) |
| e2e-gcp-ovn-upgrade (rerun) | :white_check_mark: PASS | [link](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/multi-pr-openshift-origin-31232-openshift-cluster-ingress-operator-1462-openshift-api-2865-e2e-gcp-ovn-upgrade/2062698246194597888) |

Migration log from the upgrade test confirms successful OLM-to-Sail-Library transition:
```
2026-06-04T21:15:15.852Z  INFO  operator.gatewayclass_controller  gatewayclass/controller.go:482  Migrating from OSSM to Sail Library: deleting Istio CR
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

