### PR TITLE
OCPEDGE-2785: fix: adjusting DaemonSet test to dynamically compute expected pod count

### DIFF
--- a/test/extended/edge_topologies/arbiter_topology.go
+++ b/test/extended/edge_topologies/arbiter_topology.go
@@ -244,9 +244,15 @@ var _ = g.Describe("[sig-apps][apigroup:apps.openshift.io][OCPFeatureGate:Highly
 		daemonSetSelector, err := labels.Parse("app=busybox-daemon")
 		o.Expect(err).To(o.BeNil(), "Expected to parse DaemonSet label selector without error")
 
-		daemonSetPods, err := exutil.WaitForPods(oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()), daemonSetSelector, isPodRunning, 2, time.Second*300)
+		allNodes, err := utils.GetNodes(oc, utils.AllNodes)
+		o.Expect(err).To(o.BeNil(), "Expected to list all nodes")
+
+		arbiterCount := len(arbiterNodes.Items)
+		schedulableNodes := len(allNodes.Items) - arbiterCount
+
+		daemonSetPods, err := exutil.WaitForPods(oc.AdminKubeClient().CoreV1().Pods(oc.Namespace()), daemonSetSelector, isPodRunning, schedulableNodes, time.Second*300)
 		o.Expect(err).To(o.BeNil(), "Expected DaemonSet pods to be running")
-		o.Expect(len(daemonSetPods)).To(o.Equal(2), "Expected exactly two DaemonSet pod to be running")
+		o.Expect(len(daemonSetPods)).To(o.Equal(schedulableNodes), "Expected exactly %v DaemonSet pods to be running", schedulableNodes)
 
 		g.By("Validating that DaemonSet pods are NOT scheduled on the Arbiter node")
 


### PR DESCRIPTION
The expected pod count was hardcoded to 2. This PR introduces a dynamic counting of non-arbiter nodes which avoids failures on clusters with different node counts, and prevents double counting nodes that carry both control-plane and worker labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved highly available arbiter deployment checks to account for the number of schedulable cluster nodes.
  * DaemonSet pod validation now waits for and verifies the correct number of running pods while continuing to exclude arbiter nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->