### PR TITLE
[release-4.20] OCPBUGS-85523: Remove restriction of unmanaged x-k8s.io

### DIFF
--- a/test/extended/util/annotate/generated/zz_generated.annotations.go
+++ b/test/extended/util/annotate/generated/zz_generated.annotations.go
@@ -1741,8 +1741,6 @@ var Annotations = map[string]string{
 
 	"[sig-network][OCPFeatureGate:DNSNameResolver][Feature:EgressFirewall] when using openshift ovn-kubernetes should ensure egressfirewall with wildcard dns rules is created": " [Suite:openshift/conformance/parallel]",
 
-	"[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API CRDs and ensure CRD of experimental group can not be created": " [Suite:openshift/conformance/parallel]",
-
 	"[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API CRDs and ensure CRD of experimental group is not installed": " [Suite:openshift/conformance/parallel]",
 
 	"[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io] Verify Gateway API CRDs and ensure CRD of standard group can not be created": " [Suite:openshift/conformance/parallel]",

--- a/zz_generated.manifests/test-reporting.yaml
+++ b/zz_generated.manifests/test-reporting.yaml
@@ -392,8 +392,6 @@ spec:
   - featureGate: GatewayAPI
     tests:
     - testName: '[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io]
-        Verify Gateway API CRDs and ensure CRD of experimental group can not be created'
-    - testName: '[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io]
         Verify Gateway API CRDs and ensure CRD of experimental group is not installed'
     - testName: '[sig-network][OCPFeatureGate:GatewayAPI][Feature:Router][apigroup:gateway.networking.k8s.io]
         Verify Gateway API CRDs and ensure CRD of standard group can not be created'


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/origin/pull/30718

This PR removes the restriction of users to install Gateway API CRDs from x-k8s.io group, given OSSM is able to ignore them.

The current PR removes the tests about this restriction before we are able to merge on cluster-ingress-operator