### PR TITLE
OCPBUGS-97822: test/router: retry http2 test when response comes from wrong router

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -488,6 +488,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			for i, tc := range testCases {
 				testConfig := fmt.Sprintf("%+v", tc)
 				var resp *http.Response
+				var body []byte
 				client := makeHTTPClient(tc.useHTTP2Transport, http2ClientTimeout)
 
 				o.Expect(wait.Poll(time.Second, 5*time.Minute, func() (bool, error) {
@@ -499,10 +500,34 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 						return false, nil // could be 503 if service not ready
 					}
 					if resp.StatusCode != tc.statusCode {
-						// Successful responses are checked and asserted
-						// in the o.Expect() checks below.
 						resp.Body.Close()
 						e2e.Logf("[test #%d/%d]: config: %s, expected status: %v, actual status: %v", i+1, len(testCases), testConfig, tc.statusCode, resp.StatusCode)
+						return false, nil
+					}
+					body, err = ioutil.ReadAll(resp.Body)
+					resp.Body.Close()
+					if err != nil {
+						e2e.Logf("[test #%d/%d]: config: %s, body read error: %v", i+1, len(testCases), testConfig, err)
+						return false, nil
+					}
+					// A response can transiently come from the wrong
+					// router: the shard's wildcard DNS record
+					// (*.<shard-domain>) may not have propagated yet, in
+					// which case the request matches the cluster's
+					// *.apps wildcard and is served by the default
+					// router, which admits the route too but has HTTP/2
+					// disabled by default. Such a response has the
+					// expected status code and body, but the wrong
+					// negotiated protocol. Retry until the response
+					// comes from the shard router, i.e., protocol and
+					// body both match the expectation.
+					if resp.Proto != tc.frontendProto || string(body) != tc.backendProto {
+						e2e.Logf("[test #%d/%d]: config: %s, expected frontend proto %q and backend proto %q, got %q and %q; response may come from a router without http/2 enabled, retrying", i+1, len(testCases), testConfig, tc.frontendProto, tc.backendProto, resp.Proto, string(body))
+						// Drop pooled keep-alive connections so the
+						// next attempt re-resolves DNS and opens a
+						// fresh TLS connection instead of reusing the
+						// connection to the wrong router.
+						client.CloseIdleConnections()
 						return false, nil
 					}
 					return true, nil
@@ -511,10 +536,7 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 				o.Expect(resp).ToNot(o.BeNil(), testConfig)
 				o.Expect(resp.StatusCode).To(o.Equal(tc.statusCode), testConfig)
 				o.Expect(resp.Proto).To(o.Equal(tc.frontendProto), testConfig)
-				body, err := ioutil.ReadAll(resp.Body)
-				o.Expect(err).NotTo(o.HaveOccurred(), testConfig)
 				o.Expect(string(body)).To(o.Equal(tc.backendProto), testConfig)
-				o.Expect(resp.Body.Close()).NotTo(o.HaveOccurred())
 			}
 		})
 	})


### PR DESCRIPTION
## Problem

The http2 test deploys a dedicated router shard with HTTP/2 enabled (`ingress.operator.openshift.io/default-enable-http2: true`) and reaches it via the shard's wildcard DNS record (`*.<namespace>.apps.<cluster-domain>`). Until that record propagates, the route hostname still matches the cluster's `*.apps` wildcard (RFC 4592 wildcards match multiple labels), so requests are served by the **default router**, which also admits the test routes but has HTTP/2 disabled by default.

Such a response carries the expected status code **and** body, so the poll loop accepts it, and the post-loop protocol assertion fails with `HTTP/1.1 != HTTP/2.0` — even though the shard would have served the request correctly moments later.

## Evidence

[Component Readiness regression #42853](https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/main): `The HAProxy router should pass the http2 tests` failing at ~20% on 5.0 HyperShift AWS conformance (`periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn-conformance`) since 2026-06-27.

9 of 10 sampled failures are identical and always on the first test case:

```
fail [github.com/openshift/origin/test/extended/router/http2.go:513]: {route:http2-custom-cert-edge frontendProto:HTTP/2.0 backendProto:HTTP/1.1 statusCode:200 useHTTP2Transport:true}
Expected
    <string>: HTTP/1.1
to equal
    <string>: HTTP/2.0
```

Status 200 + correct body + wrong protocol is exactly the signature of the default router (no h2) serving the request. The 10th failure is a plain DNS/LB propagation timeout at http2.go:509. The window likely widened on HyperShift with the `AWSServiceLBNetworkSecurityGroup` promotion (openshift/api#2838) changing shard LB provisioning latency, but the race itself has always been in the test.

## Fix

- Treat a response with an unexpected negotiated protocol or body as retryable inside the existing 5-minute poll loop, instead of asserting on the first 200.
- Call `client.CloseIdleConnections()` before retrying so the next attempt re-resolves DNS and opens a fresh TLS connection instead of being pinned to the wrong router by the transport's keep-alive pool.
- Move body reading into the loop; final assertions after the loop are kept.

For test cases that legitimately expect HTTP/1.1 the check is a no-op on the happy path.

Generated-by: AI (analysis + patch), reviewed by mko@redhat.com

/cc @frobware

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP/2 router conformance checks to verify both the response protocol and response body during each poll.
  * Added safer response handling by reading and closing response bodies immediately, including on failed attempts.
  * Retries now more reliably refresh the network path when the expected router or shard is not reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->