### PR TITLE
CONSOLE-5188: remove console exceptions

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -76,10 +76,7 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 					condition.Reason == "APIServices_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23746"
 			}
-			if operator == "console" && condition.Reason == "Deployment_InsufficientReplicas" {
-				return "https://issues.redhat.com/browse/OCPBUGS-67134"
-			}
-			if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
+if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
 			return ""
@@ -96,9 +93,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			}
 			if operator == "kube-scheduler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663"
-			}
-			if operator == "console" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
 			return ""
 		}
@@ -279,10 +273,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				} else {
 					return ""
 				}
-			case "console":
-				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-					return "https://issues.redhat.com/browse/OCPBUGS-38676"
-				}
 			case "kube-apiserver":
 				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 					return "https://issues.redhat.com/browse/OCPBUGS-38661"
@@ -304,10 +294,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 		case "cloud-controller-manager":
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue && condition.Reason == "SyncingFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42837"
-			}
-		case "console":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
@@ -717,10 +703,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 				if isTNFJobClusterOperatorReason(reason) {
 					return "clusteroperator/etcd may report Progressing=True while a TNF batch Job is running during DualReplica topology upgrades (CEO JobRunning condition reasons)"
 				}
-			}
-		case "console":
-			if reason == "SyncLoopRefresh_InProgress" {
-				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
 		case "ingress":
 			if reason == "Reconciling" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -106,9 +106,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 					condition.Reason == "APIServices_Error") {
 				return "https://issues.redhat.com/browse/OCPBUGS-23746"
 			}
-			if operator == "console" && condition.Reason == "Deployment_InsufficientReplicas" {
-				return "https://issues.redhat.com/browse/OCPBUGS-67134"
-			}
 			if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
@@ -142,9 +139,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			}
 			if operator == "kube-scheduler" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38663"
-			}
-			if operator == "console" {
-				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
 			return ""
 		}
@@ -365,10 +359,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				} else {
 					return ""
 				}
-			case "console":
-				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-					return "https://issues.redhat.com/browse/OCPBUGS-38676"
-				}
 			case "kube-apiserver":
 				if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
 					return "https://issues.redhat.com/browse/OCPBUGS-38661"
@@ -386,10 +376,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if isTwoNode && condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
 				strings.Contains(condition.Reason, "OAuthServerDeployment_UnavailablePod") {
 				return "authentication may report Degraded while oauth-openshift pods roll out during DualReplica disruptive upgrades"
-			}
-		case "console":
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
-				return "https://issues.redhat.com/browse/OCPBUGS-38676"
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
@@ -809,10 +795,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if isTwoNode && isNodeCADaemonProgressingReason(reason) &&
 				overlapsNodeUpdate(eventInterval, nodeUpdates, nodeUpdateNodeCADaemonGrace) {
 				return "clusteroperator/image-registry may report Progressing=True while the node-ca DaemonSet rolls during a DualReplica node update while machine-config is progressing (NodeCADaemonProgressing)"
-			}
-		case "console":
-			if reason == "SyncLoopRefresh_InProgress" {
-				return "https://issues.redhat.com/browse/OCPBUGS-64688"
 			}
 		case "ingress":
 			if reason == "Reconciling" {


### PR DESCRIPTION
### Summary
Remove temporary console exception blocks from `legacycvomonitortests/operators.go` 

**Depends on the following PRs:**
3 blocks excepted console from Degraded=True failures ([OCPBUGS-38676](https://issues.redhat.com/browse/OCPBUGS-38676), fixed in [console-operator PR #1164](https://github.com/openshift/console-operator/pull/1164))
1 block excepted console from Progressing=True during node reboots ([OCPBUGS-64688](https://issues.redhat.com/browse/OCPBUGS-64688), fixed in [console-operator PR #1169](https://github.com/openshift/console-operator/pull/1169))
### Test plan
 Package compiles cleanly
 go test ./pkg/monitortests/clusterversionoperator/legacycvomonitortests/ passes
 OTA invariant tests pass without console exceptions in CI

Assisted-by: Claude (Opus 4.6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Strengthened validation of cluster operator state transitions in stable-system and upgrade scenarios.
  * Removed previously permitted exceptions for console availability, degraded, and progressing conditions.
  * Improved detection of unexpected operator health changes during upgrades, including buffered transition windows.
  * This helps identify operator availability and upgrade-state regressions more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->