### PR TITLE
WINC-1966: Register WMCO OTE binary in extension registry

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -345,6 +345,10 @@ var extensionBinaries = []TestBinary{
 		imageTag:   "vsphere-csi-driver-operator",
 		binaryPath: "/usr/bin/vmware-vsphere-csi-driver-operator-tests-ext.gz",
 	},
+	{
+		imageTag:   "windows-machine-config-operator-test",
+		binaryPath: "/usr/bin/wmco-tests-ext.gz",
+	},
 }
 
 // extractJSON finds the first JSON object or array in output, skipping any non-JSON log lines


### PR DESCRIPTION
## Summary

Register the Windows Machine Config Operator (WMCO) OTE test extension binary
in the payload extension registry so that `openshift-tests` can discover and
run WMCO's migrated tests.

Adds an entry to `extensionBinaries` in `pkg/test/extensions/binary.go`:
- Image tag: `windows-machine-config-operator-test`
- Binary path: `/usr/bin/wmco-tests-ext.gz`

The WMCO operator image already builds and ships the gzipped OTE binary at
this path (merged in https://github.com/openshift/windows-machine-config-operator/pull/4279).
Without this registration, `openshift-tests` cannot extract the binary from
the release payload, so the migrated tests never run in CI or appear on Sippy.

## Context

- WMCO OTE infrastructure PR: https://github.com/openshift/windows-machine-config-operator/pull/4279
- Migration epic: https://issues.redhat.com/browse/WINC-1966
- Binary is built via `make build-tests-ext` and gzipped in `Dockerfile.ci`
- Tests are registered as `LifecycleInforming` with suites under `windows-machine-config-operator/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added support for extracting the Windows machine-config-operator external test binary from its payload image.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->