### PR TITLE
OCPNODE-4055: Add Additional Storage Support - API validation test cases

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -13,6 +13,47 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **node_e2e/netns_cleanup.go** - Network namespace cleanup - Verifies kubelet/CRI-O properly deletes network namespace when a pod is deleted \[OTP\]
 - **node_e2e/pdb_drain.go** - PodDisruptionBudget drain blocking (OCP-67564) - Tests that node drain is blocked when PDB has minAvailable=100% with empty selector \[Disruptive\] \[Lifecycle:informing\]
 
+### Suite: openshift/conformance/parallel
+
+- **Additional Storage Support API Validation** - API validation tests for additionalArtifactStores, additionalImageStores, and additionalLayerStores CRI-O configuration
+  
+  **Availability:**
+  - **OCP 4.22:** TechPreview (requires TechPreviewNoUpgrade feature gate)
+  - **OCP 4.23+/5.0+:** GA (Generally Available)
+  
+  **Suite:** `openshift/conformance/parallel`  
+  **Feature Tag:** `[Feature:AdditionalStorageSupport]`  
+  **Sig Tag:** `[sig-node]`  
+  **OCPFeatureGate:** `AdditionalStorageConfig`
+  
+  **Test File:**
+  - **additional_storage_api.go** - 13 API validation tests using DryRun (non-disruptive, parallel execution)
+    - Combined Additional Stores (3 tests): invalid paths, max count enforcement, duplicate detection
+    - Additional Layer Stores (8 tests): comprehensive path validation (empty, relative, spaces, special chars, length, max count, consecutive slashes, duplicates)
+    - Additional Image Stores (1 smoke test): path validation wiring
+    - Additional Artifact Stores (1 smoke test): path validation wiring
+  
+  **Requirements:**
+  - AdditionalStorageConfig feature gate must be enabled
+  - API tests are non-disruptive (use DryRun)
+  - Run in parallel with other conformance tests
+  - Skip on MicroShift (no MachineConfig support)
+  - Skip on Microsoft Azure (known platform issues)
+  
+  **Running API validation tests:**
+  ```bash
+  # Run only Additional Storage API validation tests (fast, non-disruptive)
+  ./openshift-tests run "openshift/conformance/parallel" --dry-run | \
+    grep "\[Feature:AdditionalStorageSupport\]" | \
+    ./openshift-tests run -f -
+  ```
+  
+  **Test Coverage (13 tests, ~2-3 min total):**
+  - Path format validation (absolute paths, character restrictions, length limits)
+  - Count limits enforcement (5 for artifact/layer stores, 10 for image stores)
+  - Duplicate path detection within store types
+  - Combined store configurations with invalid paths
+
 ### Suite: openshift/usernamespace
 
 - **nested_container.go** - Tests running nested containers (podman-in-pod) with user namespaces and nested-container SCC

--- a/test/extended/node/additional_storage_api.go
+++ b/test/extended/node/additional_storage_api.go
@@ -1,0 +1,492 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// API validation tests - use DryRun to avoid triggering MCO reconciliation
+var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Suite:openshift/conformance/parallel] Additional Storage API Validation", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("additional-storage-api")
+
+	g.BeforeEach(func(ctx context.Context) {
+		skipUnlessAdditionalStorageConfigEnabled(ctx, oc)
+	})
+
+	// ========================================================================
+	// Combined Additional Stores API Validation
+	// ========================================================================
+	g.Context("Combined Additional Stores", func() {
+		// Reject if any store type has invalid path
+		g.It("should reject if any store type has invalid path in combined config ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with valid layer/artifact but invalid image path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-invalid-image-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("relative/invalid/path")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred(), "Expected API to reject invalid relative image path")
+			o.Expect(err.Error()).To(o.Or(
+				o.ContainSubstring("relative"),
+				o.ContainSubstring("absolute"),
+				o.ContainSubstring("path"),
+			), "Error message should mention path validation issue")
+			framework.Logf("Test PASSED: Combined config with invalid image path rejected: %v", err)
+		})
+
+		// Reject if layer stores exceed max while other stores are valid
+		g.It("should reject if layer stores exceed max even with valid image/artifact stores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with 6 layer stores (exceeds max of 5)")
+			layerStores := make([]machineconfigv1.AdditionalLayerStore, 6)
+			for i := 0; i < 6; i++ {
+				layerStores[i] = machineconfigv1.AdditionalLayerStore{
+					Path: machineconfigv1.StorePath(fmt.Sprintf("/var/lib/layer-store-%d", i)),
+				}
+			}
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-exceed-layer-max-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: layerStores,
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("must have at most 5 items"))
+			framework.Logf("Test PASSED: Exceeding layer store max rejected: %v", err)
+		})
+
+		// Reject duplicate paths within same store type in combined config
+		g.It("should reject duplicate paths within same store type in combined config ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with duplicate paths in image stores")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-duplicate-image-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("duplicate"))
+			framework.Logf("Test PASSED: Duplicate paths in same store type rejected: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Layer Stores API Validation
+	// ========================================================================
+	g.Context("Additional Layer Stores", func() {
+		// Should fail if additionalLayerStores path is empty
+		// Note: Go API returns "Required value" while YAML returns "at least 1 chars long"
+		g.It("should reject empty path for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with empty path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-empty-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			framework.Logf("Expected substring: 'Required value' (Go API) or 'at least 1 chars long' (YAML)")
+			framework.Logf("Actual error: %v", err)
+			o.Expect(err.Error()).To(o.ContainSubstring("Required value"))
+			framework.Logf("Test PASSED: Empty path correctly rejected")
+		})
+
+		// Should fail if additionalLayerStores path is not absolute
+		g.It("should reject relative path for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with relative path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-relative-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("var/lib/stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
+			framework.Logf("Test PASSED: Relative path correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains spaces
+		g.It("should reject path with spaces for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with path containing spaces")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-path-spaces-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
+			framework.Logf("Test PASSED: Path with spaces correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains invalid characters
+		g.It("should reject path with invalid characters for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with path containing @ symbol")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-invalid-char-at-symbol-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected API to reject path with invalid character '@'")
+			framework.Logf("Path with '@' correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path is too long (>256 bytes)
+		g.It("should reject path exceeding 256 characters for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			longPath := "/" + strings.Repeat("a", 256)
+			g.By(fmt.Sprintf("Creating ContainerRuntimeConfig with path of %d characters", len(longPath)))
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-long-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath(longPath)},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.Or(o.ContainSubstring("256"), o.ContainSubstring("Too long")))
+			framework.Logf("Test PASSED: Long path correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores exceeds maximum of 5 items
+		g.It("should reject more than 5 additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with 6 layer stores (exceeds max of 5)")
+			layerStores := make([]machineconfigv1.AdditionalLayerStore, 6)
+			for i := 0; i < 6; i++ {
+				layerStores[i] = machineconfigv1.AdditionalLayerStore{Path: machineconfigv1.StorePath(fmt.Sprintf("/var/lib/store%d", i))}
+			}
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-exceed-limit-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: layerStores,
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("must have at most 5 items"))
+			framework.Logf("Test PASSED: 6 layer stores correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains consecutive forward slashes
+		g.It("should reject path with consecutive forward slashes for additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with consecutive forward slashes")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-consecutive-slashes-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib//stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("consecutive"))
+			framework.Logf("Test PASSED: Consecutive slashes correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores contains duplicate paths
+		g.It("should reject duplicate paths in additionalLayerStores ", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with duplicate paths")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-duplicate-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("duplicate"))
+			framework.Logf("Test PASSED: Duplicate paths correctly rejected: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Image Stores API Validation
+	// ========================================================================
+	g.Context("Additional Image Stores", func() {
+		// Smoke test - validates that path validation is wired up for additionalImageStores
+		g.It("should reject invalid additionalImageStores path [Validation Smoke Test]", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with invalid path (contains special character)")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "imagestore-validation-smoke-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/var/lib/image@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Artifact Stores API Validation
+	// ========================================================================
+	g.Context("Additional Artifact Stores", func() {
+		// Smoke test - validates that path validation is wired up for additionalArtifactStores
+		g.It("should reject invalid additionalArtifactStores path [Validation Smoke Test]", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with invalid path (contains special character)")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "artifactstore-validation-smoke-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/var/lib/artifact@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
+		})
+	})
+})

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -19,8 +19,10 @@ import (
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/test/e2e/framework"
 
+	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 
+	configv1 "github.com/openshift/api/config/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -902,4 +904,44 @@ func CheckNetNsCleaned(oc *exutil.CLI, nodeName, netNsPath string) error {
 	}
 	// No error means file still exists
 	return fmt.Errorf("NetNS file still exists at %s", netNsPath)
+}
+
+func skipUnlessAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) {
+	// Skip on MicroShift - MachineConfig resources are not available
+	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+	if err != nil {
+		framework.Logf("Failed to detect MicroShift cluster: %v", err)
+		g.Skip("Cannot verify cluster type")
+	}
+	if isMicroShift {
+		g.Skip("Skipping test on MicroShift cluster - MachineConfig resources are not available")
+	}
+
+	// Skip on Microsoft
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Failed to get Infrastructure resource: %v", err)
+		g.Skip("Cannot verify platform type")
+	}
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.AzurePlatformType {
+		g.Skip("Skipping test on Microsoft Azure cluster")
+	}
+
+	// Verify AdditionalStorageConfig feature gate is enabled
+	g.By("Verifying AdditionalStorageConfig feature gate is enabled")
+	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Failed to get FeatureGate resource: %v", err)
+		g.Skip("Cannot verify AdditionalStorageConfig feature gate requirement")
+	}
+
+	for _, fg := range fgs.Status.FeatureGates {
+		for _, enabledFG := range fg.Enabled {
+			if enabledFG.Name == "AdditionalStorageConfig" {
+				return // All prerequisites met, continue with test
+			}
+		}
+	}
+
+	g.Skip("Skipping test - AdditionalStorageConfig feature gate is not enabled")
 }


### PR DESCRIPTION
## Summary
     
  Add comprehensive API validation tests for Additional Storage Support (additionalArtifactStores, additionalImageStores, additionalLayerStores) feature. These tests validate ContainerRuntimeConfig API behavior
  using DryRun, ensuring proper validation without triggering MCO reconciliation.

  ## Test Coverage

  **13 API validation tests** across 4 categories:

  ### Combined Additional Stores (3 tests)
  - Reject invalid path in any store type
  - Reject when layer stores exceed maximum count
  - Reject duplicate paths within same store type

  ### Additional Layer Stores (8 tests)
  - Reject empty path
  - Reject relative path (non-absolute)
  - Reject path with spaces
  - Reject path with invalid characters (@, etc.)
  - Reject path exceeding 256 characters
  - Reject more than 5 layer stores (max enforcement)
  - Reject path with consecutive forward slashes
  - Reject duplicate paths

  ### Additional Image Stores (1 test)
  - Smoke test: validation wiring

  ### Additional Artifact Stores (1 test)
  - Smoke test: validation wiring

  ## Test Characteristics

  - **Suite:** `openshift/conformance/parallel`
  - **Execution:** Non-disruptive, parallel, ~2-3 minutes total
  - **Method:** DryRun API calls only (no actual MCO reconciliation)
  - **Feature Tag:** `[Feature:AdditionalStorageSupport]`
  - **OCPFeatureGate:** `AdditionalStorageConfig`
  - **Platform Support:** AWS, GCP, vSphere, Metal IPI (skips Azure and MicroShift)

  ## Files Changed

  ### New Files
  - `test/extended/node/additional_storage_api.go` - 13 API validation tests

  ### Modified Files  
  - `test/extended/node/node_utils.go` - Added `skipUnlessAdditionalStorageConfigEnabled()` helper function with platform and feature gate checks
  - `test/extended/node/README.md` - Added documentation for API validation test suite

##  Prerequisites

  - AdditionalStorageConfig feature gate must be enabled
  - Test automatically skips on:
    - MicroShift (no MachineConfig support)
    - Microsoft Azure (known platform issues)

 ## Related

  - Feature: Additional Storage Support
  - Availability: TechPreview (OCP 4.22), GA (OCP 4.23+/5.0)
  - Jira: [OCPNODE-4055](https://redhat.atlassian.net/browse/OCPNODE-4055)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end conformance coverage for the Additional Storage Support APIs.
  * Added validations for image, layer, and artifact store paths, including invalid formats, duplicates, excessive entries, length limits, and edge-case path rules.
  * Tests now conditionally skip when the required feature isn’t enabled or the platform isn’t supported.

* **Tests**
  * Introduced a new parallel/disruptive-longrunning suite for Additional Storage API validation.

* **Documentation**
  * Updated the Node E2E Tests documentation with suite details, prerequisites, and how to run it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->