### PR TITLE
CORENET-6822: Register ingress-node-firewall OTE test extension binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -302,6 +302,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/k8s-tests-ext.gz",
 	},
 	{
+		imageTag:   "ingress-node-firewall",
+		binaryPath: "/usr/bin/ingress-node-firewall-tests.gz",
+	},
+	{
 		imageTag:   "machine-api-operator",
 		binaryPath: "/machine-api-tests-ext.gz",
 	},


### PR DESCRIPTION
## Summary
- Register `ingress-node-firewall` OTE test extension binary in `extensionBinaries`
- Binary path: `/usr/bin/ingress-node-firewall-tests.gz`
- Companion PR: https://github.com/openshift/ingress-node-firewall/pull/694

## Test plan
- [ ] CI build passes (`go vet ./pkg/test/extensions/`)
- [ ] `openshift-tests` discovers and extracts the ingress-node-firewall test binary from the release payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for an additional test binary to the test infrastructure for ingress firewall functionality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->