### PR TITLE
METAL-1902: Remove exception for co/baremetal on Progressing

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -642,8 +642,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, d.String())
 		}
 		switch co {
-		case "baremetal":
-			return "https://issues.redhat.com/browse/OCPBUGS-66101"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "operator-lifecycle-manager":


### PR DESCRIPTION
This commit remove the exception for co/baremetal because of the bug OCPBUGS-66101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster upgrade monitoring so previously allowlisted progressing-state transitions for bare-metal clusters are now reported as failures when they do not match expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->