### PR TITLE
Use e2eskipper.Skipf to disable os version test until RHEL-10 switchover

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -173,6 +173,8 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	})
 
 	g.It("should match os version", func() {
+		// TODO: @pablintino https://redhat.atlassian.net/browse/MCO-2371
+		e2eskipper.Skipf("Temporarily disabled until RHEL-10 switchover, see MCO-2371")
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}

--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -172,8 +172,7 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 		}
 	})
 
-	// TODO: @pablintino https://redhat.atlassian.net/browse/MCO-2371
-	g.XIt("should match os version", func() {
+	g.It("should match os version", func() {
 		if jobName == "" {
 			e2eskipper.Skipf("JOB_NAME env var not set, skipping")
 		}


### PR DESCRIPTION
Based on top of the revert in #31295.

Adds `e2eskipper.Skipf` at the top of the "should match os version" test so it is properly reported as skipped rather than silently excluded via `XIt`. The test remains disabled pending the RHEL-10 switchover ([MCO-2371](https://redhat.atlassian.net/browse/MCO-2371)).

Depends on: #31295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted OS version validation test to temporarily skip pending RHEL-10 compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->