### PR TITLE
STOR-3029: Enable volume re-size offline tests for fsTypes 'ext4' and 'xfs'

### DIFF
--- a/pkg/clioptions/clusterdiscovery/csi.go
+++ b/pkg/clioptions/clusterdiscovery/csi.go
@@ -21,6 +21,9 @@ const (
 
 // InitCSITests initializes the openshift/csi suite, i.e. define CSI tests from TEST_CSI_DRIVER_FILES.
 func InitCSITests() error {
+	// Register global CSI suite extensions.
+	csi.RegisterVolumeExpandFsTypeTests()
+
 	ocpDrivers := sets.New[string]()
 	upstreamDrivers := sets.New[string]()
 

--- a/test/extended/storage/csi/volume_expand.go
+++ b/test/extended/storage/csi/volume_expand.go
@@ -1,0 +1,43 @@
+package csi
+
+import (
+	"sync"
+
+	storageframework "k8s.io/kubernetes/test/e2e/storage/framework"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+)
+
+// InitCSITests may run more than once; register volume-expand patterns only once.
+var registerVolumeExpandFsTypeTestsOnce sync.Once
+
+// RegisterVolumeExpandFsTypeTests appends ext4 and xfs allowExpansion patterns to
+// CSISuites for the upstream volume-expand test suite. Upstream DefineTests()
+// handles offline and online resize; this only registers additional fstype combinations.
+func RegisterVolumeExpandFsTypeTests() {
+	registerVolumeExpandFsTypeTestsOnce.Do(func() {
+		testsuites.CSISuites = append(testsuites.CSISuites, initVolumeExpandFsTypeSuite())
+	})
+}
+
+func initVolumeExpandFsTypeSuite() func() storageframework.TestSuite {
+	return func() storageframework.TestSuite {
+		return testsuites.InitCustomVolumeExpandTestSuite([]storageframework.TestPattern{
+			ext4AllowExpansionPattern(),
+			xfsAllowExpansionPattern(),
+		})
+	}
+}
+
+func ext4AllowExpansionPattern() storageframework.TestPattern {
+	p := storageframework.Ext4DynamicPV
+	p.Name = "Dynamic PV (ext4)(allowExpansion)"
+	p.AllowExpansion = true
+	return p
+}
+
+func xfsAllowExpansionPattern() storageframework.TestPattern {
+	p := storageframework.XfsDynamicPV
+	p.Name = "Dynamic PV (xfs)(allowExpansion)"
+	p.AllowExpansion = true
+	return p
+}


### PR DESCRIPTION
**Why we need this?**
[STOR-3028](https://redhat.atlassian.net/browse/STOR-3028): OTE Migration of  OTP storage tests to public repos

### Summary
Extend the openshift/csi external storage suite with explicit ext4 and xfs volume-expand test patterns. Upstream volume-expand already covers default-fs offline/online resize; this adds fstype-specific coverage by registering Dynamic PV (ext4)(allowExpansion) and Dynamic PV (xfs)(allowExpansion) patterns via InitCustomVolumeExpandTestSuite, reusing existing upstream resize test logic without duplicating it.

### Changes
- Add RegisterVolumeExpandFsTypeTests() in test/extended/storage/csi/volume_expand.go to append ext4/xfs allowExpansion patterns to testsuites.CSISuites
- Call it from InitCSITests() before driver manifest loading

**Test run logs:**

```
$ ./openshift-tests run 'openshift/csi' --dry-run | grep -F 'volume-expand'   | grep -Fe 'Dynamic PV (ext4)(allowExpansion)' -e 'Dynamic PV (xfs)(allowExpansion)' | ./openshift-tests run -f -
.
.
.
INFO[0905] Completed Builds test bucket in 1.265µs      
started: 0/1/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand should resize volume when PVC is edited while pod is using it"

started: 0/2/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand Verify if offline PVC expansion works"

started: 0/3/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand should resize volume when PVC is edited while pod is using it"

started: 0/4/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished"

started: 0/5/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand Verify if offline PVC expansion works"

started: 0/6/6 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished"

passed: (52.2s) 2026-06-30T18:10:36 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished"

passed: (52.6s) 2026-06-30T18:10:37 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand Verify if offline PVC expansion works"

passed: (58.5s) 2026-06-30T18:10:43 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand should resize volume when PVC is edited and the pod is re-created on the same node after controller resize is finished"

passed: (1m1s) 2026-06-30T18:10:45 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand Verify if offline PVC expansion works"

passed: (1m31s) 2026-06-30T18:11:15 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (ext4)(allowExpansion)] volume-expand should resize volume when PVC is edited while pod is using it"

passed: (1m48s) 2026-06-30T18:11:32 "External Storage [Driver: ebs.csi.aws.com] [Testpattern: Dynamic PV (xfs)(allowExpansion)] [Slow] volume-expand should resize volume when PVC is edited while pod is using it"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader CSI volume expansion test coverage for common filesystem types, including `ext4` and `xfs`.
  * Ensured these expansion checks are registered consistently before CSI driver manifests are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->