### PR TITLE
NO-ISSUE: monitor/haproxy: treat all-apiservers-down test as flake

### DIFF
--- a/pkg/monitortests/network/onpremhaproxy/monitortest.go
+++ b/pkg/monitortests/network/onpremhaproxy/monitortest.go
@@ -440,7 +440,10 @@ func evaluateFullAPIOutages(downIntervals monitorapi.Intervals) []*junitapi.JUni
 		SystemOut: strings.Join(failures, "\n"),
 	}
 
-	return []*junitapi.JUnitTestCase{failure}
+	// Return both failure and success so the CI system treats this as a flake
+	// rather than a hard failure. This lets us track flake rates in Sippy
+	// without blocking payload acceptance while we tune the detection logic.
+	return []*junitapi.JUnitTestCase{failure, {Name: testName}}
 }
 
 func (w *operatorLogAnalyzer) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {

--- a/pkg/monitortests/network/onpremhaproxy/monitortest_test.go
+++ b/pkg/monitortests/network/onpremhaproxy/monitortest_test.go
@@ -263,14 +263,18 @@ func TestEvaluateFullAPIOutages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			junits := evaluateFullAPIOutages(tt.intervals)
-			require.Len(t, junits, 1)
 
 			if !tt.expectFailure {
+				require.Len(t, junits, 1)
 				assert.Nil(t, junits[0].FailureOutput, "expected the test to pass")
 				return
 			}
 
-			require.NotNil(t, junits[0].FailureOutput, "expected the test to fail")
+			// Failures return both a failure and a success junit so that the CI system
+			// treats the result as a flake rather than a hard failure.
+			require.Len(t, junits, 2, "expected both a failure and a flake-success junit")
+			require.NotNil(t, junits[0].FailureOutput, "expected the first junit to be a failure")
+			assert.Nil(t, junits[1].FailureOutput, "expected the second junit to be a success (flake marker)")
 			for _, expectedOutput := range tt.expectedOutputs {
 				assert.Contains(t, junits[0].SystemOut, expectedOutput)
 			}


### PR DESCRIPTION
## What

The haproxy `Haproxy should not encounter all kube apiservers down simultaneously` monitor test was recently enabled to actually fail (previously it always passed), but its detection logic is still being tuned. In the meantime it blocks payload acceptance for pre-existing conditions that need to be slowly improved.

## Why

5.0 nightly payloads have been blocked by this test failing on metal-ipi and vsphere jobs. A sensitivity fix was merged in #31326 (tolerate install-phase bounces), but dgoodwin suggested we also add a flake fallback so the test can't hard-block payloads while we validate and iterate.

## How

Return both a failure **and** a success junit when the test fails. The CI system treats a test that both fails and passes as a **flake** rather than a hard failure. This is the same pattern already used by the sibling test (`Haproxy must be able to reach kubeapi server`) in the same file.

This lets us:
- Track flake rates in Sippy (Tests page → Flakes View)
- Avoid blocking payload acceptance
- Continue iterating on detection sensitivity

Once the detection logic is stable and false positives are eliminated, we can remove the flake fallback and let the test hard-fail again.

## Context

Slack thread: https://redhat-internal.slack.com/archives/C01CQA76KMX/p1782395783960919

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Full API outage detection now reports both an alerting result and a non-blocking success marker, reducing the chance that transient outage signals block normal progress.
  * Improved result handling so passing cases are validated more strictly and outage cases are tracked more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->