### PR TITLE
migrate read only tests from otp to origin

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -509,6 +509,15 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout:                90 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
+	{
+		Name: "openshift/controlplane",
+		Description: templates.LongDesc(`
+		This suite comprises the generic control plane tests.
+		`),
+		Qualifiers: []string{
+			withStandardEarlyOrLateTests(`name.contains("[Suite:openshift/controlplane]")`),
+		},
+	},
 }
 
 func withExcludedTestsFilter(baseExpr string) string {

--- a/test/extended/controlplane/OWNERS
+++ b/test/extended/controlplane/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+  - dusk125 
+  - flavianmissi 
+  - tjungblu 
+  - ardaguclu 
+  - p0lyn0mial 
+  - sandeepknd
+  - gangwgr 
+  - ropatil010 
+reviewers:
+  - dusk125 
+  - flavianmissi 
+  - tjungblu 
+  - ardaguclu 
+  - p0lyn0mial 
+  - sandeepknd
+  - gangwgr 
+  - ropatil010 

--- a/test/extended/controlplane/controlplane_tests.go
+++ b/test/extended/controlplane/controlplane_tests.go
@@ -1,0 +1,130 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	kubeAPIServerNamespace = "openshift-kube-apiserver"
+	insecureReadyzPort     = 6080
+	portForwardTimeout     = 30 * time.Second
+)
+
+type kubeAPIServerTarget struct {
+	podName   string
+	namespace string
+}
+
+var _ = g.Describe("[sig-api-machinery][Suite:openshift/controlplane] Control Plane", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithoutNamespace("controlplane")
+
+	g.BeforeEach(func(ctx context.Context) {
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			g.Skip("HTTP readyz endpoint tests are not applicable to MicroShift clusters")
+		}
+
+		isHyperShift, err := exutil.IsHypershift(ctx, oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isHyperShift {
+			g.Skip("HTTP readyz endpoint tests are not applicable to HyperShift clusters.")
+		}
+	})
+
+	g.It("[OTP] OCP-24698 should have accessible HTTP readyz endpoints for all kube-apiserver pods", func(ctx context.Context) {
+		g.By("discovering kube-apiserver pods")
+		pods, err := oc.AdminKubeClient().CoreV1().Pods(kubeAPIServerNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "app=openshift-kube-apiserver",
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to list kube-apiserver pods")
+		o.Expect(pods.Items).NotTo(o.BeEmpty(), "no kube-apiserver pods found")
+
+		// Filter for running pods with names starting with "kube-apiserver-ip"
+		var targets []kubeAPIServerTarget
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning &&
+				strings.HasPrefix(pod.Name, "kube-apiserver-ip") {
+				targets = append(targets, kubeAPIServerTarget{
+					podName:   pod.Name,
+					namespace: kubeAPIServerNamespace,
+				})
+			}
+		}
+		o.Expect(targets).NotTo(o.BeEmpty(), "no running kube-apiserver-ip pods found")
+
+		e2e.Logf("Found %d kube-apiserver pods to test", len(targets))
+
+		for _, target := range targets {
+			target := target // capture loop variable
+			g.By(fmt.Sprintf("testing HTTP readyz endpoint for pod %s", target.podName))
+
+			// Use a random local port to avoid conflicts
+			localPort := rand.Intn(65534-1025) + 1025
+
+			// Create context with timeout for port-forward
+			pfCtx, pfCancel := context.WithCancel(ctx)
+			defer pfCancel()
+
+			// Start port-forward in background
+			portForwardCmd := exec.CommandContext(pfCtx, "oc", "port-forward",
+				"-n", target.namespace,
+				target.podName,
+				fmt.Sprintf("%d:%d", localPort, insecureReadyzPort),
+			)
+
+			e2e.Logf("Starting port-forward: %s", portForwardCmd.String())
+			err := portForwardCmd.Start()
+			o.Expect(err).NotTo(o.HaveOccurred(), "failed to start port-forward for pod %s", target.podName)
+
+			// Ensure cleanup on test completion
+			g.DeferCleanup(func() {
+				e2e.Logf("Cleaning up port-forward for pod %s", target.podName)
+				pfCancel()
+				if portForwardCmd.Process != nil {
+					_ = portForwardCmd.Process.Kill()
+				}
+			})
+
+			// Wait for port-forward to be ready
+			g.By(fmt.Sprintf("checking HTTP readyz endpoint for pod %s", target.podName))
+			var responseBody string
+			var lastErr error
+			err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, portForwardTimeout, true, func(ctx context.Context) (bool, error) {
+				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/readyz?verbose", localPort))
+				if err != nil {
+					lastErr = err
+					return false, nil
+				}
+				defer resp.Body.Close()
+
+				body, _ := io.ReadAll(resp.Body)
+				responseBody = string(body)
+				return true, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), "port-forward readiness check failed for pod %s: %v", target.podName, lastErr)
+			o.Expect(responseBody).To(o.ContainSubstring("ok"), "readyz endpoint response for pod %s", target.podName)
+			e2e.Logf("Pod %s readyz response: %s", target.podName, responseBody)
+			e2e.Logf("Successfully verified HTTP readyz endpoint for pod %s", target.podName)
+		}
+	})
+})

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/cmd"
 	_ "github.com/openshift/origin/test/extended/config_operator"
 	_ "github.com/openshift/origin/test/extended/controller_manager"
+	_ "github.com/openshift/origin/test/extended/controlplane"
 	_ "github.com/openshift/origin/test/extended/coreos"
 	_ "github.com/openshift/origin/test/extended/cpu_partitioning"
 	_ "github.com/openshift/origin/test/extended/crdvalidation"


### PR DESCRIPTION
Our intention is to migrate the read-only tests of control plane modules from openshift-tests-private to origin. 
Started with test [OCP-24698](https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-24698) . 
Please find the execution logs, with the latest review comments addressed.
```
$ make openshift-tests
go build -mod=vendor -trimpath -ldflags "-X github.com/openshift/origin/pkg/version.versionFromGit="v4.1.0-11404-g4629f95" -X github.com/openshift/origin/pkg/version.commitFromGit="4629f95e16" -X github.com/openshift/origin/pkg/version.gitTreeState="dirty" -X github.com/openshift/origin/pkg/version.buildDate="2026-06-01T06:50:42Z" " github.com/openshift/origin/cmd/openshift-tests


$ ./openshift-tests run-test "[sig-api-machinery][Suite:openshift/controlplane] Control Plane [OTP] OCP-24698 should have accessible HTTP readyz endpoints for all kube-apiserver pods"
I0601 12:25:37.032189   41029 factory.go:195] Registered Plugin "containerd"
  I0601 12:25:37.486323   41029 binary.go:80] Found 8895 test specs
  I0601 12:25:37.489723   41029 binary.go:97] 1226 test specs remain, after filtering out k8s
openshift-tests v4.1.0-11404-g4629f95
  I0601 12:25:46.977193   41029 test_setup.go:125] Extended test version v4.1.0-11404-g4629f95
  I0601 12:25:46.977249   41029 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0601 12:25:46.978634 41029 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0601 12:25:47.275555 41029 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  I0601 12:25:47.276331   41029 binary.go:124] Loaded test configuration: &framework.TestContextType{KubeConfig:"/home/skundu/Downloads/kubeconfig", KubeContext:"", KubeAPIContentType:"application/vnd.kubernetes.protobuf", KubeletRootDir:"/var/lib/kubelet", KubeletConfigDropinDir:"", CertDir:"", Host:"https://api.ppt-0106c.qe.devcluster.openshift.com:6443", BearerToken:"<redacted>", RepoRoot:"../../", ListImages:false, listTests:false, listLabels:false, ListConformanceTests:false, Provider:"aws", Tooling:"", timeouts:framework.TimeoutContext{Poll:2000000000, PodStart:300000000000, PodStartShort:120000000000, PodStartSlow:900000000000, PodDelete:300000000000, ClaimProvision:300000000000, DataSourceProvision:300000000000, ClaimProvisionShort:60000000000, ClaimBound:180000000000, PVReclaim:180000000000, PVBound:180000000000, PVCreate:180000000000, PVDelete:300000000000, PVDeleteSlow:1200000000000, SnapshotCreate:300000000000, SnapshotDelete:300000000000, SnapshotControllerMetrics:300000000000, SystemPodsStartup:600000000000, NodeSchedulable:1800000000000, SystemDaemonsetStartup:300000000000, NodeNotReady:180000000000}, CloudConfig:framework.CloudConfig{APIEndpoint:"", ProjectID:"", Zone:"us-east-2a", Zones:[]string{"us-east-2a", "us-east-2b", "us-east-2c"}, Region:"us-east-2", MultiZone:true, MultiMaster:true, Cluster:"", MasterName:"", NodeInstanceGroup:"", NumNodes:3, ClusterIPRange:"", ClusterTag:"", Network:"", ConfigFile:"", NodeTag:"", MasterTag:"", Provider:(*aws.Provider)(0x105e3280)}, KubectlPath:"kubectl", OutputDir:"/tmp", ReportDir:"", ReportPrefix:"", ReportCompleteGinkgo:false, ReportCompleteJUnit:false, Prefix:"e2e", MinStartupPods:-1, EtcdUpgradeStorage:"", EtcdUpgradeVersion:"", GCEUpgradeScript:"", ContainerRuntimeEndpoint:"unix:///run/containerd/containerd.sock", ContainerRuntimeProcessName:"containerd", ContainerRuntimePidFile:"/run/containerd/containerd.pid", SystemdServices:"containerd*", DumpSystemdJournal:false, ImageServiceEndpoint:"", MasterOSDistro:"custom", NodeOSDistro:"custom", NodeOSArch:"amd64", VerifyServiceAccount:true, DeleteNamespace:true, DeleteNamespaceOnFailure:true, AllowedNotReadyNodes:-1, CleanStart:false, GatherKubeSystemResourceUsageData:"false", GatherLogsSizes:false, GatherMetricsAfterTest:"false", GatherSuiteMetricsAfterTest:false, MaxNodesToGather:0, IncludeClusterAutoscalerMetrics:false, OutputPrintType:"json", CreateTestingNS:(framework.CreateTestingNSFn)(0x6b577a0), DumpLogsOnFailure:true, DisableLogDump:false, LogexporterGCSPath:"", NodeTestContextType:framework.NodeTestContextType{NodeE2E:false, NodeName:"", NodeConformance:false, PrepullImages:false, ImageDescription:"", RuntimeConfig:map[string]string(nil), SystemSpecName:"", RestartKubelet:false, ExtraEnvs:map[string]string(nil), StandaloneMode:false, CriProxyEnabled:false}, ClusterDNSDomain:"cluster.local", NodeKiller:framework.NodeKillerConfig{Enabled:false, FailureRatio:0.01, Interval:60000000000, JitterFactor:60, SimulatedDowntime:600000000000, NodeKillerStopCtx:context.Context(nil), NodeKillerStop:(func())(nil)}, IPFamily:"ipv4", NonblockingTaints:"node-role.kubernetes.io/control-plane", ProgressReportURL:"", SriovdpConfigMapFile:"", SpecSummaryOutput:"", DockerConfigFile:"", E2EDockerConfigFile:"", KubeTestRepoList:"", SnapshotControllerPodName:"", SnapshotControllerHTTPPort:0, RequireDevices:false, EnabledVolumeDrivers:[]string(nil)}
  Running Suite:  - /home/skundu/automation/origin
  ================================================
  Random Seed: 1780296937 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-api-machinery][Suite:openshift/controlplane] Control Plane [OTP] OCP-24698 should have accessible HTTP readyz endpoints for all kube-apiserver pods
  github.com/openshift/origin/test/extended/controlplane/controlplane_tests.go:54
    STEP: Creating a kubernetes client @ 06/01/26 12:25:47.315
  I0601 12:25:47.317784   41029 discovery.go:214] Invalidating discovery information
  I0601 12:25:47.319416 41029 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0601 12:25:47.588942 41029 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: discovering kube-apiserver pods @ 06/01/26 12:25:47.846
  I0601 12:25:48.814259 41029 controlplane_tests.go:75] Found 3 kube-apiserver pods to test
    STEP: testing HTTP readyz endpoint for pod kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal @ 06/01/26 12:25:48.814
  I0601 12:25:48.814458 41029 controlplane_tests.go:95] Starting port-forward: /usr/local/sbin/oc port-forward -n openshift-kube-apiserver kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal 38979:6080
    STEP: checking HTTP readyz endpoint for pod kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal @ 06/01/26 12:25:48.815
  I0601 12:25:53.316340 41029 controlplane_tests.go:126] Pod kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal readyz response: ok
  I0601 12:25:53.316425 41029 controlplane_tests.go:127] Successfully verified HTTP readyz endpoint for pod kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal
    STEP: testing HTTP readyz endpoint for pod kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal @ 06/01/26 12:25:53.316
  I0601 12:25:53.316725 41029 controlplane_tests.go:95] Starting port-forward: /usr/local/sbin/oc port-forward -n openshift-kube-apiserver kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal 7331:6080
    STEP: checking HTTP readyz endpoint for pod kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal @ 06/01/26 12:25:53.317
  I0601 12:25:57.582558 41029 controlplane_tests.go:126] Pod kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal readyz response: ok
  I0601 12:25:57.582613 41029 controlplane_tests.go:127] Successfully verified HTTP readyz endpoint for pod kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal
    STEP: testing HTTP readyz endpoint for pod kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal @ 06/01/26 12:25:57.582
  I0601 12:25:57.582763 41029 controlplane_tests.go:95] Starting port-forward: /usr/local/sbin/oc port-forward -n openshift-kube-apiserver kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal 17891:6080
    STEP: checking HTTP readyz endpoint for pod kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal @ 06/01/26 12:25:57.583
  I0601 12:26:01.997914 41029 controlplane_tests.go:126] Pod kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal readyz response: ok
  I0601 12:26:01.998015 41029 controlplane_tests.go:127] Successfully verified HTTP readyz endpoint for pod kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal
  I0601 12:26:02.000535 41029 controlplane_tests.go:101] Cleaning up port-forward for pod kube-apiserver-ip-10-0-95-175.us-east-2.compute.internal
  I0601 12:26:02.000623 41029 controlplane_tests.go:101] Cleaning up port-forward for pod kube-apiserver-ip-10-0-33-57.us-east-2.compute.internal
  I0601 12:26:02.000705 41029 controlplane_tests.go:101] Cleaning up port-forward for pod kube-apiserver-ip-10-0-18-151.us-east-2.compute.internal
  • [14.724 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 14.726 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-api-machinery][Suite:openshift/controlplane] Control Plane [OTP] OCP-24698 should have accessible HTTP readyz endpoints for all kube-apiserver pods",
    "lifecycle": "blocking",
    "duration": 14726,
    "startTime": "2026-06-01 06:55:47.276524 UTC",
    "endTime": "2026-06-01 06:56:02.002648 UTC",
    "result": "passed",


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * New control plane test suite added to verify kube-apiserver readiness endpoint is accessible via port-forward.
  * Suite skips unsupported cluster types and includes robust port-forwarding and readiness polling with cleanup.

* **Chores**
  * Registered the control plane extended tests and established ownership for ongoing control plane testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->