### PR TITLE
OCPBUGS-84513: remove openshift-cluster-version terminationMessagePolicy exemption

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -135,8 +135,7 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 		),
 		// per TRT-2084 these were erroneously allowed to flake, so grandfather them in for now.
 		// they should be fixed and removed from here:
-		"openshift-backplane":       sets.NewString("pods/osd-delete-backplane-serviceaccounts"), // filed OCPBUGS-84527 to fix
-		"openshift-cluster-version": sets.NewString("pods/version--"),                            // filed OCPBUGS-84513 to fix
+		"openshift-backplane": sets.NewString("pods/osd-delete-backplane-serviceaccounts"), // filed OCPBUGS-84527 to fix
 		"openshift-cnv": sets.NewString( // filed OCPBUGS-84522 to fix
 			"pods/hostpath-provisioner-operator",
 			"pods/virt-platform-autopilot",


### PR DESCRIPTION
## Summary
- Remove the `openshift-cluster-version` exemption from the `existingViolations` map in the `terminationMessagePolicy` monitor test

## Context
The CVO fix in openshift/cluster-version-operator#1417 adds `terminationMessagePolicy=FallbackToLogsOnError` to all containers in the dynamically-created update-payload pods. With that fix in place, the exemption here is no longer needed and should be removed so violations are enforced as hard failures.

## Dependencies
> **This PR must not merge until openshift/cluster-version-operator#1417 has merged and landed in a payload.** Merging this first would turn the currently-flaking test into a hard failure.

## Test plan
- [x] Confirm openshift/cluster-version-operator#1417 has merged and is in the payload
- [ ] Verify `[Monitor:termination-message-policy][sig-arch] all containers in ns/openshift-cluster-version` passes without flaking

Fixes https://redhat.atlassian.net/browse/OCPBUGS-84513

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test handling for containers in the `openshift-cluster-version` namespace by removing a legacy “grandfathered” violation exception.
  * These containers are now assessed using the standard logic, which adjusts fail vs. flake behavior for older-version scenarios for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->