### PR TITLE
CNTRLPLANE-2654: registering the ote binary for cluster-kube-descheduler-operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -341,6 +341,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "vsphere-csi-driver-operator",
 		binaryPath: "/usr/bin/vmware-vsphere-csi-driver-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "cluster-kube-descheduler-operator",
+		binaryPath: "/usr/bin/cluster-kube-descheduler-operator-tests-ext.gz",
+	},
 }
 
 // extractJSON finds the first JSON object or array in output, skipping any non-JSON log lines


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test binary support for the cluster-kube-descheduler-operator, making the external test binary available for execution and extraction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->