### PR TITLE
NO-ISSUE: Always emit precondition validation synthetic test entry

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -1439,10 +1439,13 @@ func recordTestBucketInterval(monitorEventRecorder monitorapi.Recorder, bucketNa
 // a synthetic JUnit entry. Returns nil if no precondition checking was performed.
 //
 // The synthetic test:
+//   - PASSES if no precondition checks were performed (e.g. upgrade succeeded cleanly)
 //   - PASSES if precondition checks ran and all passed (no skips)
 //   - FAILS if any tests were skipped due to unmet preconditions
 //
-// This provides TRT with a consistent test name that has meaningful pass/fail rates.
+// The entry is always emitted so that aggregated jobs see consistent pass counts
+// across all child runs. This provides TRT with a consistent test name that has
+// meaningful pass/fail rates.
 func detectPreconditionChecks(tests []*testCase) *junitapi.JUnitTestCase {
 	type skipInfo struct {
 		name   string
@@ -1477,18 +1480,16 @@ func detectPreconditionChecks(tests []*testCase) *junitapi.JUnitTestCase {
 		}
 	}
 
-	// No precondition checking was performed - don't emit synthetic test
-	if !checksPerformed {
-		return nil
-	}
-
-	// Precondition checks ran - generate synthetic JUnit entry
-	if len(skips) == 0 {
-		// All precondition checks passed
-		logrus.Infof("All cluster precondition checks passed")
+	// Always emit the synthetic test entry so it appears in every child run.
+	// Without this, the aggregator sees inconsistent pass counts and rejects the payload.
+	if !checksPerformed || len(skips) == 0 {
+		if !checksPerformed {
+			logrus.Infof("No precondition checking was performed - emitting synthetic pass")
+		} else {
+			logrus.Infof("All cluster precondition checks passed")
+		}
 		return &junitapi.JUnitTestCase{
 			Name: preconditions.SyntheticTestName,
-			// No FailureOutput = passing test
 		}
 	}
 


### PR DESCRIPTION
## Summary
- The `[openshift-tests] cluster precondition validation` synthetic JUnit entry was only emitted when precondition checking was actually invoked (i.e. when a test called `preconditions.RecordCheck()`).
- In aggregated upgrade jobs, child runs where the upgrade succeeded cleanly never invoked precondition checks, so no entry was emitted. The aggregator then saw fewer passes than the required threshold (e.g. "Passed 3 times, failed 0 times, skipped 0 times: we require at least 6 attempts") and **rejected the payload**.
- This was observed in both SNO (`aggregated-aws-ovn-single-node-upgrade`) and multi-node (`aggregated-gcp-ovn-upgrade`) aggregated jobs, killing nightlies like `5.0.0-0.nightly-2026-07-06-090546`.

## Fix
Always emit a passing synthetic entry from `detectPreconditionChecks()`, even when no precondition checking was performed. This ensures the aggregator sees consistent pass counts across all child runs.

## Test plan
- [ ] Verify the change compiles: `go build ./pkg/test/ginkgo/`
- [ ] Monitor aggregated upgrade lanes (`aggregated-*-upgrade-5.0-micro-release`) after merge to confirm the `[openshift-tests] cluster precondition validation` test passes consistently across all child runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Precondition checks now consistently produce a JUnit test result, including when no checks are detected.
  * Reports show a passing result when precondition checks run without skips, improving test report completeness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->