### PR TITLE
OCPBUGS-77283: bump kubevirt fedora containerDisk to multi-arch v1.8.2 + permanent exception

### DIFF
--- a/test/extended/networking/livemigration.go
+++ b/test/extended/networking/livemigration.go
@@ -117,7 +117,7 @@ var _ = Describe("[sig-network][OCPFeatureGate:PersistentIPsForVirtualization][F
 						vmCreationParams := kubevirt.CreationTemplateParams{
 							VMName:                    vmName,
 							VMNamespace:               f.Namespace.Name,
-							FedoraContainterDiskImage: image.LocationFor("quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc"),
+							FedoraContainterDiskImage: image.LocationFor("quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.8.2"),
 						}
 
 						if netConfig.role == "primary" {

--- a/test/extended/util/image/README.md
+++ b/test/extended/util/image/README.md
@@ -54,6 +54,7 @@ Exceptions to the manifest list requirement can be configured in the `verify-man
 * `e2e-22-registry-k8s-io-e2e-test-images-node-perf-tf-wide-deep` - TensorFlow image with limited architecture support
 * `registry-k8s-io-cloud-provider-gcp-gcp-compute-persistent-disk-csi-driver` - Upstream GCE PD CSI driver images are not available on ppc64le or s390x, because GCE does not support these architectures.
 * `e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr` - This is an artifact, not an image. It's not runnable and thus it doesn't have to be multiarch.
+* `e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk` - KubeVirt Fedora guest containerDisk used by VM live-migration networking tests. The upstream image (`quay.io/kubevirt/fedora-with-test-tooling-container-disk`) ships a manifest list for `amd64`, `arm64` and `s390x` but not `ppc64le`, because KubeVirt does not currently support the `ppc64le` architecture (support was removed in kubevirt/kubevirt#14976). Restoring `ppc64le` is tracked upstream by KubeVirt VEP-258 (https://github.com/kubevirt/enhancements/pull/258); this exception should be revisited once that lands. Ref: OCPBUGS-77283.
 
 Additional permanent exceptions may be added to this list as needed with proper justification.
 

--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -60,7 +60,7 @@ var (
 		"registry.k8s.io/e2e-test-images/sample-device-plugin:1.7": -1,
 
 		// used by KubeVirt test to start fedora VMs
-		"quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc": -1,
+		"quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.8.2": -1,
 
 		// used by external OIDC tests to simulate an external IdP
 		"quay.io/keycloak/keycloak:25.0": -1,

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -3,7 +3,7 @@ docker.io/library/registry:2.8.0-beta.1 quay.io/openshift/community-e2e-images:e
 quay.io/crio/artifact:subpath quay.io/openshift/community-e2e-images:e2e-quay-io-crio-artifact-subpath-8cuvQpZ0AoyNahYr
 quay.io/crio/zstd-chunked:2 quay.io/openshift/community-e2e-images:e2e-quay-io-crio-zstd-chunked-2-8Uf42eAKe3YN2nwu
 quay.io/keycloak/keycloak:25.0 quay.io/openshift/community-e2e-images:e2e-quay-io-keycloak-keycloak-25-0-rEIw9B2Zcc3L1M6k
-quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E
+quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.8.2 quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-v1-8-2-DmMayTpvDZVswLv0
 quay.io/olmtest/webhook-operator:v0.0.5 quay.io/openshift/community-e2e-images:e2e-quay-io-olmtest-webhook-operator-v0-0-5--2OhUsk-Xv-pLaTI
 quay.io/openshifttest/ldap:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-ldap-1-2-O3f5zPgtmWzEtasv
 quay.io/openshifttest/minio:latest quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-minio-latest-p_yqYDk9rEgphwXT


### PR DESCRIPTION
## What

Two related changes for the KubeVirt Fedora `fedora-with-test-tooling-container-disk` image used by the VM live-migration networking tests (`test/extended/networking/livemigration.go`):

1. **Bump the mirrored tag** from the single-arch `20241024_891122a6fc` to `v1.8.2`, which upstream publishes as an OCI index covering `amd64`/`arm64`/`s390x`. Updates the mirror allowlist key, the test reference, and the generated `zz_generated.txt` mapping.
2. **Record a permanent multi-arch manifest-list exception** in `test/extended/util/image/README.md`.

## Why

Even at `v1.8.2` the upstream image has no `ppc64le` variant, because KubeVirt does not currently support the `ppc64le` architecture (support was removed in kubevirt/kubevirt#14976). Bumping to the multi-arch `v1.8.2` index closes the gap for the supported arches, while the documented `--allow-missing-architectures` exception (already present in the `verify-image-manifest-lists` presubmit in openshift/release) covers the still-missing `ppc64le`.

Restoring `ppc64le` is tracked upstream by **KubeVirt VEP-258** (kubevirt/enhancements#258). This exception should be revisited once that lands.

> [!IMPORTANT]
> An image-mirror owner must mirror `quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.8.2` into `quay.io/openshift/community-e2e-images` before this merges, otherwise the live-migration tests will hit `ImagePullBackOff`.

## Ref

- Jira: https://issues.redhat.com/browse/OCPBUGS-77283
- KubeVirt VEP-258: https://github.com/kubevirt/enhancements/pull/258
- ppc64le removal: https://github.com/kubevirt/kubevirt/pull/14976


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added/clarified a permanent-exception entry for a Fedora container disk image, noting upstream manifest coverage (amd64/arm64/s390x) and that `ppc64le` is not included due to lack of KubeVirt support, with an upstream tracking reference for future reevaluation.
* **Tests**
  * Updated the Fedora container disk image used in VM creation to `quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.8.2`.
  * Refreshed the related allowed-image allowlist to match the `v1.8.2` reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->