### PR TITLE
CNTRLPLANE-3518: pkg/testsuites: add parent kms test suite

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -277,6 +277,21 @@ var staticSuites = []ginkgo.TestSuite{
 		},
 	},
 	{
+		Name: "openshift/kms",
+		Description: templates.LongDesc(`
+		Run KMS encryption tests for certifying KMS plugin implementations.
+		This suite aggregates KMS tests from all API server operators (kube-apiserver,
+		openshift-apiserver, etc.) to provide a comprehensive validation of KMS plugin
+		functionality across the entire cluster.
+		`),
+		Qualifiers: []string{
+			`!name.contains("[Flaky]") && !name.contains("[Disabled:")`,
+		},
+		Parallelism:                1,
+		TestTimeout:                2 * time.Hour,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
+	{
 		Name: "openshift/network/ipsec",
 		Description: templates.LongDesc(`
 		This test suite performs IPsec e2e tests covering control plane and data plane for east west and north south traffic scenarios.


### PR DESCRIPTION
add parent kms test suite in order to make it easier for plugin vendors to run all kms tests with a single command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new OpenShift KMS test suite aggregating KMS encryption end-to-end tests.
  * Runs sequentially (parallelism = 1) with an extended 240-minute timeout.
  * Marked as disruptive to cluster stability to reflect its scope.
  * Qualifier filter excludes tests tagged as [Flaky] or [Disabled:].
  * Includes metadata to ensure consistent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->