### PR TITLE
OCPBUGS-91996: Add openshift/disruptive-longrunning testsuite in release-4.20 branch

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -451,6 +451,20 @@ var staticSuites = []ginkgo.TestSuite{
 		},
 		TestTimeout: 1 * time.Minute,
 	},
+	{
+		Name: "openshift/disruptive-longrunning",
+		Description: templates.LongDesc(`
+		Long-running disruptive test suite. Tests in this suite are disruptive (cause node reboots,
+		configuration changes, or cluster-wide disruptions) and take significant time to complete.
+		Multiple teams can use this suite for their long-running disruptive tests.
+		`),
+		Qualifiers: []string{
+			`name.contains("[Suite:openshift/disruptive-longrunning")`,
+		},
+		Parallelism:                1,
+		TestTimeout:                40 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
 }
 
 func withExcludedTestsFilter(baseExpr string) string {

--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -1,0 +1,28 @@
+# Node E2E Tests
+
+## Running Long-Running Disruptive Tests
+
+The `openshift/disruptive-longrunning` suite is a general-purpose suite for long-running disruptive tests
+across all teams. Node team tests are tagged with `[sig-node]` to identify them.
+
+To run the entire long-running disruptive test suite on a cluster manually, use the command:
+
+```bash
+./openshift-tests run "openshift/disruptive-longrunning" --cluster-stability=Disruptive
+```
+
+To run only node-specific long-running disruptive tests:
+
+```bash
+./openshift-tests run "openshift/disruptive-longrunning" --dry-run | grep "\[sig-node\]" | ./openshift-tests run -f - --cluster-stability=Disruptive
+```
+
+## Prerequisites
+
+- Make sure to set `oc` binary to match the cluster version
+- Make sure to set the kubeconfig to point to a live OCP cluster
+
+## Important Notes
+
+- Note that dry-run option won't list the test as it does not connect to a live cluster
+- Run `make update` if the test data is changed


### PR DESCRIPTION
Add openshift/disruptive-longrunning testsuite in release-4.20 branch

Manual cherry-pick of https://github.com/openshift/origin/pull/30976 (by @BhargaviGudi) to `release-4.20`.

The automatic `/cherry-pick release-4.20` failed due to a merge conflict in `pkg/testsuites/standard_suites.go` (different file structure between `release-4.21` and `release-4.20`). This PR manually applies the same change.

### What this PR does

Adds the `openshift/disruptive-longrunning` test suite definition to `pkg/testsuites/standard_suites.go` and a README with usage instructions in `test/extended/node/`. This enables long-running disruptive tests (e.g., node reboots, configuration changes, cluster-wide disruptions) to run on the 4.20 release branch.

CI job: https://github.com/openshift/release/pull/80958

The test can be executed only after the CI job is merged.

### How to run

To run the entire long-running disruptive test suite on a cluster:
```
./openshift-tests run "openshift/disruptive-longrunning" --cluster-stability=Disruptive
```

To trigger via CI:
```
/payload-job periodic-ci-openshift-release-main-nightly-4.20-e2e-aws-disruptive-longrunning
```

### Reference PRs

| Branch | PR | Author | Status |
|--------|-----|--------|--------|
| main | https://github.com/openshift/origin/pull/30648 | @BhargaviGudi | Merged |
| release-4.21 | https://github.com/openshift/origin/pull/30976 | @BhargaviGudi | Merged |
| **release-4.20** | **This PR** | @Chandan9112 | Under Review |

**Note:** pj-rehearse validation will fail because no tests are tagged with this suite yet in release-4.20. Tests are being added via subsequent PRs, but those PRs depend on merging this suite definition and CI job configuration first so the tests have a job to run in.