### PR TITLE
OCPBUGS-84518:  Remove exception for servicemesh-operator3 pod

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -161,7 +161,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 			"pods/metallb-operator-webhook-server",
 		),
 		"openshift-marketplace": sets.NewString("pods/podman"),                // filed OCPBUGS-84517 to fix
-		"openshift-operators":   sets.NewString("pods/servicemesh-operator3"), // filed OCPBUGS-84518 to fix
 		"openshift-sriov-network-operator": sets.NewString( // filed OCPBUGS-84526 to fix
 			"pods/network-resources-injector",
 			"pods/operator-webhook",


### PR DESCRIPTION
Hello! This is a draft PR (want to get feedback and make sure I've done this correctly first).
I've made a draft PR at https://github.com/openshift-service-mesh/sail-operator/pull/957 to add a terminationMessagePolicy to the servicemeshoperator3 container. Once this merges, this should mean this exception to the test can be removed here.
Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened monitor-test validation so previously ignored violations are now reported consistently.
* **Bug Fixes**
  * Cases that matched an older exception pattern may now fail instead of being silently treated as expected, improving test accuracy and reducing flaky results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->