### PR TITLE
CNTRLPLANE-3741: PKI config tests for service-ca and kube-apiserver-operator

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -513,6 +513,22 @@ var staticSuites = []ginkgo.TestSuite{
 		Parallelism: 1,
 		TestTimeout: 60 * time.Minute,
 	},
+	{
+		Name: "openshift/pkiconfig",
+		Description: templates.LongDesc(`
+		Tests that verify PKI configuration is properly applied to cluster certificates.
+		This includes validation of certificate key algorithms (RSA, ECDSA) and key sizes
+		for service-ca and kube-apiserver certificates. The tests reconfigure PKI settings
+		and trigger certificate regeneration, which causes temporary cluster disruption as
+		apiserver pods restart to apply new certificates.
+		`),
+		Qualifiers: []string{
+			withStandardEarlyOrLateTests(`name.contains("[Suite:openshift/pkiconfig]")`),
+		},
+		Parallelism:                1,
+		TestTimeout:                90 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
 }
 
 // mergeParentQualifiers appends each suite's qualifiers to its declared parent

--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/oauth"
 	_ "github.com/openshift/origin/test/extended/olm"
 	_ "github.com/openshift/origin/test/extended/operators"
+	_ "github.com/openshift/origin/test/extended/pki"
 	_ "github.com/openshift/origin/test/extended/poddisruptionbudget"
 	_ "github.com/openshift/origin/test/extended/pods"
 	_ "github.com/openshift/origin/test/extended/project"

--- a/test/extended/pki/helpers.go
+++ b/test/extended/pki/helpers.go
@@ -1,0 +1,318 @@
+package pki
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	watchtools "k8s.io/client-go/tools/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+)
+
+// certInfo contains parsed certificate information
+type certInfo struct {
+	Algorithm string
+	KeySize   int
+	Curve     string
+	IsCA      bool
+}
+
+// pkiTestConfig defines a PKI test configuration
+type pkiTestConfig struct {
+	name            string
+	algorithm       configv1alpha1.KeyAlgorithm
+	rsaSize         int32
+	ecdsaCurve      configv1alpha1.ECDSACurve
+	signerOverride  *keyOverride
+	servingOverride *keyOverride
+}
+
+// keyOverride specifies key configuration override for a certificate type
+type keyOverride struct {
+	algorithm  configv1alpha1.KeyAlgorithm
+	rsaSize    int32
+	ecdsaCurve configv1alpha1.ECDSACurve
+}
+
+// mixedPKITestConfig defines a mixed PKI test configuration with different settings per category
+type mixedPKITestConfig struct {
+	name              string
+	signerAlgorithm   configv1alpha1.KeyAlgorithm
+	signerRSASize     int32
+	signerECDSACurve  configv1alpha1.ECDSACurve
+	servingAlgorithm  configv1alpha1.KeyAlgorithm
+	servingRSASize    int32
+	servingECDSACurve configv1alpha1.ECDSACurve
+	clientAlgorithm   configv1alpha1.KeyAlgorithm
+	clientRSASize     int32
+	clientECDSACurve  configv1alpha1.ECDSACurve
+}
+
+// operatorCertificate represents a certificate managed by an operator
+type operatorCertificate struct {
+	Namespace  string
+	SecretName string
+	CertKey    string // Key in the secret containing the certificate (e.g., "tls.crt")
+	Category   string // "signer", "serving", or "client"
+}
+
+// buildKeyConfig creates a KeyConfig from algorithm and key parameters
+func buildKeyConfig(algorithm configv1alpha1.KeyAlgorithm, rsaSize int32, ecdsaCurve configv1alpha1.ECDSACurve) configv1alpha1.KeyConfig {
+	keyConfig := configv1alpha1.KeyConfig{
+		Algorithm: algorithm,
+	}
+
+	if algorithm == configv1alpha1.KeyAlgorithmRSA {
+		keyConfig.RSA = configv1alpha1.RSAKeyConfig{
+			KeySize: rsaSize,
+		}
+	} else if algorithm == configv1alpha1.KeyAlgorithmECDSA {
+		keyConfig.ECDSA = configv1alpha1.ECDSAKeyConfig{
+			Curve: ecdsaCurve,
+		}
+	}
+
+	return keyConfig
+}
+
+// applyPKIConfig applies a PKI configuration based on the test config
+func applyPKIConfig(ctx context.Context, configClient configclient.Interface, tc pkiTestConfig) error {
+	// Build default key config (used for serving certs unless overridden)
+	defaultKeyConfig := buildKeyConfig(tc.algorithm, tc.rsaSize, tc.ecdsaCurve)
+
+	pkiProfile := configv1alpha1.PKIProfile{
+		Defaults: configv1alpha1.DefaultCertificateConfig{
+			Key: defaultKeyConfig,
+		},
+	}
+
+	// Add signer certificate override if specified
+	if tc.signerOverride != nil {
+		signerKeyConfig := buildKeyConfig(tc.signerOverride.algorithm, tc.signerOverride.rsaSize, tc.signerOverride.ecdsaCurve)
+		pkiProfile.SignerCertificates = configv1alpha1.CertificateConfig{
+			Key: signerKeyConfig,
+		}
+	}
+
+	// Add serving certificate override if specified
+	if tc.servingOverride != nil {
+		servingKeyConfig := buildKeyConfig(tc.servingOverride.algorithm, tc.servingOverride.rsaSize, tc.servingOverride.ecdsaCurve)
+		pkiProfile.ServingCertificates = configv1alpha1.CertificateConfig{
+			Key: servingKeyConfig,
+		}
+	}
+
+	pki := &configv1alpha1.PKI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1alpha1.PKISpec{
+			CertificateManagement: configv1alpha1.PKICertificateManagement{
+				Mode: configv1alpha1.PKICertificateManagementModeCustom,
+				Custom: configv1alpha1.CustomPKIPolicy{
+					PKIProfile: pkiProfile,
+				},
+			},
+		},
+	}
+
+	// Try to create or update
+	existing, err := configClient.ConfigV1alpha1().PKIs().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Create new
+			_, err = configClient.ConfigV1alpha1().PKIs().Create(ctx, pki, metav1.CreateOptions{})
+			return err
+		}
+		// Return other errors (transient, permission, etc.)
+		return err
+	}
+
+	// Update existing
+	existing.Spec = pki.Spec
+	_, err = configClient.ConfigV1alpha1().PKIs().Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// applyMixedPKIConfig applies a mixed PKI configuration with different settings per category
+func applyMixedPKIConfig(ctx context.Context, configClient configclient.Interface, tc mixedPKITestConfig) error {
+	// Build default key config (we'll use signer as default)
+	defaultKeyConfig := buildKeyConfig(tc.signerAlgorithm, tc.signerRSASize, tc.signerECDSACurve)
+
+	// Build override configs for serving and client
+	servingKeyConfig := buildKeyConfig(tc.servingAlgorithm, tc.servingRSASize, tc.servingECDSACurve)
+	clientKeyConfig := buildKeyConfig(tc.clientAlgorithm, tc.clientRSASize, tc.clientECDSACurve)
+
+	pki := &configv1alpha1.PKI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: configv1alpha1.PKISpec{
+			CertificateManagement: configv1alpha1.PKICertificateManagement{
+				Mode: configv1alpha1.PKICertificateManagementModeCustom,
+				Custom: configv1alpha1.CustomPKIPolicy{
+					PKIProfile: configv1alpha1.PKIProfile{
+						Defaults: configv1alpha1.DefaultCertificateConfig{
+							Key: defaultKeyConfig,
+						},
+						SignerCertificates: configv1alpha1.CertificateConfig{
+							Key: defaultKeyConfig,
+						},
+						ServingCertificates: configv1alpha1.CertificateConfig{
+							Key: servingKeyConfig,
+						},
+						ClientCertificates: configv1alpha1.CertificateConfig{
+							Key: clientKeyConfig,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Try to create or update
+	existing, err := configClient.ConfigV1alpha1().PKIs().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Create new
+			_, err = configClient.ConfigV1alpha1().PKIs().Create(ctx, pki, metav1.CreateOptions{})
+			return err
+		}
+		// Return other errors (transient, permission, etc.)
+		return err
+	}
+
+	// Update existing
+	existing.Spec = pki.Spec
+	_, err = configClient.ConfigV1alpha1().PKIs().Update(ctx, existing, metav1.UpdateOptions{})
+	return err
+}
+
+// getCertificateFromSecret retrieves and parses a certificate from a secret
+func getCertificateFromSecret(ctx context.Context, kubeClient kubernetes.Interface, namespace, secretName, certKey string) (*certInfo, error) {
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", namespace, secretName, err)
+	}
+
+	certData, ok := secret.Data[certKey]
+	if !ok {
+		return nil, fmt.Errorf("certificate key %q not found in secret %s/%s", certKey, namespace, secretName)
+	}
+
+	return parseCertificate(certData)
+}
+
+// parseCertificate parses PEM-encoded certificate data.
+// Only the first PEM block is decoded: for serving/client certs this relies on
+// library-go writing tls.crt leaf-first ([leaf, CA...]). Callers verifying
+// serving or client certs should assert IsCA==false on the returned certInfo.
+func parseCertificate(certPEM []byte) (*certInfo, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %w", err)
+	}
+
+	info := &certInfo{
+		IsCA: cert.IsCA,
+	}
+
+	switch pub := cert.PublicKey.(type) {
+	case *rsa.PublicKey:
+		info.Algorithm = "RSA"
+		info.KeySize = pub.N.BitLen()
+	case *ecdsa.PublicKey:
+		info.Algorithm = "ECDSA"
+		switch pub.Curve {
+		case elliptic.P256():
+			info.Curve = "P256"
+		case elliptic.P384():
+			info.Curve = "P384"
+		case elliptic.P521():
+			info.Curve = "P521"
+		default:
+			info.Curve = "Unknown"
+		}
+	default:
+		return nil, fmt.Errorf("unsupported public key type: %T", pub)
+	}
+
+	return info, nil
+}
+
+// waitForSecretRegeneration waits for a secret to be recreated with new UID and populated cert data.
+// oldUID is the UID of the secret before deletion; certKey is the data key to verify (e.g., "tls.crt").
+// The timeout is controlled by ctx (e.g., use context.WithTimeout).
+func waitForSecretRegeneration(ctx context.Context, kubeClient kubernetes.Interface, namespace, secretName, certKey string, oldUID string) error {
+	lw := cache.NewListWatchFromClient(
+		kubeClient.CoreV1().RESTClient(), "secrets", namespace,
+		fields.OneTermEqualSelector("metadata.name", secretName))
+	_, err := watchtools.UntilWithSync(ctx, lw, &corev1.Secret{}, nil,
+		func(event watch.Event) (bool, error) {
+			if event.Type != watch.Added && event.Type != watch.Modified {
+				return false, nil
+			}
+			s := event.Object.(*corev1.Secret)
+			if string(s.UID) == oldUID {
+				return false, nil
+			}
+			_, ok := s.Data[certKey]
+			return ok, nil
+		})
+	return err
+}
+
+// deleteCertificateSecret deletes a certificate secret to trigger rotation/regeneration
+func deleteCertificateSecret(ctx context.Context, kubeClient kubernetes.Interface, namespace, secretName string) error {
+	return kubeClient.CoreV1().Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+}
+
+// cleanupPKIConfiguration resets the PKI configuration to default (Unmanaged)
+// NOTE: Does NOT disable the feature gate - feature gate lifecycle is managed by CI job config
+func cleanupPKIConfiguration(ctx context.Context, configClient configclient.Interface) {
+	e2e.Logf("Starting PKI cleanup...")
+
+	// Reset PKI cluster resource to default (unmanaged) configuration
+	e2e.Logf("Resetting PKI cluster resource to default configuration...")
+	pki, err := configClient.ConfigV1alpha1().PKIs().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			e2e.Logf("Warning: error getting PKI resource: %v", err)
+		} else {
+			e2e.Logf("PKI resource not found, skipping reset")
+		}
+	} else {
+		// Reset to default/unmanaged mode
+		// Note: custom field must be empty when mode is Unmanaged
+		pki.Spec.CertificateManagement.Mode = configv1alpha1.PKICertificateManagementModeUnmanaged
+		pki.Spec.CertificateManagement.Custom = configv1alpha1.CustomPKIPolicy{}
+
+		_, err = configClient.ConfigV1alpha1().PKIs().Update(ctx, pki, metav1.UpdateOptions{})
+		if err != nil {
+			e2e.Logf("Warning: error resetting PKI resource: %v", err)
+		} else {
+			e2e.Logf("✓ PKI cluster resource reset to Unmanaged mode successfully")
+		}
+	}
+
+	e2e.Logf("PKI cleanup completed")
+}

--- a/test/extended/pki/pki_kube_apiserver.go
+++ b/test/extended/pki/pki_kube_apiserver.go
@@ -1,0 +1,319 @@
+package pki
+
+import (
+	"context"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+const (
+	kubeAPIServerOperatorNamespace = "openshift-kube-apiserver-operator"
+	kubeAPIServerNamespace         = "openshift-kube-apiserver"
+)
+
+var _ = g.Describe("[sig-kube-apiserver][OCPFeatureGate:ConfigurablePKI][Serial][Disruptive][Suite:openshift/pkiconfig] PKI Configuration", g.Ordered, func() {
+	oc := exutil.NewCLIWithoutNamespace("kube-apiserver-pki")
+
+	var kubeClient kubernetes.Interface
+	var configClient configclient.Interface
+
+	g.BeforeAll(func(ctx context.Context) {
+		kubeClient = oc.AdminKubeClient()
+		configClient = oc.AdminConfigClient()
+
+		// Register cleanup to run even if tests fail
+		g.DeferCleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+			defer cancel()
+			cleanupPKIConfiguration(cleanupCtx, configClient)
+		})
+	})
+
+	g.It("should validate uniform PKI configurations and certificate regeneration [apigroup:config.openshift.io][Skipped:MicroShift]", func(ctx context.Context) {
+		testUniformPKIConfigurations(ctx, kubeClient, configClient)
+	})
+
+	g.It("should validate mixed PKI configurations and certificate regeneration [apigroup:config.openshift.io][Skipped:MicroShift]", func(ctx context.Context) {
+		testMixedPKIConfigurations(ctx, kubeClient, configClient)
+	})
+})
+
+// testUniformPKIConfigurations tests uniform PKI configurations (same algorithm for all cert categories)
+func testUniformPKIConfigurations(ctx context.Context, kubeClient kubernetes.Interface, configClient configclient.Interface) {
+	e2e.Logf("Testing uniform PKI configurations for kube-apiserver...")
+
+	testConfigs := []pkiTestConfig{
+		{
+			name:      "RSA-4096",
+			algorithm: configv1alpha1.KeyAlgorithmRSA,
+			rsaSize:   4096,
+		},
+		{
+			name:       "ECDSA-P384",
+			algorithm:  configv1alpha1.KeyAlgorithmECDSA,
+			ecdsaCurve: configv1alpha1.ECDSACurveP384,
+		},
+	}
+
+	for _, tc := range testConfigs {
+		e2e.Logf("\n=== Testing configuration: %s ===", tc.name)
+
+		// Apply the PKI configuration
+		err := applyPKIConfig(ctx, configClient, tc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error applying PKI config %s", tc.name)
+
+		e2e.Logf("PKI configuration %s applied successfully", tc.name)
+
+		// Allow the operator to observe the PKI config change before checking
+		// Progressing status. PKI config changes do not trigger a full operator
+		// rollout (Progressing stays False), so WaitForOperatorToRollout would
+		// hang. The actual cert regeneration is triggered by secret deletion
+		// below, and waitForSecretRegeneration validates the outcome.
+		time.Sleep(10 * time.Second)
+
+		e2e.Logf("Waiting for kube-apiserver operator to reconcile PKI config...")
+		err = exutil.WaitForOperatorProgressingFalse(ctx, configClient, "kube-apiserver")
+		o.Expect(err).NotTo(o.HaveOccurred(), "kube-apiserver operator did not reconcile PKI config %s", tc.name)
+		e2e.Logf("Operator has reconciled PKI configuration")
+
+		// Test certificate regeneration for kube-apiserver certificates
+		e2e.Logf("Testing kube-apiserver certificate regeneration with %s...", tc.name)
+		testKubeAPIServerCertificates(ctx, kubeClient, tc)
+
+		e2e.Logf("Configuration %s tested successfully", tc.name)
+	}
+
+	e2e.Logf("\nAll uniform PKI configuration tests passed successfully")
+}
+
+// testMixedPKIConfigurations tests mixed PKI configurations (different algorithms per cert category)
+func testMixedPKIConfigurations(ctx context.Context, kubeClient kubernetes.Interface, configClient configclient.Interface) {
+	e2e.Logf("Testing mixed PKI configurations (different key types per certificate category)...")
+
+	mixedConfigs := []mixedPKITestConfig{
+		{
+			name:              "RSA4096-P256-P521",
+			signerAlgorithm:   configv1alpha1.KeyAlgorithmRSA,
+			signerRSASize:     4096,
+			servingAlgorithm:  configv1alpha1.KeyAlgorithmECDSA,
+			servingECDSACurve: configv1alpha1.ECDSACurveP256,
+			clientAlgorithm:   configv1alpha1.KeyAlgorithmECDSA,
+			clientECDSACurve:  configv1alpha1.ECDSACurveP521,
+		},
+	}
+
+	for _, tc := range mixedConfigs {
+		e2e.Logf("\n=== Testing mixed configuration: %s ===", tc.name)
+
+		// Apply the mixed PKI configuration
+		err := applyMixedPKIConfig(ctx, configClient, tc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error applying mixed PKI config %s", tc.name)
+
+		e2e.Logf("Mixed PKI configuration %s applied successfully", tc.name)
+
+		// Allow the operator to observe the PKI config change (see comment in
+		// testUniformPKIConfigurations for why WaitForOperatorToRollout is not
+		// used here).
+		time.Sleep(10 * time.Second)
+
+		e2e.Logf("Waiting for kube-apiserver operator to reconcile PKI config...")
+		err = exutil.WaitForOperatorProgressingFalse(ctx, configClient, "kube-apiserver")
+		o.Expect(err).NotTo(o.HaveOccurred(), "kube-apiserver operator did not reconcile PKI config %s", tc.name)
+		e2e.Logf("Operator has reconciled PKI configuration")
+
+		// Test certificate regeneration with mixed configuration
+		e2e.Logf("Testing kube-apiserver certificate regeneration with mixed config %s...", tc.name)
+		testMixedKubeAPIServerCertificates(ctx, kubeClient, tc)
+
+		e2e.Logf("Mixed configuration %s tested successfully", tc.name)
+	}
+
+	e2e.Logf("\nAll mixed PKI configuration tests passed successfully")
+}
+
+// testKubeAPIServerCertificates tests certificate regeneration for kube-apiserver
+func testKubeAPIServerCertificates(ctx context.Context, kubeClient kubernetes.Interface, tc pkiTestConfig) {
+	// Test a subset of certificates to avoid excessive test time
+	// Pick one from each category (signer, serving, client)
+	testCerts := []operatorCertificate{
+		// One signer from operator namespace
+		{
+			Namespace:  kubeAPIServerOperatorNamespace,
+			SecretName: "aggregator-client-signer",
+			CertKey:    "tls.crt",
+			Category:   "signer",
+		},
+		// One serving cert from apiserver namespace
+		{
+			Namespace:  kubeAPIServerNamespace,
+			SecretName: "external-loadbalancer-serving-certkey",
+			CertKey:    "tls.crt",
+			Category:   "serving",
+		},
+		// One client cert from apiserver namespace
+		{
+			Namespace:  kubeAPIServerNamespace,
+			SecretName: "aggregator-client",
+			CertKey:    "tls.crt",
+			Category:   "client",
+		},
+	}
+
+	verifiedCount := 0
+	for _, cert := range testCerts {
+		e2e.Logf("  Testing %s certificate: %s/%s", cert.Category, cert.Namespace, cert.SecretName)
+
+		oldSecret, err := kubeClient.CoreV1().Secrets(cert.Namespace).Get(ctx, cert.SecretName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "certificate %s/%s must exist before deletion", cert.Namespace, cert.SecretName)
+		oldUID := string(oldSecret.UID)
+
+		err = deleteCertificateSecret(ctx, kubeClient, cert.Namespace, cert.SecretName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete certificate %s/%s", cert.Namespace, cert.SecretName)
+		e2e.Logf("    Certificate deleted")
+
+		e2e.Logf("    Waiting for certificate regeneration...")
+
+		regenCtx, regenCancel := context.WithTimeout(ctx, 3*time.Minute)
+		err = waitForSecretRegeneration(regenCtx, kubeClient, cert.Namespace, cert.SecretName, cert.CertKey, oldUID)
+		regenCancel()
+		o.Expect(err).NotTo(o.HaveOccurred(), "error waiting for certificate %s/%s regeneration", cert.Namespace, cert.SecretName)
+		e2e.Logf("    Certificate regenerated")
+
+		// Verify the regenerated certificate matches expected config
+		newCert, err := getCertificateFromSecret(ctx, kubeClient, cert.Namespace, cert.SecretName, cert.CertKey)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error getting regenerated certificate %s/%s", cert.Namespace, cert.SecretName)
+
+		if cert.Category == "signer" {
+			o.Expect(newCert.IsCA).To(o.BeTrue(), "signer certificate %s/%s should be a CA", cert.Namespace, cert.SecretName)
+		} else {
+			o.Expect(newCert.IsCA).To(o.BeFalse(), "%s certificate %s/%s should not be a CA (leaf-first PEM ordering may have changed)", cert.Category, cert.Namespace, cert.SecretName)
+		}
+
+		// Verify algorithm and key parameters
+		if tc.algorithm == configv1alpha1.KeyAlgorithmRSA {
+			o.Expect(newCert.Algorithm).To(o.Equal("RSA"), "expected RSA algorithm for %s/%s", cert.Namespace, cert.SecretName)
+			o.Expect(int32(newCert.KeySize)).To(o.Equal(tc.rsaSize), "expected RSA key size %d for %s/%s", tc.rsaSize, cert.Namespace, cert.SecretName)
+			e2e.Logf("    Certificate verified: RSA-%d", newCert.KeySize)
+		} else if tc.algorithm == configv1alpha1.KeyAlgorithmECDSA {
+			o.Expect(newCert.Algorithm).To(o.Equal("ECDSA"), "expected ECDSA algorithm for %s/%s", cert.Namespace, cert.SecretName)
+			expectedCurve := string(tc.ecdsaCurve)
+			o.Expect(newCert.Curve).To(o.Equal(expectedCurve), "expected ECDSA curve %s for %s/%s", expectedCurve, cert.Namespace, cert.SecretName)
+			e2e.Logf("    Certificate verified: ECDSA-%s", newCert.Curve)
+		}
+
+		verifiedCount++
+
+		// Small delay between deletions to avoid overwhelming the operators
+		time.Sleep(5 * time.Second)
+	}
+
+	o.Expect(verifiedCount).To(o.BeNumerically(">", 0), "at least one certificate must be verified")
+	e2e.Logf("  Configuration test completed: %d certificates verified", verifiedCount)
+}
+
+// testMixedKubeAPIServerCertificates tests certificate regeneration with mixed key configurations
+func testMixedKubeAPIServerCertificates(ctx context.Context, kubeClient kubernetes.Interface, tc mixedPKITestConfig) {
+	// Test one cert from each category to verify different key types
+	testCerts := []struct {
+		cert               operatorCertificate
+		expectedAlgorithm  configv1alpha1.KeyAlgorithm
+		expectedRSASize    int32
+		expectedECDSACurve configv1alpha1.ECDSACurve
+	}{
+		{
+			cert: operatorCertificate{
+				Namespace:  kubeAPIServerOperatorNamespace,
+				SecretName: "aggregator-client-signer",
+				CertKey:    "tls.crt",
+				Category:   "signer",
+			},
+			expectedAlgorithm:  tc.signerAlgorithm,
+			expectedRSASize:    tc.signerRSASize,
+			expectedECDSACurve: tc.signerECDSACurve,
+		},
+		{
+			cert: operatorCertificate{
+				Namespace:  kubeAPIServerNamespace,
+				SecretName: "external-loadbalancer-serving-certkey",
+				CertKey:    "tls.crt",
+				Category:   "serving",
+			},
+			expectedAlgorithm:  tc.servingAlgorithm,
+			expectedRSASize:    tc.servingRSASize,
+			expectedECDSACurve: tc.servingECDSACurve,
+		},
+		{
+			cert: operatorCertificate{
+				Namespace:  kubeAPIServerNamespace,
+				SecretName: "aggregator-client",
+				CertKey:    "tls.crt",
+				Category:   "client",
+			},
+			expectedAlgorithm:  tc.clientAlgorithm,
+			expectedRSASize:    tc.clientRSASize,
+			expectedECDSACurve: tc.clientECDSACurve,
+		},
+	}
+
+	verifiedCount := 0
+	for _, testCase := range testCerts {
+		cert := testCase.cert
+		e2e.Logf("  Testing %s certificate: %s/%s", cert.Category, cert.Namespace, cert.SecretName)
+
+		oldSecret, err := kubeClient.CoreV1().Secrets(cert.Namespace).Get(ctx, cert.SecretName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred(), "certificate %s/%s must exist before deletion", cert.Namespace, cert.SecretName)
+		oldUID := string(oldSecret.UID)
+
+		err = deleteCertificateSecret(ctx, kubeClient, cert.Namespace, cert.SecretName)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete certificate %s/%s", cert.Namespace, cert.SecretName)
+		e2e.Logf("    Certificate deleted")
+
+		e2e.Logf("    Waiting for certificate regeneration...")
+
+		regenCtx, regenCancel := context.WithTimeout(ctx, 3*time.Minute)
+		err = waitForSecretRegeneration(regenCtx, kubeClient, cert.Namespace, cert.SecretName, cert.CertKey, oldUID)
+		regenCancel()
+		o.Expect(err).NotTo(o.HaveOccurred(), "error waiting for certificate %s/%s regeneration", cert.Namespace, cert.SecretName)
+		e2e.Logf("    Certificate regenerated")
+
+		// Verify the regenerated certificate matches expected config
+		newCert, err := getCertificateFromSecret(ctx, kubeClient, cert.Namespace, cert.SecretName, cert.CertKey)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error getting regenerated certificate %s/%s", cert.Namespace, cert.SecretName)
+
+		if cert.Category == "signer" {
+			o.Expect(newCert.IsCA).To(o.BeTrue(), "signer certificate %s/%s should be a CA", cert.Namespace, cert.SecretName)
+		} else {
+			o.Expect(newCert.IsCA).To(o.BeFalse(), "%s certificate %s/%s should not be a CA (leaf-first PEM ordering may have changed)", cert.Category, cert.Namespace, cert.SecretName)
+		}
+
+		// Verify algorithm and key parameters
+		if testCase.expectedAlgorithm == configv1alpha1.KeyAlgorithmRSA {
+			o.Expect(newCert.Algorithm).To(o.Equal("RSA"), "expected RSA algorithm for %s certificate %s/%s", cert.Category, cert.Namespace, cert.SecretName)
+			o.Expect(int32(newCert.KeySize)).To(o.Equal(testCase.expectedRSASize), "expected RSA key size %d for %s certificate %s/%s", testCase.expectedRSASize, cert.Category, cert.Namespace, cert.SecretName)
+			e2e.Logf("    %s certificate verified: RSA-%d", cert.Category, newCert.KeySize)
+		} else if testCase.expectedAlgorithm == configv1alpha1.KeyAlgorithmECDSA {
+			o.Expect(newCert.Algorithm).To(o.Equal("ECDSA"), "expected ECDSA algorithm for %s certificate %s/%s", cert.Category, cert.Namespace, cert.SecretName)
+			expectedCurve := string(testCase.expectedECDSACurve)
+			o.Expect(newCert.Curve).To(o.Equal(expectedCurve), "expected ECDSA curve %s for %s certificate %s/%s", expectedCurve, cert.Category, cert.Namespace, cert.SecretName)
+			e2e.Logf("    %s certificate verified: ECDSA-%s", cert.Category, newCert.Curve)
+		}
+
+		verifiedCount++
+
+		// Small delay between deletions
+		time.Sleep(5 * time.Second)
+	}
+
+	o.Expect(verifiedCount).To(o.BeNumerically(">", 0), "at least one certificate must be verified")
+	e2e.Logf("  Configuration test completed: %d certificates verified", verifiedCount)
+}

--- a/test/extended/pki/pki_service_ca.go
+++ b/test/extended/pki/pki_service_ca.go
@@ -1,0 +1,323 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+
+	configv1alpha1 "github.com/openshift/api/config/v1alpha1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-service-ca][OCPFeatureGate:ConfigurablePKI][Serial][Disruptive][Suite:openshift/pkiconfig] PKI Configuration", g.Ordered, func() {
+	oc := exutil.NewCLIWithoutNamespace("service-ca-pki")
+
+	var configClient configclient.Interface
+
+	g.BeforeAll(func(ctx context.Context) {
+		configClient = oc.AdminConfigClient()
+
+		// Register cleanup to reset PKI configuration even if tests fail
+		g.DeferCleanup(func() {
+			cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+			defer cancel()
+			cleanupPKIConfiguration(cleanupCtx, configClient)
+		})
+	})
+
+	g.It("should validate PKI config and regenerate signing cert [apigroup:config.openshift.io][Skipped:MicroShift]", func(ctx context.Context) {
+		testServiceCAPKIConfiguration(ctx, oc)
+	})
+})
+
+// testServiceCAPKIConfiguration tests the PKI configuration flow:
+// 1. Verify ConfigurablePKI feature gate is enabled
+// 2. Test multiple PKI configurations (RSA and ECDSA)
+// 3. For each config, test CA signing cert and service cert generation
+//
+// NOTE: This test assumes ConfigurablePKI feature gate is already enabled via
+// FEATURE_SET=TechPreviewNoUpgrade in the CI job configuration.
+func testServiceCAPKIConfiguration(ctx context.Context, oc *exutil.CLI) {
+	kubeClient := oc.AdminKubeClient()
+	configClient := oc.AdminConfigClient()
+
+	e2e.Logf("Testing multiple PKI configurations...")
+
+	testConfigs := []pkiTestConfig{
+		{
+			name:      "RSA-4096",
+			algorithm: configv1alpha1.KeyAlgorithmRSA,
+			rsaSize:   4096,
+		},
+		{
+			name:       "ECDSA-P384",
+			algorithm:  configv1alpha1.KeyAlgorithmECDSA,
+			ecdsaCurve: configv1alpha1.ECDSACurveP384,
+		},
+		{
+			name:       "Mixed-RSA-4096-CA-ECDSA-P384-serving",
+			algorithm:  configv1alpha1.KeyAlgorithmECDSA,
+			ecdsaCurve: configv1alpha1.ECDSACurveP256,
+			signerOverride: &keyOverride{
+				algorithm: configv1alpha1.KeyAlgorithmRSA,
+				rsaSize:   4096,
+			},
+			servingOverride: &keyOverride{
+				algorithm:  configv1alpha1.KeyAlgorithmECDSA,
+				ecdsaCurve: configv1alpha1.ECDSACurveP384,
+			},
+		},
+	}
+
+	for _, tc := range testConfigs {
+		e2e.Logf("\n=== Testing configuration: %s ===", tc.name)
+
+		// Apply the PKI configuration
+		err := applyPKIConfig(ctx, configClient, tc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "error applying PKI config %s", tc.name)
+
+		// Verify the configuration was applied
+		pki, err := configClient.ConfigV1alpha1().PKIs().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(pki.Spec.CertificateManagement.Mode).To(o.Equal(configv1alpha1.PKICertificateManagementModeCustom))
+
+		e2e.Logf("PKI configuration %s applied successfully", tc.name)
+
+		// Allow the operator to observe the PKI config change before checking
+		// Progressing status. PKI config changes do not trigger a full operator
+		// rollout (Progressing stays False), so WaitForOperatorToRollout would
+		// hang. The actual cert regeneration is validated downstream.
+		time.Sleep(10 * time.Second)
+
+		e2e.Logf("Waiting for operator to reconcile PKI config...")
+		err = exutil.WaitForOperatorProgressingFalse(ctx, configClient, "service-ca")
+		o.Expect(err).NotTo(o.HaveOccurred(), "service-ca operator did not reconcile PKI config %s", tc.name)
+		e2e.Logf("Operator has reconciled PKI configuration")
+
+		// Wait for controller deployment to be updated with the new PKI config
+		// The operator updates the controller deployment with PKI config via command-line args
+		// The controller is what generates serving certs, so it must have the new config
+		e2e.Logf("Waiting for controller deployment to be updated with PKI config...")
+		err = exutil.WaitForDeploymentReadyWithTimeout(oc, "service-ca", "openshift-service-ca", -1, 5*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		e2e.Logf("Controller deployment has been updated with PKI configuration")
+
+		// Test CA signing certificate regeneration
+		e2e.Logf("Testing CA signing certificate regeneration with %s...", tc.name)
+		testSigningCertRegeneration(ctx, kubeClient, tc)
+
+		// Test service certificate generation
+		e2e.Logf("Testing service certificate generation with %s...", tc.name)
+		testServiceCertGeneration(ctx, kubeClient, tc)
+
+		e2e.Logf("Configuration %s tested successfully", tc.name)
+	}
+
+	e2e.Logf("\nAll PKI configuration tests passed successfully")
+}
+
+// testSigningCertRegeneration tests CA signing certificate regeneration
+func testSigningCertRegeneration(ctx context.Context, kubeClient kubernetes.Interface, tc pkiTestConfig) {
+	// Get the current UID of the signing-key secret before deletion
+	signingKeySecret, err := kubeClient.CoreV1().Secrets("openshift-service-ca").Get(ctx, "signing-key", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	oldSigningKeyUID := string(signingKeySecret.UID)
+
+	// Get the current UID of the operator serving cert before deletion (may not exist)
+	var oldServingCertUID string
+	servingCertSecret, err := kubeClient.CoreV1().Secrets("openshift-service-ca-operator").Get(ctx, "serving-cert", metav1.GetOptions{})
+	if err == nil {
+		oldServingCertUID = string(servingCertSecret.UID)
+	} else if !apierrors.IsNotFound(err) {
+		o.Expect(err).NotTo(o.HaveOccurred(), "error reading existing operator serving cert")
+	}
+
+	// Delete the signing certificate to trigger regeneration
+	err = kubeClient.CoreV1().Secrets("openshift-service-ca").Delete(ctx, "signing-key", metav1.DeleteOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Also delete the operator's serving cert to ensure full regeneration with new PKI config
+	err = kubeClient.CoreV1().Secrets("openshift-service-ca-operator").Delete(ctx, "serving-cert", metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		o.Expect(err).NotTo(o.HaveOccurred())
+	}
+
+	e2e.Logf("  Deleted CA signing certificate and operator serving cert, waiting for regeneration...")
+
+	regenCtx, regenCancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer regenCancel()
+	err = waitForSecretRegeneration(regenCtx, kubeClient, "openshift-service-ca", "signing-key", "tls.crt", oldSigningKeyUID)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify new certificate matches expected config
+	// For signing cert, use signerOverride if present, otherwise use default
+	newCert, err := getCertificateFromSecret(ctx, kubeClient, "openshift-service-ca", "signing-key", "tls.crt")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(newCert.IsCA).To(o.BeTrue(), "signing-key certificate should be a CA")
+
+	// Determine expected values for signing cert (CA)
+	expectedAlgo := tc.algorithm
+	expectedRSASize := tc.rsaSize
+	expectedCurve := tc.ecdsaCurve
+	if tc.signerOverride != nil {
+		expectedAlgo = tc.signerOverride.algorithm
+		expectedRSASize = tc.signerOverride.rsaSize
+		expectedCurve = tc.signerOverride.ecdsaCurve
+	}
+
+	// Verify algorithm and key parameters
+	if expectedAlgo == configv1alpha1.KeyAlgorithmRSA {
+		o.Expect(newCert.Algorithm).To(o.Equal("RSA"))
+		o.Expect(int32(newCert.KeySize)).To(o.Equal(expectedRSASize))
+		e2e.Logf("  CA signing cert: RSA-%d", newCert.KeySize)
+	} else if expectedAlgo == configv1alpha1.KeyAlgorithmECDSA {
+		o.Expect(newCert.Algorithm).To(o.Equal("ECDSA"))
+		expectedCurveStr := string(expectedCurve)
+		o.Expect(newCert.Curve).To(o.Equal(expectedCurveStr))
+		e2e.Logf("  CA signing cert: ECDSA-%s", newCert.Curve)
+	}
+
+	// Wait for controller to be ready after signing-key regeneration
+	// The controller pod will restart when signing-key is deleted/recreated
+	e2e.Logf("  Waiting for controller to be ready...")
+	_, err = exutil.WaitForPods(kubeClient.CoreV1().Pods("openshift-service-ca"), exutil.ParseLabelsOrDie("app=service-ca"), exutil.CheckPodIsReady, 1, 5*time.Minute)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	regenCtx2, regenCancel2 := context.WithTimeout(ctx, 15*time.Minute)
+	defer regenCancel2()
+	err = waitForSecretRegeneration(regenCtx2, kubeClient, "openshift-service-ca-operator", "serving-cert", "tls.crt", oldServingCertUID)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify operator's serving cert also uses the new PKI config
+	operatorCert, err := getCertificateFromSecret(ctx, kubeClient, "openshift-service-ca-operator", "serving-cert", "tls.crt")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(operatorCert.IsCA).To(o.BeFalse(), "operator serving cert should not be a CA (leaf-first PEM ordering may have changed)")
+
+	// Determine expected values for operator serving cert
+	// Use servingOverride if present, otherwise use default
+	expectedServingAlgo := tc.algorithm
+	expectedServingRSASize := tc.rsaSize
+	expectedServingCurve := tc.ecdsaCurve
+	if tc.servingOverride != nil {
+		expectedServingAlgo = tc.servingOverride.algorithm
+		expectedServingRSASize = tc.servingOverride.rsaSize
+		expectedServingCurve = tc.servingOverride.ecdsaCurve
+	}
+
+	if expectedServingAlgo == configv1alpha1.KeyAlgorithmRSA {
+		o.Expect(operatorCert.Algorithm).To(o.Equal("RSA"))
+		o.Expect(int32(operatorCert.KeySize)).To(o.Equal(expectedServingRSASize))
+		e2e.Logf("  Operator serving cert: RSA-%d", operatorCert.KeySize)
+	} else if expectedServingAlgo == configv1alpha1.KeyAlgorithmECDSA {
+		o.Expect(operatorCert.Algorithm).To(o.Equal("ECDSA"))
+		expectedCurveStr := string(expectedServingCurve)
+		o.Expect(operatorCert.Curve).To(o.Equal(expectedCurveStr))
+		e2e.Logf("  Operator serving cert: ECDSA-%s", operatorCert.Curve)
+	}
+}
+
+// testServiceCertGeneration tests service certificate generation
+func testServiceCertGeneration(ctx context.Context, kubeClient kubernetes.Interface, tc pkiTestConfig) {
+	// Create a unique test namespace (timestamp suffix to avoid conflicts with previous runs)
+	// Use hash for long names to stay under 63 character Kubernetes limit
+	configName := strings.ToLower(tc.name)
+	if len(configName) > 30 {
+		// For long names, use first 20 chars + hash of full name
+		// This ensures uniqueness while keeping under the limit
+		hash := fmt.Sprintf("%x", time.Now().UnixNano()%0xFFFFFF) // 6 hex chars
+		configName = configName[:20] + "-" + hash
+	}
+	testNS := fmt.Sprintf("test-pki-%s-%d", configName, time.Now().Unix())
+
+	// Create the namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNS,
+		},
+	}
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Cleanup namespace at the end
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+		err := kubeClient.CoreV1().Namespaces().Delete(cleanupCtx, testNS, metav1.DeleteOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			e2e.Logf("Warning: failed to delete test namespace %s: %v", testNS, err)
+		}
+	}()
+
+	// Create a test service with serving-cert annotation
+	testSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: testNS,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": "test-service-cert",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "https",
+					Port:     443,
+					Protocol: corev1.ProtocolTCP,
+				},
+			},
+			Selector: map[string]string{
+				"app": "test",
+			},
+		},
+	}
+
+	_, err = kubeClient.CoreV1().Services(testNS).Create(ctx, testSvc, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	e2e.Logf("  Created test service in namespace %s", testNS)
+
+	// Wait for the service certificate to be generated
+	e2e.Logf("  Waiting for service certificate to be generated...")
+	regenCtx, regenCancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer regenCancel()
+	err = waitForSecretRegeneration(regenCtx, kubeClient, testNS, "test-service-cert", "tls.crt", "")
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	// Verify the service certificate
+	serviceCert, err := getCertificateFromSecret(ctx, kubeClient, testNS, "test-service-cert", "tls.crt")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(serviceCert.IsCA).To(o.BeFalse(), "service cert should not be a CA (leaf-first PEM ordering may have changed)")
+
+	// Verify algorithm and key parameters match expected config
+	// Use servingOverride if present, otherwise use default
+	expectedServingAlgo := tc.algorithm
+	expectedServingRSASize := tc.rsaSize
+	expectedServingCurve := tc.ecdsaCurve
+	if tc.servingOverride != nil {
+		expectedServingAlgo = tc.servingOverride.algorithm
+		expectedServingRSASize = tc.servingOverride.rsaSize
+		expectedServingCurve = tc.servingOverride.ecdsaCurve
+	}
+
+	if expectedServingAlgo == configv1alpha1.KeyAlgorithmRSA {
+		o.Expect(serviceCert.Algorithm).To(o.Equal("RSA"))
+		o.Expect(int32(serviceCert.KeySize)).To(o.Equal(expectedServingRSASize))
+		e2e.Logf("  Service cert: RSA-%d", serviceCert.KeySize)
+	} else if expectedServingAlgo == configv1alpha1.KeyAlgorithmECDSA {
+		o.Expect(serviceCert.Algorithm).To(o.Equal("ECDSA"))
+		expectedCurveStr := string(expectedServingCurve)
+		o.Expect(serviceCert.Curve).To(o.Equal(expectedCurveStr))
+		e2e.Logf("  Service cert: ECDSA-%s", serviceCert.Curve)
+	}
+}


### PR DESCRIPTION
Tests for kube-apiserver and service-ca added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new external test suite (`openshift/pkiconfig`) to validate configurable PKI certificate regeneration.
  * Expanded coverage for `kube-apiserver` PKI regeneration by deleting targeted certificate Secrets and confirming regenerated certificate key properties for uniform and mixed configurations.
  * Expanded coverage for `service-ca` under the `ConfigurablePKI` feature gate, including regeneration and validation of signing and serving certificates (RSA and ECDSA key/curve parameters, with mixed overrides).
  * Strengthened secret rotation assertions by verifying Secrets are replaced and certificates match expected algorithms and parameters.
  * Improved reliability with deferred cleanup that restores prior PKI configuration after failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->