### PR TITLE
OCPBUGS-84512: Remove exception terminationMessagePolicy=TerminationMessageFallbackToLogsOnError

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -111,14 +111,12 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			if container.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
 				failuresByNamespace[pod.Namespace] = append(failuresByNamespace[pod.Namespace],
 					fmt.Sprintf("pods/%s containers[%v]", pod.Name, container.Name))
-
 			}
 		}
 		for _, container := range pod.Spec.EphemeralContainers {
 			if container.TerminationMessagePolicy != corev1.TerminationMessageFallbackToLogsOnError {
 				failuresByNamespace[pod.Namespace] = append(failuresByNamespace[pod.Namespace],
 					fmt.Sprintf("pods/%s ephemeralContainers[%v]", pod.Name, container.Name))
-
 			}
 		}
 	}
@@ -137,9 +135,8 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 		),
 		// per TRT-2084 these were erroneously allowed to flake, so grandfather them in for now.
 		// they should be fixed and removed from here:
-		"openshift-backplane":                sets.NewString("pods/osd-delete-backplane-serviceaccounts"), // filed OCPBUGS-84527 to fix
-		"openshift-cloud-controller-manager": sets.NewString("pods/aws-cloud-controller-manager"),         // filed OCPBUGS-84512 to fix
-		"openshift-cluster-version":          sets.NewString("pods/version--"),                            // filed OCPBUGS-84513 to fix
+		"openshift-backplane":       sets.NewString("pods/osd-delete-backplane-serviceaccounts"), // filed OCPBUGS-84527 to fix
+		"openshift-cluster-version": sets.NewString("pods/version--"),                            // filed OCPBUGS-84513 to fix
 		"openshift-cnv": sets.NewString( // filed OCPBUGS-84522 to fix
 			"pods/hostpath-provisioner-operator",
 			"pods/virt-platform-autopilot",


### PR DESCRIPTION
Removes the exception for cloud-provider-aws on terminationMessagePolicy=FallbackToLogsOnError violations

Fixed by **https://github.com/openshift/release/pull/80840https://github.com/openshift/release/pull/80840**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a previously exempt namespace entry, so TerminationMessagePolicy issues that may have been ignored before are now reported consistently. Previously exempt pods/containers in that namespace may now show as new violations, subject to the existing version and message-matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->