### PR TITLE
OCPBUGS-99183: Fix NetworkDiagnosticsConfig serial test race condition

### DIFF
--- a/test/extended/networking/network_diagnostics.go
+++ b/test/extended/networking/network_diagnostics.go
@@ -53,6 +53,55 @@ var _ = g.Describe("[sig-network][OCPFeatureGate:NetworkDiagnosticsConfig][Seria
 		_, err := oc.AdminConfigClient().ConfigV1().Networks().Apply(ctx, netConfigApply,
 			metav1.ApplyOptions{FieldManager: fieldManager, Force: true})
 		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Wait for the network diagnostics namespace to be Active and pods to be running.
+		// This prevents a race where the next test starts before CNO has fully recreated
+		// the namespace after it was deleted by a "disable diagnostics" test.
+		o.Eventually(func() bool {
+			ns, err := oc.AdminKubeClient().CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+			if err != nil {
+				framework.Logf("Waiting for namespace %s: %v", namespace, err)
+				return false
+			}
+			if ns.Status.Phase != corev1.NamespaceActive {
+				framework.Logf("Namespace %s is %s, waiting for Active", namespace, ns.Status.Phase)
+				return false
+			}
+
+			srcPods, err := oc.AdminKubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=network-check-source"})
+			if err != nil {
+				framework.Logf("Error listing source pods: %v", err)
+				return false
+			}
+			if len(srcPods.Items) == 0 {
+				framework.Logf("No network-check-source pods found yet")
+				return false
+			}
+
+			targetPods, err := oc.AdminKubeClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: "app=network-check-target"})
+			if err != nil {
+				framework.Logf("Error listing target pods: %v", err)
+				return false
+			}
+			if len(targetPods.Items) == 0 {
+				framework.Logf("No network-check-target pods found yet")
+				return false
+			}
+
+			cfg, err := oc.AdminConfigClient().ConfigV1().Networks().Get(ctx, clusterConfig, metav1.GetOptions{})
+			if err != nil {
+				framework.Logf("Error getting cluster config: %v", err)
+				return false
+			}
+			if !meta.IsStatusConditionTrue(cfg.Status.Conditions, condition) {
+				framework.Logf("NetworkDiagnosticsAvailable condition is not True yet")
+				return false
+			}
+
+			return true
+		}, 5*time.Minute, 5*time.Second).Should(o.BeTrue())
 	})
 
 	g.It("Should be enabled by default", func(ctx context.Context) {


### PR DESCRIPTION
## Summary

The `AfterEach` handler in the `NetworkDiagnosticsConfig` serial test suite resets the network diagnostics config but does not wait for the `openshift-network-diagnostics` namespace to be fully recreated. After the "Should remove all network diagnostics pods when disabled" test, the namespace enters Terminating state. The next test starts immediately and cannot find diagnostics pods, polling indefinitely until the 5h job timeout is hit.

## Root Cause

1. `Should remove all network diagnostics pods when disabled` disables diagnostics → namespace gets deleted
2. `AfterEach` resets config to nil (default/enabled) but returns immediately
3. Next test starts before CNO recreates the namespace
4. CNO tries to apply NetworkPolicy but namespace is still Terminating → `ApplyOperatorConfig` Degraded
5. Job times out at 5h

## Fix

Add a wait in `AfterEach` that ensures:
1. The `openshift-network-diagnostics` namespace is Active (not Terminating)
2. `network-check-source` pods exist
3. `network-check-target` pods exist
4. `NetworkDiagnosticsAvailable` condition is True

5 minute timeout with 5s polling — matching the existing test timeouts in the suite.

## Evidence

4 consecutive failures on 5.0 metal techpreview serial jobs (ipv4, ipv6, dualstack), all with identical pattern. Sippy regression ID 43316.

Example: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-serial-ovn-ipv4-techpreview-1of2/2078329267703255040

## Bug

https://issues.redhat.com/browse/OCPBUGS-99183

---

🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved network diagnostics test cleanup by waiting for the diagnostics environment to fully become active before subsequent tests run.
  * Added verification that required namespaces, pods, and availability status are ready, with diagnostic logging when readiness is delayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->