### PR TITLE
Add CodeRabbit instruction to prefer k8s sets over bespoke maps

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,10 @@
 inheritance: true
 reviews:
   request_changes_workflow: true
+  path_instructions:
+    - path: "**/*.go"
+      instructions: |
+        Use `k8s.io/apimachinery/pkg/util/sets` instead of bespoke map-based sets
+        (e.g. `map[string]bool`, `map[string]struct{}`). The `sets` package provides
+        type-safe, well-tested set operations (Insert, Has, Delete, Union, Intersection,
+        etc.) and is already a dependency of this project.

--- a/pkg/test/ginkgo/retries.go
+++ b/pkg/test/ginkgo/retries.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/origin/pkg/dataloader"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 )
 
@@ -23,17 +24,13 @@ type retryAllowedTestsConfig struct {
 
 // loadRetryAllowedTests parses the embedded YAML and returns the set of test names
 // that are permitted to retry on failure.
-func loadRetryAllowedTests() map[string]bool {
+func loadRetryAllowedTests() sets.Set[string] {
 	var config retryAllowedTestsConfig
 	if err := yaml.Unmarshal(retryAllowedTestsYAML, &config); err != nil {
 		logrus.WithError(err).Error("Failed to parse retry_allowed_tests.yaml, no tests will be allowed to retry")
-		return map[string]bool{}
+		return sets.New[string]()
 	}
-	allowed := make(map[string]bool, len(config.Tests))
-	for _, test := range config.Tests {
-		allowed[test] = true
-	}
-	return allowed
+	return sets.New(config.Tests...)
 }
 
 const (
@@ -83,7 +80,7 @@ type RetryStrategy interface {
 }
 
 type RetryOnceStrategy struct {
-	AllowedRetryTests map[string]bool
+	AllowedRetryTests sets.Set[string]
 }
 
 func NewRetryOnceStrategy() *RetryOnceStrategy {
@@ -135,7 +132,7 @@ func (s *RetryOnceStrategy) DecideOutcome(attempts []*testCase) RetryOutcome {
 }
 
 func (s *RetryOnceStrategy) shouldRetryTest(test *testCase) bool {
-	if s.AllowedRetryTests[test.name] {
+	if s.AllowedRetryTests.Has(test.name) {
 		logrus.WithField("test", test.name).Debug("Test is in the retry allowlist, permitting retry")
 		return true
 	}

--- a/pkg/test/ginkgo/retries_test.go
+++ b/pkg/test/ginkgo/retries_test.go
@@ -3,30 +3,32 @@ package ginkgo
 import (
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestRetryOnceStrategy_ShouldRetryTest_Allowlist(t *testing.T) {
 	tests := []struct {
 		name         string
-		allowedTests map[string]bool
+		allowedTests sets.Set[string]
 		testName     string
 		wantRetry    bool
 	}{
 		{
 			name:         "test_on_allowlist_gets_retry",
-			allowedTests: map[string]bool{"[sig-network] some flaky test": true},
+			allowedTests: sets.New("[sig-network] some flaky test"),
 			testName:     "[sig-network] some flaky test",
 			wantRetry:    true,
 		},
 		{
 			name:         "test_not_on_allowlist_gets_no_retry",
-			allowedTests: map[string]bool{"[sig-network] some flaky test": true},
+			allowedTests: sets.New("[sig-network] some flaky test"),
 			testName:     "[sig-node] some other test",
 			wantRetry:    false,
 		},
 		{
 			name:         "empty_allowlist_blocks_all",
-			allowedTests: map[string]bool{},
+			allowedTests: sets.New[string](),
 			testName:     "[sig-network] some flaky test",
 			wantRetry:    false,
 		},
@@ -53,7 +55,7 @@ func TestLoadRetryAllowedTests(t *testing.T) {
 	// Verify the embedded YAML file can be parsed without error.
 	tests := loadRetryAllowedTests()
 	if tests == nil {
-		t.Error("loadRetryAllowedTests returned nil, expected an initialized map")
+		t.Error("loadRetryAllowedTests returned nil, expected an initialized set")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds a CodeRabbit path instruction for `**/*.go` that flags new usage of `map[string]bool` or `map[string]struct{}` as ad-hoc sets and recommends `k8s.io/apimachinery/pkg/util/sets` instead.

## Existing bespoke map-set usage

There are ~50 non-vendor files currently using this pattern that could be migrated over time:

<details>
<summary>Files using <code>map[string]bool</code> or <code>map[string]struct{}</code> as sets</summary>

**pkg/**
- `pkg/e2eanalysis/e2e_analysis.go`
- `pkg/monitortestlibrary/allowedalerts/matches_test.go`
- `pkg/monitortestlibrary/allowedbackenddisruption/matches_test.go`
- `pkg/monitortestlibrary/historicaldata/next_best_guess.go`
- `pkg/monitortestlibrary/historicaldata/next_best_guess_test.go`
- `pkg/monitortests/cli/adm_upgrade/status/controlplane.go`
- `pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go`
- `pkg/monitortests/etcd/etcdloganalyzer/etcd_recorder_test.go`
- `pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_latency.go`
- `pkg/monitortests/kubeapiserver/crdversionchecker/monitortest.go`
- `pkg/monitortests/kubeapiserver/faultyloadbalancer/monitortest.go`
- `pkg/monitortests/network/legacynetworkmonitortests/networking.go`
- `pkg/monitortests/node/legacynodemonitortests/kubelet.go`
- `pkg/monitortests/testframework/highcputestanalyzer/monitortest.go`
- `pkg/monitortests/testframework/operatorloganalyzer/operator_lease_check.go`
- `pkg/resourcewatch/observe/observe.go`
- `pkg/test/ginkgo/cmd_runsuite.go`
- `pkg/test/ginkgo/podanalysis.go`
- `pkg/test/ginkgo/queue_test.go`
- `pkg/test/ginkgo/retries.go`
- `pkg/test/ginkgo/retries_test.go`
- `pkg/test/ginkgo/sharder_test.go`
- `pkg/testsuites/suites_test.go`

**test/extended/**
- `test/extended/builds/run_policy.go`
- `test/extended/cluster/cm.go`
- `test/extended/dr/common.go`
- `test/extended/edge_topologies/arbiter_topology.go`
- `test/extended/edge_topologies/tnf_node_replacement_flow.go`
- `test/extended/edge_topologies/tnf_node_replacement_ovn_vm.go`
- `test/extended/edge_topologies/tnf_node_replacement_types.go`
- `test/extended/edge_topologies/utils/services/pacemaker.go`
- `test/extended/images/imagechange_buildtrigger.go`
- `test/extended/machine_config/helpers.go`
- `test/extended/machines/cluster.go`
- `test/extended/networking/egressip.go`
- `test/extended/networking/egressip_helpers.go`
- `test/extended/networking/network_segmentation.go`
- `test/extended/networking/route_advertisements.go`
- `test/extended/operators/cluster.go`
- `test/extended/prometheus/prometheus.go`
- `test/extended/prometheus/prometheus_builds.go`
- `test/extended/prometheus/storage.go`
- `test/extended/router/h2spec.go`
- `test/extended/router/metrics.go`
- `test/extended/router/stress.go`
- `test/extended/tls/tls_observed_config.go`
- `test/extended/util/compat_otp/clusters.go`
- `test/extended/util/compat_otp/rosacli/kubelet_config_service.go`
- `test/extended/util/configv1shim.go`
- `test/extended/util/prometheus/helpers.go`

**tools/**
- `tools/changelog/changelog.go`

</details>

## Test plan

- [ ] Verify CodeRabbit picks up the new instruction on future PRs that introduce `map[string]bool`/`map[string]struct{}` set patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development guidelines to prefer the standardized Go set implementation for set-like data.
* **Internal / Reliability**
  * Retry allowlist handling now uses the standardized set type internally (behavior unchanged).
* **Tests**
  * Updated unit tests to reflect the new internal set usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->