### PR TITLE
SPLAT-2802: Added VVCDO OTE binary to extensionBinary list

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -333,6 +333,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "service-ca-operator",
 		binaryPath: "/usr/bin/service-ca-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "vsphere-csi-driver-operator",
+		binaryPath: "/usr/bin/vmware-vsphere-csi-driver-operator-tests-ext.gz",
+	},
 }
 
 // Info returns information about this particular extension.


### PR DESCRIPTION
[SPLAT-2802](https://redhat.atlassian.net/browse/SPLAT-2802)

### Changes
- Added VVCDO OTE binary

### Prerequisites
- https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/349

### Notes

Original Main branch (5.0) PRs:
- https://github.com/openshift/vmware-vsphere-csi-driver-operator/pull/335
- https://github.com/openshift/origin/pull/31014