### PR TITLE
NO-JIRA: Fix Flaky e2e tests - Update the Cleanup order

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -1195,18 +1195,23 @@ func (c *CLI) GetClientConfigForUser(username string) *rest.Config {
 	}
 
 	privToken, pubToken := GenerateOAuthTokenPair()
-	token, err := oauthClient.OauthV1().OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{
+	_, err = oauthClient.OauthV1().OAuthAccessTokens().Create(ctx, &oauthv1.OAuthAccessToken{
 		ObjectMeta:  metav1.ObjectMeta{Name: pubToken},
 		ClientName:  oauthClientName,
 		UserName:    username,
 		UserUID:     string(user.UID),
 		Scopes:      []string{"user:full"},
 		RedirectURI: "https://localhost:8443/oauth/token/implicit",
+		ExpiresIn:   21600, // 6 h TTL; auto-expires without explicit deletion
 	}, metav1.CreateOptions{})
 	if err != nil {
 		FatalErr(err)
 	}
-	c.AddResourceToDelete(oauthv1.GroupVersion.WithResource("oauthaccesstokens"), token)
+	// The token is intentionally not added to resourcesToDelete.
+	// TeardownProject (AfterEach) runs before DeferCleanup. Deleting the token
+	// there causes cached clients to get 401 Unauthorized, fall back to
+	// system:anonymous, and fail with 403 Forbidden during DeferCleanup.
+	// ExpiresIn: 21600 provides TTL-based cleanup without breaking DeferCleanup.
 
 	userClientConfig := rest.AnonymousClientConfig(turnOffRateLimiting(rest.CopyConfig(c.AdminConfig())))
 	userClientConfig.BearerToken = privToken


### PR DESCRIPTION
Fix  premature OAuth token deletion in CLI

###  OAuthAccessToken deleted before framework DeferCleanup runs
GetClientConfigForUser created an OAuthAccessToken and registered it in resourcesToDelete. This meant it was deleted during TeardownProject, which is registered as a g.AfterEach. The Kubernetes framework's namespace cleanup, however, runs via ginkgo.DeferCleanup (registered inside f.BeforeEach), and the documented execution order is:

It block
  → all AfterEach nodes (including TeardownProject)   ← token deleted here
  → all DeferCleanups (LIFO)                          ← framework cleanup here
  → f.AfterEach (namespace deletion)
This meant the bearer token embedded in the returned *rest.Config became invalid before any DeferCleanup callbacks had a chance to run. Any deferred cleanup that tried to make authenticated API calls as that user would receive 401 Unauthorized.

### Fix: 
Remove the token from resourcesToDelete and instead set ExpiresIn: 6 hours. The associated User object is still explicitly deleted in TeardownProject, which is sufficient to revoke effective access. The ExpiresIn TTL ensures the token is eventually cleaned up by the OpenShift OAuth token controller without needing explicit deletion.

### Latent OIDC test bug fixed as a consequence
test/extended/authentication/oidc.go calls GetClientConfigForUser in a g.BeforeAll and stores the result in oauthUserConfig. This config is then used across two separate ordered It blocks:

"should not accept tokens provided by the OAuth server" (expects Unauthorized)
"should accept tokens provided by the OpenShift OAuth server" (expects 200 OK)
With the old code, TeardownProject deleted the OAuthAccessToken after the first It block. The first test passed for the wrong reason (deleted token → Unauthorized, which matched the expectation, but for the wrong cause). The second test silently used an invalid bearer token. As the current fix keeps the token alive across all ordered It blocks as intended, so both tests validate the correct behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted OAuth access token provisioning to use a 6-hour automatic expiration, reducing the risk of stale authentication artifacts.
  * Improved test cleanup by avoiding explicit token deletion during teardown, preventing cached clients from losing credentials (which could otherwise lead to authentication fallback and follow-on failures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->