### PR TITLE
Revert "Temporarily map the glibc-dns-testing image while we're paylo…

### DIFF
--- a/pkg/cmd/openshift-tests/images/images_command.go
+++ b/pkg/cmd/openshift-tests/images/images_command.go
@@ -101,12 +101,6 @@ func NewImagesCommand() *cobra.Command {
 				fmt.Fprintln(os.Stdout, line)
 			}
 
-			// TODO(k8s-1.36): remove this when k8s 1.36 lands
-			injectedLines := injectNewImages(ref, !o.Upstream)
-			for _, line := range injectedLines {
-				fmt.Fprintln(os.Stdout, line)
-			}
-
 			return nil
 		},
 	}
@@ -298,29 +292,4 @@ func setLogLevel(level string) error {
 	}
 	logrus.SetLevel(lvl)
 	return nil
-}
-
-// TODO(k8s-1.36): remove this when k8s 1.36 lands
-func injectNewImages(ref reference.DockerImageReference, mirrored bool) []string {
-	target := ref.Exact()
-
-	images := map[string]string{
-		// glibc-dns-testing:2.0.0 replaces jessie-dnsutils:1.7 in k8s 1.36,
-		// but the tests binary still references the old name
-		"registry.k8s.io/e2e-test-images/glibc-dns-testing:2.0.0": "e2e-11-registry-k8s-io-e2e-test-images-glibc-dns-testing-2-0-0-doWtNeL-8jnuqU8E",
-	}
-
-	lines := []string{}
-	for originalImage, mirrorTag := range images {
-		if mirrored {
-			lines = append(lines, fmt.Sprintf("%s:%s %s:%s",
-				imagesetup.DefaultTestImageMirrorLocation, mirrorTag,
-				target, mirrorTag))
-		} else {
-			lines = append(lines, fmt.Sprintf("%s %s:%s",
-				originalImage, target, mirrorTag))
-		}
-	}
-	sort.Strings(lines)
-	return lines
 }

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -56,4 +56,3 @@ registry.k8s.io/sig-storage/hostpathplugin:v1.17.0 quay.io/openshift/community-e
 registry.k8s.io/sig-storage/livenessprobe:v2.17.0 quay.io/openshift/community-e2e-images:e2e-33-registry-k8s-io-sig-storage-livenessprobe-v2-17-0-Xad6CG72djzxptGw
 registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8 quay.io/openshift/community-e2e-images:e2e-14-registry-k8s-io-sig-storage-nfs-provisioner-v4-0-8-W5pbwDbNliDm1x4k
 registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0 quay.io/openshift/community-e2e-images:e2e-29-registry-k8s-io-sig-storage-volume-data-source-validator-v1-0-0-pJwTeQGTDmAV8753
-registry.k8s.io/e2e-test-images/glibc-dns-testing:2.0.0 quay.io/openshift/community-e2e-images:e2e-11-registry-k8s-io-e2e-test-images-glibc-dns-testing-2-0-0-doWtNeL-8jnuqU8E


### PR DESCRIPTION
…ad testing 1.36 before the openshift/origin PR has merged."

This reverts commit 64e79b7fa016343d183347757009a8670a68b9ba (#30687)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed hardcoded mirror mappings for glibc-dns-testing image from the `oc image mirror` command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->