### PR TITLE
OPNET-602: Fail haproxy monitor test when log collection fails

### DIFF
--- a/pkg/monitortests/network/onpremhaproxy/monitortest.go
+++ b/pkg/monitortests/network/onpremhaproxy/monitortest.go
@@ -13,16 +13,20 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/monitortestlibrary/podaccess"
+	"github.com/openshift/origin/pkg/monitortestlibrary/utility"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 type operatorLogAnalyzer struct {
-	kubeClient kubernetes.Interface
+	kubeClient         kubernetes.Interface
+	notSupportedReason error
 }
 
 func InitialAndFinalOperatorLogScraper() monitortestframework.MonitorTest {
@@ -30,10 +34,39 @@ func InitialAndFinalOperatorLogScraper() monitortestframework.MonitorTest {
 }
 
 func (w *operatorLogAnalyzer) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	configClient, err := configclient.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	var infra *configv1.Infrastructure
+	if err := utility.RetryWithExponentialBackoff(ctx, func() error {
+		var getErr error
+		infra, getErr = configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		return getErr
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Clusters without the infrastructure config (e.g. MicroShift) never run the on-prem
+			// API loadbalancer.
+			w.notSupportedReason = &monitortestframework.NotSupportedError{Reason: "infrastructure config not found, the cluster does not run the on-prem API loadbalancer"}
+			return w.notSupportedReason
+		}
+		return err
+	}
+
+	if reason := notSupportedPlatformReason(infra); len(reason) > 0 {
+		w.notSupportedReason = &monitortestframework.NotSupportedError{Reason: reason}
+		return w.notSupportedReason
+	}
+
 	return nil
 }
 
 func (w *operatorLogAnalyzer) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	if w.notSupportedReason != nil {
+		return w.notSupportedReason
+	}
+
 	// move to prepare?
 	var err error
 	w.kubeClient, err = kubernetes.NewForConfig(adminRESTConfig)
@@ -70,6 +103,13 @@ func scanAllOperatorPods(ctx context.Context, kubeClient kubernetes.Interface, l
 		}
 	}
 
+	// On the platforms this monitor test supports, the haproxy pods must exist. Finding none
+	// means the collection silently broke (e.g. the namespaces or labels changed), so report it
+	// as a collection failure instead of passing the test without any data.
+	if len(infraPods) == 0 {
+		return fmt.Errorf("found no haproxy pods to scan: expected pods with the app=<platform>-infra-api-lb label in one of the openshift-{kni,openstack,vsphere}-infra namespaces on an on-prem cluster")
+	}
+
 	errs := []error{}
 	for _, pod := range infraPods {
 		for _, container := range pod.Spec.Containers {
@@ -88,6 +128,10 @@ func scanAllOperatorPods(ctx context.Context, kubeClient kubernetes.Interface, l
 }
 
 func (w *operatorLogAnalyzer) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, nil, w.notSupportedReason
+	}
+
 	localRecorder := monitor.NewRecorder()
 	if err := scanAllOperatorPods(ctx, w.kubeClient, newOperatorLogHandlerAfterTime(localRecorder, beginning)); err != nil {
 		return nil, nil, fmt.Errorf("unable to scan operator logs: %w", err)
@@ -96,7 +140,11 @@ func (w *operatorLogAnalyzer) CollectData(ctx context.Context, storageDir string
 	return localRecorder.Intervals(time.Time{}, time.Time{}), nil, nil
 }
 
-func (*operatorLogAnalyzer) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+func (w *operatorLogAnalyzer) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	if w.notSupportedReason != nil {
+		return nil, w.notSupportedReason
+	}
+
 	constructedIntervals := monitorapi.Intervals{}
 
 	allHaproxyChanges := startingIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
@@ -180,7 +228,11 @@ func (*operatorLogAnalyzer) ConstructComputedIntervals(ctx context.Context, star
 	return constructedIntervals, nil
 }
 
-func (*operatorLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+func (w *operatorLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	if w.notSupportedReason != nil {
+		return nil, w.notSupportedReason
+	}
+
 	leaseIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
 		if eventInterval.Message.Reason == monitorapi.OnPremHaproxyDetectsDown {
 			return true
@@ -230,7 +282,7 @@ func (*operatorLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Co
 }
 
 func (w *operatorLogAnalyzer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
-	return nil
+	return w.notSupportedReason
 }
 
 func (*operatorLogAnalyzer) Cleanup(ctx context.Context) error {

--- a/pkg/monitortests/network/onpremhaproxy/platform.go
+++ b/pkg/monitortests/network/onpremhaproxy/platform.go
@@ -1,0 +1,59 @@
+package onpremhaproxy
+
+import (
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// notSupportedPlatformReason returns an empty string when the cluster runs the OpenShift-managed
+// on-prem API loadbalancer (the haproxy static pods scanned by this monitor test), or a
+// human-readable reason why it does not.
+//
+// The haproxy static pods are deployed only on the on-prem platforms scanned by this monitor test
+// (BareMetal, OpenStack and vSphere), and only when an API VIP is configured (e.g. vSphere UPI has
+// none) and the loadbalancer is not user-managed.
+func notSupportedPlatformReason(infra *configv1.Infrastructure) string {
+	if infra.Status.PlatformStatus == nil {
+		return "platform status is not set, the cluster does not run the on-prem API loadbalancer"
+	}
+
+	platformType := infra.Status.PlatformStatus.Type
+	hasAPIVIP := false
+	loadBalancerType := configv1.LoadBalancerTypeOpenShiftManagedDefault
+
+	switch platformType {
+	case configv1.BareMetalPlatformType:
+		if status := infra.Status.PlatformStatus.BareMetal; status != nil {
+			hasAPIVIP = len(status.APIServerInternalIPs) > 0 || len(status.APIServerInternalIP) > 0
+			if status.LoadBalancer != nil && len(status.LoadBalancer.Type) > 0 {
+				loadBalancerType = status.LoadBalancer.Type
+			}
+		}
+	case configv1.OpenStackPlatformType:
+		if status := infra.Status.PlatformStatus.OpenStack; status != nil {
+			hasAPIVIP = len(status.APIServerInternalIPs) > 0 || len(status.APIServerInternalIP) > 0
+			if status.LoadBalancer != nil && len(status.LoadBalancer.Type) > 0 {
+				loadBalancerType = status.LoadBalancer.Type
+			}
+		}
+	case configv1.VSpherePlatformType:
+		if status := infra.Status.PlatformStatus.VSphere; status != nil {
+			hasAPIVIP = len(status.APIServerInternalIPs) > 0 || len(status.APIServerInternalIP) > 0
+			if status.LoadBalancer != nil && len(status.LoadBalancer.Type) > 0 {
+				loadBalancerType = status.LoadBalancer.Type
+			}
+		}
+	default:
+		return fmt.Sprintf("platform %q does not use the OpenShift-managed on-prem API loadbalancer", platformType)
+	}
+
+	if !hasAPIVIP {
+		return fmt.Sprintf("platform %q has no API VIP configured, the OpenShift-managed on-prem API loadbalancer is not deployed", platformType)
+	}
+	if loadBalancerType != configv1.LoadBalancerTypeOpenShiftManagedDefault {
+		return fmt.Sprintf("platform %q uses a %q API loadbalancer, the OpenShift-managed on-prem API loadbalancer is not deployed", platformType, loadBalancerType)
+	}
+
+	return ""
+}

--- a/pkg/monitortests/network/onpremhaproxy/platform_test.go
+++ b/pkg/monitortests/network/onpremhaproxy/platform_test.go
@@ -1,0 +1,161 @@
+package onpremhaproxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+func TestNotSupportedPlatformReason(t *testing.T) {
+	tests := []struct {
+		name            string
+		platformStatus  *configv1.PlatformStatus
+		expectSupported bool
+	}{
+		{
+			name:            "no platform status",
+			platformStatus:  nil,
+			expectSupported: false,
+		},
+		{
+			name: "aws",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.AWSPlatformType,
+				AWS:  &configv1.AWSPlatformStatus{Region: "us-east-1"},
+			},
+			expectSupported: false,
+		},
+		{
+			name: "platform none",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.NonePlatformType,
+			},
+			expectSupported: false,
+		},
+		{
+			name: "nutanix with API VIP is not scanned by this monitor test",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.NutanixPlatformType,
+				Nutanix: &configv1.NutanixPlatformStatus{
+					APIServerInternalIPs: []string{"192.168.111.5"},
+				},
+			},
+			expectSupported: false,
+		},
+		{
+			name: "baremetal with API VIPs",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+				BareMetal: &configv1.BareMetalPlatformStatus{
+					APIServerInternalIPs: []string{"192.168.111.5"},
+				},
+			},
+			expectSupported: true,
+		},
+		{
+			name: "baremetal with only the deprecated API VIP field",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+				BareMetal: &configv1.BareMetalPlatformStatus{
+					APIServerInternalIP: "192.168.111.5",
+				},
+			},
+			expectSupported: true,
+		},
+		{
+			name: "baremetal with the default loadbalancer set explicitly",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+				BareMetal: &configv1.BareMetalPlatformStatus{
+					APIServerInternalIPs: []string{"192.168.111.5"},
+					LoadBalancer: &configv1.BareMetalPlatformLoadBalancer{
+						Type: configv1.LoadBalancerTypeOpenShiftManagedDefault,
+					},
+				},
+			},
+			expectSupported: true,
+		},
+		{
+			name: "baremetal with a user-managed loadbalancer",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+				BareMetal: &configv1.BareMetalPlatformStatus{
+					APIServerInternalIPs: []string{"192.168.111.5"},
+					LoadBalancer: &configv1.BareMetalPlatformLoadBalancer{
+						Type: configv1.LoadBalancerTypeUserManaged,
+					},
+				},
+			},
+			expectSupported: false,
+		},
+		{
+			name: "baremetal without platform-specific status",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.BareMetalPlatformType,
+			},
+			expectSupported: false,
+		},
+		{
+			name: "openstack with API VIPs",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.OpenStackPlatformType,
+				OpenStack: &configv1.OpenStackPlatformStatus{
+					APIServerInternalIPs: []string{"10.0.0.5"},
+				},
+			},
+			expectSupported: true,
+		},
+		{
+			name: "openstack without API VIP",
+			platformStatus: &configv1.PlatformStatus{
+				Type:      configv1.OpenStackPlatformType,
+				OpenStack: &configv1.OpenStackPlatformStatus{},
+			},
+			expectSupported: false,
+		},
+		{
+			name: "vsphere IPI with API VIPs",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.VSpherePlatformType,
+				VSphere: &configv1.VSpherePlatformStatus{
+					APIServerInternalIPs: []string{"10.0.0.5"},
+				},
+			},
+			expectSupported: true,
+		},
+		{
+			name: "vsphere UPI without API VIP",
+			platformStatus: &configv1.PlatformStatus{
+				Type:    configv1.VSpherePlatformType,
+				VSphere: &configv1.VSpherePlatformStatus{},
+			},
+			expectSupported: false,
+		},
+		{
+			name: "vsphere without platform-specific status",
+			platformStatus: &configv1.PlatformStatus{
+				Type: configv1.VSpherePlatformType,
+			},
+			expectSupported: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			infra := &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					PlatformStatus: tt.platformStatus,
+				},
+			}
+
+			reason := notSupportedPlatformReason(infra)
+			if tt.expectSupported {
+				assert.Empty(t, reason, "expected the platform to be supported")
+			} else {
+				assert.NotEmpty(t, reason, "expected the platform not to be supported")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/OPNET-602 (mirrored at https://redhat.atlassian.net/browse/OPNET-602).

As suggested in https://github.com/openshift/origin/pull/29149#discussion_r1802622638, the haproxy reachability test itself should flake, but a *failed* test should mean collection errors. So far the on-prem haproxy monitor test could not distinguish between "no data because the platform has no haproxy" and "no data because collection silently broke": on AWS and other cloud platforms it produced vacuous test passes, and on on-prem clusters a renamed namespace or label would silently disable the test forever. This also answers the follow-up question in that thread about a programmatic `platform.isOnPrem()` check.

Changes:

- `notSupportedPlatformReason()` (new `platform.go`): the monitor test is supported only where the haproxy api-lb static pods are actually deployed - platform BareMetal/OpenStack/vSphere with an API VIP configured and the `OpenShiftManagedDefault` loadbalancer. vSphere UPI (no VIP), user-managed LB deployments and all other platforms are not.
- `PrepareCollection` reads the Infrastructure config and stores a `monitortestframework.NotSupportedError`, which all phases return on unsupported platforms - the framework turns this into junit skips instead of today's vacuous passes. Clusters without the infrastructure config (e.g. MicroShift) are skipped via the `IsNotFound` check.
- On supported platforms, `scanAllOperatorPods` now returns an error when it finds no haproxy pods at all, guarding against silent rot of the namespace/label assumptions. Together with the errors already returned when reading pod logs fails, the framework converts those into a failed junit for the collection phase ("failed during collection"), which fails the run - a failed test now always means collection errors.
- Unit tests for the platform gating.

Verified with `go build`, `go vet` and `go test ./pkg/monitortests/network/onpremhaproxy/...` (all tests pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform detection for on-premises API loadbalancer monitoring to properly identify unsupported platforms and report reasons accordingly.
  * Enhanced error handling to fail collection when HAProxy pods are not found, replacing silent failures.

* **Tests**
  * Added comprehensive test coverage for platform compatibility validation across various cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->