### PR TITLE
OCPBUGS-84961: append suite names to external extension binary tests

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -947,6 +947,12 @@ func (binaries TestBinaries) ListTests(ctx context.Context, parallelism int, env
 		return nil, fmt.Errorf("encountered errors while listing tests: %s", strings.Join(errs, ";"))
 	}
 
+	var baseSpecs extensiontests.ExtensionTestSpecs
+	for _, spec := range allTests {
+		baseSpecs = append(baseSpecs, spec.ExtensionTestSpec)
+	}
+	appendSuiteNames(baseSpecs)
+
 	return allTests, nil
 }
 

--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -951,6 +951,9 @@ func (binaries TestBinaries) ListTests(ctx context.Context, parallelism int, env
 	for _, spec := range allTests {
 		baseSpecs = append(baseSpecs, spec.ExtensionTestSpec)
 	}
+	baseSpecs = filterOutDisabledSpecs(baseSpecs)
+	addEnvironmentSelectors(baseSpecs)
+	addLabelsToSpecs(baseSpecs)
 	appendSuiteNames(baseSpecs)
 
 	return allTests, nil


### PR DESCRIPTION
## Summary

- `TestBinaries.ListTests()` loads tests from external extension binaries (k8s-tests-ext, ovn-kubernetes-tests-ext, etc.) but never calls `appendSuiteNames()` on them
- Without `[Suite:openshift/conformance/...]` tags, the conformance suite filter excludes these tests
- This causes the `openshift/conformance` suite to drop from ~4000 to ~190 tests on OCP 4.21+
- Fixes [OCPBUGS-84961](https://issues.redhat.com/browse/OCPBUGS-84961)

## Root Cause

`appendSuiteNames()` is called for origin's built-in tests during `InitializeOpenShiftTestsExtensionFramework()` (line 104), but the `TestBinaries.ListTests()` code path for external binaries never calls it. Pre-4.20, all tests were built-in so this was never an issue. Starting in 4.20+, tests were moved to external binaries and the tagging step was missed.

## Fix

Call `appendSuiteNames()` on the aggregated external binary test specs after `ListTests()` returns them. The function already has a guard (`if strings.Contains(spec.Name, "[Suite:")`) that skips tests already tagged, so it's safe for tests that already have suite tags from their own binaries.

## Test Plan

- [x] Built patched `openshift-tests` binary from `release-4.21` branch
- [x] Deployed OCP 4.21.8 GA cluster on AWS
- [x] Ran `openshift-tests run openshift/conformance --dry-run` with stock binary: **184 tests**
- [x] Ran same command with patched binary: **3,895 tests**
- [x] Unit tests pass: `go test ./pkg/test/extensions/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test listing behavior: discovered test specifications are now post-processed before being returned — filtering out disabled entries, adding environment selectors and labels, and appending suite names to better reflect test grouping and visibility during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->