### PR TITLE
CNTRLPLANE-2157: Migrate test cases to Project API testing KubeAPI server functionality

### DIFF
--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -582,72 +582,8 @@ func hasExactlyTheseProjects(lister projectv1client.ProjectInterface, projects s
 	return nil
 }
 
-var _ = g.Describe("[sig-api-machinery] [Jira:apiserver-auth] Project API", func() {
+var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 	oc := exutil.NewCLIWithoutNamespace("project-api")
-
-	// Test that project creation validates node selector syntax and rejects invalid formats
-	g.It("[OTP] should reject project creation when an invalid node selector is given [apigroup:project.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
-		const caseID = "project-invalid-node-selector"
-		projectName := caseID + "-" + rand.String(5)
-		// Invalid formats: colons instead of equals, commas, brackets, trailing commas
-		invalidNodeSelectors := []string{"env:qa", "env,qa", "env [qa]", "env,"}
-
-		for _, invalidNodeSelector := range invalidNodeSelectors {
-			output, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args(
-				"new-project", projectName, fmt.Sprintf("--node-selector=%s", invalidNodeSelector),
-			).Output()
-			o.Expect(err).To(o.HaveOccurred(), "expected failure for node selector %q", invalidNodeSelector)
-			o.Expect(output).To(o.MatchRegexp(
-				fmt.Sprintf("Invalid value.*%s", regexp.QuoteMeta(invalidNodeSelector)),
-			), "unexpected error message for node selector %q", invalidNodeSelector)
-		}
-	})
-
-	// Test that users can retrieve and view node selector configuration from projects
-	// Validates that 'oc describe project' correctly displays node selectors for both:
-	// 1. Projects without node selectors (should show <none>)
-	// 2. Projects with configured node selectors (should show the selector)
-	g.It("[OTP] should allow a user to get the node selector from a project [apigroup:project.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
-		const caseID = "project-get-node-selector"
-		suffix := rand.String(5)
-		firstProject := fmt.Sprintf("%s-without-selector-%s", caseID, suffix)
-		secondProject := fmt.Sprintf("%s-with-selector-%s", caseID, suffix)
-		labelValue := "qa" + suffix
-
-		// Setup user context
-		oc.SetupProject()
-		userName := oc.Username()
-
-		// Create first project WITHOUT node selector
-		defer func() {
-			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", firstProject, "--ignore-not-found").Execute(); err != nil {
-				framework.Logf("cleanup: failed to delete project %q: %v", firstProject, err)
-			}
-		}()
-		err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("new-project", firstProject, "--admin="+userName).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Create second project WITH node selector
-		defer func() {
-			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", secondProject, "--ignore-not-found").Execute(); err != nil {
-				framework.Logf("cleanup: failed to delete project %q: %v", secondProject, err)
-			}
-		}()
-		err = oc.AsAdmin().WithoutNamespace().Run("adm").Args(
-			"new-project", secondProject, "--node-selector=env="+labelValue, "--admin="+userName,
-		).Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		// Verify first project shows <none> for node selector
-		firstProjectOut, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("project", firstProject, "--as="+userName).Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(firstProjectOut).To(o.MatchRegexp(`Node Selector:.*<none>`))
-
-		// Verify second project shows the configured node selector
-		secondProjectOut, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("project", secondProject, "--as="+userName).Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(secondProjectOut).To(o.MatchRegexp(`Node Selector:.*env=` + regexp.QuoteMeta(labelValue)))
-	})
 
 	// Test that custom project request templates can automatically apply ResourceQuotas and LimitRanges
 	// to newly created projects. This validates that:
@@ -724,11 +660,6 @@ var _ = g.Describe("[sig-api-machinery] [Jira:apiserver-auth] Project API", func
 		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", templateYamlFile, "-n", "openshift-config").Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// Wait for openshift-apiserver to stabilize after template creation
-		stableCtx, stableCancel := context.WithTimeout(ctx, 2*time.Minute)
-		defer stableCancel()
-		o.Expect(exutil.WaitForOperatorProgressingFalse(stableCtx, oc.AdminConfigClient(), "openshift-apiserver")).To(o.Succeed())
-
 		// Configure cluster to use the custom project request template
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			project, err := oc.AdminConfigClient().ConfigV1().Projects().Get(ctx, "cluster", metav1.GetOptions{})
@@ -759,10 +690,14 @@ var _ = g.Describe("[sig-api-machinery] [Jira:apiserver-auth] Project API", func
 		})
 		o.Expect(err).NotTo(o.HaveOccurred())
 
-		// Wait for openshift-apiserver operator to become stable after the config change
+		// Wait for openshift-apiserver operator to roll out the config change
 		waitCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 		defer cancel()
-		_ = exutil.WaitForOperatorProgressingTrue(waitCtx, oc.AdminConfigClient(), "openshift-apiserver")
+		// First wait for operator to start progressing (optional - logs warning if it doesn't)
+		if err := exutil.WaitForOperatorProgressingTrue(waitCtx, oc.AdminConfigClient(), "openshift-apiserver"); err != nil {
+			framework.Logf("warning: failed to wait for openshift-apiserver to start progressing: %v", err)
+		}
+		// Then wait for operator to become stable (Available=True, Progressing=False, Degraded=False)
 		err = wait.PollUntilContextCancel(waitCtx, 30*time.Second, true, func(pollCtx context.Context) (bool, error) {
 			co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(pollCtx, "openshift-apiserver", metav1.GetOptions{})
 			if err != nil {
@@ -915,7 +850,7 @@ var _ = g.Describe("[sig-api-machinery] [Jira:apiserver-auth] Project API", func
 })
 
 func cleanupProjectRequestTemplateTest(oc *exutil.CLI, templateName, project1, project2 string, restoreSpec configv1.ProjectSpec) {
-	// Clean up test projects and restore cluster configuration
+	// Clean up test projects
 	for _, projectName := range []string{project1, project2} {
 		if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", projectName, "--ignore-not-found").Execute(); err != nil {
 			framework.Logf("cleanup: failed to delete project %q: %v", projectName, err)
@@ -924,14 +859,7 @@ func cleanupProjectRequestTemplateTest(oc *exutil.CLI, templateName, project1, p
 		}
 	}
 
-	// Delete the custom template from openshift-config
-	if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("templates", templateName, "-n", "openshift-config", "--ignore-not-found").Execute(); err != nil {
-		framework.Logf("cleanup: failed to delete template %q from openshift-config: %v", templateName, err)
-	} else {
-		framework.Logf("cleanup: deleted template %q from openshift-config", templateName)
-	}
-
-	// Restore the original cluster project configuration
+	// Restore the original cluster project configuration (before deleting template)
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		project, err := oc.AdminConfigClient().ConfigV1().Projects().Get(context.Background(), "cluster", metav1.GetOptions{})
 		if err != nil {
@@ -943,22 +871,33 @@ func cleanupProjectRequestTemplateTest(oc *exutil.CLI, templateName, project1, p
 	})
 	if err != nil {
 		framework.Logf("cleanup: failed to restore project.config.openshift.io/cluster: %v", err)
-		return
+		// Continue with remaining cleanup steps even if restore failed
 	}
 
 	// Wait for the template to be cleared from openshift-apiserver observed config
-	_ = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 		observedTemplate, err := openshiftAPIServerObservedProjectRequestTemplate(ctx, oc)
 		if err != nil {
 			return false, err
 		}
 		return !strings.Contains(observedTemplate, templateName), nil
-	})
+	}); err != nil {
+		framework.Logf("cleanup: failed to wait for template to clear from observed config: %v", err)
+	}
 
 	// Wait for openshift-apiserver to stabilize after config restoration
 	restoreCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
-	_ = waitForOpenShiftAPIServerOperatorStableWithPolling(restoreCtx, oc)
+	if err := waitForOpenShiftAPIServerOperatorStableWithPolling(restoreCtx, oc); err != nil {
+		framework.Logf("cleanup: failed to wait for openshift-apiserver to stabilize: %v", err)
+	}
+
+	// Delete the custom template from openshift-config (only after config is restored)
+	if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("templates", templateName, "-n", "openshift-config", "--ignore-not-found").Execute(); err != nil {
+		framework.Logf("cleanup: failed to delete template %q from openshift-config: %v", templateName, err)
+	} else {
+		framework.Logf("cleanup: deleted template %q from openshift-config", templateName)
+	}
 }
 
 // openshiftAPIServerObservedProjectRequestTemplate extracts the current project request template

--- a/test/extended/project/project.go
+++ b/test/extended/project/project.go
@@ -2,14 +2,20 @@ package project
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	"github.com/openshift/api/annotations"
 	authorizationv1 "github.com/openshift/api/authorization/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	"github.com/openshift/apiserver-library-go/pkg/authorization/scope"
@@ -19,11 +25,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	commonResourceTypes = []string{"deployments", "pods", "services", "configmaps", "secrets"}
 )
 
 var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
@@ -352,7 +367,7 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			threeName := oc.SetupProject()
 			fourName := oc.SetupProject()
 
-			oneTwoBobConfig, err := GetScopedClientForUser(oc, bobName, []string{
+			oneTwoBobConfig, err := GetScopedClientForUser(ctx, oc, bobName, []string{
 				scope.UserListScopedProjects,
 				scope.ClusterRoleIndicator + "view:" + oneName,
 				scope.ClusterRoleIndicator + "view:" + twoName,
@@ -362,14 +377,17 @@ var _ = g.Describe("[sig-auth][Feature:ProjectAPI] ", func() {
 			}
 			oneTwoBobClient := projectv1client.NewForConfigOrDie(oneTwoBobConfig)
 
-			twoThreeBobConfig, err := GetScopedClientForUser(oc, bobName, []string{
+			twoThreeBobConfig, err := GetScopedClientForUser(ctx, oc, bobName, []string{
 				scope.UserListScopedProjects,
 				scope.ClusterRoleIndicator + "view:" + twoName,
 				scope.ClusterRoleIndicator + "view:" + threeName,
 			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			twoThreeBobClient := projectv1client.NewForConfigOrDie(twoThreeBobConfig)
 
-			allBobConfig, err := GetScopedClientForUser(oc, bobName, []string{
+			allBobConfig, err := GetScopedClientForUser(ctx, oc, bobName, []string{
 				scope.UserListScopedProjects,
 				scope.ClusterRoleIndicator + "view:*",
 			})
@@ -564,9 +582,438 @@ func hasExactlyTheseProjects(lister projectv1client.ProjectInterface, projects s
 	return nil
 }
 
-func GetScopedClientForUser(oc *exutil.CLI, username string, scopes []string) (*rest.Config, error) {
+var _ = g.Describe("[sig-api-machinery] [Jira:apiserver-auth] Project API", func() {
+	oc := exutil.NewCLIWithoutNamespace("project-api")
+
+	// Test that project creation validates node selector syntax and rejects invalid formats
+	g.It("[OTP] should reject project creation when an invalid node selector is given [apigroup:project.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
+		const caseID = "project-invalid-node-selector"
+		projectName := caseID + "-" + rand.String(5)
+		// Invalid formats: colons instead of equals, commas, brackets, trailing commas
+		invalidNodeSelectors := []string{"env:qa", "env,qa", "env [qa]", "env,"}
+
+		for _, invalidNodeSelector := range invalidNodeSelectors {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args(
+				"new-project", projectName, fmt.Sprintf("--node-selector=%s", invalidNodeSelector),
+			).Output()
+			o.Expect(err).To(o.HaveOccurred(), "expected failure for node selector %q", invalidNodeSelector)
+			o.Expect(output).To(o.MatchRegexp(
+				fmt.Sprintf("Invalid value.*%s", regexp.QuoteMeta(invalidNodeSelector)),
+			), "unexpected error message for node selector %q", invalidNodeSelector)
+		}
+	})
+
+	// Test that users can retrieve and view node selector configuration from projects
+	// Validates that 'oc describe project' correctly displays node selectors for both:
+	// 1. Projects without node selectors (should show <none>)
+	// 2. Projects with configured node selectors (should show the selector)
+	g.It("[OTP] should allow a user to get the node selector from a project [apigroup:project.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
+		const caseID = "project-get-node-selector"
+		suffix := rand.String(5)
+		firstProject := fmt.Sprintf("%s-without-selector-%s", caseID, suffix)
+		secondProject := fmt.Sprintf("%s-with-selector-%s", caseID, suffix)
+		labelValue := "qa" + suffix
+
+		// Setup user context
+		oc.SetupProject()
+		userName := oc.Username()
+
+		// Create first project WITHOUT node selector
+		defer func() {
+			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", firstProject, "--ignore-not-found").Execute(); err != nil {
+				framework.Logf("cleanup: failed to delete project %q: %v", firstProject, err)
+			}
+		}()
+		err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("new-project", firstProject, "--admin="+userName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Create second project WITH node selector
+		defer func() {
+			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", secondProject, "--ignore-not-found").Execute(); err != nil {
+				framework.Logf("cleanup: failed to delete project %q: %v", secondProject, err)
+			}
+		}()
+		err = oc.AsAdmin().WithoutNamespace().Run("adm").Args(
+			"new-project", secondProject, "--node-selector=env="+labelValue, "--admin="+userName,
+		).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify first project shows <none> for node selector
+		firstProjectOut, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("project", firstProject, "--as="+userName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(firstProjectOut).To(o.MatchRegexp(`Node Selector:.*<none>`))
+
+		// Verify second project shows the configured node selector
+		secondProjectOut, err := oc.AsAdmin().WithoutNamespace().Run("describe").Args("project", secondProject, "--as="+userName).Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(secondProjectOut).To(o.MatchRegexp(`Node Selector:.*env=` + regexp.QuoteMeta(labelValue)))
+	})
+
+	// Test that custom project request templates can automatically apply ResourceQuotas and LimitRanges
+	// to newly created projects. This validates that:
+	// 1. Projects created BEFORE template is configured don't get the resources
+	// 2. Projects created AFTER template is configured automatically get the resources
+	// 3. The template configuration propagates through openshift-apiserver properly
+	g.It("[Serial][Slow][OTP] should apply a customized project request template with ResourceQuota and LimitRange [apigroup:project.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
+		const caseID = "project-request-template"
+		suffix := rand.String(5)
+		templateName := "project-request-template-request-" + suffix
+		dirname, err := os.MkdirTemp("", caseID+"-")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer os.RemoveAll(dirname)
+
+		templateYamlFile := dirname + "/template.yaml"
+		projectRequestLimitsQuotaFixture := exutil.FixturePath("testdata", "project", "project-request-limits-quota.yaml")
+		project1 := caseID + "-before-" + suffix
+		project2 := caseID + "-after-" + suffix
+
+		// Save current cluster project config to restore at the end
+		entryProject, err := oc.AdminConfigClient().ConfigV1().Projects().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		restoreProjectSpec := entryProject.Spec.DeepCopy()
+
+		defer cleanupProjectRequestTemplateTest(oc, templateName, project1, project2, *restoreProjectSpec)
+
+		// BEFORE: Create a project before template is configured - should NOT have quota/limits
+		_, err = oc.AdminProjectClient().ProjectV1().ProjectRequests().Create(ctx, &projectv1.ProjectRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: project1},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify project1 has no custom template resources
+		output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("limitrange,resourcequota", "-n", project1, "--ignore-not-found").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.ContainSubstring(project1 + "-quota"))
+		o.Expect(output).NotTo(o.ContainSubstring(project1 + "-limits"))
+
+		// Create a custom project template with ResourceQuota and LimitRange
+		templateContent, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("create-bootstrap-project-template", "-o", "yaml").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Parse the bootstrap template
+		var template unstructured.Unstructured
+		err = yaml.Unmarshal([]byte(templateContent), &template)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Change template name
+		template.SetName(templateName)
+
+		// Load and parse the quota/limit objects to inject
+		quotaLimitsYAML, err := os.ReadFile(projectRequestLimitsQuotaFixture)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var additionalObjects []interface{}
+		err = yaml.Unmarshal(quotaLimitsYAML, &additionalObjects)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Append the quota and limit objects to the template's objects array
+		objects, found, err := unstructured.NestedSlice(template.Object, "objects")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(found).To(o.BeTrue())
+		objects = append(objects, additionalObjects...)
+		err = unstructured.SetNestedSlice(template.Object, objects, "objects")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Write the modified template
+		modifiedTemplateYAML, err := yaml.Marshal(template.Object)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = os.WriteFile(templateYamlFile, modifiedTemplateYAML, 0o644)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Upload the template to openshift-config namespace
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-f", templateYamlFile, "-n", "openshift-config").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for openshift-apiserver to stabilize after template creation
+		stableCtx, stableCancel := context.WithTimeout(ctx, 2*time.Minute)
+		defer stableCancel()
+		o.Expect(exutil.WaitForOperatorProgressingFalse(stableCtx, oc.AdminConfigClient(), "openshift-apiserver")).To(o.Succeed())
+
+		// Configure cluster to use the custom project request template
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			project, err := oc.AdminConfigClient().ConfigV1().Projects().Get(ctx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			project.Spec.ProjectRequestTemplate = configv1.TemplateReference{Name: templateName}
+			_, err = oc.AdminConfigClient().ConfigV1().Projects().Update(ctx, project, metav1.UpdateOptions{})
+			return err
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for the template configuration to propagate to openshift-apiserver's observed config
+		err = wait.PollUntilContextTimeout(ctx, 30*time.Second, 4*time.Minute, false, func(pollCtx context.Context) (bool, error) {
+			project, err := oc.AdminConfigClient().ConfigV1().Projects().Get(pollCtx, "cluster", metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if project.Spec.ProjectRequestTemplate.Name != templateName {
+				return false, nil
+			}
+
+			observedTemplate, err := openshiftAPIServerObservedProjectRequestTemplate(pollCtx, oc)
+			if err != nil {
+				return false, err
+			}
+			return strings.Contains(observedTemplate, templateName), nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for openshift-apiserver operator to become stable after the config change
+		waitCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
+		_ = exutil.WaitForOperatorProgressingTrue(waitCtx, oc.AdminConfigClient(), "openshift-apiserver")
+		err = wait.PollUntilContextCancel(waitCtx, 30*time.Second, true, func(pollCtx context.Context) (bool, error) {
+			co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(pollCtx, "openshift-apiserver", metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			var available, progressing, degraded bool
+			for _, c := range co.Status.Conditions {
+				if c.Type == configv1.OperatorAvailable {
+					available = c.Status == configv1.ConditionTrue
+				} else if c.Type == configv1.OperatorProgressing {
+					progressing = c.Status == configv1.ConditionTrue
+				} else if c.Type == configv1.OperatorDegraded {
+					degraded = c.Status == configv1.ConditionTrue
+				}
+			}
+			if degraded {
+				return false, fmt.Errorf("openshift-apiserver operator is degraded")
+			}
+			return available && !progressing, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// AFTER: Create a project after template is configured - should automatically get quota/limits
+		_, err = oc.AdminProjectClient().ProjectV1().ProjectRequests().Create(ctx, &projectv1.ProjectRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: project2},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify project2 has the custom template resources automatically applied
+		o.Eventually(func(gomega o.Gomega) {
+			output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("limitrange,resourcequota", "-n", project2).Output()
+			gomega.Expect(err).NotTo(o.HaveOccurred())
+			gomega.Expect(output).To(o.ContainSubstring(project2 + "-limits"))
+			gomega.Expect(output).To(o.ContainSubstring(project2 + "-quota"))
+		}).WithTimeout(1 * time.Minute).WithPolling(3 * time.Second).Should(o.Succeed())
+
+		// Re-verify project1 still doesn't have the resources (retroactive application doesn't happen)
+		output, err = oc.AsAdmin().WithoutNamespace().Run("get").Args("limitrange,resourcequota", "-n", project1, "--ignore-not-found").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(output).NotTo(o.ContainSubstring(project1 + "-quota"))
+		o.Expect(output).NotTo(o.ContainSubstring(project1 + "-limits"))
+	})
+
+	// Test that deleting a project cascades and removes all resources within it,
+	// and that recreating a project with the same name starts fresh with no leftover resources
+	g.It("[Serial][OTP] should delete all resources when the project is deleted [apigroup:project.openshift.io][apigroup:apps.openshift.io]", ote.Informing(), func(ctx g.SpecContext) {
+		const caseID = "project-cascading-delete"
+		suffix := rand.String(5)
+		projectName := caseID + "-" + suffix
+		resourcePrefix := caseID + "-" + suffix
+		testImage := imageutils.GetE2EImage(imageutils.Agnhost)
+
+		defer func() {
+			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", projectName, "--ignore-not-found").Execute(); err != nil {
+				framework.Logf("cleanup: failed to delete project %q: %v", projectName, err)
+			}
+		}()
+
+		// Create project and populate it with various resource types
+		err := oc.AsAdmin().WithoutNamespace().Run("new-project").Args(projectName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.AsAdmin().WithoutNamespace().Run("new-app").Args(
+			"--name=hello-openshift", testImage, "-n", projectName, "--import-mode=PreserveOriginal",
+		).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", projectName, "configmap", resourcePrefix+"-cm", "--from-literal=key=value").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().WithoutNamespace().Run("create").Args("-n", projectName, "secret", "generic", resourcePrefix+"-secret", "--from-literal=user=Bob").Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for pods to be running (not just created)
+		err = wait.PollUntilContextTimeout(ctx, 10*time.Second, 3*time.Minute, false, func(pollCtx context.Context) (bool, error) {
+			podOutput, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pods", "-n", projectName, "--no-headers").Output()
+			if err != nil {
+				return false, err
+			}
+			if matched, _ := regexp.MatchString(`(ContainerCreating|Init|Pending)`, podOutput); matched {
+				return false, nil
+			}
+			return strings.TrimSpace(podOutput) != "", nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "pods in project %s did not become ready", projectName)
+
+		// Verify all expected resource types exist in the project
+		for _, resource := range commonResourceTypes {
+			out, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(resource, "-n", projectName, "-o=jsonpath={.items[*].metadata.name}").Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(len(strings.TrimSpace(out))).To(o.BeNumerically(">", 0), "expected %s in project %s", resource, projectName)
+		}
+
+		// Delete the project and wait for complete removal
+		err = oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", projectName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for the project namespace to be fully deleted
+		err = wait.PollUntilContextTimeout(ctx, 20*time.Second, 5*time.Minute, false, func(pollCtx context.Context) (bool, error) {
+			out, getErr := oc.AsAdmin().WithoutNamespace().Run("get").Args("project", projectName).Output()
+			if getErr != nil {
+				matched, _ := regexp.MatchString("not found", getErr.Error())
+				return matched, nil
+			}
+			matched, _ := regexp.MatchString("namespaces .* not found", out)
+			return matched, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred(), "project %s was not fully deleted", projectName)
+
+		// Verify all resources were cascading-deleted with the project
+		for _, resource := range commonResourceTypes {
+			out, getErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(
+				resource, "-n", projectName, "-o=jsonpath={.items[*].metadata.name}", "--ignore-not-found",
+			).Output()
+			if getErr != nil && strings.Contains(getErr.Error(), "not found") {
+				continue
+			}
+			o.Expect(getErr).NotTo(o.HaveOccurred())
+			o.Expect(strings.TrimSpace(out)).To(o.BeEmpty(), "expected no %s remaining after project deletion", resource)
+		}
+
+		// Recreate project with same name and verify it's a clean slate
+		err = oc.AsAdmin().WithoutNamespace().Run("new-project").Args(projectName).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() {
+			if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", projectName, "--ignore-not-found").Execute(); err != nil {
+				framework.Logf("cleanup: failed to delete project %q: %v", projectName, err)
+			}
+		}()
+
+		// Verify the new project has no leftover resources from the deleted project
+		// Check for specific resources that were created in the first project incarnation
+		resourceChecks := map[string][]string{
+			"deployment": {"hello-openshift"},
+			"service":    {"hello-openshift"},
+			"configmap":  {resourcePrefix + "-cm"},
+			"secret":     {resourcePrefix + "-secret"},
+			"pods":       {"-l", "app=hello-openshift"},
+		}
+
+		for resourceType, args := range resourceChecks {
+			checkArgs := append([]string{resourceType}, args...)
+			checkArgs = append(checkArgs, "-n", projectName, "-o=name", "--ignore-not-found")
+			out, getErr := oc.AsAdmin().WithoutNamespace().Run("get").Args(checkArgs...).Output()
+			if getErr != nil {
+				continue
+			}
+			o.Expect(strings.TrimSpace(out)).To(o.BeEmpty(), "expected no leftover %s from deleted project, found: %s", resourceType, out)
+		}
+	})
+})
+
+func cleanupProjectRequestTemplateTest(oc *exutil.CLI, templateName, project1, project2 string, restoreSpec configv1.ProjectSpec) {
+	// Clean up test projects and restore cluster configuration
+	for _, projectName := range []string{project1, project2} {
+		if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("project", projectName, "--ignore-not-found").Execute(); err != nil {
+			framework.Logf("cleanup: failed to delete project %q: %v", projectName, err)
+		} else {
+			framework.Logf("cleanup: deleted project %q", projectName)
+		}
+	}
+
+	// Delete the custom template from openshift-config
+	if err := oc.AsAdmin().WithoutNamespace().Run("delete").Args("templates", templateName, "-n", "openshift-config", "--ignore-not-found").Execute(); err != nil {
+		framework.Logf("cleanup: failed to delete template %q from openshift-config: %v", templateName, err)
+	} else {
+		framework.Logf("cleanup: deleted template %q from openshift-config", templateName)
+	}
+
+	// Restore the original cluster project configuration
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		project, err := oc.AdminConfigClient().ConfigV1().Projects().Get(context.Background(), "cluster", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		project.Spec = restoreSpec
+		_, err = oc.AdminConfigClient().ConfigV1().Projects().Update(context.Background(), project, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
+		framework.Logf("cleanup: failed to restore project.config.openshift.io/cluster: %v", err)
+		return
+	}
+
+	// Wait for the template to be cleared from openshift-apiserver observed config
+	_ = wait.PollUntilContextTimeout(context.Background(), 30*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		observedTemplate, err := openshiftAPIServerObservedProjectRequestTemplate(ctx, oc)
+		if err != nil {
+			return false, err
+		}
+		return !strings.Contains(observedTemplate, templateName), nil
+	})
+
+	// Wait for openshift-apiserver to stabilize after config restoration
+	restoreCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	_ = waitForOpenShiftAPIServerOperatorStableWithPolling(restoreCtx, oc)
+}
+
+// openshiftAPIServerObservedProjectRequestTemplate extracts the current project request template
+// from the openshift-apiserver operator's observed configuration
+func openshiftAPIServerObservedProjectRequestTemplate(ctx context.Context, oc *exutil.CLI) (string, error) {
+	osapi, err := oc.AdminOperatorClient().OperatorV1().OpenShiftAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	if osapi.Spec.ObservedConfig.Raw == nil {
+		return "", nil
+	}
+	var observedConfig map[string]interface{}
+	if err := json.Unmarshal(osapi.Spec.ObservedConfig.Raw, &observedConfig); err != nil {
+		return "", err
+	}
+	projectConfig, ok := observedConfig["projectConfig"].(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+	template, _ := projectConfig["projectRequestTemplate"].(string)
+	return template, nil
+}
+
+// waitForOpenShiftAPIServerOperatorStableWithPolling polls until the openshift-apiserver
+// ClusterOperator reports Available=True, Progressing=False, and Degraded=False
+func waitForOpenShiftAPIServerOperatorStableWithPolling(ctx context.Context, oc *exutil.CLI) error {
+	return wait.PollUntilContextCancel(ctx, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		co, err := oc.AdminConfigClient().ConfigV1().ClusterOperators().Get(ctx, "openshift-apiserver", metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		var available, progressing, degraded bool
+		for _, c := range co.Status.Conditions {
+			switch c.Type {
+			case configv1.OperatorAvailable:
+				available = c.Status == configv1.ConditionTrue
+			case configv1.OperatorProgressing:
+				progressing = c.Status == configv1.ConditionTrue
+			case configv1.OperatorDegraded:
+				degraded = c.Status == configv1.ConditionTrue
+			}
+		}
+
+		if degraded {
+			return false, fmt.Errorf("openshift-apiserver operator is degraded")
+		}
+		return available && !progressing, nil
+	})
+}
+
+func GetScopedClientForUser(ctx context.Context, oc *exutil.CLI, username string, scopes []string) (*rest.Config, error) {
 	// make sure the user exists
-	user, err := oc.AdminUserClient().UserV1().Users().Get(context.Background(), username, metav1.GetOptions{})
+	user, err := oc.AdminUserClient().UserV1().Users().Get(ctx, username, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -581,10 +1028,15 @@ func GetScopedClientForUser(oc *exutil.CLI, username string, scopes []string) (*
 		UserName:    user.Name,
 		UserUID:     string(user.UID),
 	}
-	if _, err := oc.AdminOAuthClient().OauthV1().OAuthAccessTokens().Create(context.Background(), token, metav1.CreateOptions{}); err != nil {
+	if _, err := oc.AdminOAuthClient().OauthV1().OAuthAccessTokens().Create(ctx, token, metav1.CreateOptions{}); err != nil {
 		return nil, err
 	}
-	oc.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), token)
+	// Delete token directly to avoid logging token hash
+	g.DeferCleanup(func(cleanupCtx g.SpecContext) {
+		if err := oc.AdminOAuthClient().OauthV1().OAuthAccessTokens().Delete(cleanupCtx, sha256TokenStr, metav1.DeleteOptions{}); err != nil {
+			g.Fail("failed to delete scoped OAuth token")
+		}
+	})
 
 	scopedConfig := rest.AnonymousClientConfig(oc.AdminConfig())
 	scopedConfig.BearerToken = tokenStr

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -470,6 +470,7 @@
 // test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml
 // test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml
+// test/extended/testdata/project/project-request-limits-quota.yaml
 // test/extended/testdata/releases/payload-1/etcd-operator/image-references
 // test/extended/testdata/releases/payload-1/etcd-operator/manifest.yaml
 // test/extended/testdata/releases/payload-1/image-registry/10_image-registry_crd.yaml
@@ -51197,6 +51198,49 @@ func testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml
 	return a, nil
 }
 
+var _testExtendedTestdataProjectProjectRequestLimitsQuotaYaml = []byte(`- apiVersion: v1
+  kind: "LimitRange"
+  metadata:
+    name: ${PROJECT_NAME}-limits
+  spec:
+    limits:
+      - type: "Container"
+        default:
+          cpu: "1"
+          memory: "1Gi"
+        defaultRequest:
+          cpu: "500m"
+          memory: "500Mi"
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: ${PROJECT_NAME}-quota
+    namespace: ${PROJECT_NAME}
+  spec:
+    hard:
+      pods: "10"
+      requests.cpu: "4"
+      requests.memory: 8Gi
+      limits.cpu: "6"
+      limits.memory: 16Gi
+      requests.storage: "20G"
+`)
+
+func testExtendedTestdataProjectProjectRequestLimitsQuotaYamlBytes() ([]byte, error) {
+	return _testExtendedTestdataProjectProjectRequestLimitsQuotaYaml, nil
+}
+
+func testExtendedTestdataProjectProjectRequestLimitsQuotaYaml() (*asset, error) {
+	bytes, err := testExtendedTestdataProjectProjectRequestLimitsQuotaYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "test/extended/testdata/project/project-request-limits-quota.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences = []byte(`kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
@@ -56777,6 +56821,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/extended/testdata/poddisruptionbudgets/always-allow-policy-pdb.yaml":                               testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/if-healthy-budget-policy-pdb.yaml":                          testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml,
 	"test/extended/testdata/poddisruptionbudgets/nginx-with-delayed-ready-deployment.yaml":                   testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml,
+	"test/extended/testdata/project/project-request-limits-quota.yaml":                                       testExtendedTestdataProjectProjectRequestLimitsQuotaYaml,
 	"test/extended/testdata/releases/payload-1/etcd-operator/image-references":                               testExtendedTestdataReleasesPayload1EtcdOperatorImageReferences,
 	"test/extended/testdata/releases/payload-1/etcd-operator/manifest.yaml":                                  testExtendedTestdataReleasesPayload1EtcdOperatorManifestYaml,
 	"test/extended/testdata/releases/payload-1/image-registry/10_image-registry_crd.yaml":                    testExtendedTestdataReleasesPayload1ImageRegistry10_imageRegistry_crdYaml,
@@ -57590,6 +57635,9 @@ var _bintree = &bintree{nil, map[string]*bintree{
 					"always-allow-policy-pdb.yaml":             {testExtendedTestdataPoddisruptionbudgetsAlwaysAllowPolicyPdbYaml, map[string]*bintree{}},
 					"if-healthy-budget-policy-pdb.yaml":        {testExtendedTestdataPoddisruptionbudgetsIfHealthyBudgetPolicyPdbYaml, map[string]*bintree{}},
 					"nginx-with-delayed-ready-deployment.yaml": {testExtendedTestdataPoddisruptionbudgetsNginxWithDelayedReadyDeploymentYaml, map[string]*bintree{}},
+				}},
+				"project": {nil, map[string]*bintree{
+					"project-request-limits-quota.yaml": {testExtendedTestdataProjectProjectRequestLimitsQuotaYaml, map[string]*bintree{}},
 				}},
 				"releases": {nil, map[string]*bintree{
 					"payload-1": {nil, map[string]*bintree{

--- a/test/extended/testdata/project/project-request-limits-quota.yaml
+++ b/test/extended/testdata/project/project-request-limits-quota.yaml
@@ -1,0 +1,26 @@
+- apiVersion: v1
+  kind: "LimitRange"
+  metadata:
+    name: ${PROJECT_NAME}-limits
+  spec:
+    limits:
+      - type: "Container"
+        default:
+          cpu: "1"
+          memory: "1Gi"
+        defaultRequest:
+          cpu: "500m"
+          memory: "500Mi"
+- apiVersion: v1
+  kind: ResourceQuota
+  metadata:
+    name: ${PROJECT_NAME}-quota
+    namespace: ${PROJECT_NAME}
+  spec:
+    hard:
+      pods: "10"
+      requests.cpu: "4"
+      requests.memory: 8Gi
+      limits.cpu: "6"
+      limits.memory: 16Gi
+      requests.storage: "20G"


### PR DESCRIPTION
  ## Summary
  Migrates project API test cases to the OpenShift Tests Extension (OTE) framework, following OTE integration guidelines and origin test standards.

  ## Tests Added

   ### Project Request Template Configuration
  - **Test**: `[OTP] should apply a customized project request template with ResourceQuota and LimitRange`
  - **Validates**:
    - Custom project request templates automatically apply resources to new projects
    - Template configuration propagates through openshift-apiserver observed config
    - Existing projects are not retroactively affected


  ### Cascading Project Deletion
  - **Test**: `[OTP] should delete all resources when the project is deleted`
  - **Validates**:
    - Deleting a project cascades and removes all resources (deployments, pods, services, configmaps, secrets)
    - Recreating a project with the same name starts with a clean slate

```

  }
]yshanmug@yshanmug-thinkpadp1gen7:~/Documents/dev/forks/origin$./openshift-tests run-test "[sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][OTP] should delete all resources when the project is deleted [apigroup:project.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/serial]"
I0617 19:10:34.070573  878885 factory.go:195] Registered Plugin "containerd"
  I0617 19:10:34.297270  878885 binary.go:80] Found 8876 test specs
  I0617 19:10:34.299020  878885 binary.go:97] 1207 test specs remain, after filtering out k8s
openshift-tests v4.1.0-11252-g26ba874
  I0617 19:10:38.599173  878885 test_setup.go:125] Extended test version v4.1.0-11252-g26ba874
  I0617 19:10:38.599204  878885 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0617 19:10:38.599582 878885 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0617 19:10:38.838969 878885 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  
  Running Suite:  - /home/yshanmug/Documents/dev/forks/origin
  ===========================================================
  Random Seed: 1781703634 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][OTP] should delete all resources when the project is deleted [apigroup:project.openshift.io][apigroup:apps.openshift.io] [Lifecycle:informing]
  github.com/openshift/origin/test/extended/project/project.go:798
    STEP: Creating a kubernetes client @ 06/17/26 19:10:38.848
  I0617 19:10:38.849246  878885 discovery.go:214] Invalidating discovery information
  Now using project "project-cascading-delete" on server "https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443".

  You can add applications to this project with the 'new-app' command. For example, try:

      oc new-app rails-postgresql-example

  to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

      kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname
  --> Found container image 4200f43 (2 seconds old) from quay.io for "quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83"

      * An image stream tag will be created as "hello-openshift:latest" that will track this image

  --> Creating resources ...
      imagestream.image.openshift.io "hello-openshift" created
      deployment.apps "hello-openshift" created
      service "hello-openshift" created
  --> Success
      Application is not exposed. You can expose services to the outside world by executing one or more of the commands below:
       'oc expose service/hello-openshift' 
      Run 'oc status' to view your app.
  configmap/project-cascading-delete-cm created
  secret/project-cascading-delete-secret created
  project.project.openshift.io "project-cascading-delete" deleted
  I0617 19:11:41.524712 878885 client.go:1094] Error running oc --kubeconfig=/home/yshanmug/Documents/del/kubeconfig get project project-cascading-delete:
  StdOut>
  Error from server (NotFound): namespaces "project-cascading-delete" not found
  StdErr>
  Error from server (NotFound): namespaces "project-cascading-delete" not found

  Already on project "project-cascading-delete" on server "https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443".

  You can add applications to this project with the 'new-app' command. For example, try:

      oc new-app rails-postgresql-example

  to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

      kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname
  project.project.openshift.io "project-cascading-delete" deleted

  • [78.403 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 78.403 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][OTP] should delete all resources when the project is deleted [apigroup:project.openshift.io][apigroup:apps.openshift.io] [Suite:openshift/conformance/serial]",
    "lifecycle": "informing",
    "duration": 78402,
    "startTime": "2026-06-17 13:40:38.839279 UTC",
    "endTime": "2026-06-17 13:41:57.242176 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 06/17/26 19:10:38.848\nNow using project \"project-cascading-delete\" on server \"https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443\".\n\nYou can add applications to this project with the 'new-app' command. For example, try:\n\n    oc new-app rails-postgresql-example\n\nto build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:\n\n    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname\n--\u003e Found container image 4200f43 (2 seconds old) from quay.io for \"quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83\"\n\n    * An image stream tag will be created as \"hello-openshift:latest\" that will track this image\n\n--\u003e Creating resources ...\n    imagestream.image.openshift.io \"hello-openshift\" created\n    deployment.apps \"hello-openshift\" created\n    service \"hello-openshift\" created\n--\u003e Success\n    Application is not exposed. You can expose services to the outside world by executing one or more of the commands below:\n     'oc expose service/hello-openshift' \n    Run 'oc status' to view your app.\nconfigmap/project-cascading-delete-cm created\nsecret/project-cascading-delete-secret created\nproject.project.openshift.io \"project-cascading-delete\" deleted\nI0617 19:11:41.524712 878885 client.go:1094] Error running oc --kubeconfig=/home/yshanmug/Documents/del/kubeconfig get project project-cascading-delete:\nStdOut\u003e\nError from server (NotFound): namespaces \"project-cascading-delete\" not found\nStdErr\u003e\nError from server (NotFound): namespaces \"project-cascading-delete\" not found\n\nAlready on project \"project-cascading-delete\" on server \"https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443\".\n\nYou can add applications to this project with the 'new-app' command. For example, try:\n\n    oc new-app rails-postgresql-example\n\nto build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:\n\n    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname\nproject.project.openshift.io \"project-cascading-delete\" deleted\n\n",
    "error": "    STEP: Creating a kubernetes client @ 06/17/26 19:10:38.848\n  I0617 19:10:38.849246  878885 discovery.go:214] Invalidating discovery information\n  Now using project \"project-cascading-delete\" on server \"https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443\".\n\n  You can add applications to this project with the 'new-app' command. For example, try:\n\n      oc new-app rails-postgresql-example\n\n  to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:\n\n      kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname\n  --\u003e Found container image 4200f43 (2 seconds old) from quay.io for \"quay.io/openshifttest/hello-openshift@sha256:4200f438cf2e9446f6bcff9d67ceea1f69ed07a2f83363b7fb52529f7ddd8a83\"\n\n      * An image stream tag will be created as \"hello-openshift:latest\" that will track this image\n\n  --\u003e Creating resources ...\n      imagestream.image.openshift.io \"hello-openshift\" created\n      deployment.apps \"hello-openshift\" created\n      service \"hello-openshift\" created\n  --\u003e Success\n      Application is not exposed. You can expose services to the outside world by executing one or more of the commands below:\n       'oc expose service/hello-openshift' \n      Run 'oc status' to view your app.\n  configmap/project-cascading-delete-cm created\n  secret/project-cascading-delete-secret created\n  project.project.openshift.io \"project-cascading-delete\" deleted\n  I0617 19:11:41.524712 878885 client.go:1094] Error running oc --kubeconfig=/home/yshanmug/Documents/del/kubeconfig get project project-cascading-delete:\n  StdOut\u003e\n  Error from server (NotFound): namespaces \"project-cascading-delete\" not found\n  StdErr\u003e\n  Error from server (NotFound): namespaces \"project-cascading-delete\" not found\n\n  Already on project \"project-cascading-delete\" on server \"https://api.ci-ln-6btzg6t-76ef8.aws-4.ci.openshift.org:6443\".\n\n  You can add applications to this project with the 'new-app' command. For example, try:\n\n      oc new-app rails-postgresql-example\n\n  to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:\n\n      kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname\n  project.project.openshift.io \"project-cascading-delete\" deleted\n\n"
  }
]
./openshift-tests run-test "[sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][Slow][OTP] should apply a customized project request template with ResourceQuota and LimitRange [apigroup:project.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io]"
I0617 19:19:24.008381  880713 factory.go:195] Registered Plugin "containerd"
  I0617 19:19:24.240033  880713 binary.go:80] Found 8876 test specs
  I0617 19:19:24.241929  880713 binary.go:97] 1207 test specs remain, after filtering out k8s
openshift-tests v4.1.0-11252-g26ba874
  I0617 19:19:30.436643  880713 test_setup.go:125] Extended test version v4.1.0-11252-g26ba874
  I0617 19:19:30.436672  880713 test_context.go:558] Tolerating taints "node-role.kubernetes.io/control-plane" when considering if nodes are ready
  I0617 19:19:30.437213 880713 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0617 19:19:30.765096 880713 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  Running Suite:  - /home/yshanmug/Documents/dev/forks/origin
  ===========================================================
  Random Seed: 1781704164 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][Slow][OTP] should apply a customized project request template with ResourceQuota and LimitRange [apigroup:project.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io] [Lifecycle:informing]
  github.com/openshift/origin/test/extended/project/project.go:645
    STEP: Creating a kubernetes client @ 06/17/26 19:19:30.775
  I0617 19:19:30.775858  880713 discovery.go:214] Invalidating discovery information
  template.template.openshift.io/project-request-template-request created
  project.project.openshift.io "project-request-template-before" deleted
  I0617 19:26:47.207016 880713 project.go:885] cleanup: deleted project "project-request-template-before"
  project.project.openshift.io "project-request-template-after" deleted
  I0617 19:26:55.288162 880713 project.go:885] cleanup: deleted project "project-request-template-after"
  template.template.openshift.io "project-request-template-request" deleted from openshift-config namespace
  I0617 19:26:56.517763 880713 project.go:893] cleanup: deleted template "project-request-template-request" from openshift-config
  • [777.626 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 777.626 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[sig-api-machinery] [Jira:apiserver-auth] Project API [Serial][Slow][OTP] should apply a customized project request template with ResourceQuota and LimitRange [apigroup:project.openshift.io][apigroup:config.openshift.io][apigroup:template.openshift.io]",
    "lifecycle": "informing",
    "duration": 777626,
    "startTime": "2026-06-17 13:49:30.765351 UTC",
    "endTime": "2026-06-17 14:02:28.391814 UTC",
    "result": "passed",
    "output": "  STEP: Creating a kubernetes client @ 06/17/26 19:19:30.775\ntemplate.template.openshift.io/project-request-template-request created\nproject.project.openshift.io \"project-request-template-before\" deleted\nI0617 19:26:47.207016 880713 project.go:885] cleanup: deleted project \"project-request-template-before\"\nproject.project.openshift.io \"project-request-template-after\" deleted\nI0617 19:26:55.288162 880713 project.go:885] cleanup: deleted project \"project-request-template-after\"\ntemplate.template.openshift.io \"project-request-template-request\" deleted from openshift-config namespace\nI0617 19:26:56.517763 880713 project.go:893] cleanup: deleted template \"project-request-template-request\" from openshift-config\n",
    "error": "    STEP: Creating a kubernetes client @ 06/17/26 19:19:30.775\n  I0617 19:19:30.775858  880713 discovery.go:214] Invalidating discovery information\n  template.template.openshift.io/project-request-template-request created\n  project.project.openshift.io \"project-request-template-before\" deleted\n  I0617 19:26:47.207016 880713 project.go:885] cleanup: deleted project \"project-request-template-before\"\n  project.project.openshift.io \"project-request-template-after\" deleted\n  I0617 19:26:55.288162 880713 project.go:885] cleanup: deleted project \"project-request-template-after\"\n  template.template.openshift.io \"project-request-template-request\" deleted from openshift-config namespace\n  I0617 19:26:56.517763 880713 project.go:893] cleanup: deleted template \"project-request-template-request\" from openshift-config\n"
  }

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Expanded end-to-end coverage for project creation, including rejection of multiple invalid node-selector formats.
  * Verified user-visible node selector output in project descriptions (`<none>` when unset, configured values when set).
  * Added slow/serialized checks to ensure custom project request templates propagate and apply `ResourceQuota`/`LimitRange` only to projects created after readiness.
  * Added serialized checks that deleting a project fully removes resources and recreating it starts clean.
  * Added an embedded YAML fixture for project request limits/quotas and improved test OAuth token cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->