### PR TITLE
OCPBUGS-87001: Update source of CAPI ImageVolumeAlreadyPresent events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -493,14 +493,15 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 
 	// The kubelet calls getImageVolumes() on every SyncPod reconciliation, which emits a
 	// "Pulled" event for each image volume even when the pod is in steady state. Pods with
-	// many image volumes (e.g. capi-operator with 10 provider images) accumulate hundreds of
-	// these benign events over their lifetime. Remove when upstream fix lands:
-	// https://github.com/kubernetes/kubernetes/issues/138644
+	// many image volumes (e.g. capi-operator or capi-installer with 10 provider images)
+	// accumulate hundreds of these benign events over their lifetime.
+	// Upstream: https://github.com/kubernetes/kubernetes/issues/138644
+	// The fix has merged and will be included in 1.37+
 	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
 		name: "ImageVolumeAlreadyPresent",
 		locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
 			monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-api-operator$`),
-			monitorapi.LocatorPodKey:       regexp.MustCompile(`^capi-operator-`),
+			monitorapi.LocatorPodKey:       regexp.MustCompile(`^capi-(operator|installer)-`),
 		},
 		messageReasonRegex: regexp.MustCompile(`^Pulled$`),
 		messageHumanRegex:  regexp.MustCompile(`already present on machine`),


### PR DESCRIPTION
https://github.com/openshift/cluster-capi-operator/pull/576 changes the name of the deployment which produces these events, which breaks the existing match.

Also update the comment to note that the upstream fix merged and will be in 1.37.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced image volume event detection to recognize newer installer naming patterns in test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->