### PR TITLE
OCPSTRAT-3036: Temporarily skip API LBs follow /readyz of kube-apiserver and don't send request early test

### DIFF
--- a/pkg/test/extensions/disabled_tests.go
+++ b/pkg/test/extensions/disabled_tests.go
@@ -46,6 +46,9 @@ func filterOutDisabledSpecs(specs et.ExtensionTestSpecs) et.ExtensionTestSpecs {
 
 			// https://issues.redhat.com/browse/OCPBUGS-37799
 			"[sig-builds][Feature:Builds][Slow] can use private repositories as build input build using an HTTP token should be able to clone source code via an HTTP token [apigroup:build.openshift.io]",
+
+			// https://redhat.atlassian.net/browse/OCPBUGS-86789
+			"[sig-api-machinery][Feature:APIServer][Late] API LBs follow /readyz of kube-apiserver and don't send request early",
 		},
 		// tests that are known flaky
 		"Flaky": {


### PR DESCRIPTION
The "API LBs follow /readyz of kube-apiserver and don't send request early" test is temporarily skipped while investigating intermittent failures during the 1.36 rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test case entry to track and handle a known issue (OCPBUGS-86789) in the APIServer component testing suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->