### PR TITLE
OCPBUGS-98956: use admin-client namespace creation for IRI workload test

### DIFF
--- a/test/extended/internalreleaseimage/helper.go
+++ b/test/extended/internalreleaseimage/helper.go
@@ -3,9 +3,11 @@ package internalreleaseimage
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
+
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -159,6 +161,47 @@ func (h *IRITestHelper) DeleteTestPod(namespace, name string) {
 	err := h.oc.AdminKubeClient().CoreV1().Pods(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		e2e.Logf("Warning: failed to delete test pod %s/%s: %v", namespace, name, err)
+	}
+}
+
+// CreateSimpleNamespace creates a namespace with pod security labels and waits
+// for SCC annotations. It uses admin client only, avoiding the user/OAuth/project
+// request flow in SetupProject that breaks in proxied CI environments.
+func (h *IRITestHelper) CreateSimpleNamespace() string {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "e2e-test-" + string(uuid.NewUUID()),
+			Labels: map[string]string{
+				"pod-security.kubernetes.io/enforce":             "restricted",
+				"pod-security.kubernetes.io/warn":                "restricted",
+				"pod-security.kubernetes.io/audit":               "restricted",
+				"security.openshift.io/scc.podSecurityLabelSync": "false",
+			},
+		},
+	}
+
+	createdNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create namespace")
+	e2e.Logf("Created namespace: %s", createdNs.Name)
+
+	err = exutil.WaitForNamespaceSCCAnnotations(h.oc.AdminKubeClient().CoreV1(), createdNs.Name)
+	if err != nil {
+		h.DeleteNamespace(createdNs.Name)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for namespace %s to get SCC annotations", createdNs.Name)
+	}
+
+	return createdNs.Name
+}
+
+// DeleteNamespace deletes a namespace
+func (h *IRITestHelper) DeleteNamespace(name string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	err := h.oc.AdminKubeClient().CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		e2e.Logf("Warning: failed to delete namespace %s: %v", name, err)
+	} else {
+		e2e.Logf("Deleted namespace: %s", name)
 	}
 }
 

--- a/test/extended/internalreleaseimage/internalreleaseimage.go
+++ b/test/extended/internalreleaseimage/internalreleaseimage.go
@@ -151,7 +151,7 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] InternalRe
 var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] Cluster operates without external registry using managed OCP release bundle images", func() {
 	defer g.GinkgoRecover()
 
-	var oc = exutil.NewCLI("no-registry")
+	var oc = exutil.NewCLIWithoutNamespace("no-registry")
 	var helper *IRITestHelper
 
 	g.BeforeEach(func() {
@@ -168,8 +168,9 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] Cluster op
 			// Verify the image repo is present in IDMS (proves it will be pulled from mirror)
 			g.By("Verifying image repo is present in ImageDigestMirrorSet")
 			helper.VerifyIDMSConfigured(releaseImage)
-			g.By("Creating test pod in framework-managed namespace")
-			ns := oc.Namespace()
+			g.By("Creating test namespace and pod")
+			ns := helper.CreateSimpleNamespace()
+			defer helper.DeleteNamespace(ns)
 
 			pod := helper.CreateTestPod(ns, releaseImage)
 			defer helper.DeleteTestPod(ns, pod.Name)


### PR DESCRIPTION
NewCLI's SetupProject drops the proxy-url when creating the user kubeconfig, causing DNS failures in proxied CI environments. Use admin-client namespace creation with pod security labels and the framework's SCC annotation wait instead.

Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test isolation by switching workload execution to a dedicated, uniquely named namespace instead of the default framework namespace.
  * Added namespace lifecycle management, including automatic teardown after the test completes.
  * Enhanced test setup by applying restricted Pod Security settings and waiting for the namespace’s security configuration to be fully ready before starting workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->