### PR TITLE
POC - Adding stable suite to build tests

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -110,11 +110,22 @@ var staticSuites = []ginkgo.TestSuite{
 	{
 		Name: "openshift/stable",
 		Description: templates.LongDesc(`
-		Umbrella suite for component suites that run under stable cluster conditions.
+		Umbrella suite for stable, highly reliable component tests that run under
+		stable cluster conditions. All tests in this suite are expected to pass
+		consistently without flakes.
 		`),
 		Qualifiers: []string{
 			"name.contains('[Feature:Builds]')",
 		},
+		Parallelism:                30,
+		MaximumAllowedFlakes:       0,
+		ClusterStabilityDuringTest: ginkgo.Stable,
+	},
+	{
+		Name: "openshift/active",
+		Description: templates.LongDesc(`
+		Umbrella suite for component suites that are actively being validated.
+		`),
 		Parallelism:                30,
 		ClusterStabilityDuringTest: ginkgo.Stable,
 	},

--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -115,7 +115,7 @@ var staticSuites = []ginkgo.TestSuite{
 		consistently without flakes.
 		`),
 		Qualifiers: []string{
-			"name.contains('[Feature:Builds]')",
+			`labels.exists(l, l=="STABLE")`,
 		},
 		Parallelism:                30,
 		MaximumAllowedFlakes:       0,
@@ -126,6 +126,9 @@ var staticSuites = []ginkgo.TestSuite{
 		Description: templates.LongDesc(`
 		Umbrella suite for component suites that are actively being validated.
 		`),
+		Qualifiers: []string{
+			`labels.exists(l, l=="ACTIVE")`,
+		},
 		Parallelism:                30,
 		ClusterStabilityDuringTest: ginkgo.Stable,
 	},

--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -111,8 +111,10 @@ var staticSuites = []ginkgo.TestSuite{
 		Name: "openshift/stable",
 		Description: templates.LongDesc(`
 		Umbrella suite for component suites that run under stable cluster conditions.
-		Component suites opt in by declaring this suite as a parent.
 		`),
+		Qualifiers: []string{
+			"name.contains('[Feature:Builds]')",
+		},
 		Parallelism:                30,
 		ClusterStabilityDuringTest: ginkgo.Stable,
 	},
@@ -166,7 +168,6 @@ var staticSuites = []ginkgo.TestSuite{
 		Description: templates.LongDesc(`
 		Tests that exercise the OpenShift build functionality.
 		`),
-		Parents: []string{"openshift/stable"},
 		Qualifiers: []string{
 			withStandardEarlyOrLateTests("name.contains('[Feature:Builds]')"),
 		},

--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -108,6 +108,15 @@ func AllTestSuites(ctx context.Context) ([]*ginkgo.TestSuite, error) {
 // staticSuites are all known test suites this binary should run
 var staticSuites = []ginkgo.TestSuite{
 	{
+		Name: "openshift/stable",
+		Description: templates.LongDesc(`
+		Umbrella suite for component suites that run under stable cluster conditions.
+		Component suites opt in by declaring this suite as a parent.
+		`),
+		Parallelism:                30,
+		ClusterStabilityDuringTest: ginkgo.Stable,
+	},
+	{
 		Name: "openshift/conformance",
 		Description: templates.LongDesc(`
 		Tests that ensure an OpenShift cluster and components are working properly.
@@ -157,6 +166,7 @@ var staticSuites = []ginkgo.TestSuite{
 		Description: templates.LongDesc(`
 		Tests that exercise the OpenShift build functionality.
 		`),
+		Parents: []string{"openshift/stable"},
 		Qualifiers: []string{
 			withStandardEarlyOrLateTests("name.contains('[Feature:Builds]')"),
 		},


### PR DESCRIPTION
/hold

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two built-in umbrella test suites for OpenShift: `openshift/stable` and `openshift/active`.
  * `openshift/stable` and `openshift/active` run with high parallelism under stable cluster conditions and select tests using label-based qualifiers for `STABLE` and `ACTIVE`, respectively.
  * `openshift/stable` also disables allowed flake retries to keep results strict.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->