### PR TITLE
NO-JIRA: Replace a bug id: 25739 -> 92835

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -82,6 +82,9 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			if operator == "kube-storage-version-migrator" && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
+			if operator == "ingress" && condition.Reason == "IngressUnavailable" {
+				return "https://issues.redhat.com/browse/OCPBUGS-92835"
+			}
 			return ""
 		}
 		if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue {
@@ -314,7 +317,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
-				return "https://issues.redhat.com/browse/OCPBUGS-25739"
+				return "https://issues.redhat.com/browse/OCPBUGS-92835"
 			}
 		case "kube-storage-version-migrator":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {


### PR DESCRIPTION
The old one is closed but the symptom is still there. It is tracked it by a new bug.

Moreover, the symptom `Available=False` extends

* from bare-metal to Hypershift
* from upgrade to non-upgrade tests

/cc @mkowalski @candita 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring to recognize a known acceptable `ingress` availability transition when the component reports unavailable.
  * Adjusted the reported issue reference for this condition during upgrades, aligning it with the current tracked behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->