### PR TITLE
CNTRLPLANE-3386: Required scc annotation checker updates

### DIFF
--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -44,27 +44,6 @@ var namespacesWithPendingSCCPinning = sets.NewString(
 	"openshift-ingress",
 	"openshift-insights",
 	"openshift-machine-api",
-	// run-level namespaces
-	"openshift-cloud-controller-manager",
-	"openshift-cloud-controller-manager-operator",
-	"openshift-cluster-api",
-	"openshift-cluster-machine-approver",
-	"openshift-dns",
-	"openshift-dns-operator",
-	"openshift-etcd",
-	"openshift-etcd-operator",
-	"openshift-kube-apiserver",
-	"openshift-kube-apiserver-operator",
-	"openshift-kube-controller-manager",
-	"openshift-kube-controller-manager-operator",
-	"openshift-kube-proxy",
-	"openshift-kube-scheduler",
-	"openshift-kube-scheduler-operator",
-	"openshift-multus",
-	"openshift-network-operator",
-	"openshift-ovn-kubernetes",
-	"openshift-sdn",
-	"openshift-storage",
 )
 
 // systemNamespaces includes namespaces that should be treated as flaking.
@@ -114,6 +93,11 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 	for _, ns := range namespaces.Items {
 		// skip managed service namespaces
 		if exutil.ManagedServiceNamespaces.Has(ns.Name) {
+			continue
+		}
+
+		// skip run-level namespaces; SCC admission does not run on them
+		if _, hasRunLevel := ns.Labels["openshift.io/run-level"]; hasRunLevel {
 			continue
 		}
 

--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -37,17 +37,7 @@ var nonStandardSCCNamespaces = map[string]sets.Set[string]{
 	"machine-api-termination-handler": sets.New("openshift-machine-api"),
 }
 
-// namespacesWithPendingSCCPinning includes namespaces with workloads that have pending SCC pinning.
-var namespacesWithPendingSCCPinning = sets.NewString(
-	"openshift-cluster-csi-drivers",
-	"openshift-image-registry",
-	"openshift-ingress",
-	"openshift-insights",
-	"openshift-machine-api",
-)
-
-// systemNamespaces includes namespaces that should be treated as flaking.
-// these namespaces are included because we don't control their creation or labeling on their creation.
+// systemNamespaces are skipped because we don't control their creation or labeling.
 var systemNamespaces = sets.NewString(
 	"default",
 	"kube-system",
@@ -91,20 +81,7 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 
 	junits := []*junitapi.JUnitTestCase{}
 	for _, ns := range namespaces.Items {
-		// skip managed service namespaces
-		if exutil.ManagedServiceNamespaces.Has(ns.Name) {
-			continue
-		}
-
-		// skip run-level namespaces; SCC admission does not run on them
-		if _, hasRunLevel := ns.Labels["openshift.io/run-level"]; hasRunLevel {
-			continue
-		}
-
-		// require that all workloads in openshift, kube-*, or default namespaces must have the required-scc annotation
-		// ignore openshift-must-gather-* namespaces which are generated dynamically
-		isPermanentOpenShiftNamespace := (ns.Name == "openshift" || strings.HasPrefix(ns.Name, "openshift-")) && !strings.HasPrefix(ns.Name, "openshift-must-gather-")
-		if !strings.HasPrefix(ns.Name, "kube-") && ns.Name != "default" && !isPermanentOpenShiftNamespace {
+		if shouldSkipNamespace(&ns) {
 			continue
 		}
 
@@ -172,14 +149,6 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 				SystemOut:     failureMsg,
 				FailureOutput: &junitapi.FailureOutput{Output: failureMsg},
 			})
-
-		// add a successful test with the same name to cause a flake if the namespace should be flaking
-		if namespacesWithPendingSCCPinning.Has(ns.Name) || systemNamespaces.Has(ns.Name) {
-			junits = append(junits,
-				&junitapi.JUnitTestCase{
-					Name: testName,
-				})
-		}
 	}
 
 	return nil, junits, nil
@@ -201,6 +170,21 @@ func (w *requiredSCCAnnotationChecker) Cleanup(ctx context.Context) error {
 	return nil
 }
 
+func shouldSkipNamespace(ns *v1.Namespace) bool {
+	if exutil.ManagedServiceNamespaces.Has(ns.Name) {
+		return true
+	}
+	if systemNamespaces.Has(ns.Name) {
+		return true
+	}
+	if _, hasRunLevel := ns.Labels["openshift.io/run-level"]; hasRunLevel {
+		return true
+	}
+	if !strings.HasPrefix(ns.Name, "openshift-") || strings.HasPrefix(ns.Name, "openshift-must-gather-") {
+		return true
+	}
+	return false
+}
 func ownerReferences(pod *v1.Pod) string {
 	ownerRefs := make([]string, len(pod.OwnerReferences))
 	for i, or := range pod.OwnerReferences {

--- a/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
+++ b/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go
@@ -47,6 +47,13 @@ var systemNamespaces = sets.NewString(
 	"openshift",
 )
 
+var ignoredWorkloads = sets.NewString(
+	// proprietary workloads; we do not have a way to pin the required SCC
+	"openshift-cluster-csi-drivers/nutanix-csi",
+	"openshift-cluster-csi-drivers/nutanix-csi-controller",
+	"openshift-cluster-csi-drivers/nutanix-csi-operator-controller-manager",
+)
+
 type requiredSCCAnnotationChecker struct {
 	kubeClient kubernetes.Interface
 }
@@ -92,6 +99,10 @@ func (w *requiredSCCAnnotationChecker) CollectData(ctx context.Context, storageD
 
 		failures := make([]string, 0)
 		for _, pod := range pods.Items {
+			if shouldSkipPod(&pod) {
+				continue
+			}
+
 			validatedSCC := pod.Annotations[securityv1.ValidatedSCCAnnotation]
 			allowedNamespaces, isNonStandard := nonStandardSCCNamespaces[validatedSCC]
 
@@ -170,6 +181,18 @@ func (w *requiredSCCAnnotationChecker) Cleanup(ctx context.Context) error {
 	return nil
 }
 
+func shouldSkipPod(pod *v1.Pod) bool {
+	for _, owner := range pod.OwnerReferences {
+		ownerKey := fmt.Sprintf("%s/%s", pod.Namespace, owner.Name)
+		for _, workload := range ignoredWorkloads.UnsortedList() {
+			if ownerKey == workload || strings.HasPrefix(ownerKey, workload+"-") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func shouldSkipNamespace(ns *v1.Namespace) bool {
 	if exutil.ManagedServiceNamespaces.Has(ns.Name) {
 		return true
@@ -185,6 +208,7 @@ func shouldSkipNamespace(ns *v1.Namespace) bool {
 	}
 	return false
 }
+
 func ownerReferences(pod *v1.Pod) string {
 	ownerRefs := make([]string, len(pod.OwnerReferences))
 	for i, or := range pod.OwnerReferences {


### PR DESCRIPTION
This PR does the following updates in the `required-scc-annotation-checker` monitor test:

  1. **Ignore run-level namespaces**: skip namespaces labeled with `openshift.io/run-level` since SCC admission does not run on them, instead of carrying them as pending exceptions.
  2. **Remove pending namespaces mechanism**: all previously pending namespaces have been fixed, so the `namespacesWithPendingSCCPinning` list and its flake-on-failure behavior are removed. System namespaces now cause a hard failure instead of a flake.
  3. **Ignore specific proprietary workloads**: skip Nutanix CSI pods (`nutanix-csi`, `nutanix-csi-controller`, `nutanix-csi-operator-controller-manager`) that we cannot pin a required SCC to. Matching uses both exact and prefix comparison to handle Deployment-owned pods whose ReplicaSet names include a hash suffix.
  4. **Refactor namespace filtering** into a dedicated `shouldSkipNamespace` helper for readability.

## Dependencies
This PR depends on the following fix-PRs:
- https://github.com/openshift/machine-api-operator/pull/1511
- https://github.com/openshift/release/pull/80993
- https://github.com/openshift/cluster-image-registry-operator/pull/1351
- https://github.com/openshift/insights-operator/pull/1309
- https://github.com/openshift/csi-operator/pull/569
- https://github.com/openshift/gcp-filestore-csi-driver-operator/pull/148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved required security-context monitoring accuracy by excluding infrastructure, managed-service, and non-applicable workloads from validation.
  * Reduced false positives by refining which namespaces and workloads are evaluated.
  * Removed misleading extra success results, making monitoring test outcomes more consistent and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->