### PR TITLE
OCPBUGS-86789: Make early request monitor test informing

### DIFF
--- a/test/extended/apiserver/graceful_termination.go
+++ b/test/extended/apiserver/graceful_termination.go
@@ -11,6 +11,7 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -151,7 +152,7 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Late]", func() {
 		}
 	})
 
-	g.It("API LBs follow /readyz of kube-apiserver and don't send request early", func() {
+	g.It("API LBs follow /readyz of kube-apiserver and don't send request early", ote.Informing(), func() {
 		t := g.GinkgoT()
 
 		client, err := kubernetes.NewForConfig(oc.AdminConfig())


### PR DESCRIPTION
Early requests have been occurring and have been uncaught due to an event emission error in KAS. Making it informing here (for now) allows us to keep collecting data on it but not block the event emission fix on an actual early request fix (both of which need to happen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to improve robustness of API server graceful termination validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->