### PR TITLE
OCPBUGS-88742: Fix nested container test mount check for BusyBox

### DIFF
--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50671,6 +50671,11 @@ insert_skip 090-events.bats "events with file backend and journald logdriver wit
 insert_skip 090-events.bats "events - container inspect data - journald"
 insert_skip 220-healthcheck.bats "podman healthcheck --health-log-destination journal"
 insert_skip 420-cgroups.bats "podman run, preserves initial --cgroup-manager"
+
+# Replace ` + "`" + `mount` + "`" + ` with /proc/self/mounts — BusyBox mount truncates output
+# when /proc/self/mounts entries exceed ~1008 bytes
+# https://redhat.atlassian.net/browse/OCPBUGS-88742?focusedCommentId=17458910
+sed -i 's#mount | grep /tmp#grep /tmp /proc/self/mounts#' $TEST_DIR/700-play.bats
 `)
 
 func testExtendedTestdataNodeNested_containerSkip_testsShBytes() ([]byte, error) {

--- a/test/extended/testdata/node/nested_container/skip_tests.sh
+++ b/test/extended/testdata/node/nested_container/skip_tests.sh
@@ -98,3 +98,8 @@ insert_skip 090-events.bats "events with file backend and journald logdriver wit
 insert_skip 090-events.bats "events - container inspect data - journald"
 insert_skip 220-healthcheck.bats "podman healthcheck --health-log-destination journal"
 insert_skip 420-cgroups.bats "podman run, preserves initial --cgroup-manager"
+
+# Replace `mount` with /proc/self/mounts — BusyBox mount truncates output
+# when /proc/self/mounts entries exceed ~1008 bytes
+# https://redhat.atlassian.net/browse/OCPBUGS-88742?focusedCommentId=17458910
+sed -i 's#mount | grep /tmp#grep /tmp /proc/self/mounts#' $TEST_DIR/700-play.bats


### PR DESCRIPTION
BusyBox `mount` truncates output when /proc/self/mounts entries exceed ~1008 bytes, causing 700-play.bats to fail. Replace `mount | grep /tmp` with `grep /tmp /proc/self/mounts`.

# OCPBUGS-88742: Summary

**Bug:** `podman kube generate tmpfs on /tmp` test failure in OCP 5.0
**Component:** Node / Kubelet | **Version:** 5.0 | **Label:** component-regression
**Jira:** https://redhat.atlassian.net/browse/OCPBUGS-88742
**Triage:** https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/586

---

## What Happened

The podman system test `podman kube generate tmpfs on /tmp` (`containers/podman:test/system/700-play.bats`) passes on OCP 4.22 but fails on OCP 5.0. The test runs inside a user-namespace pod (`hostUsers: false`), creates a nested container via `podman kube play`, and checks for `/tmp` by running `mount | grep /tmp`. On OCP 5.0, BusyBox `mount` returns only 3 entries instead of 36, so `/tmp` is missing from the output.

**The `/tmp` mount IS present and functional** — visible via `cat /proc/self/mounts`, `findmnt`, and `df -h`. Only BusyBox `mount` fails to display it.

## Root Cause

BusyBox `mount` calls musl's `getmntent_r()` with a fixed ~1008-byte buffer. When a line in `/proc/self/mounts` exceeds this, musl returns NULL and **aborts all iteration**. In nested containers, overlay bind-mount entries (e.g. `/etc/hosts`) are ~1881 bytes due to long `lowerdir=` paths. Once BusyBox hits the first such entry, all remaining mounts — including `/tmp` — are invisible.

### Why this regresses on OCP 5.0

The overlay entries are equally long on both OCP versions. The difference is **mount ordering in `/proc/self/mounts`**:

- **Kernel 5.14 (OCP 4.22):** mounts listed in insertion order (linked list). `/tmp` appears at line 5, before the first long overlay entry at line 12. BusyBox parses 11 entries including `/tmp`.
- **Kernel 6.12 (OCP 5.0):** kernel commit [`2eea9ce4310d`](https://patchwork.kernel.org/project/linux-fsdevel/patch/20231025140205.3586473-3-mszeredi@redhat.com/) (Linux 6.8) replaced the linked list with a red-black tree keyed by `mnt_id_unique`. Long overlay entries now appear at line 4, `/tmp` at line 12. BusyBox parses only 3 entries.

| | Kernel 5.14 (OCP 4.22) | Kernel 6.12 (OCP 5.0) |
|---|---|---|
| `/tmp` position in `/proc/self/mounts` | Line 5 (before first long entry) | Line 12 (after first long entry) |
| BusyBox entries shown | 11 (including `/tmp`) | 3 (without `/tmp`) |

## How to Reproduce

On OCP 5.0 (kernel 6.12+), run a user-namespace pod with nested podman, create a container via `podman kube play` with a tmpfs on `/tmp`, then compare:

```bash
podman exec <ctr> mount                        # 3 entries, no /tmp
podman exec <ctr> grep /tmp /proc/self/mounts  # /tmp is there
```

Automated reproducer: https://gist.github.com/bitoku/770d63cf49a9a1597090a1988cdcf39c

## Recommended Fix

Change the test to use `grep /tmp /proc/self/mounts` or `findmnt /tmp` instead of `mount | grep /tmp`.

## Sources

- **Kernel commit `2eea9ce4310d`**: https://patchwork.kernel.org/project/linux-fsdevel/patch/20231025140205.3586473-3-mszeredi@redhat.com/
- **Alpine bug #7093** (same `getmntent_r` issue): https://gitlab.alpinelinux.org/alpine/aports/-/issues/7093
- **BusyBox mailing list Dec 2025** (same issue on Fedora 43): [problem report](http://www.mail-archive.com/busybox@busybox.net/msg30438.html), [patch](http://www.mail-archive.com/busybox@busybox.net/msg30440.html)
- **Reproducer script**: https://gist.github.com/bitoku/770d63cf49a9a1597090a1988cdcf39c


Assisted-by: Claude Code <https://claude.com/claude-code>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated test behavior to avoid truncated output in environments with large mount listings, improving reliability on BusyBox-based systems.
  * Adjusted nested container test setup to use a more stable mount lookup approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->