### PR TITLE
NO-ISSUE: Remove Feature:NodeSwap tag and update README selectors

### DIFF
--- a/test/extended/node/node_swap_cnv.go
+++ b/test/extended/node/node_swap_cnv.go
@@ -38,7 +38,7 @@ var (
 	cnvNoSwapConfigPath = exutil.FixturePath("testdata", "node", "cnv-swap", "kubelet-noswap-dropin.yaml")
 )
 
-var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Kubelet LimitedSwap Drop-in Configuration for CNV", g.Ordered, func() {
+var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Kubelet LimitedSwap Drop-in Configuration for CNV", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("cnv-swap")

--- a/test/extended/testdata/node/cnv-swap/README.md
+++ b/test/extended/testdata/node/cnv-swap/README.md
@@ -71,26 +71,24 @@ The configuration files support the following automated tests in `node_swap_cnv.
 
 | TC | Description |
 |----|-------------|
-| TC1 | Verify silent creation and ownership of drop-in directory on CNV nodes |
+| TC1 | Verify drop-in directory exists on all nodes with correct ownership |
 | TC2 | Verify kubelet starts normally with empty directory |
 | TC3 | Apply LimitedSwap configuration from drop-in file |
 | TC4 | Revert to NoSwap when drop-in file is removed |
-| TC5 | Verify control plane kubelets ignore drop-in config |
-| TC6 | Verify drop-in directory is auto-recreated after deletion |
-| TC7 | Validate security and permissions of drop-in directory |
-| TC8 | Verify cluster stability with LimitedSwap enabled |
-| TC9 | Verify non-CNV workers have no swap configuration |
-| TC10 | Apply correct precedence with multiple files |
-| TC11 | Maintain consistent configuration with checksum verification across CNV nodes |
-| TC12 | Handle LimitedSwap config gracefully when OS swap is disabled |
-| TC13 | Work correctly with various swap sizes |
-| TC14 | Expose swap metrics correctly via Prometheus |
+| TC5 | Validate security and permissions of drop-in directory |
+| TC6 | Verify cluster stability with LimitedSwap enabled |
+| TC7 | Verify non-CNV workers have no swap configuration |
+| TC8 | Apply correct precedence with multiple files |
+| TC9 | Maintain consistent configuration with checksum verification across CNV nodes |
+| TC10 | Handle LimitedSwap config gracefully when OS swap is disabled |
+| TC11 | Work correctly with various swap sizes |
+| TC12 | Expose swap metrics correctly via Prometheus |
 
 ## Running Tests
 
 ```bash
 # Run individual test
-./openshift-tests run-test "[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disruptive][Suite:openshift/nodes/cnv] Kubelet LimitedSwap Drop-in Configuration for CNV TC1: should verify silent creation and ownership of drop-in directory on CNV nodes"
+./openshift-tests run-test "[Jira:Node/Kubelet][sig-node][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Kubelet LimitedSwap Drop-in Configuration for CNV TC1: should verify drop-in directory exists on all nodes with correct ownership"
 
 # Run entire suite
 ./openshift-tests run openshift/nodes/cnv


### PR DESCRIPTION
Summary
  - Remove [Feature:NodeSwap] label from the CNV swap test Describe block, Since this is already GA in Kubernetes 1.34, removing it will immediately accelerate our `disruptive-longrunning-techpreview` execution times.
  - Update README example run-test command to match the new test name (removed tag, corrected suite to openshift/disruptive-longrunning)
  - Align README test case table with actual TC1–TC12 definitions in node_swap_cnv.go

Purpose of this PR:
```
INSUFFICIENT CI testing for "AdditionalStorageConfig".
At least five tests are expected for a feature
Tests must be run on every TechPreview platform (ask for an exception if your feature doesn't support a variant)
All tests must run at least 14 times on every platform
All tests must pass at least 95% of the time
```