### PR TITLE
TRT-2617: Fix CPU metrics monitor node role lookup

### DIFF
--- a/pkg/monitortests/testframework/cpumetriccollector/functional_test.go
+++ b/pkg/monitortests/testframework/cpumetriccollector/functional_test.go
@@ -1,0 +1,68 @@
+package cpumetriccollector
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	prometheusapi "github.com/prometheus/client_golang/api"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// TestCollectCPUMetrics_Functional calls collectCPUMetricsFromPrometheusClient
+// against KaaS and PromeCIeus servers from captured CI job data.
+// Doesn't test much but useful for debugging with actual data.
+//
+// Required env vars:
+//
+//	PROMETHEUS_URL   - URL of the Prometheus server
+//	KUBECONFIG       - kubeconfig for node listing
+//	CPU_START_TIME   - RFC3339 start time for the query range
+func TestCollectCPUMetrics_Functional(t *testing.T) {
+	promURL := os.Getenv("PROMETHEUS_URL")
+	if promURL == "" {
+		t.Skip("PROMETHEUS_URL not set")
+	}
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		t.Skip("KUBECONFIG not set")
+	}
+	startStr := os.Getenv("CPU_START_TIME")
+	if startStr == "" {
+		t.Skip("CPU_START_TIME not set")
+	}
+
+	startTime, err := time.Parse(time.RFC3339, startStr)
+	require.NoError(t, err, "CPU_START_TIME must be RFC3339")
+
+	ctx := context.Background()
+
+	restConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	require.NoError(t, err)
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	require.NoError(t, err)
+
+	promClient, err := prometheusapi.NewClient(prometheusapi.Config{
+		Address: promURL,
+		Client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+	})
+	require.NoError(t, err)
+	promAPI := prometheusv1.NewAPI(promClient)
+
+	collector := &cpuMetricCollector{highCPUThreshold: 95.0}
+	intervals, err := collector.collectCPUMetricsFromPrometheusClient(ctx, promAPI, kubeClient, startTime)
+	require.NoError(t, err)
+
+	t.Logf("high-cpu intervals: %d, data points: %d", len(intervals), len(collector.cpuDataPoints))
+	require.NotEmpty(t, collector.cpuDataPoints, "expected some cpu data points")
+}

--- a/pkg/monitortests/testframework/cpumetriccollector/monitortest.go
+++ b/pkg/monitortests/testframework/cpumetriccollector/monitortest.go
@@ -78,7 +78,6 @@ func (w *cpuMetricCollector) CollectData(ctx context.Context, storageDir string,
 }
 
 func (w *cpuMetricCollector) collectCPUMetricsFromPrometheus(ctx context.Context, restConfig *rest.Config, startTime time.Time) ([]monitorapi.Interval, error) {
-	logger := logrus.WithField("func", "collectCPUMetricsFromPrometheus")
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
@@ -103,6 +102,12 @@ func (w *cpuMetricCollector) collectCPUMetricsFromPrometheus(ctx context.Context
 	if intervals, err := prometheus.EnsureThanosQueriersConnectedToPromSidecars(ctx, prometheusClient); err != nil {
 		return intervals, fmt.Errorf("failed to check Thanos querier connection to Prometheus sidecars: %w", err)
 	}
+
+	return w.collectCPUMetricsFromPrometheusClient(ctx, prometheusClient, kubeClient, startTime)
+}
+
+func (w *cpuMetricCollector) collectCPUMetricsFromPrometheusClient(ctx context.Context, prometheusClient prometheusv1.API, kubeClient *kubernetes.Clientset, startTime time.Time) ([]monitorapi.Interval, error) {
+	logger := logrus.WithField("func", "collectCPUMetricsFromPrometheusClient")
 
 	// Get node information for determining node roles
 	nodeList, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/pkg/monitortests/testframework/cpumetriccollector/monitortest.go
+++ b/pkg/monitortests/testframework/cpumetriccollector/monitortest.go
@@ -149,7 +149,8 @@ func (w *cpuMetricCollector) collectCPUDataPointsFromMetrics(promVal prometheust
 			nodeInfo := nodeInfoMap[instance]
 			nodeName := nodeInfo.name
 			if nodeName == "" {
-				nodeName = instance // Fallback to instance if name not found
+				// Fallback to instance if name not found (transient nodes may not be mapped)
+				nodeName = instance
 			}
 
 			// Collect all CPU data points for timeline export
@@ -181,7 +182,8 @@ func (w *cpuMetricCollector) createIntervalsFromCPUMetrics(logger logrus.FieldLo
 			nodeInfo := nodeInfoMap[instance]
 			nodeName := nodeInfo.name
 			if nodeName == "" {
-				nodeName = instance // Fallback to instance if name not found
+				// Fallback to instance if name not found (transient nodes may not be mapped)
+				nodeName = instance
 			}
 
 			// Create locator for the node with role
@@ -318,27 +320,27 @@ type nodeInfo struct {
 	nodeRole string
 }
 
-// buildNodeInfoMap creates a map from node IP addresses to node information
+// buildNodeInfoMap creates a map from node IP addresses and instance name to node information
 func buildNodeInfoMap(nodeList *corev1.NodeList) map[string]nodeInfo {
 	nodeInfoMap := make(map[string]nodeInfo)
 
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
-		nodeRole := getNodeRole(node)
+		info := nodeInfo{
+			name:     node.Name,
+			nodeRole: getNodeRole(node),
+		}
+
+		// Always map with instance name
+		nodeInfoMap[node.Name] = info
 
 		// Map all node IP addresses to the node info
 		for _, address := range node.Status.Addresses {
 			if address.Type == corev1.NodeInternalIP {
 				// Prometheus typically uses IP:port format
-				nodeInfoMap[address.Address] = nodeInfo{
-					name:     node.Name,
-					nodeRole: nodeRole,
-				}
+				nodeInfoMap[address.Address] = info
 				// Also map with port suffix (common Prometheus format)
-				nodeInfoMap[address.Address+":9100"] = nodeInfo{
-					name:     node.Name,
-					nodeRole: nodeRole,
-				}
+				nodeInfoMap[address.Address+":9100"] = info
 			}
 		}
 	}


### PR DESCRIPTION
Add functional test to enable observation, and fill the missing node role column that's been empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new functional integration test that validates CPU metrics collection using Prometheus and Kubernetes connectivity; skips when required environment variables are unset.

* **Refactor**
  * Reorganized CPU metric collection logic for clearer separation of responsibilities and improved node metadata mapping to better handle node identification and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->