### PR TITLE
SPLAT-2794: Added 3CMO OTE binary to extensionBinary list

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -234,6 +234,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cloud-controller-manager-aws-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-cloud-controller-manager-operator",
+		binaryPath: "/usr/bin/cloud-controller-manager-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-config-operator",
 		binaryPath: "/usr/bin/cluster-config-operator-tests-ext.gz",
 	},


### PR DESCRIPTION
[SPLAT-2794](https://redhat.atlassian.net/browse/SPLAT-2794)

### Changes
- Added 3CMO OTE to binary extension list for 4.22

### Prereqs
- https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/471

### Notes

Original Main branch (5.0) PRs:
- https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/446
- https://github.com/openshift/origin/pull/31004