### PR TITLE
NO-JIRA: Update hello-openshift base images from 4.16/4.17 to 4.22

### DIFF
--- a/images/hello-openshift/Dockerfile.rhel
+++ b/images/hello-openshift/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/hello-openshift
 COPY examples/hello-openshift .
 RUN go build -o /hello-openshift
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /hello-openshift /hello-openshift
 EXPOSE 8080 8888
 USER 1001


### PR DESCRIPTION
## Summary
- Update builder and base images in `images/hello-openshift/Dockerfile.rhel` from ocp/4.16 and 4.17 to 4.22
- The old images have been pruned from the CI registry, causing `PullBuilderImageFailed` on payload-job-with-prs runs

## Test plan
- [x] CI passes with updated base images

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container images to OpenShift 4.22 and Go 1.25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->