### PR TITLE
AGENT-1535: Increase the time checking for IRI SCC uid-range

### DIFF
--- a/test/extended/internalreleaseimage/helper.go
+++ b/test/extended/internalreleaseimage/helper.go
@@ -179,7 +179,7 @@ func (h *IRITestHelper) CreateSimpleNamespace() string {
 
 	// Wait for the namespace controller to set the SCC uid-range annotation,
 	// which is required by the admission controller before pods can be created.
-	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, 60*time.Second, true, func(ctx context.Context) (bool, error) {
 		updatedNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Get(ctx, createdNs.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Increase the time to check for the SCC uid-range annotation to appear in the InternalReleaseImage test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout configuration for namespace annotation verification in test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->