### PR TITLE
OCPBUGS-97965: oc adm inspect test fails due to partial pod log collection errors in…

### DIFF
--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -478,20 +478,20 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 		checkInspectLogTime(tempDir, podname, timeStamp)
 
 		g.By("2. Test inspect with wrong since-time format should fail.\n")
-		_, warningErr, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since-time="+now.Format("2006-01-02T15:04:05"), "--dest-dir="+tempDir).Outputs()
+		_, warningErr, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns/openshift-console", "--since-time="+now.Format("2006-01-02T15:04:05"), "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "--since-time only accepts times matching RFC3339")).To(o.BeTrue())
 
 		g.By("3. Test inspect with wrong since-time format should fail.\n")
-		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since-time="+now.Format("2006-01-02"), "--dest-dir="+tempDir).Outputs()
+		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns/openshift-console", "--since-time="+now.Format("2006-01-02"), "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "--since-time only accepts times matching RFC3339")).To(o.BeTrue())
 
 		g.By("4. Test inspect with correct since format should succeed.\n")
-		o.Expect(oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since=1m", "--dest-dir="+tempDir).Execute()).To(o.Succeed())
+		o.Expect(oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns/openshift-console", "--since=1m", "--dest-dir="+tempDir).Execute()).To(o.Succeed())
 
 		g.By("5. Test inspect with wrong since format should fail.\n")
-		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since=1", "--dest-dir="+tempDir).Outputs()
+		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns/openshift-console", "--since=1", "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "time: missing unit")).To(o.BeTrue())
 	})

--- a/test/extended/cli/mustgather.go
+++ b/test/extended/cli/mustgather.go
@@ -464,25 +464,34 @@ var _ = g.Describe("[sig-cli] oc adm must-gather", func() {
 
 		podname, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-n", "openshift-multus", "-l", "app=multus", "-o=jsonpath={.items[0].metadata.name}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since-time="+now.Add(time.Minute*-2).Format("2006-01-02T15:04:05Z"), "--dest-dir="+tempDir).Execute()).To(o.Succeed())
+		// Use Output() instead of Execute() because oc adm inspect returns non-zero
+		// for partial pod log collection errors (e.g., terminated init containers,
+		// transient API timeouts) even when the data was gathered successfully.
+		inspectOutput, inspectErr := oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since-time="+now.Add(time.Minute*-2).Format("2006-01-02T15:04:05Z"), "--dest-dir="+tempDir).Output()
+		if inspectErr != nil {
+			// Fail only if the error is about the flag format, not partial collection errors
+			o.Expect(inspectOutput).NotTo(o.ContainSubstring("since-time only accepts times matching RFC3339"),
+				"inspect rejected the --since-time flag format")
+			e2e.Logf("inspect completed with partial errors (expected): %v", inspectErr)
+		}
 
 		checkInspectLogTime(tempDir, podname, timeStamp)
 
-		g.By("2. Test inspect with wrong since-time format should failed.\n")
-		_, warningErr, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since-time="+now.Format("2006-01-02T15:04:05"), "--dest-dir="+tempDir).Outputs()
+		g.By("2. Test inspect with wrong since-time format should fail.\n")
+		_, warningErr, err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since-time="+now.Format("2006-01-02T15:04:05"), "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "--since-time only accepts times matching RFC3339")).To(o.BeTrue())
 
-		g.By("3. Test inspect with wrong since-time format should failed.\n")
-		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since-time="+now.Format("2006-01-02"), "--dest-dir="+tempDir).Outputs()
+		g.By("3. Test inspect with wrong since-time format should fail.\n")
+		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since-time="+now.Format("2006-01-02"), "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "--since-time only accepts times matching RFC3339")).To(o.BeTrue())
 
 		g.By("4. Test inspect with correct since format should succeed.\n")
-		o.Expect(oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since=1m", "--dest-dir="+tempDir).Execute()).To(o.Succeed())
+		o.Expect(oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since=1m", "--dest-dir="+tempDir).Execute()).To(o.Succeed())
 
-		g.By("5. Test inspect with wrong since format should failed.\n")
-		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "ns", "openshift-multus", "--since=1", "--dest-dir="+tempDir).Outputs()
+		g.By("5. Test inspect with wrong since format should fail.\n")
+		_, warningErr, err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("inspect", "clusteroperator/openshift-apiserver", "--since=1", "--dest-dir="+tempDir).Outputs()
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(strings.Contains(warningErr, "time: missing unit")).To(o.BeTrue())
 	})


### PR DESCRIPTION
… openshift-multus namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced `oc adm inspect` coverage for `--since` and `--since-time` filtering, including valid RFC3339 time handling.
  * Confirmed that non-zero results from partial log collection are tolerated when the time is valid, while still verifying gathered log timestamps.
  * Ensured invalid time values continue to fail with the expected `--since-time` RFC3339 error message.
  * Updated inspection scenarios to target a different cluster target for more robust validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->