### PR TITLE
OCPBUGS-99047: Fix flaky oc adm storage-admin test

### DIFF
--- a/test/extended/cli/admin.go
+++ b/test/extended/cli/admin.go
@@ -265,15 +265,15 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 		g.By("Test storage-admin can not do normal project scoped tasks")
 		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm", "create", "pods", "--all-namespaces").Output()
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(out).To(o.HaveSuffix("no"))
+		o.Expect(out).To(o.MatchRegexp(`(?m)^no`))
 
 		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm", "create", "projects").Output()
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(out).To(o.HaveSuffix("no"))
+		o.Expect(out).To(o.MatchRegexp(`(?m)^no`))
 
 		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm", "create", "pvc").Output()
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(out).To(o.HaveSuffix("no"))
+		o.Expect(out).To(o.MatchRegexp(`(?m)^no`))
 
 		g.By("Test storage-admin can read pvc and pods, and create pv and storageclass")
 		out, err = oc.Run("auth", "can-i").Args("--as=storage-adm", "get", "pvc", "--all-namespaces").Output()
@@ -314,7 +314,7 @@ var _ = g.Describe("[sig-cli] oc adm", func() {
 
 		out, err = oc.Run("auth", "can-i").Args("--namespace="+projectName, "--as=storage-adm2", "create", "pod", "--all-namespaces").Output()
 		o.Expect(err).To(o.HaveOccurred())
-		o.Expect(out).To(o.HaveSuffix("no"))
+		o.Expect(out).To(o.MatchRegexp(`(?m)^no`))
 
 		out, err = oc.Run("auth", "can-i").Args("--namespace="+projectName, "--as=storage-adm2", "create", "pod").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
The [sig-cli] oc adm storage-admin test fails intermittently when the parallel role-selectors test creates and deletes a ClusterRoleBinding bound to system:authenticated at the same time. During cleanup, there is a brief window where the ClusterRoleBinding still exists but its referenced ClusterRole has already been deleted. If oc auth can-i runs during this window, the RBAC authorizer appends a diagnostic message to the denial output (e.g. no - RBAC: clusterrole.rbac.authorization.k8s.io "basic-user2-pnjfn" not found), causing the HaveSuffix("no") assertion to fail.

Replace HaveSuffix("no") with MatchRegexp("(?m)^no") so the assertion matches no at the start of any line, tolerating both warning lines before and RBAC diagnostic text after. The exit code check on the preceding line continues to validate that the command returned non-zero (denied).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of CLI authorization results for disallowed actions.
  * Ensured negative permission checks correctly recognize standalone “no” responses, including in project-scoped contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->