### PR TITLE
OCPNODE-4604: add quay-proxy.ci.openshift.org as alllowed to reboot requried  test

### DIFF
--- a/test/extended/node/node_e2e/image_registry_config.go
+++ b/test/extended/node/node_e2e/image_registry_config.go
@@ -79,7 +79,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 			}
 			imageConfig.Spec.RegistrySources.AllowedRegistries = []string{
 				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,
-				"image-registry.openshift-image-registry.svc:5000",
+				"image-registry.openshift-image-registry.svc:5000", "quay-proxy.ci.openshift.org",
 			}
 			imageConfig.Spec.RegistrySources.ContainerRuntimeSearchRegistries = []string{
 				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,


### PR DESCRIPTION
fix test wait for node drain/reboot timeout error, in the presubmit test job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31324-openshift-api-2900-openshift-machine-config-operator-6220-nightly-5.0-e2e-aws-disruptive-longrunning-techpreview-1of2/2071833054464184320
```
[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config [OTP] change container registry config [OCP-44820] [Serial]


fail [github.com/openshift/origin/test/extended/imagepolicy/imagepolicy.go:710]: Timed out after 1200.001s.
Expected
    <bool>: false
to be true
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated registry configuration checks to account for an additional allowed container registry, aligning node validation with the latest expected registry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->