### PR TITLE
OCPBUGS-99166: wait for default ServiceAccount before creating IRI test pod

### DIFF
--- a/test/extended/internalreleaseimage/helper.go
+++ b/test/extended/internalreleaseimage/helper.go
@@ -190,6 +190,12 @@ func (h *IRITestHelper) CreateSimpleNamespace() string {
 		o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for namespace %s to get SCC annotations", createdNs.Name)
 	}
 
+	err = exutil.WaitForServiceAccount(h.oc.AdminKubeClient().CoreV1().ServiceAccounts(createdNs.Name), "default")
+	if err != nil {
+		h.DeleteNamespace(createdNs.Name)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for default ServiceAccount in namespace %s", createdNs.Name)
+	}
+
 	return createdNs.Name
 }
 


### PR DESCRIPTION
CreateSimpleNamespace waited for SCC annotations but not for the default ServiceAccount, causing a race on ha5 clusters where the service-account-controller is slower to provision it.

Assisted-by: claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment setup by waiting for the default service account to become available when creating namespaces.
  * Added cleanup handling when service account creation does not complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->