### PR TITLE
OCPBUGS-86221: update authentication operator conditions to no longer expect WellKnownReadyProgressing

### DIFF
--- a/test/extended/operators/management_plane_operators.go
+++ b/test/extended/operators/management_plane_operators.go
@@ -63,7 +63,6 @@ var (
 					"RouterCertsDegraded",
 					"SystemServiceCAConfigDegraded",
 					"WellKnownAvailable",
-					"WellKnownReadyControllerProgressing",
 				}, nil
 			}
 		},


### PR DESCRIPTION
Because the WellKnownReadyController should never have been reporting a progressing condition based on the current definitions of the cluster operator status condition types as it does not have any operands and is a strictly observational controller.

See https://github.com/openshift/cluster-authentication-operator/pull/901 which depends on this change to pass CI.

In an attempt to prevent breaking CI prior to https://github.com/openshift/cluster-authentication-operator/pull/901 being merged, a follow up PR will add the new `WellKnownReadyDegradationObserved` condition to this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication operator status condition requirements for non-OIDC scenarios, removing an unnecessary operator condition from the expected status list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->