### PR TITLE
"OCPSTRAT-3036: Temporary 1.36 image fixes (revert in rebase PR)"

### DIFF
--- a/pkg/cmd/openshift-tests/images/images_command.go
+++ b/pkg/cmd/openshift-tests/images/images_command.go
@@ -101,6 +101,12 @@ func NewImagesCommand() *cobra.Command {
 				fmt.Fprintln(os.Stdout, line)
 			}
 
+			// TODO(k8s-1.36): remove this when k8s 1.36 lands
+			injectedLines := injectNewImages(ref, !o.Upstream)
+			for _, line := range injectedLines {
+				fmt.Fprintln(os.Stdout, line)
+			}
+
 			return nil
 		},
 	}
@@ -292,4 +298,29 @@ func setLogLevel(level string) error {
 	}
 	logrus.SetLevel(lvl)
 	return nil
+}
+
+// TODO(k8s-1.36): remove this when k8s 1.36 lands
+func injectNewImages(ref reference.DockerImageReference, mirrored bool) []string {
+	target := ref.Exact()
+
+	images := map[string]string{
+		// glibc-dns-testing:2.0.0 replaces jessie-dnsutils:1.7 in k8s 1.36,
+		// but the tests binary still references the old name
+		"registry.k8s.io/e2e-test-images/glibc-dns-testing:2.0.0": "e2e-11-registry-k8s-io-e2e-test-images-glibc-dns-testing-2-0-0-doWtNeL-8jnuqU8E",
+	}
+
+	lines := []string{}
+	for originalImage, mirrorTag := range images {
+		if mirrored {
+			lines = append(lines, fmt.Sprintf("%s:%s %s:%s",
+				imagesetup.DefaultTestImageMirrorLocation, mirrorTag,
+				target, mirrorTag))
+		} else {
+			lines = append(lines, fmt.Sprintf("%s %s:%s",
+				originalImage, target, mirrorTag))
+		}
+	}
+	sort.Strings(lines)
+	return lines
 }

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -56,3 +56,4 @@ registry.k8s.io/sig-storage/hostpathplugin:v1.17.0 quay.io/openshift/community-e
 registry.k8s.io/sig-storage/livenessprobe:v2.17.0 quay.io/openshift/community-e2e-images:e2e-33-registry-k8s-io-sig-storage-livenessprobe-v2-17-0-Xad6CG72djzxptGw
 registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8 quay.io/openshift/community-e2e-images:e2e-14-registry-k8s-io-sig-storage-nfs-provisioner-v4-0-8-W5pbwDbNliDm1x4k
 registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0 quay.io/openshift/community-e2e-images:e2e-29-registry-k8s-io-sig-storage-volume-data-source-validator-v1-0-0-pJwTeQGTDmAV8753
+registry.k8s.io/e2e-test-images/glibc-dns-testing:2.0.0 quay.io/openshift/community-e2e-images:e2e-11-registry-k8s-io-e2e-test-images-glibc-dns-testing-2-0-0-doWtNeL-8jnuqU8E


### PR DESCRIPTION
Temporarily map the glibc-dns-testing image to jessie-dnsutils while we're payload testing 1.36 before the openshift/origin PR has merged. Should be reverted when that happens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The images command now appends extra image mirror mappings to its output. The added mappings target test images and adapt their output format depending on whether upstream or mirrored mode is selected, ensuring correct source/target representation for mirror workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->