### PR TITLE
Replace XIt with e2eskipper.Skipf for disabled os version test

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -172,8 +172,9 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	// TODO: @pablintino https://redhat.atlassian.net/browse/MCO-2371
-	g.XIt("should match os version", func() {
+	g.It("should match os version", func() {
+		// TODO: @pablintino https://redhat.atlassian.net/browse/MCO-2371
+		e2eskipper.Skipf("Temporarily disabled until RHEL-10 switchover, see MCO-2371")
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}


### PR DESCRIPTION
Replaces the `XIt` used in #31287 with the standard `e2eskipper.Skipf` helper. `XIt` silently excludes the test from the suite, while `Skipf` properly reports it as skipped so it remains visible in test results.

The test is still disabled pending the RHEL-10 switchover ([MCO-2371](https://redhat.atlassian.net/browse/MCO-2371)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reorganized test execution approach for OS version compatibility. A previously excluded test is now integrated into the test suite but remains temporarily skipped pending platform configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->