### PR TITLE
OCPNODE-4494: Testcase to test runc Upgrade case

### DIFF
--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -77,6 +77,19 @@ func getKubeletConfigFromNode(ctx context.Context, oc *exutil.CLI, nodeName stri
 	return configzResponse.KubeletConfig, nil
 }
 
+// getPureWorkerNodesFromCluster returns worker nodes that are not also control plane nodes.
+func getPureWorkerNodesFromCluster(ctx context.Context, oc *exutil.CLI) ([]corev1.Node, error) {
+	workers, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
+	if err != nil {
+		return nil, err
+	}
+	pureWorkers := getPureWorkerNodes(workers)
+	if len(pureWorkers) == 0 {
+		return nil, fmt.Errorf("no pure worker nodes available")
+	}
+	return pureWorkers, nil
+}
+
 // getPureWorkerNodes returns worker nodes that are not also control plane nodes.
 // On SNO clusters, the single node has both worker and control-plane roles,
 // so it should be validated as a control plane node (failSwapOn=true), not as a worker.
@@ -516,53 +529,114 @@ func waitForHyperConvergedReady(ctx context.Context, oc *exutil.CLI) error {
 	})
 }
 
-// waitForMCP waits for a MachineConfigPool to be ready (not updating, updated, and all machines ready)
-// Returns error immediately if the MCP becomes degraded
-func waitForMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration) error {
+type waitMCPOptions struct {
+	machineCount  *int32
+	allowDegraded bool
+}
+
+// WaitMCPWithMachineCount waits until the pool has the exact machine count.
+func WaitMCPWithMachineCount(count int32) func(*waitMCPOptions) {
+	return func(o *waitMCPOptions) {
+		o.machineCount = &count
+	}
+}
+
+// WaitMCPAllowDegraded tolerates transient Degraded/RenderDegraded during polling instead of
+// failing immediately. The pool must still become fully healthy (!degraded, !renderDegraded,
+// updated, all machines ready) before this wait succeeds.
+func WaitMCPAllowDegraded() func(*waitMCPOptions) {
+	return func(o *waitMCPOptions) {
+		o.allowDegraded = true
+	}
+}
+
+// waitForMCP waits for a MachineConfigPool to be ready (not updating, updated, and all machines ready).
+// By default it returns an error immediately if the MCP becomes degraded.
+func waitForMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration, opts ...func(*waitMCPOptions)) error {
+	options := waitMCPOptions{}
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	framework.Logf("Waiting for MCP %s to be ready (timeout: %v)...", poolName, timeout)
 
+	poolSeen := false
 	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				// Only treat NotFound as success when draining a pool we have previously observed.
+				// A typo in poolName must not pass silently on the first poll.
+				if poolSeen && options.machineCount != nil && *options.machineCount == 0 {
+					framework.Logf("MachineConfigPool %s no longer exists after draining to 0 machines", poolName)
+					return true, nil
+				}
+			}
 			return false, err
 		}
+		poolSeen = true
 
-		// Check conditions
 		updating := false
 		degraded := false
+		renderDegraded := false
 		ready := false
 
 		for _, condition := range mcp.Status.Conditions {
 			switch condition.Type {
-			case "Updating":
+			case machineconfigv1.MachineConfigPoolUpdating:
 				if condition.Status == corev1.ConditionTrue {
 					updating = true
 				}
-			case "Degraded":
+			case machineconfigv1.MachineConfigPoolDegraded:
 				if condition.Status == corev1.ConditionTrue {
 					degraded = true
 				}
-			case "Updated":
+			case machineconfigv1.MachineConfigPoolRenderDegraded:
+				if condition.Status == corev1.ConditionTrue {
+					renderDegraded = true
+				}
+			case machineconfigv1.MachineConfigPoolUpdated:
 				if condition.Status == corev1.ConditionTrue {
 					ready = true
 				}
 			}
 		}
 
-		// Fail immediately if degraded
-		if degraded {
-			return false, fmt.Errorf("MachineConfigPool %s is degraded", poolName)
+		if !options.allowDegraded {
+			if degraded {
+				return false, fmt.Errorf("MachineConfigPool %s is degraded", poolName)
+			}
+			if renderDegraded {
+				return false, fmt.Errorf("MachineConfigPool %s render is degraded", poolName)
+			}
 		}
 
-		// Ready when not updating, updated condition is true, and pool has machines
-		isReady := !updating && ready && mcp.Status.MachineCount > 0 && mcp.Status.ReadyMachineCount == mcp.Status.MachineCount
+		// Drained pool: all nodes removed and conditions stable before cleanup continues.
+		if options.machineCount != nil && *options.machineCount == 0 {
+			isDrained := mcp.Status.MachineCount == 0 &&
+				mcp.Status.ReadyMachineCount == 0 &&
+				!updating && !degraded && !renderDegraded
+			if isDrained {
+				framework.Logf("MachineConfigPool %s drained: 0 machines, not updating/degraded", poolName)
+				return true, nil
+			}
+			framework.Logf("MachineConfigPool %s waiting to drain: updating=%v degraded=%v renderDegraded=%v machines=%d/%d",
+				poolName, updating, degraded, renderDegraded, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+			return false, nil
+		}
+
+		isReady := !updating && !degraded && !renderDegraded && ready &&
+			mcp.Status.MachineCount > 0 && mcp.Status.ReadyMachineCount == mcp.Status.MachineCount
+		if options.machineCount != nil {
+			isReady = isReady && mcp.Status.MachineCount == *options.machineCount
+		}
 
 		if isReady {
 			framework.Logf("MachineConfigPool %s is ready: %d/%d machines ready",
 				poolName, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
 		} else {
-			framework.Logf("MachineConfigPool %s not ready yet: updating=%v, ready=%v, machines=%d/%d",
-				poolName, updating, ready, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+			framework.Logf("MachineConfigPool %s not ready yet: updating=%v degraded=%v renderDegraded=%v updated=%v machines=%d/%d",
+				poolName, updating, degraded, renderDegraded, ready, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
 		}
 
 		return isReady, nil

--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -1,0 +1,861 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	v1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	runcRHCOS10GuardPool = "runc-rhcos10-guard"
+	streamRHEL9          = "rhel-9"
+	streamRHEL10         = "rhel-10"
+
+	runcGuardCRCName          = "99-runc-rhcos10-guard-runc"
+	runcCRCDefaultRuntimePath = "/etc/crio/crio.conf.d/01-ctrcfg-defaultRuntime"
+
+	machineConfigClusterOperator = "machine-config"
+
+	degradedPoolUpgradeableReason  = "DegradedPool"
+	degradedPoolUpgradeableMessage = "One or more machine config pools are degraded"
+)
+
+var rhelMajorOSImagePattern = regexp.MustCompile(`Linux\s+([0-9]+)`)
+
+// When a pool uses runc and targets osImageStream rhel-10, MCO must block RHCOS 9→10
+// rollout by setting MachineConfigPool Degraded / RenderDegraded. MCO then sets
+// ClusterOperator Upgradeable=False (DegradedPool), which CVO aggregates on ClusterVersion.
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                   = exutil.NewCLI("runc-rhcos10-guard")
+		mcClient             *machineconfigclient.Clientset
+		nodeName             string
+		clusterDefaultStream string
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		var err error
+		mcClient, err = machineconfigclient.NewForConfig(oc.AdminConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isMicroShift {
+			// MicroShift defaults to crun and does not support configuring runc via ContainerRuntimeConfig.
+			g.Skip("Skipping on MicroShift cluster: runc cannot be configured")
+		}
+
+		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			g.Skip("Skipping on external control plane (Hypershift) cluster")
+		}
+		if *controlPlaneTopology == configv1.SingleReplicaTopologyMode {
+			g.Skip("Skipping on single-replica topology: requires a pure worker node")
+		}
+
+		clusterDefaultStream = requireOSImageStreams(ctx, mcClient)
+	})
+
+	g.It("blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
+		g.By("Creating custom MachineConfigPool pinned to rhel-9 with runc ContainerRuntimeConfig")
+		o.Expect(createRuncGuardPool(ctx, mcClient)).To(o.Succeed())
+
+		g.By("Labeling one worker into the custom pool")
+		var err error
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10GuardPool)
+		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
+
+		g.By("Waiting for pool rollout on rhel-9 with runc")
+		o.Expect(waitForMCPWithLabeledNode(ctx, oc, mcClient, runcRHCOS10GuardPool, nodeName, 30*time.Minute)).To(o.Succeed(),
+			"node did not join custom MCP")
+
+		g.By("Checking default runtime is runc on RHCOS 9")
+		o.Expect(expectRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed())
+		rhelMajor, err := nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "pool should be on RHCOS 9 before attempting rhel-10 stream")
+
+		g.By("Upgrading RHCOS version to RHCOS 10 via osImageStream")
+		o.Expect(setPoolOSImageStream(ctx, mcClient, runcRHCOS10GuardPool, streamRHEL10)).To(o.Succeed())
+		o.Expect(waitForMCPRenderDegraded(ctx, mcClient, runcRHCOS10GuardPool, 10*time.Minute)).To(o.Succeed())
+
+		g.By("Verifying cluster upgrade is blocked via CO and CVO Upgradeable=False")
+		o.Expect(waitForUpgradeBlockedByDegradedPool(ctx, oc)).To(o.Succeed())
+
+		g.By("Verifying node remains ready, not rolling out, on RHCOS 9 with runc after guard blocks rollout")
+		o.Expect(verifyNodeReadyAndNotRollingOut(ctx, oc, nodeName)).To(o.Succeed())
+		rhelMajor, err = nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "node should remain on RHCOS 9 after guard blocks rollout")
+		o.Expect(expectRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed(),
+			"node should keep runc as default runtime after guard blocks rollout")
+
+		g.By("Recovering pool by setting osImageStream back to rhel-9")
+		o.Expect(setPoolOSImageStream(ctx, mcClient, runcRHCOS10GuardPool, streamRHEL9)).To(o.Succeed())
+		o.Expect(waitForMCP(ctx, mcClient, runcRHCOS10GuardPool, 10*time.Minute, WaitMCPAllowDegraded())).To(o.Succeed())
+
+		g.By("Verifying cluster upgradeability recovers after pool returns to rhel-9")
+		// MCO may take up to ~30 minutes to propagate Upgradeable after RenderDegraded clears.
+		o.Expect(waitForClusterUpgradeable(ctx, oc, 30*time.Minute)).To(o.Succeed())
+
+		g.By("Verifying node remains ready, not rolling out, on RHCOS 9 with runc after recovery")
+		o.Expect(verifyNodeReadyAndNotRollingOut(ctx, oc, nodeName)).To(o.Succeed())
+		rhelMajor, err = nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "node should remain on RHCOS 9 after recovery")
+		o.Expect(expectRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed(),
+			"node should keep runc as default runtime after recovery")
+
+		if clusterDefaultStream == streamRHEL10 {
+			g.By("Recovering pool to cluster default RHCOS 10 with crun after removing runc config")
+			node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			priorRenderedConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+			o.Expect(priorRenderedConfig).NotTo(o.BeEmpty(), "node should have a stable rendered config before CRC removal")
+
+			o.Expect(deleteContainerRuntimeConfig(ctx, mcClient, runcGuardCRCName)).To(o.Succeed())
+			o.Expect(waitForPoolConfigRolloutAfterCRCRemoval(ctx, oc, mcClient, runcRHCOS10GuardPool, nodeName, priorRenderedConfig, 30*time.Minute)).To(o.Succeed(),
+				"pool should re-render and roll out on the node without runc ContainerRuntimeConfig before moving to rhel-10")
+			o.Expect(waitForRuncRemovedFromNode(ctx, oc, nodeName, 15*time.Minute)).To(o.Succeed(),
+				"CRC removal should drop the runc CRI-O drop-in before moving to rhel-10")
+
+			g.By("Moving pool to cluster default RHCOS 10 stream")
+			o.Expect(setPoolOSImageStream(ctx, mcClient, runcRHCOS10GuardPool, streamRHEL10)).To(o.Succeed())
+			o.Expect(waitForNodeRHELMajorVersion(ctx, oc, nodeName, "10", 45*time.Minute)).To(o.Succeed(),
+				"node should reboot onto RHCOS 10 after rhel-10 stream change without runc")
+			o.Expect(waitForMCP(ctx, mcClient, runcRHCOS10GuardPool, 30*time.Minute)).To(o.Succeed())
+
+			g.By("Verifying node rolled out to RHCOS 10 with crun")
+			o.Expect(verifyNodeReadyAndNotRollingOut(ctx, oc, nodeName)).To(o.Succeed())
+			o.Expect(assertCrunRuntimeOnNode(oc, nodeName)).To(o.Succeed(), "node should use crun after runc config is removed")
+		}
+	})
+
+	g.AfterEach(func(ctx context.Context) {
+		// Do not use Expect here; a failed assertion would skip subsequent cleanup steps.
+		if nodeName != "" {
+			roleLabel := poolNodeRoleLabel(runcRHCOS10GuardPool)
+			if err := removeNodeLabel(ctx, oc, nodeName, roleLabel); err != nil {
+				framework.Logf("cleanup: failed to remove node label %s from %s: %v", roleLabel, nodeName, err)
+			}
+		}
+		if err := deleteContainerRuntimeConfig(ctx, mcClient, runcGuardCRCName); err != nil {
+			framework.Logf("cleanup: failed to delete ContainerRuntimeConfig %s: %v", runcGuardCRCName, err)
+		}
+		if nodeName != "" {
+			if err := waitForMCP(ctx, mcClient, runcRHCOS10GuardPool, 10*time.Minute, WaitMCPWithMachineCount(0)); err != nil {
+				framework.Logf("cleanup: failed waiting for MCP %s machine count 0: %v", runcRHCOS10GuardPool, err)
+			}
+			if err := waitForNodeWorkerConfigRollback(ctx, oc, nodeName, runcRHCOS10GuardPool, 15*time.Minute); err != nil {
+				framework.Logf("cleanup: failed waiting for node %s worker config rollback: %v", nodeName, err)
+			}
+		}
+		if err := deleteMachineConfigPool(ctx, mcClient, runcRHCOS10GuardPool); err != nil {
+			framework.Logf("cleanup: failed to delete MachineConfigPool %s: %v", runcRHCOS10GuardPool, err)
+		}
+		if nodeName != "" {
+			if err := waitForMCP(ctx, mcClient, "worker", 30*time.Minute); err != nil {
+				framework.Logf("cleanup: failed waiting for worker MCP to become ready: %v", err)
+			}
+		}
+	})
+})
+
+// waitForUpgradeBlockedByDegradedPool waits for MCO to propagate an isolated MCP render failure
+// to ClusterOperator and ClusterVersion Upgradeable=False. CO/CVO Degraded may take ~30 minutes
+// to flip; this check mirrors MCO extended tests that assert Upgradeable without waiting for Degraded.
+func waitForUpgradeBlockedByDegradedPool(ctx context.Context, oc *exutil.CLI) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, machineConfigClusterOperator, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if degraded := findClusterConditionStatus(co.Status.Conditions, configv1.OperatorDegraded); degraded == configv1.ConditionTrue {
+			return false, fmt.Errorf("ClusterOperator %s Degraded=True; expected Upgradeable=False only while isolated pool guard is active", machineConfigClusterOperator)
+		}
+		if available := findClusterConditionStatus(co.Status.Conditions, configv1.OperatorAvailable); available != configv1.ConditionTrue {
+			return false, fmt.Errorf("ClusterOperator %s Available=%s, expected True", machineConfigClusterOperator, available)
+		}
+
+		upgradeable := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorUpgradeable)
+		if upgradeable == nil || upgradeable.Status != configv1.ConditionFalse {
+			status := configv1.ConditionUnknown
+			if upgradeable != nil {
+				status = upgradeable.Status
+			}
+			framework.Logf("waiting for ClusterOperator %s Upgradeable=False, current status=%s", machineConfigClusterOperator, status)
+			return false, nil
+		}
+		if upgradeable.Reason != degradedPoolUpgradeableReason {
+			framework.Logf("waiting for ClusterOperator %s Upgradeable reason=%s, current reason=%q", machineConfigClusterOperator, degradedPoolUpgradeableReason, upgradeable.Reason)
+			return false, nil
+		}
+		if !strings.Contains(upgradeable.Message, degradedPoolUpgradeableMessage) {
+			framework.Logf("waiting for ClusterOperator %s Upgradeable message to contain %q, current message=%q", machineConfigClusterOperator, degradedPoolUpgradeableMessage, upgradeable.Message)
+			return false, nil
+		}
+
+		cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if available := findClusterConditionStatus(cv.Status.Conditions, configv1.OperatorAvailable); available != configv1.ConditionTrue {
+			return false, fmt.Errorf("ClusterVersion Available=%s, expected True", available)
+		}
+		if progressing := findClusterConditionStatus(cv.Status.Conditions, configv1.OperatorProgressing); progressing == configv1.ConditionTrue {
+			return false, fmt.Errorf("ClusterVersion Progressing=True while isolated pool guard is active")
+		}
+		if degraded := findClusterConditionStatus(cv.Status.Conditions, configv1.OperatorDegraded); degraded == configv1.ConditionTrue {
+			return false, fmt.Errorf("ClusterVersion Degraded=True while isolated pool guard is active")
+		}
+
+		cvUpgradeable := v1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorUpgradeable)
+		if cvUpgradeable == nil || cvUpgradeable.Status != configv1.ConditionFalse {
+			status := configv1.ConditionUnknown
+			if cvUpgradeable != nil {
+				status = cvUpgradeable.Status
+			}
+			framework.Logf("waiting for ClusterVersion Upgradeable=False, current status=%s", status)
+			return false, nil
+		}
+
+		// TechPreview/CustomNoUpgrade clusters, and clusters with ClusterVersion overrides (e.g.
+		// from mco-push replace), may already report Upgradeable=False without listing
+		// machine-config in the CVO message. MCO extended tests assert only
+		// co/machine-config Upgradeable=False (DegradedPool).
+		if clusterVersionUpgradeableGloballyBlocked(oc, cv, cvUpgradeable) {
+			framework.Logf("ClusterOperator %s reports Upgradeable=False (reason %s); ClusterVersion Upgradeable=False without machine-config in message (feature set, CV overrides, or stale override reason present)",
+				machineConfigClusterOperator, degradedPoolUpgradeableReason)
+			return true, nil
+		}
+		if !strings.Contains(cvUpgradeable.Message, machineConfigClusterOperator) {
+			framework.Logf("waiting for ClusterVersion Upgradeable message to mention %s, current message=%q", machineConfigClusterOperator, cvUpgradeable.Message)
+			return false, nil
+		}
+
+		framework.Logf("ClusterOperator %s and ClusterVersion %q report Upgradeable=False (reason %s) with isolated MCP guard active",
+			machineConfigClusterOperator, cv.Status.Desired.Version, degradedPoolUpgradeableReason)
+		return true, nil
+	})
+}
+
+// clusterVersionUpgradeableGloballyBlocked reports whether ClusterVersion Upgradeable=False
+// is expected for reasons unrelated to an isolated MCP render guard (feature set, CV overrides).
+func clusterVersionUpgradeableGloballyBlocked(oc *exutil.CLI, cv *configv1.ClusterVersion, cvUpgradeable *configv1.ClusterOperatorStatusCondition) bool {
+	if exutil.IsNoUpgradeFeatureSet(oc) || len(cv.Spec.Overrides) > 0 {
+		return true
+	}
+	if cvUpgradeable == nil {
+		return false
+	}
+	return strings.Contains(cvUpgradeable.Message, "cluster version overrides")
+}
+
+// waitForClusterUpgradeable waits until machine-config Upgradeable=True after an isolated MCP
+// guard is cleared. ClusterVersion Upgradeable=True is required only when the cluster is not
+// already globally non-upgradeable (mirrors waitForUpgradeBlockedByDegradedPool).
+func waitForClusterUpgradeable(ctx context.Context, oc *exutil.CLI, timeout time.Duration) error {
+	var lastCOReason, lastCOMessage, lastCVReason, lastCVMessage string
+
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, machineConfigClusterOperator, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		coUpgradeable := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorUpgradeable)
+		if coUpgradeable == nil || coUpgradeable.Status != configv1.ConditionTrue {
+			status := configv1.ConditionUnknown
+			if coUpgradeable != nil {
+				status = coUpgradeable.Status
+				lastCOReason = coUpgradeable.Reason
+				lastCOMessage = coUpgradeable.Message
+			}
+			framework.Logf("waiting for ClusterOperator %s Upgradeable=True, current status=%s reason=%q message=%q",
+				machineConfigClusterOperator, status, lastCOReason, lastCOMessage)
+			return false, nil
+		}
+
+		cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		cvUpgradeable := v1helpers.FindStatusCondition(cv.Status.Conditions, configv1.OperatorUpgradeable)
+		if cvUpgradeable != nil {
+			lastCVReason = cvUpgradeable.Reason
+			lastCVMessage = cvUpgradeable.Message
+		}
+
+		if clusterVersionUpgradeableGloballyBlocked(oc, cv, cvUpgradeable) {
+			framework.Logf("ClusterOperator %s Upgradeable=True after pool recovery; ClusterVersion Upgradeable not required (feature set, CV overrides, or stale override reason present)",
+				machineConfigClusterOperator)
+			return true, nil
+		}
+
+		if cvUpgradeable != nil && cvUpgradeable.Status == configv1.ConditionTrue {
+			framework.Logf("ClusterOperator %s and ClusterVersion %q report Upgradeable=True after pool recovery",
+				machineConfigClusterOperator, cv.Status.Desired.Version)
+			return true, nil
+		}
+
+		if cvUpgradeable != nil && cvUpgradeable.Status == configv1.ConditionFalse &&
+			strings.Contains(cvUpgradeable.Message, machineConfigClusterOperator) {
+			framework.Logf("waiting for ClusterVersion Upgradeable to recover from machine-config block, current reason=%q message=%q",
+				cvUpgradeable.Reason, cvUpgradeable.Message)
+			return false, nil
+		}
+
+		status := configv1.ConditionUnknown
+		if cvUpgradeable != nil {
+			status = cvUpgradeable.Status
+		}
+		framework.Logf("ClusterOperator %s Upgradeable=True after pool recovery; ClusterVersion Upgradeable=%s reason=%q (not blocked by machine-config)",
+			machineConfigClusterOperator, status, lastCVReason)
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("cluster upgradeability did not recover within %s (co/machine-config reason=%q message=%q; clusterversion reason=%q message=%q): %w",
+			timeout, lastCOReason, lastCOMessage, lastCVReason, lastCVMessage, err)
+	}
+	return nil
+}
+
+// waitForNodeWorkerConfigRollback waits until the node is fully back on the worker pool rendered
+// config. This must complete before deleting the custom MCP; otherwise the node's currentConfig
+// can reference a rendered MC that no longer exists.
+func waitForNodeWorkerConfigRollback(ctx context.Context, oc *exutil.CLI, nodeName, poolName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			framework.Logf("Node %s no longer exists; skipping worker config rollback wait", nodeName)
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		rolledBack := currentConfig != "" &&
+			!strings.Contains(currentConfig, poolName) &&
+			currentConfig == desiredConfig
+		if !rolledBack {
+			framework.Logf("Node %s waiting for worker rollback: current=%q desired=%q",
+				nodeName, currentConfig, desiredConfig)
+		}
+		return rolledBack, nil
+	})
+}
+
+func verifyNodeReadyAndNotRollingOut(ctx context.Context, oc *exutil.CLI, nodeName string) error {
+	node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	ready := false
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+	if !ready {
+		return fmt.Errorf("node %s is not Ready", nodeName)
+	}
+
+	currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+	desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+	if currentConfig == "" || desiredConfig == "" {
+		return fmt.Errorf("node %s missing MCO config annotations (current=%q desired=%q)", nodeName, currentConfig, desiredConfig)
+	}
+	if currentConfig != desiredConfig {
+		return fmt.Errorf("node %s is rolling out MCO config (current=%q desired=%q)", nodeName, currentConfig, desiredConfig)
+	}
+
+	framework.Logf("Node %s is Ready and not rolling out MCO config (%s)", nodeName, currentConfig)
+	return nil
+}
+
+func findClusterConditionStatus(conditions []configv1.ClusterOperatorStatusCondition, condType configv1.ClusterStatusConditionType) configv1.ConditionStatus {
+	if c := v1helpers.FindStatusCondition(conditions, condType); c != nil {
+		return c.Status
+	}
+	return configv1.ConditionUnknown
+}
+
+func requireOSImageStreams(ctx context.Context, mcClient *machineconfigclient.Clientset) string {
+	osi, err := mcClient.MachineconfigurationV1().OSImageStreams().Get(ctx, "cluster", metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		g.Skip("OSImageStream API is not available; enable OSStreams feature gate on the cluster")
+	}
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	streamNames := make([]string, 0, len(osi.Status.AvailableStreams))
+	for _, s := range osi.Status.AvailableStreams {
+		streamNames = append(streamNames, s.Name)
+	}
+	o.Expect(streamNames).To(o.ContainElements(streamRHEL9, streamRHEL10),
+		"dual stream (rhel-9 and rhel-10) must be available")
+	framework.Logf("OSImageStream default=%q streams=%v", osi.Status.DefaultStream, streamNames)
+	return osi.Status.DefaultStream
+}
+
+func poolNodeRoleLabel(poolName string) string {
+	return fmt.Sprintf("node-role.kubernetes.io/%s", poolName)
+}
+
+func poolOperatorLabel(poolName string) string {
+	return fmt.Sprintf("pools.operator.machineconfiguration.openshift.io/%s", poolName)
+}
+
+func createRuncGuardPool(ctx context.Context, mcClient *machineconfigclient.Clientset) error {
+	if err := createRuncGuardMCP(ctx, mcClient); err != nil {
+		return err
+	}
+	return createRuncGuardCRC(ctx, mcClient)
+}
+
+func createRuncGuardMCP(ctx context.Context, mcClient *machineconfigclient.Clientset) error {
+	mcp := &machineconfigv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: runcRHCOS10GuardPool,
+			Labels: map[string]string{
+				poolOperatorLabel(runcRHCOS10GuardPool): "",
+			},
+		},
+		Spec: machineconfigv1.MachineConfigPoolSpec{
+			OSImageStream: machineconfigv1.OSImageStreamReference{Name: streamRHEL9},
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      machineconfigv1.MachineConfigRoleLabelKey,
+					Operator: metav1.LabelSelectorOpIn,
+					// worker is required by custom-machine-config-pool-selector VAP for custom pools.
+					Values: []string{"worker", runcRHCOS10GuardPool},
+				}},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					poolNodeRoleLabel(runcRHCOS10GuardPool): "",
+				},
+			},
+		},
+	}
+	_, err := mcClient.MachineconfigurationV1().MachineConfigPools().Create(ctx, mcp, metav1.CreateOptions{})
+	return err
+}
+
+func createRuncGuardCRC(ctx context.Context, mcClient *machineconfigclient.Clientset) error {
+	crc := &machineconfigv1.ContainerRuntimeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: runcGuardCRCName,
+		},
+		Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+			MachineConfigPoolSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					poolOperatorLabel(runcRHCOS10GuardPool): "",
+				},
+			},
+			ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+				DefaultRuntime: machineconfigv1.ContainerRuntimeDefaultRuntimeRunc,
+			},
+		},
+	}
+	_, err := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, crc, metav1.CreateOptions{})
+	return err
+}
+
+// waitForMCPWithLabeledNode waits for a pool to reach 1 ready machine while verifying the labeled
+// test node still exists. Fails fast if the node is replaced/deleted instead of polling until timeout.
+func waitForMCPWithLabeledNode(ctx context.Context, oc *exutil.CLI, mcClient *machineconfigclient.Clientset, poolName, nodeName string, timeout time.Duration) error {
+	framework.Logf("Waiting for MCP %s to adopt labeled node %s (timeout: %v)...", poolName, nodeName, timeout)
+
+	var lastReady, lastTotal int32
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("node %s was removed from the cluster during MCP rollout (likely MachineSet replacement)", nodeName)
+		}
+		if err != nil {
+			return false, err
+		}
+
+		roleLabel := poolNodeRoleLabel(poolName)
+		if _, ok := node.Labels[roleLabel]; !ok {
+			return false, fmt.Errorf("node %s lost label %q required by pool %s", nodeName, roleLabel, poolName)
+		}
+
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		lastReady = mcp.Status.ReadyMachineCount
+		lastTotal = mcp.Status.MachineCount
+
+		updated, degraded, renderDegraded, updating := mcpPoolConditions(mcp)
+		if degraded {
+			return false, fmt.Errorf("MachineConfigPool %s is degraded while waiting for node %s", poolName, nodeName)
+		}
+		if renderDegraded {
+			return false, fmt.Errorf("MachineConfigPool %s render is degraded while waiting for node %s", poolName, nodeName)
+		}
+
+		isReady := !updating && updated &&
+			mcp.Status.MachineCount == 1 &&
+			mcp.Status.ReadyMachineCount == mcp.Status.MachineCount
+		if isReady {
+			framework.Logf("MachineConfigPool %s is ready with node %s: %d/%d machines ready",
+				poolName, nodeName, lastReady, lastTotal)
+			return true, nil
+		}
+
+		framework.Logf("MachineConfigPool %s not ready yet for node %s: updating=%v degraded=%v renderDegraded=%v updated=%v machines=%d/%d",
+			poolName, nodeName, updating, degraded, renderDegraded, updated, lastReady, lastTotal)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("pool %s did not reach 1 ready machine with node %s (last machines=%d/%d): %w",
+			poolName, nodeName, lastReady, lastTotal, err)
+	}
+	return nil
+}
+
+func mcpPoolConditions(mcp *machineconfigv1.MachineConfigPool) (updated, degraded, renderDegraded, updating bool) {
+	for _, condition := range mcp.Status.Conditions {
+		switch condition.Type {
+		case machineconfigv1.MachineConfigPoolUpdating:
+			updating = condition.Status == corev1.ConditionTrue
+		case machineconfigv1.MachineConfigPoolDegraded:
+			degraded = condition.Status == corev1.ConditionTrue
+		case machineconfigv1.MachineConfigPoolRenderDegraded:
+			renderDegraded = condition.Status == corev1.ConditionTrue
+		case machineconfigv1.MachineConfigPoolUpdated:
+			updated = condition.Status == corev1.ConditionTrue
+		}
+	}
+	return updated, degraded, renderDegraded, updating
+}
+
+func labelFirstPureWorker(ctx context.Context, oc *exutil.CLI, poolName string) (string, error) {
+	workers, err := getPureWorkerNodesFromCluster(ctx, oc)
+	if err != nil {
+		return "", err
+	}
+
+	node := workers[0]
+	label := poolNodeRoleLabel(poolName)
+	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, label))
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		_, patchErr := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		return patchErr
+	})
+	if err != nil {
+		return "", err
+	}
+	framework.Logf("Labeled node %s with %s", node.Name, label)
+	return node.Name, nil
+}
+
+func removeNodeLabel(ctx context.Context, oc *exutil.CLI, nodeName, label string) error {
+	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, label))
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		_, patchErr := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+		if apierrors.IsNotFound(patchErr) {
+			return nil
+		}
+		return patchErr
+	})
+	return err
+}
+
+func setPoolOSImageStream(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName, stream string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		mcp.Spec.OSImageStream = machineconfigv1.OSImageStreamReference{Name: stream}
+		_, err = mcClient.MachineconfigurationV1().MachineConfigPools().Update(ctx, mcp, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func waitForMCPRenderDegraded(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		renderDegraded := false
+		var renderMessage string
+		for _, c := range mcp.Status.Conditions {
+			if c.Type == machineconfigv1.MachineConfigPoolRenderDegraded && c.Status == corev1.ConditionTrue {
+				renderDegraded = true
+				renderMessage = c.Message
+			}
+		}
+
+		// The runc guard is enforced in the render controller; RenderDegraded is the
+		// authoritative signal. Degraded may propagate later via the node controller.
+		if renderDegraded &&
+			strings.Contains(renderMessage, "runc") &&
+			strings.Contains(renderMessage, streamRHEL10) {
+			framework.Logf("MCP %s render degraded as expected: %s", poolName, renderMessage)
+			return true, nil
+		}
+
+		framework.Logf("MCP %s waiting for runc+rhel-10 guard: renderDegraded=%v message=%q",
+			poolName, renderDegraded, renderMessage)
+		return false, nil
+	})
+}
+
+func hasRuncRuntimeOnNode(oc *exutil.CLI, nodeName string) (bool, error) {
+	// Use a shell guard so missing drop-ins do not make oc debug exit non-zero (which spams test logs).
+	readDropIn := fmt.Sprintf("if [ -f %q ]; then grep default_runtime %q; fi", runcCRCDefaultRuntimePath, runcCRCDefaultRuntimePath)
+	out, err := ExecOnNodeWithChroot(oc, nodeName, "sh", "-c", readDropIn)
+	if err != nil {
+		if isTransientNodeDebugError(err) {
+			return false, err
+		}
+		return false, fmt.Errorf("failed to check runc runtime on node %s: %w", nodeName, err)
+	}
+	return strings.Contains(out, "runc"), nil
+}
+
+func expectRuncRuntimeOnNode(ctx context.Context, oc *exutil.CLI, nodeName string, timeout time.Duration) error {
+	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		hasRunc, err := hasRuncRuntimeOnNode(oc, nodeName)
+		if err != nil {
+			if isTransientNodeDebugError(err) {
+				framework.Logf("Transient debug error checking runc on node %s: %v", nodeName, err)
+				return false, nil
+			}
+			return false, err
+		}
+		if !hasRunc {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		if wait.Interrupted(err) {
+			return fmt.Errorf("node %s does not have runc as default runtime within %s", nodeName, timeout)
+		}
+		return err
+	}
+	return nil
+}
+
+func isTransientNodeDebugError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unable to create the debug pod") ||
+		strings.Contains(msg, "unable to attach to the debug pod") ||
+		strings.Contains(msg, "the node is currently unavailable") ||
+		strings.Contains(msg, "node is not ready")
+}
+
+// waitForPoolConfigRolloutAfterCRCRemoval waits for MCO to re-render the pool without the CRC and
+// roll the new config out to the labeled node. MCP can report ready with the old rendered config
+// briefly after CRC deletion; node annotations are the authoritative rollout signal.
+func waitForPoolConfigRolloutAfterCRCRemoval(ctx context.Context, oc *exutil.CLI, mcClient *machineconfigclient.Clientset, poolName, nodeName, priorRenderedConfig string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("node %s was removed from the cluster during pool re-render after CRC removal", nodeName)
+		}
+		if err != nil {
+			return false, err
+		}
+
+		currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		updated, degraded, renderDegraded, updating := mcpPoolConditions(mcp)
+		if degraded {
+			return false, fmt.Errorf("MachineConfigPool %s is degraded during post-CRC rollout", poolName)
+		}
+		if renderDegraded {
+			return false, fmt.Errorf("MachineConfigPool %s render is degraded during post-CRC rollout", poolName)
+		}
+
+		poolReady := !updating && updated &&
+			mcp.Status.MachineCount == 1 &&
+			mcp.Status.ReadyMachineCount == mcp.Status.MachineCount
+		rerendered := desiredConfig != "" && desiredConfig != priorRenderedConfig
+		synced := currentConfig != "" && currentConfig == desiredConfig
+
+		if poolReady && rerendered && synced {
+			framework.Logf("Node %s rolled out post-CRC rendered config %s (was %s)", nodeName, currentConfig, priorRenderedConfig)
+			return true, nil
+		}
+
+		framework.Logf("Node %s waiting for post-CRC pool rollout: current=%q desired=%q prior=%q poolReady=%v updating=%v",
+			nodeName, currentConfig, desiredConfig, priorRenderedConfig, poolReady, updating)
+		return false, nil
+	})
+}
+
+func waitForRuncRemovedFromNode(ctx context.Context, oc *exutil.CLI, nodeName string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("node %s was removed from the cluster while waiting for runc removal", nodeName)
+		}
+		if err != nil {
+			return false, err
+		}
+		if node.Spec.Unschedulable {
+			framework.Logf("Node %s is unschedulable while waiting for runc removal", nodeName)
+		}
+
+		hasRunc, err := hasRuncRuntimeOnNode(oc, nodeName)
+		if err != nil {
+			if isTransientNodeDebugError(err) {
+				framework.Logf("Node %s debug unavailable during runc removal rollout, retrying: %v", nodeName, err)
+				return false, nil
+			}
+			return false, err
+		}
+		if !hasRunc {
+			framework.Logf("Node %s no longer has runc default runtime configured", nodeName)
+			return true, nil
+		}
+		framework.Logf("Node %s still has runc default runtime configured", nodeName)
+		return false, nil
+	})
+}
+
+func waitForNodeRHELMajorVersion(ctx context.Context, oc *exutil.CLI, nodeName, expectedMajor string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 15*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		ready := false
+		for _, c := range node.Status.Conditions {
+			if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue {
+				ready = true
+				break
+			}
+		}
+		if !ready {
+			framework.Logf("Node %s waiting for Ready while rolling out RHCOS %s (current OSImage=%q)",
+				nodeName, expectedMajor, node.Status.NodeInfo.OSImage)
+			return false, nil
+		}
+
+		major, err := rhelMajorFromOSImage(node.Status.NodeInfo.OSImage)
+		if err != nil {
+			framework.Logf("Node %s waiting to parse RHCOS major version: %v (OSImage=%q)",
+				nodeName, err, node.Status.NodeInfo.OSImage)
+			return false, nil
+		}
+		if major != expectedMajor {
+			framework.Logf("Node %s waiting for RHCOS %s, currently RHCOS %s (OSImage=%q)",
+				nodeName, expectedMajor, major, node.Status.NodeInfo.OSImage)
+			return false, nil
+		}
+
+		currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
+		if currentConfig == "" || desiredConfig == "" || currentConfig != desiredConfig {
+			framework.Logf("Node %s on RHCOS %s but still rolling out MCO config (current=%q desired=%q)",
+				nodeName, major, currentConfig, desiredConfig)
+			return false, nil
+		}
+
+		framework.Logf("Node %s is Ready on RHCOS %s with stable MCO config %s", nodeName, major, currentConfig)
+		return true, nil
+	})
+}
+
+func assertCrunRuntimeOnNode(oc *exutil.CLI, nodeName string) error {
+	hasRunc, err := hasRuncRuntimeOnNode(oc, nodeName)
+	if err != nil {
+		if isTransientNodeDebugError(err) {
+			return fmt.Errorf("failed to verify runtime on node %s: debug unavailable: %w", nodeName, err)
+		}
+		return fmt.Errorf("failed to verify runtime on node %s: %w", nodeName, err)
+	}
+	if hasRunc {
+		return fmt.Errorf("node %s still has runc default runtime configured on RHCOS 10", nodeName)
+	}
+	// RHCOS 10 defaults to crun; absence of the CRC runc drop-in is sufficient.
+	return nil
+}
+
+func nodeRHELMajorVersion(ctx context.Context, oc *exutil.CLI, nodeName string) (string, error) {
+	node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	major, err := rhelMajorFromOSImage(node.Status.NodeInfo.OSImage)
+	if err != nil {
+		return "", fmt.Errorf("%w on node %s", err, nodeName)
+	}
+	return major, nil
+}
+
+func rhelMajorFromOSImage(osImage string) (string, error) {
+	switch {
+	case strings.Contains(osImage, "CoreOS 10."):
+		return "10", nil
+	case strings.Contains(osImage, "CoreOS 9."):
+		return "9", nil
+	}
+
+	if matches := rhelMajorOSImagePattern.FindStringSubmatch(osImage); len(matches) >= 2 {
+		return matches[1], nil
+	}
+	return "", fmt.Errorf("could not parse RHEL major version from OSImage %q", osImage)
+}
+
+func deleteContainerRuntimeConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, name string) error {
+	err := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func deleteMachineConfigPool(ctx context.Context, mcClient *machineconfigclient.Clientset, name string) error {
+	err := mcClient.MachineconfigurationV1().MachineConfigPools().Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/test/extended/node/runc_upgrade_cases.md
+++ b/test/extended/node/runc_upgrade_cases.md
@@ -1,0 +1,44 @@
+# runc RHCOS 10 Upgrade Guard Test Case
+
+## Overview
+
+Verify MCO blocks a pool move to RHCOS 10 when **runc** is configured via
+`ContainerRuntimeConfig`, and that the cluster reports `Upgradeable=False` without
+silently rebooting nodes onto an unsupported OS/runtime combination.
+
+## Test Environment
+
+- openshift 5.0 - 5.3 (dual stream cluster)
+- skip on Microshift, Hypershift, SNO
+
+## Test Implementation
+
+Automated in [`test/extended/node/runc_upgrade_cases.go`](runc_upgrade_cases.go)
+
+- **Suite:** `[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard`
+- **Case:** `blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime`
+- **Lifecycle:** `ote.Informing()`
+
+Run:
+
+```bash
+cd origin && make WHAT=cmd/openshift-tests
+./openshift-tests run-test \
+  "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime"
+```
+
+Suggested CI: `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-disruptive-longrunning-techpreview-1of2` (with MCO payload)
+
+## Notes
+
+- `RenderDegraded` is the authoritative guard signal; `Degraded` may appear shortly after.
+- CO/CVO `Degraded=True` can take ~30 minutes on a stuck pool; the test asserts
+  `Upgradeable=False` within 5 minutes and recovers before delayed Degraded propagation.
+- Typical runtime: ~15–30 minutes when optional RHCOS 10 recovery runs on 5.0 clusters.
+- MCP is pinned to `rhel-9` at creation so it does not inherit cluster default `rhel-10`.
+- Runtime is configured via **ContainerRuntimeConfig** (supported path), not a hand-crafted MC drop-in.
+
+## References
+
+- [openshift/enhancements#2032](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/block-runc-on-rhcos10-upgrade.md)
+- [OCPSTRAT-3154](https://issues.redhat.com/browse/OCPSTRAT-3154) — runc deprecation warning (separate)


### PR DESCRIPTION
This PR adds an end-to-end test that validates MCO's guard blocking a RHCOS 9→10 OS stream transition when a MachineConfigPool has runc configured as the default container runtime. Also this PR contains runc_upgrade_cases.md file which contains the Test Plan with all the required meta data.

**What the test does**
- Creates an isolated MachineConfigPool (runc-rhcos10-guard) pinned to spec.osImageStream: rhel-9 and a runc CRI-O drop-in MachineConfig
- Labels one pure worker into the pool and waits for a healthy baseline rollout
- Verifies the node is on RHCOS 9 with runc as the default runtime
- Patches the pool's osImageStream to rhel-10
- Asserts the guard fires: MCP Degraded=True + RenderDegraded=True with a message referencing runc and rhel-10
- Confirms the node remains on RHCOS 9 with runc (rollout was blocked)
- Cleans up: removes node label, waits for pool to drain to zero machines, deletes MC and MCP
- Skips on: MicroShift, Hypershift

MCO change PR: https://github.com/openshift/machine-config-operator/pull/5891

Locally tested with my custom mco image against the above mco PR and it got passed:
`./openshift-tests run-test "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive] runc RHCOS 10 upgrade guard blocks upgrade of RHCOS 9 to 10 when default runtime is runc"`

```  Running Suite:  - /Users/asahay/rhcos/origin
  ============================================
  Random Seed: 1781098173 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive] runc RHCOS 10 upgrade guard blocks upgrade of RHCOS 9 to 10 when ContainerRuntimeConfig sets default runtime to runc
  github.com/openshift/origin/test/extended/node/runc_upgrade_cases.go:74
    STEP: Creating a kubernetes client @ 06/10/26 18:59:38.429
  I0610 18:59:38.430912   28909 discovery.go:214] Invalidating discovery information
  I0610 18:59:41.287958 28909 client.go:293] configPath is now "/var/folders/95/wktd6vvd57g5hgy7prd1sgmh0000gn/T/configfile3340602746"
  I0610 18:59:41.288021 28909 client.go:368] The user is now "e2e-test-runc-rhcos10-guard-l4h9r-user"
  I0610 18:59:41.288039 28909 client.go:370] Creating project "e2e-test-runc-rhcos10-guard-l4h9r"
  I0610 18:59:41.596911 28909 client.go:378] Waiting on permissions in project "e2e-test-runc-rhcos10-guard-l4h9r" ...
  I0610 18:59:42.545306 28909 client.go:407] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0610 18:59:42.781600 28909 client.go:422] Waiting for ServiceAccount "default" to be provisioned...
  I0610 18:59:43.358224 28909 client.go:422] Waiting for ServiceAccount "builder" to be provisioned...
  I0610 18:59:43.927713 28909 client.go:422] Waiting for ServiceAccount "deployer" to be provisioned...
  I0610 18:59:44.500341 28909 client.go:432] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0610 18:59:44.739219 28909 client.go:432] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0610 18:59:44.973297 28909 client.go:432] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0610 18:59:46.166253 28909 client.go:469] Project "e2e-test-runc-rhcos10-guard-l4h9r" has been fully provisioned.
  I0610 18:59:46.170372 28909 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0610 18:59:46.405904 28909 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  I0610 18:59:47.109390 28909 runc_upgrade_cases.go:316] OSImageStream default="rhel-10" streams=[rhel-10 rhel-9]
    STEP: Labeling one worker into the custom pool @ 06/10/26 18:59:47.109
  I0610 18:59:47.819865 28909 runc_upgrade_cases.go:398] Labeled node ip-10-0-52-146.us-east-2.compute.internal with node-role.kubernetes.io/runc-rhcos10-guard
    STEP: Creating custom MachineConfigPool pinned to rhel-9 @ 06/10/26 18:59:47.819
    STEP: Creating ContainerRuntimeConfig that sets default runtime to runc for the custom pool @ 06/10/26 18:59:48.057
    STEP: Waiting for node to join the custom pool @ 06/10/26 18:59:48.296
  I0610 18:59:48.529168 28909 runc_upgrade_cases.go:429] MCP runc-rhcos10-guard waiting for machine count 1 (current 0)
  I0610 18:59:58.532087 28909 runc_upgrade_cases.go:426] MCP runc-rhcos10-guard machine count reached 1
    STEP: Waiting for pool rollout on rhel-9 with runc @ 06/10/26 18:59:58.532
  I0610 18:59:58.533212 28909 node_utils.go:522] Waiting for MCP runc-rhcos10-guard to be ready (timeout: 30m0s)...
  I0610 18:59:58.767138 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:08.771281 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:18.767127 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:28.770810 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:38.766299 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:48.768751 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:00:58.768087 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:08.769373 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:18.771215 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:28.769220 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:38.768343 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:48.767514 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:01:58.803288 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:02:08.772007 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:02:18.768793 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:02:28.770728 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:02:38.768422 28909 node_utils.go:564] MachineConfigPool runc-rhcos10-guard not ready yet: updating=true, ready=false, machines=0/1
  I0610 19:02:48.769024 28909 node_utils.go:561] MachineConfigPool runc-rhcos10-guard is ready: 1/1 machines ready
    STEP: Checking default runtime is runc on RHCOS 9 @ 06/10/26 19:02:48.769
    STEP: Upgrading RHCOS version to RHCOS 10 via osImageStream @ 06/10/26 19:02:55.544
  I0610 19:02:56.256629 28909 runc_upgrade_cases.go:512] MCP runc-rhcos10-guard waiting for runc+rhel-10 guard: degraded=false renderDegraded=false message=""
  I0610 19:03:06.256954 28909 runc_upgrade_cases.go:508] MCP runc-rhcos10-guard is degraded as expected: Failed to render configuration for pool runc-rhcos10-guard: MachineConfigPool runc-rhcos10-guard targets OS image stream "rhel-10" where runc is not available. To unblock, migrate to crun by removing any ContainerRuntimeConfig that sets defaultRuntime to runc, and removing any MachineConfig that sets default_runtime = "runc" in CRI-O configuration under /etc/crio/crio.conf.d/
    STEP: Verifying cluster upgrade is blocked via CO and CVO Upgradeable=False @ 06/10/26 19:03:06.257
  I0610 19:03:06.493276 28909 runc_upgrade_cases.go:165] waiting for ClusterOperator machine-config Upgradeable=False, current status=True
  I0610 19:03:16.969176 28909 runc_upgrade_cases.go:206] ClusterOperator machine-config reports Upgradeable=False (reason DegradedPool); ClusterVersion already Upgradeable=False on a non-upgradeable feature set
    STEP: Verifying node remains ready, not rolling out, on RHCOS 9 with runc after guard blocks rollout @ 06/10/26 19:03:16.969
  I0610 19:03:17.204793 28909 runc_upgrade_cases.go:269] Node ip-10-0-52-146.us-east-2.compute.internal is Ready and not rolling out MCO config (rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46)
    STEP: Recovering pool by setting osImageStream back to rhel-9 @ 06/10/26 19:03:23.628
  I0610 19:03:24.347021 28909 runc_upgrade_cases.go:476] MCP runc-rhcos10-guard recovery in progress: degraded=true renderDegraded=true updating=false updated=true machines=1/1
  I0610 19:03:34.346099 28909 runc_upgrade_cases.go:476] MCP runc-rhcos10-guard recovery in progress: degraded=true renderDegraded=false updating=false updated=true machines=1/1
  I0610 19:03:44.345580 28909 runc_upgrade_cases.go:474] MCP runc-rhcos10-guard recovered: 1/1 machines ready
    STEP: Verifying node remains ready, not rolling out, on RHCOS 9 with runc after recovery @ 06/10/26 19:03:44.345
  I0610 19:03:44.581161 28909 runc_upgrade_cases.go:269] Node ip-10-0-52-146.us-east-2.compute.internal is Ready and not rolling out MCO config (rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46)
  I0610 19:03:50.946796 28909 client.go:689] Deleted {user.openshift.io/v1, Resource=users  e2e-test-runc-rhcos10-guard-l4h9r-user}, err: <nil>
  I0610 19:03:51.186287 28909 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-runc-rhcos10-guard-l4h9r}, err: <nil>
  I0610 19:03:51.427324 28909 client.go:689] Deleted {oauth.openshift.io/v1, Resource=oauthaccesstokens  sha256~tWa-UUGD9Smz2iuTtKnolopZ0pQW3t2BUnfMF0Q1KHA}, err: <nil>
  I0610 19:03:52.607144 28909 runc_upgrade_cases.go:429] MCP runc-rhcos10-guard waiting for machine count 0 (current 1)
  I0610 19:04:02.609102 28909 runc_upgrade_cases.go:426] MCP runc-rhcos10-guard machine count reached 0
  I0610 19:04:02.842461 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:04:13.077751 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:04:23.074983 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:04:33.071528 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:04:43.079118 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:04:53.074058 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:03.077638 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:13.074225 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:23.073158 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:33.073196 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:43.074853 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:05:53.075259 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:06:03.076921 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:06:13.075494 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:06:23.074745 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:06:33.077765 28909 runc_upgrade_cases.go:236] Node ip-10-0-52-146.us-east-2.compute.internal waiting for worker rollback: current="rendered-runc-rhcos10-guard-0fc3ccf9f7cf9db328bdd5ae8b38ef46" desired="rendered-worker-89ea806348f73bebafe0707724fde161"
  I0610 19:06:43.337398 28909 node_utils.go:522] Waiting for MCP worker to be ready (timeout: 30m0s)...
  I0610 19:06:43.574108 28909 node_utils.go:561] MachineConfigPool worker is ready: 3/3 machines ready
    STEP: Destroying namespace "e2e-test-runc-rhcos10-guard-l4h9r" for this suite. @ 06/10/26 19:06:43.575
  • [425.409 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 425.411 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive] runc RHCOS 10 upgrade guard blocks upgrade of RHCOS 9 to 10 when ContainerRuntimeConfig sets default runtime to runc",
    "lifecycle": "blocking",
    "duration": 425411,
    "startTime": "2026-06-10 13:29:38.401773 UTC",
    "endTime": "2026-06-10 13:36:43.813577 UTC",
    "result": "passed",
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a disruptive serial e2e test suite validating that an MCO upgrade from RHCOS 9 to 10 is blocked when the cluster’s default container runtime is set to `runc`, including pool-scoped degraded/render-degraded signals and verification that the node stays on the expected OS/runtime throughout and after recovery.

* **Documentation**
  * Added/updated an end-to-end test plan describing prerequisites, skip conditions, step flow, pass/fail criteria, and cleanup behavior for the runc RHCOS 9→10 upgrade guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->