### PR TITLE
CNTRLPLANE-3629: authentication: skip external oidc kube-apiserver configuration check when new architecture gate is enabled

### DIFF
--- a/test/extended/authentication/oidc.go
+++ b/test/extended/authentication/oidc.go
@@ -10,6 +10,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned/typed/operator/v1"
@@ -125,6 +126,25 @@ var _ = g.Describe("[sig-auth][Suite:openshift/auth/external-oidc][Serial][Slow]
 
 		g.Describe("external IdP is configured", g.Ordered, func() {
 			g.It("should configure kube-apiserver", func() {
+				// Get the FeatureGates resource
+				fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred(), "error getting cluster FeatureGates.")
+
+				// Loop through the feature gates to see if the desired one is enabled
+				externalClaimsSourcingEnabled := false
+				for _, fg := range fgs.Status.FeatureGates {
+					for _, enabledFG := range fg.Enabled {
+						if enabledFG.Name == features.FeatureGateExternalOIDCExternalClaimsSourcing {
+							externalClaimsSourcingEnabled = true
+							break
+						}
+					}
+				}
+
+				if externalClaimsSourcingEnabled {
+					g.Skip("ExternalOIDCExternalClaimsSourcing is enabled which makes this test case obsolete, skipping.")
+				}
+
 				kas, err := oc.AdminOperatorClient().OperatorV1().KubeAPIServers().Get(ctx, "cluster", metav1.GetOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred(), "should not encounter an error getting the kubeapiservers.operator.openshift.io/cluster")
 


### PR DESCRIPTION
As part of the work to accomplish https://redhat.atlassian.net/browse/CNTRLPLANE-2512 we've done some re-architecting as to how the ExternalOIDC feature works under the hood.

This PR updates the tests to skip a test case that was opinionated as to the underlying architecture for the feature that is obsolete with the incoming architecture changes. We will not remove the test case entirely until the new feature that introduces the new architecture has been promoted to the Default feature set and has shipped in a GA release. This prevents a lapse in automated regression coverage for how the baseline ExternalOIDC feature works in fully supported clusters today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OIDC authentication test suite to properly handle pre-configured feature states, improving test reliability and preventing obsolete test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->