### PR TITLE
TRT-2689: Add `verify-apm` to the `verify` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ test: test-tools
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
 
 # Requires uv (installed in devcontainer). Regenerates CLAUDE.md, AGENTS.md, etc.
-_uvx_flags = $(if $(filter true,$(CI)),--no-cache)
+_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools)
 apm:
-	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm install
-	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm compile
+	$(_uvx_env) uvx --from apm-cli@0.13.0 apm install
+	$(_uvx_env) uvx --from apm-cli@0.13.0 apm compile
 .PHONY: apm
 
 verify-apm: apm

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test: test-tools
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
 
 # Requires uv (installed in devcontainer). Regenerates CLAUDE.md, AGENTS.md, etc.
-_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools)
+_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools UV_PYTHON=python3.12)
 apm:
 	$(_uvx_env) uvx --from apm-cli@0.13.0 apm install
 	$(_uvx_env) uvx --from apm-cli@0.13.0 apm compile

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ verify-origin:
 	hack/verify-generated.sh
 	hack/verify-tls-ownership.sh
 .PHONY: verify-origin
-verify: verify-origin
+verify: verify-origin verify-apm
 
 # Update all generated artifacts.
 #

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ test: test-tools
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
 
 # Requires uv (installed in devcontainer). Regenerates CLAUDE.md, AGENTS.md, etc.
-_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools UV_PYTHON=python3.12)
+_uvx_env = $(if $(filter true,$(CI)),UV_CACHE_DIR=/tmp/uv-cache UV_TOOL_DIR=/tmp/uv-tools)
 apm:
 	$(_uvx_env) uvx --from apm-cli@0.13.0 apm install
 	$(_uvx_env) uvx --from apm-cli@0.13.0 apm compile

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ verify-origin:
 	hack/verify-jsonformat.sh
 	hack/verify-generated.sh
 	hack/verify-tls-ownership.sh
-.PHONY: verify-origin
+.PHONY: verify-origin verify
 verify: verify-origin verify-apm
 
 # Update all generated artifacts.

--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,10 @@ test: test-tools
 $(call add-bindata,bindata,-ignore ".*\.(go|md)$$$$" examples/db-templates examples/image-streams examples/sample-app examples/quickstarts/... examples/hello-openshift examples/jenkins/... examples/quickstarts/cakephp-mysql.json test/extended/testdata/... e2echart,testextended,testdata,test/extended/testdata/bindata.go)
 
 # Requires uv (installed in devcontainer). Regenerates CLAUDE.md, AGENTS.md, etc.
+_uvx_flags = $(if $(filter true,$(CI)),--no-cache)
 apm:
-	uvx --from apm-cli@0.13.0 apm install
-	uvx --from apm-cli@0.13.0 apm compile
+	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm install
+	uvx $(_uvx_flags) --from apm-cli@0.13.0 apm compile
 .PHONY: apm
 
 verify-apm: apm


### PR DESCRIPTION
Ensures that apm generation stays up-to-date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the standard verification command to also validate generated APM documentation files, ensuring the workflow fails if regeneration is required.
  * Improved APM tooling behavior in automated runs by applying CI-specific caching settings for more consistent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->