### PR TITLE
OCPBUGS-84521: remove openshift/cluster-machine-approver `terminationMessagePolicy` exemption

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -139,7 +139,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 		// they should be fixed and removed from here:
 		"openshift-backplane":                sets.NewString("pods/osd-delete-backplane-serviceaccounts"), // filed OCPBUGS-84527 to fix
 		"openshift-cloud-controller-manager": sets.NewString("pods/aws-cloud-controller-manager"),         // filed OCPBUGS-84512 to fix
-		"openshift-cluster-machine-approver": sets.NewString("pods/machine-approver-capi"),                // filed OCPBUGS-84521 to fix
 		"openshift-cluster-version":          sets.NewString("pods/version--"),                            // filed OCPBUGS-84513 to fix
 		"openshift-cnv": sets.NewString( // filed OCPBUGS-84522 to fix
 			"pods/hostpath-provisioner-operator",


### PR DESCRIPTION
## Summary

Remove the violation for `cluster-machine-approver`.

All containers in `openshift/cluster-machine-approver` have the `TerminationMessagePolicy` correctly set. The fix is in main for a while already:
- https://github.com/openshift/cluster-machine-approver/blob/main/manifests/04-deployment.yaml#L62
- https://github.com/openshift/cluster-machine-approver/blob/main/manifests/04-deployment-capi.yaml#L66

## Additional Info

The `kube-rbac-proxy` sidecar in `openshift/cluster-machine-approver` had `terminationMessagePolicy: File`. The sidecar was removed in https://github.com/openshift/cluster-machine-approver/commit/545d7e4883 (Jan 2026), so the exemption is no longer needed.

Fixes: https://issues.redhat.com/browse/OCPBUGS-84521


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how existing termination message policy violations are handled, so one previously exempted namespace is no longer automatically treated as a flaky result.
  * As a result, matching issues in that area will now be reported more consistently instead of being silently grandfathered in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->