### PR TITLE
OCPEDGE-2787: fix: skip MCPs with non-ready nodes during MCN property validation

### DIFF
--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -134,10 +134,10 @@ func GetRolesToTest(oc *exutil.CLI, machineConfigClient *machineconfigclient.Cli
 	mcps, mcpErr := machineConfigClient.MachineconfigurationV1().MachineConfigPools().List(context.TODO(), metav1.ListOptions{})
 	o.Expect(mcpErr).NotTo(o.HaveOccurred(), "Error getting MCPs.")
 
-	// For any MCP with machines, add the MCP name as a role to test.
+	/// For any MCP with machines where all machines are ready, add the MCP name as a role to test.
 	var rolesToTest []string
 	for _, mcp := range mcps.Items {
-		if mcp.Status.MachineCount > 0 {
+		if mcp.Status.MachineCount > 0 && mcp.Status.ReadyMachineCount == mcp.Status.MachineCount {
 			rolesToTest = append(rolesToTest, mcp.Name)
 		}
 	}


### PR DESCRIPTION
In TNA + Day 2 worker upgrade scenarios, the worker MCP has machines but the nod may by in mid-upgrade and not ready yet. The test would fail trying to validate MCN properties on a node that hasn't converged. Only validate pools where all machines are ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks so only fully ready machine configurations are included in extended testing.
  * Prevented MCP entries from being added unless all machines are present and ready, avoiding partial readiness from being treated as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->