### PR TITLE
OCPBUGS-85782: Add extra wait after mco and cvo considers upgrade complete

### DIFF
--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/upgrades/apps"
 	"k8s.io/kubernetes/test/e2e/upgrades/node"
 
+	"github.com/openshift/origin/pkg/clioptions/clusterinfo"
 	e2e_analysis "github.com/openshift/origin/pkg/e2eanalysis"
 	"github.com/openshift/origin/test/e2e/upgrade/adminack"
 	"github.com/openshift/origin/test/e2e/upgrade/dns"
@@ -192,9 +193,14 @@ var _ = g.Describe("[sig-arch][Feature:ClusterUpgrade]", func() {
 						clusterUpgrade(f, client, dynamicClient, config, upgCtx.Versions[i]),
 						fmt.Sprintf("during upgrade to %s", upgCtx.Versions[i].NodeImage))
 				}
-				// Sleep to give some time to the workloads on the last upgraded
-				// node to restart.
-				time.Sleep(5 * time.Second)
+				// Wait for all operators to stabilize after upgrade. MCO may
+				// report upgrade complete before the last worker node finishes
+				// rebooting, and workloads need additional time to start after
+				// nodes become Ready.
+				framework.Logf("Waiting for cluster to stabilize after upgrade")
+				if _, waitErr := clusterinfo.WaitForStableCluster(context.Background(), config); waitErr != nil {
+					framework.Logf("WARNING: cluster did not stabilize within timeout after upgrade: %v", waitErr)
+				}
 			},
 		)
 	})


### PR DESCRIPTION
This is due to the fact that MCO does not wait for worker pool before declaring upgrade complete. So when the remaining tests started running, some daemonset were still not ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cluster upgrade testing with enhanced stability verification between upgrade steps. The upgrade testing process now validates cluster readiness rather than using fixed wait times. Better error handling logs stability check delays as warnings instead of causing test failures, providing improved visibility into cluster state and ensuring more reliable upgrade operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->