### PR TITLE
[release-4.21] OCPBUGS-88328: Fix Pod.Create() to use --local flag for template proc…

### DIFF
--- a/test/extended/util/compat_otp/pods.go
+++ b/test/extended/util/compat_otp/pods.go
@@ -152,7 +152,9 @@ type Pod struct {
 // The pod name parameter must be NAME in the template file
 func (pod *Pod) Create(oc *exutil.CLI) {
 	e2e.Logf("Creating pod: %s", pod.Name)
-	params := []string{"--ignore-unknown-parameters=true", "-f", pod.Template, "-p", "NAME=" + pod.Name}
+	// Use --local to process template locally, avoiding kubeconfig context namespace pollution
+	// from other tests that may have changed the current context to a different/non-existent namespace
+	params := []string{"--local", "--ignore-unknown-parameters=true", "-f", pod.Template, "-p", "NAME=" + pod.Name}
 	CreateNsResourceFromTemplate(oc, pod.Namespace, append(params, pod.Parameters...)...)
 	AssertPodToBeReady(oc, pod.Name, pod.Namespace)
 }


### PR DESCRIPTION
…essing

Use --local flag when processing pod templates in compat_otp.Pod.Create() to avoid kubeconfig context namespace pollution from other tests.

Problem:
When multiple tests run in sequence (especially in Prow rehearsal jobs), a test may change the kubeconfig's current context to a different namespace. The 'oc process' command validates namespace existence using the kubeconfig context BEFORE processing template parameters, causing failures when:
1. Previous test sets context to namespace N1
2. Namespace N1 gets deleted after that test completes
3. Current test calls Pod.Create() with namespace N2
4. 'oc process' tries to validate N1 (from kubeconfig context)
5. Validation fails because N1 no longer exists

Example error from OCP-10662 test:
  Error running oc process ... -p NAMESPACE=e2e-test-default-bhtjm:
  error: unable to process template
    namespaces "e2e-test-olm-all-o9bvjlxg-7qwkb" not found

Solution:
The --local flag makes 'oc process' work client-side without contacting the API server, eliminating namespace validation and kubeconfig context dependency. This is safe for Pod.Create() since:
- Only 5 tests use compat_otp.Pod (all simple pod templates)
- Pod templates use basic parameter substitution (no server-side features)
- Local processing produces identical output to server-side processing
- Tested with the actual failing template - works correctly

Impact:
- Fixes OCP-10662 test failure in rehearsal jobs
- Prevents future kubeconfig pollution issues for pod creation
- No functional changes to existing tests (output identical)
- Low risk (only affects 5 tests using compat_otp.Pod)

(cherry picked from commit a309500ddfd42f06f5c0cc893d4ea761a257b15b)

--
https://redhat.atlassian.net/browse/OCPQE-32057 LEVEL0-High-10662 fails in CI: Missing --local flag causes template processing failure due to kubeconfig context pollution