### PR TITLE
OCPBUGS-97822: Wait for DNS before running http2 tests

### DIFF
--- a/test/extended/router/http2.go
+++ b/test/extended/router/http2.go
@@ -485,6 +485,12 @@ var _ = g.Describe("[sig-network-edge][Conformance][Area:Networking][Feature:Rou
 			o.Expect(shardService).NotTo(o.BeNil())
 			o.Expect(shardService.Status.LoadBalancer.Ingress).To(o.Not(o.BeEmpty()))
 
+			g.By("Waiting for DNS resolution of the shard domain")
+			host := testCases[0].route + "." + shardFQDN
+			addrs, err := resolveHost(oc, 2*time.Second, 10*time.Minute, host)
+			o.Expect(err).NotTo(o.HaveOccurred(), "DNS resolution for %q timed out", host)
+			e2e.Logf("resolved %s to %v", host, addrs)
+
 			for i, tc := range testCases {
 				testConfig := fmt.Sprintf("%+v", tc)
 				var resp *http.Response


### PR DESCRIPTION
## Summary

- Add an explicit DNS resolution step with a 10-minute timeout before running the HTTP/2 test cases, matching the pattern already used in `h2spec.go`
- Without this, the test starts HTTP requests immediately after the IngressController becomes available and burns poll iterations on DNS failures until the shard domain propagates

## Example Failure

DNS timeout causing test failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_router/792/pull-ci-openshift-router-master-e2e-aws-fips/2074206177318670336


🤖 Generated with [Claude Code](https://claude.com/claude-code)