### PR TITLE
OCPCLOUD-3010: Enable OTE for Cluster CAPI Operator

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -230,6 +230,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/cluster-authentication-operator-tests-ext.gz",
 	},
 	{
+		imageTag:   "cluster-capi-operator",
+		binaryPath: "/usr/bin/cluster-capi-operator-tests-ext.gz",
+	},
+	{
 		imageTag:   "cluster-cloud-controller-manager-operator",
 		binaryPath: "/usr/bin/cloud-controller-manager-aws-tests-ext.gz",
 	},


### PR DESCRIPTION
## Summary

- Adds `cluster-capi-operator` / `/usr/bin/cluster-capi-operator-tests-ext.gz` to the `extensionBinaries` registry in `pkg/test/extensions/binary.go`
- Enables `openshift-tests` to extract and invoke the extension binary from the `cluster-capi-operator` payload image during test suite execution
- The binary is added in the component with: https://github.com/openshift/cluster-capi-operator/pull/597 - must be merged first

Depends-On: openshift/cluster-capi-operator#597

## Test plan

- [x] Verify `openshift-tests` discovers and extracts the binary from the `cluster-capi-operator` payload image at runtime
- [x] Confirm the extension binary appears in platform-wide periodic suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added an additional external test binary for the `cluster-capi-operator` image tag to improve cluster operator validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->