### PR TITLE
OPNET-601: Add on-prem haproxy timeline to e2e interval chart

### DIFF
--- a/e2echart/e2e-chart-template.html
+++ b/e2echart/e2e-chart-template.html
@@ -147,6 +147,10 @@
         return (eventInterval.source === "APIUnreachableFromClient")
     }
 
+    function isOnPremHaproxyActivity(eventInterval) {
+        return (eventInterval.source === "OnPremHaproxyMonitor")
+    }
+
     function isStaticPodInstallMonitorActivity(eventInterval) {
         return (eventInterval.source === "StaticPodInstallMonitor")
     }
@@ -292,6 +296,10 @@
 
     function isAPIUnreachableFromClientValue(item) {
         return [buildLocatorDisplayString(item.locator), "", "APIUnreachableFromClientMetrics"]
+    }
+
+    function onPremHaproxyValue(item) {
+        return [buildLocatorDisplayString(item.locator), "", "Disruption"]
     }
 
     function isStaticPodInstallMonitorValue(item) {
@@ -518,6 +526,9 @@
 
         timelineGroups.push({group: "api-unreachable", data: []})
         createTimelineData(isAPIUnreachableFromClientValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIUnreachableFromClientActivity, regex)
+
+        timelineGroups.push({group: "onprem-haproxy", data: []})
+        createTimelineData(onPremHaproxyValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOnPremHaproxyActivity, regex)
 
         timelineGroups.push({group: "staticpod-install", data: []})
         createTimelineData(isStaticPodInstallMonitorValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isStaticPodInstallMonitorActivity, regex)

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -54556,6 +54556,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
         return (eventInterval.source === "APIUnreachableFromClient")
     }
 
+    function isOnPremHaproxyActivity(eventInterval) {
+        return (eventInterval.source === "OnPremHaproxyMonitor")
+    }
+
     function isStaticPodInstallMonitorActivity(eventInterval) {
         return (eventInterval.source === "StaticPodInstallMonitor")
     }
@@ -54701,6 +54705,10 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
     function isAPIUnreachableFromClientValue(item) {
         return [buildLocatorDisplayString(item.locator), "", "APIUnreachableFromClientMetrics"]
+    }
+
+    function onPremHaproxyValue(item) {
+        return [buildLocatorDisplayString(item.locator), "", "Disruption"]
     }
 
     function isStaticPodInstallMonitorValue(item) {
@@ -54927,6 +54935,9 @@ var _e2echartE2eChartTemplateHtml = []byte(`<html lang="en">
 
         timelineGroups.push({group: "api-unreachable", data: []})
         createTimelineData(isAPIUnreachableFromClientValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isAPIUnreachableFromClientActivity, regex)
+
+        timelineGroups.push({group: "onprem-haproxy", data: []})
+        createTimelineData(onPremHaproxyValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isOnPremHaproxyActivity, regex)
 
         timelineGroups.push({group: "staticpod-install", data: []})
         createTimelineData(isStaticPodInstallMonitorValue, timelineGroups[timelineGroups.length - 1].data, eventIntervals, isStaticPodInstallMonitorActivity, regex)


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OPNET-601 (mirrored at https://redhat.atlassian.net/browse/OPNET-601).

The on-prem haproxy monitor test added in #29149 constructs intervals with source `OnPremHaproxyMonitor` when haproxy detects a kube-apiserver as down, but the spyglass interval chart template had no handler for that source, so the intervals were present in the intervals JSON yet never rendered on the timeline.

As suggested in https://github.com/openshift/origin/pull/29149#pullrequestreview-2370086169, update the interval template so haproxy events can be correlated with apiserver disruption events, following the pattern of 08cb5eb:

- add `isOnPremHaproxyActivity()` precondition matching `source === "OnPremHaproxyMonitor"`
- add `onPremHaproxyValue()` classifying the intervals as `Disruption` (same coloring as the apiserver disruption rows)
- add an `onprem-haproxy` timeline group placed next to the `disruption`, `apiserver-shutdown` and `api-unreachable` groups
- regenerate bindata via `make update-bindata`

Verified with `make verify-bindata`, `go build` of the affected packages, and `node --check` on the template JavaScript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds monitoring and visualization for OnPrem HAProxy activity within e2e performance charts.
  * Introduces a dedicated timeline group that surfaces OnPrem HAProxy disruption events.
  * Adds filtering and custom formatting to recognize and classify OnPrem HAProxy monitor events for clearer visibility and analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->