### PR TITLE
MCO-2370: Temporarily disable the stream test

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -172,7 +172,8 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	g.It("should match os version", func() {
+	// TODO: @pablintino https://redhat.atlassian.net/browse/MCO-2371
+	g.XIt("should match os version", func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}


### PR DESCRIPTION
This change is about disabling "should match os version" till the switchover to rhel-10 happens. At that point, a new version of the tests that consider rhel-10 as the default for standalone will be added back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Disabled a CI test that validated OS/RHCOS version name compatibility, so that specific OS version check will no longer run during CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->