### PR TITLE
[dnm] Test: validate CodeRabbit request-changes workflow

### DIFF
--- a/test/extended/pods/dynamic_pod_name.go
+++ b/test/extended/pods/dynamic_pod_name.go
@@ -1,0 +1,49 @@
+package pods
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+)
+
+var _ = Describe("[sig-node] Pod lifecycle", func() {
+	oc := exutil.NewCLI("pod-lifecycle")
+
+	It(fmt.Sprintf("should create pod %s and verify it starts", "test-pod-"+oc.Namespace()), func() {
+		podName := "test-pod-" + oc.Namespace()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podName,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "test",
+						Image:   image.ShellImage(),
+						Command: []string{"/bin/sh", "-c", "echo hello && sleep 10"},
+					},
+				},
+				RestartPolicy: corev1.RestartPolicyNever,
+			},
+		}
+
+		_, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Create(context.Background(), pod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() corev1.PodPhase {
+			p, err := oc.KubeClient().CoreV1().Pods(oc.Namespace()).Get(context.Background(), podName, metav1.GetOptions{})
+			if err != nil {
+				return corev1.PodUnknown
+			}
+			return p.Status.Phase
+		}, "60s", "5s").Should(Equal(corev1.PodSucceeded))
+	})
+})


### PR DESCRIPTION
## Summary

This PR deliberately introduces a test with a dynamic pod name in the Ginkgo test title to validate that CodeRabbit's `request_changes_workflow` is working correctly (enabled in #31047).

The test violates the "Stable and Deterministic Test Names" rule from the [org CodeRabbit config](https://github.com/openshift/coderabbit/blob/main/.coderabbit.yaml) by using `fmt.Sprintf` with a namespace-derived pod name in the `It()` description.

**Expected:** CodeRabbit should post a "Changes Requested" review on this PR.

This PR should NOT be merged — it exists only to validate the CodeRabbit integration.

## What triggers the review

```go
It(fmt.Sprintf("should create pod %s and verify it starts", "test-pod-"+oc.Namespace()), func() {
```

This embeds a dynamic namespace value in the test title, which the CodeRabbit rule explicitly flags as an error.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Kubernetes Pod lifecycle management, including validation of Pod creation and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->