### PR TITLE
TRT-2673: Filter NoExecuteTaintManager disruption from backend-disruption.json

### DIFF
--- a/pkg/monitortestlibrary/disruptionfilter/filter.go
+++ b/pkg/monitortestlibrary/disruptionfilter/filter.go
@@ -1,0 +1,48 @@
+package disruptionfilter
+
+import (
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+// FilterOutKnownDisruptiveTestIntervals removes disruption intervals that overlap with
+// known-disruptive serial tests like NoExecuteTaintManager, which applies NoExecute taints
+// to worker nodes where its test pods land, evicting pods and causing expected unavailability.
+func FilterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals) monitorapi.Intervals {
+	knownDisruptiveTests := intervals.Filter(func(i monitorapi.Interval) bool {
+		if i.Source != monitorapi.SourceE2ETest {
+			return false
+		}
+		testName := i.Locator.Keys[monitorapi.LocatorE2ETestKey]
+		return strings.Contains(testName, "NoExecuteTaintManager")
+	})
+
+	if len(knownDisruptiveTests) == 0 {
+		return intervals
+	}
+
+	return intervals.Filter(func(i monitorapi.Interval) bool {
+		for _, disruptiveTest := range knownDisruptiveTests {
+			if intervalsOverlap(i, disruptiveTest) && monitorapi.IsErrorEvent(i) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func intervalsOverlap(interval1, interval2 monitorapi.Interval) bool {
+	end1 := interval1.To
+	if end1.IsZero() {
+		end1 = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+	}
+
+	end2 := interval2.To
+	if end2.IsZero() {
+		end2 = time.Date(9999, 12, 31, 23, 59, 59, 999999999, time.UTC)
+	}
+
+	return (interval1.From.Before(end2)) && (interval2.From.Before(end1))
+}

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/allowedbackenddisruption"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionfilter"
 	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
-	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -239,33 +239,6 @@ func historicalAllowedDisruption(ctx context.Context, backend *backenddisruption
 	return allowedbackenddisruption.GetAllowedDisruption(backend.GetDisruptionBackendName(), *jobType)
 }
 
-// filterOutKnownDisruptiveTestIntervals removes disruption intervals that overlap with
-// known-disruptive serial tests like NoExecuteTaintManager, which applies NoExecute taints
-// to worker nodes where its test pods land, potentially evicting pods (including
-// metrics-server) and causing expected API unavailability that is not a product bug.
-func filterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals) monitorapi.Intervals {
-	knownDisruptiveTests := intervals.Filter(func(i monitorapi.Interval) bool {
-		if i.Source != monitorapi.SourceE2ETest {
-			return false
-		}
-		testName := i.Locator.Keys[monitorapi.LocatorE2ETestKey]
-		return strings.Contains(testName, "NoExecuteTaintManager")
-	})
-
-	if len(knownDisruptiveTests) == 0 {
-		return intervals
-	}
-
-	return intervals.Filter(func(i monitorapi.Interval) bool {
-		for _, disruptiveTest := range knownDisruptiveTests {
-			if utility.IntervalsOverlap(i, disruptiveTest) && monitorapi.IsErrorEvent(i) {
-				return false
-			}
-		}
-		return true
-	})
-}
-
 func (w *Availability) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 	if w == nil {
 		return nil, fmt.Errorf("unable to evaluate tests because instance is nil")
@@ -278,7 +251,7 @@ func (w *Availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	}
 
 	// Filter out disruption that occurred during known-disruptive serial tests
-	filteredIntervals := filterOutKnownDisruptiveTestIntervals(finalIntervals)
+	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals)
 
 	newConnectionJunit, err := w.junitForNewConnections(ctx, filteredIntervals, jobType)
 	if err != nil {

--- a/pkg/monitortests/testframework/disruptionserializer/monitortest.go
+++ b/pkg/monitortests/testframework/disruptionserializer/monitortest.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionfilter"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -44,7 +45,8 @@ func (*disruptionSummarySerializer) EvaluateTestsFromConstructedIntervals(ctx co
 }
 
 func (*disruptionSummarySerializer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	backendDisruption := computeDisruptionData(finalIntervals)
+	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals)
+	backendDisruption := computeDisruptionData(filteredIntervals)
 	return writeDisruptionData(filepath.Join(storageDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption)
 }
 


### PR DESCRIPTION
The NoExecuteTaintManager serial test applies NoExecute taints to worker nodes, evicting pods without matching tolerations. This causes ~20s of expected disruption for backends like image-registry when both replicas happen to be on the tainted nodes.

https://github.com/openshift/origin/pull/30855 added a filter to exclude this disruption from JUnit test evaluation, but the filter was not applied to the disruption serializer that writes backend-disruption.json. This file feeds disruption dashboards, so the expected disruption continued to appear there.

Move FilterOutKnownDisruptiveTestIntervals to the shared utility package and apply it in the disruption serializer's WriteContentToStorage before computing backend-disruption.json. Disruption that overlaps with NoExecuteTaintManager test windows will no longer appear in the serialized data or on dashboards.

This means disruption during known-disruptive serial tests is fully excluded from both JUnit evaluation and dashboard data. If finer-grained visibility is desired in the future (e.g. showing expected disruption in a different color on the Sippy intervals chart), that would be a separate effort to annotate rather than filter these intervals.

It is still unclear why we are only noticing this on `4.22` in `GCP`, but this should keep it from appearing at all...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized disruption interval filtering to ensure consistent behavior when handling known disruptive test scenarios across monitoring components. Previously, filtering logic was duplicated in individual components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->