### PR TITLE
NO-ISSUE: Remove exception for OCPBUGS-45921

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -88,9 +88,6 @@ func testStableSystemOperatorStateTransitions(events monitorapi.Intervals, topol
 			if operator == "cloud-controller-manager" && condition.Reason == "SyncingFailed" {
 				return "https://issues.redhat.com/browse/OCPBUGS-42837"
 			}
-			if operator == "ingress" {
-				return "https://issues.redhat.com/browse/OCPBUGS-45921"
-			}
 			if operator == "kube-apiserver" {
 				return "https://issues.redhat.com/browse/OCPBUGS-38661"
 			}


### PR DESCRIPTION
The bug is fixed on both 4.22 and 5.0 [1].

[1]. https://redhat.atlassian.net/browse/OCPBUGS-45921?focusedCommentId=17383073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a stale exception for the ingress operator during stable-system availability checks.
  * This keeps operator status handling aligned with the current behavior and avoids showing an outdated special-case message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->