### PR TITLE
CLID-589: add oc-mirror to extensionBinaries

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -314,6 +314,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/oauth-apiserver-tests-ext.gz",
 	},
 	{
+		imageTag:   "oc-mirror",
+		binaryPath: "/usr/bin/oc-mirror-tests-ext.gz",
+	},
+	{
 		imageTag:   "olm-operator-controller",
 		binaryPath: "/usr/bin/olmv1-tests-ext.gz",
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an external test binary to the testing infrastructure for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->