### PR TITLE
OCPBUGS-91956: Fix isNoOLMFeatureGateEnabled to check only the current cluster version

### DIFF
--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -643,18 +643,28 @@ func isIPv6OrDualStack(oc *exutil.CLI) (bool, error) {
 }
 
 func isNoOLMFeatureGateEnabled(oc *exutil.CLI) (bool, error) {
+	cv, err := oc.AdminConfigClient().ConfigV1().ClusterVersions().Get(context.TODO(), "version", metav1.GetOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to get ClusterVersion: %v", err)
+	}
+	currentVersion := cv.Status.Desired.Version
+
 	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{})
 	if err != nil {
 		return false, fmt.Errorf("failed to get cluster FeatureGates: %v", err)
 	}
 	for _, fg := range fgs.Status.FeatureGates {
+		if fg.Version != currentVersion {
+			continue
+		}
 		for _, enabledFG := range fg.Enabled {
 			if enabledFG.Name == "GatewayAPIWithoutOLM" {
-				e2e.Logf("GatewayAPIWithoutOLM featuregate is enabled")
+				e2e.Logf("GatewayAPIWithoutOLM featuregate is enabled for version %s", currentVersion)
 				return true, nil
 			}
 		}
 	}
+	e2e.Logf("GatewayAPIWithoutOLM featuregate is not enabled for version %s", currentVersion)
 	return false, nil
 }
 


### PR DESCRIPTION
## Summary
- `isNoOLMFeatureGateEnabled` was iterating all version entries in `status.featureGates`, which after an upgrade includes entries for both old and new cluster versions
- This caused the function to incorrectly return `true` by finding `GatewayAPIWithoutOLM` enabled in the pre-upgrade version's entry, even when the current version has it disabled
- Fix: look up the current cluster version from `ClusterVersion.status.desired.version` and only check the matching `featureGates` entry
- Fixes the `e2e-upgrade-out-of-change` test failure for openshift/api#2865 where the test expected a sail finalizer that the CIO had already removed during the downgrade path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected feature gate validation for Gateway API to properly check against your cluster's current OpenShift version. Previously, the feature would activate if enabled for any version; now it only activates when explicitly enabled for your specific version. This ensures appropriate feature availability based on your cluster configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->