### PR TITLE
CORENET-7353: OTE: register egress-router-cni test extension binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -334,6 +334,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/olmv0-tests-ext.gz",
 	},
 	{
+		imageTag:   "egress-router-cni",
+		binaryPath: "/usr/bin/egress-router-cni-tests-ext.gz",
+	},
+	{
 		imageTag:   "ovn-kubernetes",
 		binaryPath: "/usr/bin/ovn-kubernetes-tests-ext.gz",
 	},


### PR DESCRIPTION
## Summary
- Register `egress-router-cni-tests-ext.gz` in the openshift-tests extension binary registry
- Companion to https://github.com/openshift/egress-router-cni/pull/105 which adds the OTE framework to egress-router-cni

## Test plan
- [ ] Verify CI builds successfully
- [ ] Use `/testwith openshift/egress-router-cni#105` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for discovering, extracting, and running the `egress-router-cni` test extension binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->