### PR TITLE
OCPNODE-4604: allow registry.redhat.io reboot requried test

### DIFF
--- a/test/extended/node/node_e2e/image_registry_config.go
+++ b/test/extended/node/node_e2e/image_registry_config.go
@@ -79,7 +79,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 			}
 			imageConfig.Spec.RegistrySources.AllowedRegistries = []string{
 				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,
-				"image-registry.openshift-image-registry.svc:5000", "quay-proxy.ci.openshift.org",
+				"image-registry.openshift-image-registry.svc:5000", "quay-proxy.ci.openshift.org", "registry.redhat.io",
 			}
 			imageConfig.Spec.RegistrySources.ContainerRuntimeSearchRegistries = []string{
 				"registry.access.redhat.com", "docker.io", "quay.io", searchRegistry,


### PR DESCRIPTION
Fix presubmits payload job failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/openshift-origin-31324-nightly-5.0-e2e-aws-disruptive-longrunning-techpreview-1of2/2076788709641949184
`Back-off pulling image \"registry.redhat.io...`
```
from similar events): Container image \"quay-proxy.ci.openshift.org/openshift/ci@sha256:01b9dcc7e27f1174669d64465c7704a26a1e4fb3b3aaf5a231fffa013bedf8a1\" already present on machine and can be accessed by the pod map[count:49 firstTimestamp:2026-07-14T00:53:02Z lastTimestamp:2026-07-14T01:24:20Z reason:Pulled]}"
time="2026-07-14T01:24:43Z" level=info msg="event interval matches AllowImagePullBackOffFromRedHatRegistry" locator="{Kind map[hmsg:9cbd5bc1d8 namespace:openshift-marketplace node:ip-10-0-53-67.us-east-2.compute.internal pod:redhat-operators-qgrd9]}" message="{BackOff  Back-off pulling image \"registry.redhat.io/redhat/redhat-operator-index:v5.0\" map[count:108 firstTimestamp:2026-07-14T00:59:45Z lastTimestamp:2026-07-14T01:24:43Z reason:BackOff]}"
time="2026-07-14T01:24:46Z" level=info msg="event interval matches AllowImagePullBackOffFromRedHatRegistry" locator="{Kind map[hmsg:2cbaa4df2c namespace:openshift-marketplace node:ip-10-0-53-67.us-east-2.compute.internal pod:community-operators-v9lgp]}" message="{BackOff  Back-off pulling image \"registry.redhat.io/redhat/community-operator-index:v5.0\" map[count:108 firstTimestamp:2026-07-14T00:59:43Z lastTimestamp:2026-07-14T01:24:46Z reason:BackOff]}"
time="2026-07-14T01:24:51Z" level=info msg="event interval matches AllowImagePullBackOffFromRedHatRegistry" locator="{Kind map[hmsg:5c3c2b1a15 namespace:openshift-marketplace node:ip-10-0-53-67.us-east-2.compute.internal pod:certified-operators-fqbx4]}" message="{BackOff  Back-off pulling image \"registry.redhat.io/redhat/certified-operator-index:v5.0\" map[count:109 firstTimestamp:2026-07-14T00:59:42Z lastTimestamp:2026-07-14T01:24:51Z reason:BackOff]}"
  STEP: Creating a kubernetes client @ 07/14/26 00:45:48.472
I0714 00:45:48.474148 6594 framework.go:2330] [precondition-check] checking if cluster is MicroShift
I0714 00:45:48.476826 6594 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
  STEP: Save the original image.config for later restore @ 07/14/26 00:45:48.476
  STEP: Update image.config to add search registry and allowed registries @ 07/14/26 00:45:48.491
  STEP: Wait for worker and master MCP rollout to complete @ 07/14/26 00:45:48.508
I0714 00:45:48.508702 6594 imagepolicy.go:695] Waiting for pool worker to complete
I0714 00:53:54.856755 6594 imagepolicy.go:695] Waiting for pool master to complete
  [FAILED] in [It] - github.com/openshift/origin/test/extended/imagepolicy/imagepolicy.go:710 @ 07/14/26 01:13:54.864
I0714 01:13:54.865054 6594 image_registry_config.go:50] Cleanup: restoring original image.config
I0714 01:13:54.884376 6594 imagepolicy.go:695] Waiting for pool worker to complete
I0714 01:21:15.089361 6594 imagepolicy.go:695] Waiting for pool master to complete
  [INTERRUPTED] in [DeferCleanup (Each)] - github.com/openshift/origin/test/extended/node/node_e2e/image_registry_config.go:49 @ 07/14/26 01:25:48.096
  ------------------------------
  Interrupted by User
  First interrupt received; Ginkgo will run any cleanup and reporting nodes but will skip all remaining specs.  Interrupt again to skip cleanup.
  Here's a current progress report:
    [Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config [OTP] change container registry config [OCP-44820] (Spec Runtime: 39m59.635s)
      github.com/openshift/origin/test/extended/node/node_e2e/image_registry_config.go:38
      In [DeferCleanup (Each)] (Node Runtime: 11m53.231s)
        github.com/openshift/origin/test/extended/node/node_e2e/image_registry_config.go:49

      Spec Goroutine
      goroutine 487 [select]
        github.com/onsi/gomega/internal.(*AsyncAssertion).match(0x3739c7b0c310, {0x9d54110, 0x3739c989e3f0}, 0x1, {0x0, 0x0, 0x0})
          github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:558
        github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0x3739c7b0c310, {0x9d54110, 0x3739c989e3f0}, {0x0, 0x0, 0x0})
          github.com/onsi/gomega@v1.38.2/internal/async_assertion.go:145
        github.com/openshift/origin/test/extended/imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(0x3739c9f25200, {0x958a59f, 0x6}, {0x3739c7427290, 0x30})
          github.com/openshift/origin/test/extended/imagepolicy/imagepolicy.go:710
      > github.com/openshift/origin/test/extended/node/node_e2e.init.func2.2.1()
          github.com/openshift/origin/test/extended/node/node_e2e/image_registry_config.go:66
        reflect.Value.call({0x83bc880?, 0x3739cb6f9290?, 0x13?}, {0x9584bae, 0x4}, {0x10d372a0, 0x0, 0x0?})
          reflect/value.go:586
        reflect.Value.Call({0x83bc880?, 0x3739cb6f9290?, 0x0?}, {0x10d372a0?, 0x3739c6f85e98?, 0x0?})
          reflect/value.go:369
        github.com/onsi/ginkgo/v2/internal.NewCleanupNode.func3()
          github.com/onsi/ginkgo/v2@v2.25.1/internal/node.go:646
        github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3({0x0?, 0x0?})
          github.com/onsi/ginkgo/v2@v2.25.1/internal/node.go:524
        github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
          github.com/onsi/ginkgo/v2@v2.25.1/internal/suite.go:949
        github.com/onsi/ginkgo/v2/internal.(*Suite).runNode in goroutine 239
          github.com/onsi/ginkgo/v2@v2.25.1/internal/suite.go:914
  ------------------------------

fail [github.com/openshift/origin/test/extended/imagepolicy/imagepolicy.go:710]: Timed out after 1200.002s.
Expected
    <bool>: false
to be true
failed: (40m0s) 2026-07-14T01:25:48 "[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config [OTP] change container registry config [OCP-44820] [Serial]"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end registry configuration coverage to include `registry.redhat.io` as an allowed image registry.
  * Continued validating registry settings across cluster nodes after configuration rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->