### PR TITLE
OCPBUGS-84517: Remove stale openshift-marketplace terminationMessagePolicy exemption

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -160,8 +160,7 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/metallb-operator-controller-manager",
 			"pods/metallb-operator-webhook-server",
 		),
-		"openshift-marketplace": sets.NewString("pods/podman"),                // filed OCPBUGS-84517 to fix
-		"openshift-operators":   sets.NewString("pods/servicemesh-operator3"), // filed OCPBUGS-84518 to fix
+		"openshift-operators": sets.NewString("pods/servicemesh-operator3"), // filed OCPBUGS-84518 to fix
 		"openshift-sriov-network-operator": sets.NewString( // filed OCPBUGS-84526 to fix
 			"pods/network-resources-injector",
 			"pods/operator-webhook",


### PR DESCRIPTION
## Summary

Remove the `openshift-marketplace` namespace exemption from the
terminationMessagePolicy monitor test.

Backport of https://github.com/openshift/origin/pull/31355 to release-4.23.

## Background

The monitor test `[sig-arch] all containers in ns/openshift-marketplace
must have terminationMessagePolicy=FallbackToLogsOnError` was flaking
because osd-patch-subscription-source CronJob pods lacked
`terminationMessagePolicy: FallbackToLogsOnError`.

A temporary exemption was added, but it incorrectly exempted
`pods/podman` rather than the actual violating pods. The root cause has
been fixed upstream by adding `terminationMessagePolicy:
FallbackToLogsOnError` to the CronJob containers.

## Dependencies

This PR depends on the upstream fix:
- openshift/managed-cluster-config#2800 — *OCPBUGS-84517: Add terminationMessagePolicy to openshift-marketplace Cronjobs*

Bug: OCPBUGS-84517