### PR TITLE
OCPBUGS-96581: alerting: allow KubeCPUOvercommit on compact clusters

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -874,6 +874,11 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 				allowedAlertNames = append(allowedAlertNames, "OperatorHubSourceError")
 			}
 
+			// https://issues.redhat.com/browse/OCPBUGS-96581
+			if isCompactCluster(ctx, oc) {
+				allowedAlertNames = append(allowedAlertNames, "KubeCPUOvercommit")
+			}
+
 			tests := map[string]bool{
 				// openshift-e2e-loki alerts should never fail this test, we've seen this happen on daemon set rollout stuck when CI loki was down.
 				//
@@ -1187,6 +1192,19 @@ func hasTelemeterClient(client clientset.Interface) bool {
 		e2e.Failf("could not list pods: %v", err)
 	}
 	return true
+}
+
+// isCompactCluster returns true when the cluster has a highly-available
+// control plane but no dedicated worker nodes (infrastructureTopology is
+// SingleReplica).
+func isCompactCluster(ctx context.Context, oc *exutil.CLI) bool {
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		e2e.Logf("could not retrieve infrastructure resource: %v", err)
+		return false
+	}
+	return infra.Status.ControlPlaneTopology == configv1.HighlyAvailableTopologyMode &&
+		infra.Status.InfrastructureTopology == configv1.SingleReplicaTopologyMode
 }
 
 func SkipOperatorHubMetricsCheck(oc *exutil.CLI) bool {


### PR DESCRIPTION
On compact 3-node clusters where control-plane nodes also serve as workers, CPU overcommit is expected during e2e test workloads. Add KubeCPUOvercommit to the allowed alert names in the [Early] firing alerts test when running on a compact cluster (no dedicated worker nodes).

Fixes https://issues.redhat.com/browse/OCPBUGS-96581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alert validation now accounts for compact cluster deployments, allowing a relevant CPU overcommit alert to be expected in those environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->