### PR TITLE
skip disruption monitor cases on kms sno jobs

### DIFF
--- a/pkg/monitortestlibrary/disruptionfilter/filter.go
+++ b/pkg/monitortestlibrary/disruptionfilter/filter.go
@@ -7,10 +7,19 @@ import (
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 )
 
+const (
+	kmsEncryptionFeatureGateTag = "[OCPFeatureGate:KMSEncryption]"
+	kmsTestIntervalBuffer       = 5 * time.Minute
+)
+
 // FilterOutKnownDisruptiveTestIntervals removes disruption intervals that overlap with
 // known-disruptive serial tests like NoExecuteTaintManager, which applies NoExecute taints
 // to worker nodes where its test pods land, evicting pods and causing expected unavailability.
-func FilterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals) monitorapi.Intervals {
+//
+// On SNO jobs that run OCP KMS encryption tests, disruption overlapping those tests is
+// also removed. KMS tests trigger kube-apiserver rollouts that cascade to oauth and
+// apiserver backends.
+func FilterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals, topology string) monitorapi.Intervals {
 	knownDisruptiveTests := intervals.Filter(func(i monitorapi.Interval) bool {
 		if i.Source != monitorapi.SourceE2ETest {
 			return false
@@ -18,6 +27,10 @@ func FilterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals) monit
 		testName := i.Locator.Keys[monitorapi.LocatorE2ETestKey]
 		return strings.Contains(testName, "NoExecuteTaintManager")
 	})
+
+	if topology == "single" && kmsEncryptionTestsDetected(intervals) {
+		knownDisruptiveTests = append(knownDisruptiveTests, bufferedKMSEncryptionTestIntervals(intervals)...)
+	}
 
 	if len(knownDisruptiveTests) == 0 {
 		return intervals
@@ -31,6 +44,28 @@ func FilterOutKnownDisruptiveTestIntervals(intervals monitorapi.Intervals) monit
 		}
 		return true
 	})
+}
+
+func kmsEncryptionTestsDetected(intervals monitorapi.Intervals) bool {
+	return len(kmsEncryptionTestIntervals(intervals)) > 0
+}
+
+func kmsEncryptionTestIntervals(intervals monitorapi.Intervals) monitorapi.Intervals {
+	return intervals.Filter(func(i monitorapi.Interval) bool {
+		if i.Source != monitorapi.SourceE2ETest {
+			return false
+		}
+		return strings.Contains(i.Locator.Keys[monitorapi.LocatorE2ETestKey], kmsEncryptionFeatureGateTag)
+	})
+}
+
+func bufferedKMSEncryptionTestIntervals(intervals monitorapi.Intervals) monitorapi.Intervals {
+	kmsTests := kmsEncryptionTestIntervals(intervals)
+	for i := range kmsTests {
+		kmsTests[i].From = kmsTests[i].From.Add(-kmsTestIntervalBuffer)
+		kmsTests[i].To = kmsTests[i].To.Add(kmsTestIntervalBuffer)
+	}
+	return kmsTests
 }
 
 func intervalsOverlap(interval1, interval2 monitorapi.Interval) bool {

--- a/pkg/monitortestlibrary/disruptionfilter/filter_test.go
+++ b/pkg/monitortestlibrary/disruptionfilter/filter_test.go
@@ -1,0 +1,114 @@
+package disruptionfilter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+)
+
+func TestFilterOutKnownDisruptiveTestIntervals_KMSEncryptionOnSNO(t *testing.T) {
+	now := time.Now()
+	kmsTest := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Level: monitorapi.Info,
+			Locator: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeE2ETest,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorE2ETestKey: "[sig-api-machinery][OCPFeatureGate:KMSEncryption] test encryption",
+				},
+			},
+		},
+		Source: monitorapi.SourceE2ETest,
+		From:   now,
+		To:     now.Add(30 * time.Minute),
+	}
+	disruptionDuringKMS := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Level: monitorapi.Error,
+			Locator: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeDisruption,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorBackendDisruptionNameKey: "ingress-to-oauth-server-new-connections",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: monitorapi.DisruptionBeganEventReason,
+			},
+		},
+		Source: monitorapi.SourceDisruption,
+		From:   now.Add(5 * time.Minute),
+		To:     now.Add(6 * time.Minute),
+	}
+
+	filtered := FilterOutKnownDisruptiveTestIntervals(monitorapi.Intervals{kmsTest, disruptionDuringKMS}, "single")
+	if len(filtered) != 1 {
+		t.Fatalf("expected disruption during KMS test to be filtered on SNO, got %d intervals", len(filtered))
+	}
+}
+
+func TestFilterOutKnownDisruptiveTestIntervals_NotFilteredOnSNOWithoutKMSTests(t *testing.T) {
+	now := time.Now()
+	disruption := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Level: monitorapi.Error,
+			Locator: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeDisruption,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorBackendDisruptionNameKey: "ingress-to-oauth-server-new-connections",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: monitorapi.DisruptionBeganEventReason,
+			},
+		},
+		Source: monitorapi.SourceDisruption,
+		From:   now,
+		To:     now.Add(time.Minute),
+	}
+
+	filtered := FilterOutKnownDisruptiveTestIntervals(monitorapi.Intervals{disruption}, "single")
+	if len(filtered) != 1 {
+		t.Fatalf("expected disruption to remain on SNO without KMS tests, got %d intervals", len(filtered))
+	}
+}
+
+func TestFilterOutKnownDisruptiveTestIntervals_KMSEncryptionNotFilteredOnHA(t *testing.T) {
+	now := time.Now()
+	kmsTest := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Level: monitorapi.Info,
+			Locator: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeE2ETest,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorE2ETestKey: "[sig-api-machinery][OCPFeatureGate:KMSEncryption] test encryption",
+				},
+			},
+		},
+		Source: monitorapi.SourceE2ETest,
+		From:   now,
+		To:     now.Add(30 * time.Minute),
+	}
+	disruptionDuringKMS := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Level: monitorapi.Error,
+			Locator: monitorapi.Locator{
+				Type: monitorapi.LocatorTypeDisruption,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorBackendDisruptionNameKey: "cache-kube-api-reused-connections",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: monitorapi.DisruptionBeganEventReason,
+			},
+		},
+		Source: monitorapi.SourceDisruption,
+		From:   now.Add(5 * time.Minute),
+		To:     now.Add(6 * time.Minute),
+	}
+
+	filtered := FilterOutKnownDisruptiveTestIntervals(monitorapi.Intervals{kmsTest, disruptionDuringKMS}, "ha")
+	if len(filtered) != 2 {
+		t.Fatalf("expected KMS disruption to remain on HA, got %d intervals", len(filtered))
+	}
+}

--- a/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
+++ b/pkg/monitortestlibrary/disruptionlibrary/disruption_invariant_adapter.go
@@ -251,7 +251,7 @@ func (w *Availability) EvaluateTestsFromConstructedIntervals(ctx context.Context
 	}
 
 	// Filter out disruption that occurred during known-disruptive serial tests
-	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals)
+	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals, jobType.Topology)
 
 	newConnectionJunit, err := w.junitForNewConnections(ctx, filteredIntervals, jobType)
 	if err != nil {

--- a/pkg/monitortests/testframework/disruptionserializer/monitortest.go
+++ b/pkg/monitortests/testframework/disruptionserializer/monitortest.go
@@ -45,7 +45,7 @@ func (*disruptionSummarySerializer) EvaluateTestsFromConstructedIntervals(ctx co
 }
 
 func (*disruptionSummarySerializer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals)
+	filteredIntervals := disruptionfilter.FilterOutKnownDisruptiveTestIntervals(finalIntervals, "")
 	backendDisruption := computeDisruptionData(filteredIntervals)
 	return writeDisruptionData(filepath.Join(storageDir, fmt.Sprintf("backend-disruption%s.json", timeSuffix)), backendDisruption)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved disruption interval filtering to account for cluster topology; KMS encryption test intervals are now properly excluded from disruption reporting in single-node clusters.

* **Tests**
  * Added test coverage for topology-aware disruption filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->