### PR TITLE
OCPBUGS-85486: Add client retry to critical monitor test setup to avoid transient et…

### DIFF
--- a/pkg/monitortestlibrary/utility/retry.go
+++ b/pkg/monitortestlibrary/utility/retry.go
@@ -2,6 +2,7 @@ package utility
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -12,12 +13,16 @@ import (
 )
 
 func IsTransientAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
 	if apierrors.IsServerTimeout(err) || apierrors.IsTimeout(err) ||
 		apierrors.IsTooManyRequests(err) || apierrors.IsServiceUnavailable(err) ||
 		apierrors.IsInternalError(err) {
 		return true
 	}
-	if statusErr, ok := err.(*apierrors.StatusError); ok {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
 		code := statusErr.Status().Code
 		if code == http.StatusGatewayTimeout || code == http.StatusBadGateway {
 			return true
@@ -30,6 +35,7 @@ func IsTransientAPIError(err error) bool {
 }
 
 func RetryWithExponentialBackoff(ctx context.Context, fn func() error) error {
+	var lastErr error
 	backoff := wait.Backoff{
 		Duration: 500 * time.Millisecond,
 		Factor:   2.0,
@@ -37,15 +43,20 @@ func RetryWithExponentialBackoff(ctx context.Context, fn func() error) error {
 		Steps:    5,
 		Cap:      16 * time.Second,
 	}
-	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
 		err := fn()
 		if err == nil {
 			return true, nil
 		}
+		lastErr = err
 		if IsTransientAPIError(err) {
 			klog.Warningf("Transient API error during monitor setup, retrying: %v", err)
 			return false, nil
 		}
 		return false, err
 	})
+	if err != nil && lastErr != nil && errors.Is(err, wait.ErrWaitTimeout) {
+		return lastErr
+	}
+	return err
 }

--- a/pkg/monitortestlibrary/utility/retry.go
+++ b/pkg/monitortestlibrary/utility/retry.go
@@ -1,0 +1,51 @@
+package utility
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+)
+
+func IsTransientAPIError(err error) bool {
+	if apierrors.IsServerTimeout(err) || apierrors.IsTimeout(err) ||
+		apierrors.IsTooManyRequests(err) || apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) {
+		return true
+	}
+	if statusErr, ok := err.(*apierrors.StatusError); ok {
+		code := statusErr.Status().Code
+		if code == http.StatusGatewayTimeout || code == http.StatusBadGateway {
+			return true
+		}
+	}
+	if strings.Contains(err.Error(), "etcdserver: request timed out") {
+		return true
+	}
+	return false
+}
+
+func RetryWithExponentialBackoff(ctx context.Context, fn func() error) error {
+	backoff := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   2.0,
+		Jitter:   0.1,
+		Steps:    5,
+		Cap:      16 * time.Second,
+	}
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		err := fn()
+		if err == nil {
+			return true, nil
+		}
+		if IsTransientAPIError(err) {
+			klog.Warningf("Transient API error during monitor setup, retrying: %v", err)
+			return false, nil
+		}
+		return false, err
+	})
+}

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -12,6 +12,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	"github.com/openshift/origin/pkg/test/extensions"
 	"github.com/openshift/origin/test/extended/util/payload"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,6 +22,7 @@ import (
 
 	exutil "github.com/openshift/origin/test/extended/util"
 
+	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
@@ -167,9 +169,14 @@ func (i *InvariantInClusterDisruption) createDeploymentAndWaitToRollout(ctx cont
 	deploymentObj = disruptionlibrary.UpdateDeploymentENVs(deploymentObj, deploymentID, "")
 
 	client := i.kubeClient.AppsV1().Deployments(deploymentObj.Namespace)
-	_, err := client.Create(ctx, deploymentObj, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("error creating deployment %s: %v", deploymentObj.Namespace, err)
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, deploymentObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
+		return fmt.Errorf("error creating deployment %s: %v", deploymentObj.Name, err)
 	}
 
 	timeLimitedCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
@@ -209,10 +216,14 @@ func (i *InvariantInClusterDisruption) createInternalLBDeployment(ctx context.Co
 
 	pdbObj := resourceread.ReadPodDisruptionBudgetV1OrDie(internalLBPDBYaml)
 	pdbObj.SetNamespace(i.namespaceName)
-	client := i.kubeClient.PolicyV1().PodDisruptionBudgets(i.namespaceName)
-	_, err = client.Create(ctx, pdbObj, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("error creating PDB %s: %v", deploymentObj.Namespace, err)
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := i.kubeClient.PolicyV1().PodDisruptionBudgets(i.namespaceName).Create(ctx, pdbObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
+		return fmt.Errorf("error creating PDB %s: %v", pdbObj.Name, err)
 	}
 	return nil
 }
@@ -232,10 +243,14 @@ func (i *InvariantInClusterDisruption) createServiceNetworkDeployment(ctx contex
 
 	pdbObj := resourceread.ReadPodDisruptionBudgetV1OrDie(serviceNetworkPDBYaml)
 	pdbObj.SetNamespace(i.namespaceName)
-	client := i.kubeClient.PolicyV1().PodDisruptionBudgets(i.namespaceName)
-	_, err = client.Create(ctx, pdbObj, metav1.CreateOptions{})
-	if err != nil {
-		return fmt.Errorf("error creating PDB %s: %v", deploymentObj.Namespace, err)
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := i.kubeClient.PolicyV1().PodDisruptionBudgets(i.namespaceName).Create(ctx, pdbObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
+		return fmt.Errorf("error creating PDB %s: %v", pdbObj.Name, err)
 	}
 	return nil
 }
@@ -261,11 +276,16 @@ func (i *InvariantInClusterDisruption) createRBACPrivileged(ctx context.Context)
 	rbacPrivilegedObj.Subjects[0].Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().ClusterRoleBindings()
-	obj, err := client.Create(ctx, rbacPrivilegedObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, rbacPrivilegedObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating privileged SCC CRB: %v", err)
 	}
-	rbacPrivilegedCRBName = obj.Name
+	rbacPrivilegedCRBName = rbacPrivilegedObj.Name
 	return nil
 }
 
@@ -273,8 +293,13 @@ func (i *InvariantInClusterDisruption) createMonitorClusterRole(ctx context.Cont
 	rbacMonitorRoleObj := resourceread.ReadClusterRoleV1OrDie(rbacMonitorClusterRoleYaml)
 
 	client := i.kubeClient.RbacV1().ClusterRoles()
-	_, err := client.Create(ctx, rbacMonitorRoleObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, rbacMonitorRoleObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating oauthclients list role: %v", err)
 	}
 	rbacMonitorClusterRoleName = rbacMonitorRoleObj.Name
@@ -286,8 +311,13 @@ func (i *InvariantInClusterDisruption) createMonitorRole(ctx context.Context) er
 	rbacMonitorRoleObj.Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().Roles(i.namespaceName)
-	_, err := client.Create(ctx, rbacMonitorRoleObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, rbacMonitorRoleObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating oauthclients list role: %v", err)
 	}
 	return nil
@@ -298,24 +328,34 @@ func (i *InvariantInClusterDisruption) createMonitorCRB(ctx context.Context) err
 	rbacMonitorCRBObj.Subjects[0].Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().ClusterRoleBindings()
-	obj, err := client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating oauthclients list CRB: %v", err)
 	}
-	rbacMonitorCRBName = obj.Name
+	rbacMonitorCRBName = rbacMonitorCRBObj.Name
 	return nil
 }
 
 func (i *InvariantInClusterDisruption) createMonitorRB(ctx context.Context) error {
-	rbacMonitorCRBObj := resourceread.ReadRoleBindingV1OrDie(rbacMonitorRBYaml)
-	rbacMonitorCRBObj.Subjects[0].Namespace = i.namespaceName
+	rbacMonitorRBObj := resourceread.ReadRoleBindingV1OrDie(rbacMonitorRBYaml)
+	rbacMonitorRBObj.Subjects[0].Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().RoleBindings(i.namespaceName)
-	obj, err := client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, rbacMonitorRBObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating monitor RB: %v", err)
 	}
-	rbacMonitorCRBName = obj.Name
+	rbacMonitorCRBName = rbacMonitorRBObj.Name
 	return nil
 }
 
@@ -324,8 +364,13 @@ func (i *InvariantInClusterDisruption) createServiceAccount(ctx context.Context)
 	serviceAccountObj.SetNamespace(i.namespaceName)
 
 	client := i.kubeClient.CoreV1().ServiceAccounts(i.namespaceName)
-	_, err := client.Create(ctx, serviceAccountObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := client.Create(ctx, serviceAccountObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating service account: %v", err)
 	}
 	return nil
@@ -337,8 +382,15 @@ func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (str
 	namespaceObj := resourceread.ReadNamespaceV1OrDie(namespaceYaml)
 
 	client := i.kubeClient.CoreV1().Namespaces()
-	actualNamespace, err := client.Create(ctx, namespaceObj, metav1.CreateOptions{})
-	if err != nil && !apierrors.IsAlreadyExists(err) {
+	var actualNamespace *corev1.Namespace
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var createErr error
+		actualNamespace, createErr = client.Create(ctx, namespaceObj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			actualNamespace, createErr = client.Get(ctx, namespaceObj.Name, metav1.GetOptions{})
+		}
+		return createErr
+	}); err != nil {
 		return "", fmt.Errorf("error creating namespace: %v", err)
 	}
 	log.Infof("created namespace %s", actualNamespace.Name)
@@ -471,8 +523,12 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	if err != nil {
 		return fmt.Errorf("error constructing openshift config client: %v", err)
 	}
-	infra, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
-	if err != nil {
+	var infra *configv1.Infrastructure
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var getErr error
+		infra, getErr = configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		return getErr
+	}); err != nil {
 		return fmt.Errorf("error getting openshift infrastructure: %v", err)
 	}
 
@@ -501,18 +557,26 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 		}
 	}
 
-	allNodes, err := i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
+	var allNodes *corev1.NodeList
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var listErr error
+		allNodes, listErr = i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		return listErr
+	}); err != nil {
 		return fmt.Errorf("error getting nodes: %v", err)
 	}
 	i.replicas = 2
 	if len(allNodes.Items) == 1 {
 		i.replicas = 1
 	}
-	controlPlaneNodes, err := i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
-	})
-	if err != nil {
+	var controlPlaneNodes *corev1.NodeList
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var listErr error
+		controlPlaneNodes, listErr = i.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+			LabelSelector: labels.Set{"node-role.kubernetes.io/master": ""}.AsSelector().String(),
+		})
+		return listErr
+	}); err != nil {
 		return fmt.Errorf("error getting control plane nodes: %v", err)
 	}
 	i.controlPlaneNodes = int32(len(controlPlaneNodes.Items))
@@ -551,10 +615,12 @@ func (i *InvariantInClusterDisruption) StartCollection(ctx context.Context, admi
 	if err != nil {
 		return fmt.Errorf("error creating service network deployment: %v", err)
 	}
+	time.Sleep(2 * time.Second)
 	err = i.createLocalhostDeployment(ctx)
 	if err != nil {
 		return fmt.Errorf("error creating localhost: %v", err)
 	}
+	time.Sleep(2 * time.Second)
 	err = i.createInternalLBDeployment(ctx, apiIntHost, apiIntPort)
 	if err != nil {
 		return fmt.Errorf("error creating internal LB: %v", err)

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/monitortest.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -29,11 +30,13 @@ import (
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	rbacv1client "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
@@ -276,8 +279,10 @@ func (i *InvariantInClusterDisruption) createRBACPrivileged(ctx context.Context)
 	rbacPrivilegedObj.Subjects[0].Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().ClusterRoleBindings()
+	var created *rbacv1.ClusterRoleBinding
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
-		_, createErr := client.Create(ctx, rbacPrivilegedObj, metav1.CreateOptions{})
+		var createErr error
+		created, createErr = client.Create(ctx, rbacPrivilegedObj, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(createErr) {
 			return nil
 		}
@@ -285,7 +290,15 @@ func (i *InvariantInClusterDisruption) createRBACPrivileged(ctx context.Context)
 	}); err != nil {
 		return fmt.Errorf("error creating privileged SCC CRB: %v", err)
 	}
-	rbacPrivilegedCRBName = rbacPrivilegedObj.Name
+	if created != nil {
+		rbacPrivilegedCRBName = created.Name
+	} else {
+		name, err := findClusterRoleBindingByPrefix(ctx, client, rbacPrivilegedObj.GenerateName)
+		if err != nil {
+			return fmt.Errorf("error finding existing privileged SCC CRB: %v", err)
+		}
+		rbacPrivilegedCRBName = name
+	}
 	return nil
 }
 
@@ -328,8 +341,10 @@ func (i *InvariantInClusterDisruption) createMonitorCRB(ctx context.Context) err
 	rbacMonitorCRBObj.Subjects[0].Namespace = i.namespaceName
 
 	client := i.kubeClient.RbacV1().ClusterRoleBindings()
+	var created *rbacv1.ClusterRoleBinding
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
-		_, createErr := client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
+		var createErr error
+		created, createErr = client.Create(ctx, rbacMonitorCRBObj, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(createErr) {
 			return nil
 		}
@@ -337,7 +352,15 @@ func (i *InvariantInClusterDisruption) createMonitorCRB(ctx context.Context) err
 	}); err != nil {
 		return fmt.Errorf("error creating oauthclients list CRB: %v", err)
 	}
-	rbacMonitorCRBName = rbacMonitorCRBObj.Name
+	if created != nil {
+		rbacMonitorCRBName = created.Name
+	} else {
+		name, err := findClusterRoleBindingByPrefix(ctx, client, rbacMonitorCRBObj.GenerateName)
+		if err != nil {
+			return fmt.Errorf("error finding existing monitor CRB: %v", err)
+		}
+		rbacMonitorCRBName = name
+	}
 	return nil
 }
 
@@ -355,7 +378,6 @@ func (i *InvariantInClusterDisruption) createMonitorRB(ctx context.Context) erro
 	}); err != nil {
 		return fmt.Errorf("error creating monitor RB: %v", err)
 	}
-	rbacMonitorCRBName = rbacMonitorRBObj.Name
 	return nil
 }
 
@@ -376,6 +398,19 @@ func (i *InvariantInClusterDisruption) createServiceAccount(ctx context.Context)
 	return nil
 }
 
+func findClusterRoleBindingByPrefix(ctx context.Context, client rbacv1client.ClusterRoleBindingInterface, prefix string) (string, error) {
+	list, err := client.List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, crb := range list.Items {
+		if strings.HasPrefix(crb.Name, prefix) {
+			return crb.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no ClusterRoleBinding found with prefix %q", prefix)
+}
+
 func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (string, error) {
 	log := logrus.WithField("monitorTest", "apiserver-incluster-availability").WithField("namespace", i.namespaceName).WithField("func", "createNamespace")
 
@@ -386,9 +421,6 @@ func (i *InvariantInClusterDisruption) createNamespace(ctx context.Context) (str
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		actualNamespace, createErr = client.Create(ctx, namespaceObj, metav1.CreateOptions{})
-		if apierrors.IsAlreadyExists(createErr) {
-			actualNamespace, createErr = client.Get(ctx, namespaceObj.Name, metav1.GetOptions{})
-		}
 		return createErr
 	}); err != nil {
 		return "", fmt.Errorf("error creating namespace: %v", err)
@@ -698,29 +730,35 @@ func (i *InvariantInClusterDisruption) Cleanup(ctx context.Context) error {
 
 	log.Infof("removing monitoring cluster roles and bindings")
 	crbClient := i.kubeClient.RbacV1().ClusterRoleBindings()
-	err = crbClient.Delete(ctx, rbacPrivilegedCRBName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("error removing cluster reader CRB: %v", err)
-	}
-	if !apierrors.IsNotFound(err) {
-		log.Infof("CRB %s removed", rbacPrivilegedCRBName)
+	if rbacPrivilegedCRBName != "" {
+		err = crbClient.Delete(ctx, rbacPrivilegedCRBName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error removing cluster reader CRB: %v", err)
+		}
+		if !apierrors.IsNotFound(err) {
+			log.Infof("CRB %s removed", rbacPrivilegedCRBName)
+		}
 	}
 
-	err = crbClient.Delete(ctx, rbacMonitorCRBName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("error removing monitor CRB: %v", err)
-	}
-	if !apierrors.IsNotFound(err) {
-		log.Infof("CRB %s removed", rbacMonitorCRBName)
+	if rbacMonitorCRBName != "" {
+		err = crbClient.Delete(ctx, rbacMonitorCRBName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error removing monitor CRB: %v", err)
+		}
+		if !apierrors.IsNotFound(err) {
+			log.Infof("CRB %s removed", rbacMonitorCRBName)
+		}
 	}
 
 	rolesClient := i.kubeClient.RbacV1().ClusterRoles()
-	err = rolesClient.Delete(ctx, rbacMonitorClusterRoleName, metav1.DeleteOptions{})
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("error removing monitor role: %v", err)
-	}
-	if !apierrors.IsNotFound(err) {
-		log.Infof("Role %s removed", rbacMonitorClusterRoleName)
+	if rbacMonitorClusterRoleName != "" {
+		err = rolesClient.Delete(ctx, rbacMonitorClusterRoleName, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("error removing monitor role: %v", err)
+		}
+		if !apierrors.IsNotFound(err) {
+			log.Infof("Role %s removed", rbacMonitorClusterRoleName)
+		}
 	}
 	log.Infof("collect data completed")
 	return nil

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -114,6 +114,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		actualNamespace, createErr = pna.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			actualNamespace, createErr = pna.kubeClient.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -122,6 +125,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.RbacV1().RoleBindings(pna.namespaceName).Create(ctx, pollerRoleBinding, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -144,6 +150,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	podNetworkToPodNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(podNetworkToPodNetworkPollerDeployment, deploymentID, "")
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -155,6 +164,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	podNetworkToHostNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(podNetworkToHostNetworkPollerDeployment, deploymentID, "")
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -166,6 +178,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	hostNetworkToPodNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(hostNetworkToPodNetworkPollerDeployment, deploymentID, "")
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -177,6 +192,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	hostNetworkToHostNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(hostNetworkToHostNetworkPollerDeployment, deploymentID, "")
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -189,6 +207,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	podNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = image.LocationFor(originalAgnhost.GetE2EImage())
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkTargetDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -197,6 +218,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		service, createErr = pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(ctx, podNetworkTargetService, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			service, createErr = pna.kubeClient.CoreV1().Services(pna.namespaceName).Get(ctx, podNetworkTargetService.Name, metav1.GetOptions{})
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -208,12 +232,18 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	hostNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkTargetDeployment, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
 	}
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		_, createErr := pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(ctx, hostNetworkTargetService, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			return nil
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -233,6 +263,9 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 		deployment = disruptionlibrary.UpdateDeploymentENVs(deployment, deploymentID, service.Spec.ClusterIP)
 		if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 			_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, deployment, metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(createErr) {
+				return nil
+			}
 			return createErr
 		}); err != nil {
 			return err

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -114,9 +114,6 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		actualNamespace, createErr = pna.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-		if apierrors.IsAlreadyExists(createErr) {
-			actualNamespace, createErr = pna.kubeClient.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
-		}
 		return createErr
 	}); err != nil {
 		return err

--- a/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
+++ b/pkg/monitortests/network/disruptionpodnetwork/monitortest.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	"github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -109,19 +110,30 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 		return err
 	}
 
-	actualNamespace, err := pna.kubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
-	if err != nil {
+	var actualNamespace *corev1.Namespace
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var createErr error
+		actualNamespace, createErr = pna.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	pna.namespaceName = actualNamespace.Name
 
-	if _, err = pna.kubeClient.RbacV1().RoleBindings(pna.namespaceName).Create(context.Background(), pollerRoleBinding, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.RbacV1().RoleBindings(pna.namespaceName).Create(ctx, pollerRoleBinding, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 
 	// our pods tolerate masters, so create one for each of them.
-	nodes, err := pna.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
+	var nodes *corev1.NodeList
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var listErr error
+		nodes, listErr = pna.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		return listErr
+	}); err != nil {
 		return err
 	}
 	numNodes := int32(len(nodes.Items))
@@ -130,7 +142,10 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	podNetworkToPodNetworkPollerDeployment.Spec.Replicas = &numNodes
 	podNetworkToPodNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 	podNetworkToPodNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(podNetworkToPodNetworkPollerDeployment, deploymentID, "")
-	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), podNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	time.Sleep(2 * time.Second)
@@ -138,7 +153,10 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	podNetworkToHostNetworkPollerDeployment.Spec.Replicas = &numNodes
 	podNetworkToHostNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 	podNetworkToHostNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(podNetworkToHostNetworkPollerDeployment, deploymentID, "")
-	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), podNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	time.Sleep(2 * time.Second)
@@ -146,7 +164,10 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	hostNetworkToPodNetworkPollerDeployment.Spec.Replicas = &numNodes
 	hostNetworkToPodNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 	hostNetworkToPodNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(hostNetworkToPodNetworkPollerDeployment, deploymentID, "")
-	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkToPodNetworkPollerDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	time.Sleep(2 * time.Second)
@@ -154,7 +175,10 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	hostNetworkToHostNetworkPollerDeployment.Spec.Replicas = &numNodes
 	hostNetworkToHostNetworkPollerDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 	hostNetworkToHostNetworkPollerDeployment = disruptionlibrary.UpdateDeploymentENVs(hostNetworkToHostNetworkPollerDeployment, deploymentID, "")
-	if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkToHostNetworkPollerDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	time.Sleep(2 * time.Second)
@@ -163,11 +187,18 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	originalAgnhost := k8simage.GetOriginalImageConfigs()[k8simage.Agnhost]
 	podNetworkTargetDeployment.Spec.Replicas = &numNodes
 	podNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = image.LocationFor(originalAgnhost.GetE2EImage())
-	if _, err := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), podNetworkTargetDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, podNetworkTargetDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
-	service, err := pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(context.Background(), podNetworkTargetService, metav1.CreateOptions{})
-	if err != nil {
+	var service *corev1.Service
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var createErr error
+		service, createErr = pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(ctx, podNetworkTargetService, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	pna.targetService = service
@@ -175,10 +206,16 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 	klog.Infof("Starting deployment: %s", hostNetworkTargetDeployment.Name)
 	hostNetworkTargetDeployment.Spec.Replicas = &numNodes
 	hostNetworkTargetDeployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
-	if _, err := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), hostNetworkTargetDeployment, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, hostNetworkTargetDeployment, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
-	if _, err := pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(context.Background(), hostNetworkTargetService, metav1.CreateOptions{}); err != nil {
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		_, createErr := pna.kubeClient.CoreV1().Services(pna.namespaceName).Create(ctx, hostNetworkTargetService, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 
@@ -194,7 +231,10 @@ func (pna *podNetworkAvalibility) PrepareCollection(ctx context.Context, adminRE
 		deployment.Spec.Replicas = &numNodes
 		deployment.Spec.Template.Spec.Containers[0].Image = openshiftTestsImagePullSpec
 		deployment = disruptionlibrary.UpdateDeploymentENVs(deployment, deploymentID, service.Spec.ClusterIP)
-		if _, err = pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(context.Background(), deployment, metav1.CreateOptions{}); err != nil {
+		if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+			_, createErr := pna.kubeClient.AppsV1().Deployments(pna.namespaceName).Create(ctx, deployment, metav1.CreateOptions{})
+			return createErr
+		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -166,9 +166,6 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		actualNamespace, createErr = w.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
-		if apierrors.IsAlreadyExists(createErr) {
-			actualNamespace, createErr = w.kubeClient.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
-		}
 		return createErr
 	}); err != nil {
 		return err

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openshift/origin/pkg/monitor/backenddisruption"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestlibrary/disruptionlibrary"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	exutil "github.com/openshift/origin/test/extended/util"
 	"github.com/openshift/origin/test/extended/util/image"
@@ -115,8 +116,12 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 		return err
 	}
 
-	infra, err := configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-	if err != nil {
+	var infra *configv1.Infrastructure
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var getErr error
+		infra, getErr = configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		return getErr
+	}); err != nil {
 		return err
 	}
 	// ovirt does not support service type loadbalancer because it doesn't program a cloud.
@@ -140,8 +145,12 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 			Reason: fmt.Sprintf("topology %q is not supported", infra.Status.ControlPlaneTopology),
 		}
 	}
-	nodeList, err := w.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
+	var nodeList *corev1.NodeList
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var listErr error
+		nodeList, listErr = w.kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		return listErr
+	}); err != nil {
 		return err
 	}
 	if len(nodeList.Items) < 2 {
@@ -153,53 +162,62 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 		return w.notSupportedReason
 	}
 
-	actualNamespace, err := w.kubeClient.CoreV1().Namespaces().Create(context.Background(), namespace, metav1.CreateOptions{})
-	if err != nil {
+	var actualNamespace *corev1.Namespace
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var createErr error
+		actualNamespace, createErr = w.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		return createErr
+	}); err != nil {
 		return err
 	}
 	w.namespaceName = actualNamespace.Name
 
+	time.Sleep(2 * time.Second)
 	serviceName := "service-test"
 	jig := service.NewTestJig(w.kubeClient, w.namespaceName, serviceName)
 
 	fmt.Fprintf(os.Stderr, "creating a TCP service %v with type=LoadBalancer in namespace %v\n", serviceName, w.namespaceName)
-	tcpService, err := jig.CreateTCPService(ctx, func(s *corev1.Service) {
-		s.Spec.Type = corev1.ServiceTypeLoadBalancer
-		// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
-		s.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
-		if s.Annotations == nil {
-			s.Annotations = make(map[string]string)
-		}
-		// We tune the LB checks to match the longest intervals available so that interactions between
-		// upgrading components and the service are more obvious.
-		// - AWS allows configuration, default is 70s (6 failed with 10s interval in 1.17) set to match GCP
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
-		s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
-		// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
-		// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
-		//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
-
-		// Configure dual-stack if the cluster created with dual-stack IP families.
-		// NLB is required on AWS for dual-stack load balancers.
-		if infra.Status.PlatformStatus.AWS != nil {
-			var dualStackIPFamilies []corev1.IPFamily
-			switch infra.Status.PlatformStatus.AWS.IPFamily {
-			case configv1.DualStackIPv4Primary:
-				dualStackIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
-			case configv1.DualStackIPv6Primary:
-				dualStackIPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+	var tcpService *corev1.Service
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var createErr error
+		tcpService, createErr = jig.CreateTCPService(ctx, func(s *corev1.Service) {
+			s.Spec.Type = corev1.ServiceTypeLoadBalancer
+			// ServiceExternalTrafficPolicyTypeCluster performs during disruption, Local does not
+			s.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
+			if s.Annotations == nil {
+				s.Annotations = make(map[string]string)
 			}
+			// We tune the LB checks to match the longest intervals available so that interactions between
+			// upgrading components and the service are more obvious.
+			// - AWS allows configuration, default is 70s (6 failed with 10s interval in 1.17) set to match GCP
+			s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval"] = "8"
+			s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold"] = "3"
+			s.Annotations["service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold"] = "2"
+			// - Azure is hardcoded to 15s (2 failed with 5s interval in 1.17) and is sufficient
+			// - GCP has a non-configurable interval of 32s (3 failed health checks with 8s interval in 1.17)
+			//   - thus pods need to stay up for > 32s, so pod shutdown period will will be 45s
 
-			if len(dualStackIPFamilies) > 0 {
-				s.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
-				dualStackPolicy := corev1.IPFamilyPolicyRequireDualStack
-				s.Spec.IPFamilyPolicy = &dualStackPolicy
-				s.Spec.IPFamilies = dualStackIPFamilies
+			// Configure dual-stack if the cluster created with dual-stack IP families.
+			// NLB is required on AWS for dual-stack load balancers.
+			if infra.Status.PlatformStatus.AWS != nil {
+				var dualStackIPFamilies []corev1.IPFamily
+				switch infra.Status.PlatformStatus.AWS.IPFamily {
+				case configv1.DualStackIPv4Primary:
+					dualStackIPFamilies = []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}
+				case configv1.DualStackIPv6Primary:
+					dualStackIPFamilies = []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}
+				}
+
+				if len(dualStackIPFamilies) > 0 {
+					s.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"] = "nlb"
+					dualStackPolicy := corev1.IPFamilyPolicyRequireDualStack
+					s.Spec.IPFamilyPolicy = &dualStackPolicy
+					s.Spec.IPFamilies = dualStackIPFamilies
+				}
 			}
-		}
-	})
-	if err != nil {
+		})
+		return createErr
+	}); err != nil {
 		return fmt.Errorf("error creating tcp service: %w", err)
 	}
 	tcpService, err = jig.WaitForLoadBalancer(ctx, service.GetServiceLoadBalancerCreationTimeout(ctx, w.kubeClient))
@@ -211,6 +229,7 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 	tcpIngressIP := service.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
 	svcPort := int(tcpService.Spec.Ports[0].Port)
 
+	time.Sleep(2 * time.Second)
 	fmt.Fprintf(os.Stderr, "creating RC to be part of service %v\n", serviceName)
 	rc, err := jig.Run(ctx, func(deployment *appsv1.Deployment) {
 		// ensure the pod waits long enough during update for the LB to see the newly ready pod, which
@@ -239,6 +258,7 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 		return fmt.Errorf("error waiting for replicaset: %w", err)
 	}
 
+	time.Sleep(2 * time.Second)
 	fmt.Fprintf(os.Stderr, "creating a PodDisruptionBudget to cover the ReplicationController\n")
 	_, err = jig.CreatePDB(ctx, rc)
 	if err != nil {

--- a/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
+++ b/pkg/monitortests/network/disruptionserviceloadbalancer/monitortest.go
@@ -166,6 +166,9 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
 		var createErr error
 		actualNamespace, createErr = w.kubeClient.CoreV1().Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(createErr) {
+			actualNamespace, createErr = w.kubeClient.CoreV1().Namespaces().Get(ctx, namespace.Name, metav1.GetOptions{})
+		}
 		return createErr
 	}); err != nil {
 		return err
@@ -216,6 +219,9 @@ func (w *availability) PrepareCollection(ctx context.Context, adminRESTConfig *r
 				}
 			}
 		})
+		if apierrors.IsAlreadyExists(createErr) {
+			tcpService, createErr = w.kubeClient.CoreV1().Services(w.namespaceName).Get(ctx, serviceName, metav1.GetOptions{})
+		}
 		return createErr
 	}); err != nil {
 		return fmt.Errorf("error creating tcp service: %w", err)


### PR DESCRIPTION
…cd errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated retry with exponential backoff that detects transient API failures and retries setup operations only for those cases.
  * Retries now return the last transient error on overall timeout to surface the root cause.

* **Tests**
  * Wrapped multiple test setup steps in the new retry logic and made "already exists" conditions non-fatal by reusing existing resources.
  * Added short, strategic delays around load-balancer and deployment steps to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->