### PR TITLE
OCPBUGS-99397: remove custom MCP and pause master pool in mirror-set tests to prevent PDB drain deadlock and suite timeout

### DIFF
--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -31,15 +31,27 @@ func getMCPSpecs(oc *exutil.CLI) (workerSpec, masterSpec string) {
 }
 
 // waitForWorkerRollout waits for the worker pool only. Used during test steps
-// since we only verify registries.conf on worker nodes; master drains in background.
+// since master pool is paused and we only verify registries.conf on worker nodes.
 func waitForWorkerRollout(oc *exutil.CLI, workerSpec string) {
 	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "worker", workerSpec)
 }
 
-// waitForPoolsRollout waits for both worker and master pools to complete.
-// Used in cleanup to ensure the cluster is fully stable for the next test.
-func waitForPoolsRollout(oc *exutil.CLI, workerSpec, masterSpec string) {
-	imagepolicy.WaitForMCPsConfigSpecChangeAndUpdated(oc, workerSpec, masterSpec)
+// pauseMasterPool pauses the master MCP so it does not drain during test steps.
+// Only worker nodes roll out, keeping the test fast.
+func pauseMasterPool(oc *exutil.CLI) {
+	err := oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+		"machineconfigpool/master", "--type=merge", "-p", `{"spec":{"paused":true}}`).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to pause master pool")
+	e2e.Logf("Master pool paused")
+}
+
+// unpauseMasterPool unpauses the master MCP. After all test resources are deleted,
+// MCO sees the master config matches current state, so no drain is needed.
+func unpauseMasterPool(oc *exutil.CLI) {
+	err := oc.AsAdmin().WithoutNamespace().Run("patch").Args(
+		"machineconfigpool/master", "--type=merge", "-p", `{"spec":{"paused":false}}`).Execute()
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to unpause master pool")
+	e2e.Logf("Master pool unpaused")
 }
 
 func readRegistriesConfOnWorker(ctx context.Context, oc *exutil.CLI) string {
@@ -82,6 +94,10 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		idmsName := fmt.Sprintf("digest-mirror-%s", suffix)
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 
+		g.By("Pause master pool to avoid master drains during test")
+		pauseMasterPool(oc)
+		g.DeferCleanup(func() { unpauseMasterPool(oc) })
+
 		workerSpec := getWorkerMCPSpec(oc)
 
 		g.By("Step 1: Create an ImageDigestMirrorSet")
@@ -114,7 +130,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 
 		g.DeferCleanup(func() {
 			g.By("Cleanup: Delete IDMS and ITMS resources")
-			wSpec, mSpec := getMCPSpecs(oc)
+			wSpec := getWorkerMCPSpec(oc)
 			deleted := false
 			if delErr := configClient.ImageTagMirrorSets().Delete(context.Background(), itmsName, metav1.DeleteOptions{}); delErr == nil {
 				deleted = true
@@ -127,7 +143,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 				e2e.Logf("Warning: failed to delete IDMS %s: %v", idmsName, delErr)
 			}
 			if deleted {
-				waitForPoolsRollout(oc, wSpec, mSpec)
+				waitForWorkerRollout(oc, wSpec)
 			}
 		})
 
@@ -210,6 +226,10 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 		icspName2 := fmt.Sprintf("ubi9repo-%s", suffix)
 
+		g.By("Pause master pool to avoid master drains during test")
+		pauseMasterPool(oc)
+		g.DeferCleanup(func() { unpauseMasterPool(oc) })
+
 		workerSpec := getWorkerMCPSpec(oc)
 
 		g.By("Step 1: Create ICSP with digest mirrors for ubi8/ubi-minimal and openshift5")
@@ -242,8 +262,8 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		e2e.Logf("ICSP %s created successfully", icspName1)
 
 		g.DeferCleanup(func() {
-			g.By("Cleanup: Delete any remaining test resources and wait for pools to settle")
-			wSpec, mSpec := getMCPSpecs(oc)
+			g.By("Cleanup: Delete any remaining test resources")
+			wSpec := getWorkerMCPSpec(oc)
 			toDelete := false
 
 			for _, name := range []string{icspName1, icspName2} {
@@ -273,7 +293,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 				}
 			}
 			if toDelete {
-				waitForPoolsRollout(oc, wSpec, mSpec)
+				waitForWorkerRollout(oc, wSpec)
 			}
 		})
 

--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -11,14 +10,9 @@ import (
 
 	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 	configv1 "github.com/openshift/api/config/v1"
-	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
-	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	"github.com/openshift/origin/test/extended/imagepolicy"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
@@ -27,164 +21,22 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-// mirrorTestPool isolates mirror-set testing to a single-node custom MCP so rollouts
-// do not wait on the full worker and master pools.
-type mirrorTestPool struct {
-	oc        *exutil.CLI
-	mcClient  *machineconfigclient.Clientset
-	PoolName  string
-	NodeName  string
-	nodeLabel string
+func getMCPSpecs(oc *exutil.CLI) (workerSpec, masterSpec string) {
+	return imagepolicy.GetMCPCurrentSpecConfigName(oc, "worker"),
+		imagepolicy.GetMCPCurrentSpecConfigName(oc, "master")
 }
 
-func newMirrorTestPool(oc *exutil.CLI, ctx context.Context) *mirrorTestPool {
-	poolName := fmt.Sprintf("mirror-test-%s", utilrand.String(5))
-	nodeLabel := fmt.Sprintf("node-role.kubernetes.io/%s", poolName)
+func waitForPoolsRollout(oc *exutil.CLI, workerSpec, masterSpec string) {
+	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "worker", workerSpec)
+	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", masterSpec)
+}
 
-	mcClient, err := machineconfigclient.NewForConfig(oc.AdminConfig())
-	o.Expect(err).NotTo(o.HaveOccurred(), "failed to create MachineConfig client")
-
+func readRegistriesConfOnWorker(ctx context.Context, oc *exutil.CLI) string {
 	nodeName := nodeutils.GetFirstReadyWorkerNode(oc)
-	o.Expect(nodeName).NotTo(o.BeEmpty(), "no ready worker node found for custom MCP")
-	err = nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, nodeName)
-	o.Expect(err).NotTo(o.HaveOccurred())
-
-	testMCP := &mcfgv1.MachineConfigPool{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: poolName,
-			Labels: map[string]string{
-				"machineconfiguration.openshift.io/pool": poolName,
-			},
-		},
-		Spec: mcfgv1.MachineConfigPoolSpec{
-			MachineConfigSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "machineconfiguration.openshift.io/role",
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   []string{"worker", poolName},
-					},
-				},
-			},
-			NodeSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					nodeLabel: "",
-				},
-			},
-		},
-	}
-	_, err = mcClient.MachineconfigurationV1().MachineConfigPools().Create(ctx, testMCP, metav1.CreateOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred(), "failed to create custom MachineConfigPool %s", poolName)
-
-	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, nodeLabel))
-	_, err = oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
-	o.Expect(err).NotTo(o.HaveOccurred(), "failed to label node %s for custom MCP", nodeName)
-
-	pool := &mirrorTestPool{
-		oc:        oc,
-		mcClient:  mcClient,
-		PoolName:  poolName,
-		NodeName:  nodeName,
-		nodeLabel: nodeLabel,
-	}
-
-	err = waitForMirrorTestMCPReady(ctx, mcClient, poolName, 10*time.Minute)
-	o.Expect(err).NotTo(o.HaveOccurred(), "custom MachineConfigPool %s did not become ready", poolName)
-	e2e.Logf("Custom mirror test pool %s ready on node %s", poolName, nodeName)
-
-	return pool
-}
-
-func (p *mirrorTestPool) currentSpec() string {
-	return imagepolicy.GetMCPCurrentSpecConfigName(p.oc, p.PoolName)
-}
-
-func (p *mirrorTestPool) waitForRollout(initialSpec string) {
-	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(p.oc, p.PoolName, initialSpec)
-}
-
-func (p *mirrorTestPool) readRegistriesConf(ctx context.Context) string {
-	registriesConf, err := nodeutils.ExecOnNodeWithChroot(ctx, p.oc, p.NodeName, "cat", "/etc/containers/registries.conf")
-	o.Expect(err).NotTo(o.HaveOccurred(), "failed to read registries.conf from node %s", p.NodeName)
+	o.Expect(nodeName).NotTo(o.BeEmpty(), "no ready worker node found")
+	registriesConf, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, nodeName, "cat", "/etc/containers/registries.conf")
+	o.Expect(err).NotTo(o.HaveOccurred(), "failed to read registries.conf from node %s", nodeName)
 	return registriesConf
-}
-
-func (p *mirrorTestPool) Teardown() {
-	ctx := context.Background()
-
-	e2e.Logf("Teardown: removing label %s from node %s", p.nodeLabel, p.NodeName)
-	removePatch := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, p.nodeLabel))
-	_, patchErr := p.oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, p.NodeName, types.MergePatchType, removePatch, metav1.PatchOptions{})
-	if patchErr != nil && !apierrors.IsNotFound(patchErr) {
-		e2e.Logf("Warning: failed to remove label from node %s: %v", p.NodeName, patchErr)
-	}
-
-	e2e.Logf("Teardown: waiting for node %s to transition back to worker pool", p.NodeName)
-	waitErr := wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
-		currentNode, getErr := p.oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, p.NodeName, metav1.GetOptions{})
-		if getErr != nil {
-			return false, nil
-		}
-		currentConfig := currentNode.Annotations["machineconfiguration.openshift.io/currentConfig"]
-		desiredConfig := currentNode.Annotations["machineconfiguration.openshift.io/desiredConfig"]
-		return currentConfig != "" && !strings.Contains(currentConfig, p.PoolName) && currentConfig == desiredConfig, nil
-	})
-	if waitErr != nil {
-		e2e.Logf("Warning: node %s did not transition back to worker pool: %v", p.NodeName, waitErr)
-	}
-
-	deleteErr := p.mcClient.MachineconfigurationV1().MachineConfigPools().Delete(ctx, p.PoolName, metav1.DeleteOptions{})
-	if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
-		e2e.Logf("Warning: failed to delete MachineConfigPool %s: %v", p.PoolName, deleteErr)
-	}
-
-	if deleteErr == nil || apierrors.IsNotFound(deleteErr) {
-		e2e.Logf("Teardown: waiting for worker MCP to stabilize")
-		if stabilizeErr := nodeutils.WaitForMCP(ctx, p.mcClient, "worker", 10*time.Minute); stabilizeErr != nil {
-			e2e.Logf("Warning: worker MCP did not stabilize: %v", stabilizeErr)
-		}
-	}
-}
-
-// waitForMirrorTestMCPReady waits for a custom MCP to finish its initial bootstrap.
-func waitForMirrorTestMCPReady(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string, timeout time.Duration) error {
-	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
-		if err != nil {
-			return false, err
-		}
-
-		updating := false
-		degraded := false
-		updated := false
-		for _, condition := range mcp.Status.Conditions {
-			switch condition.Type {
-			case "Updating":
-				if condition.Status == corev1.ConditionTrue {
-					updating = true
-				}
-			case "Degraded":
-				if condition.Status == corev1.ConditionTrue {
-					degraded = true
-				}
-			case "Updated":
-				if condition.Status == corev1.ConditionTrue {
-					updated = true
-				}
-			}
-		}
-
-		if degraded {
-			return false, fmt.Errorf("MachineConfigPool %s is degraded", poolName)
-		}
-
-		isReady := !updating && updated &&
-			mcp.Status.MachineCount > 0 &&
-			mcp.Status.ReadyMachineCount == mcp.Status.MachineCount &&
-			mcp.Spec.Configuration.Name == mcp.Status.Configuration.Name
-
-		return isReady, nil
-	})
 }
 
 // pollMCPSpecUnchanged polls the given MCP spec name every 15 seconds for the duration.
@@ -219,8 +71,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		idmsName := fmt.Sprintf("digest-mirror-%s", suffix)
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 
-		pool := newMirrorTestPool(oc, ctx)
-		g.DeferCleanup(pool.Teardown)
+		workerSpec, masterSpec := getMCPSpecs(oc)
 
 		g.By("Step 1: Create an ImageDigestMirrorSet")
 		idms := &configv1.ImageDigestMirrorSet{
@@ -246,31 +97,49 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 				},
 			},
 		}
-
-		initialSpec := pool.currentSpec()
-
-		createdIDMS, err := configClient.ImageDigestMirrorSets().Create(ctx, idms, metav1.CreateOptions{})
+		_, err := configClient.ImageDigestMirrorSets().Create(ctx, idms, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ImageDigestMirrorSet")
-		e2e.Logf("ImageDigestMirrorSet %q created successfully", createdIDMS.Name)
+		e2e.Logf("ImageDigestMirrorSet %q created successfully", idmsName)
 
 		g.DeferCleanup(func() {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
 			g.By("Cleanup: Delete IDMS and ITMS resources")
-			cleanupSpec := pool.currentSpec()
-			if delErr := configClient.ImageTagMirrorSets().Delete(cleanupCtx, itmsName, metav1.DeleteOptions{}); delErr != nil {
-				e2e.Logf("Warning: failed to delete ImageTagMirrorSet: %v", delErr)
+			wSpec, mSpec := getMCPSpecs(oc)
+			deleted := false
+			if delErr := configClient.ImageTagMirrorSets().Delete(context.Background(), itmsName, metav1.DeleteOptions{}); delErr == nil {
+				deleted = true
+			} else {
+				e2e.Logf("Warning: failed to delete ITMS %s: %v", itmsName, delErr)
 			}
-			if delErr := configClient.ImageDigestMirrorSets().Delete(cleanupCtx, idmsName, metav1.DeleteOptions{}); delErr != nil {
-				e2e.Logf("Warning: failed to delete ImageDigestMirrorSet: %v", delErr)
+			if delErr := configClient.ImageDigestMirrorSets().Delete(context.Background(), idmsName, metav1.DeleteOptions{}); delErr == nil {
+				deleted = true
+			} else {
+				e2e.Logf("Warning: failed to delete IDMS %s: %v", idmsName, delErr)
 			}
-			pool.waitForRollout(cleanupSpec)
+			if deleted {
+				waitForPoolsRollout(oc, wSpec, mSpec)
+			}
 		})
 
-		pool.waitForRollout(initialSpec)
-		e2e.Logf("IDMS MCP rollout complete on custom pool %s", pool.PoolName)
+		g.By("Step 2: Wait for MCP rollout and verify IDMS entries in registries.conf")
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after IDMS creation")
 
-		g.By("Step 2: Create an ImageTagMirrorSet")
+		registriesConf := readRegistriesConfOnWorker(ctx, oc)
+		e2e.Logf("registries.conf after IDMS: read %d bytes", len(registriesConf))
+
+		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.redhat.io/openshift4"`),
+			"registries.conf should contain the IDMS source for openshift4")
+		o.Expect(registriesConf).To(o.ContainSubstring(`location = "mirror.example.com/redhat"`),
+			"registries.conf should contain the IDMS mirror for openshift4")
+		o.Expect(registriesConf).To(o.ContainSubstring(`pull-from-mirror = "digest-only"`),
+			"registries.conf should have pull-from-mirror set to digest-only for IDMS mirrors")
+		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.redhat.io/rhel8"`),
+			"registries.conf should contain the IDMS source for rhel8")
+		o.Expect(registriesConf).To(o.ContainSubstring("location = \"registry.redhat.io/rhel8\"\n  blocked = true"),
+			"registry.redhat.io/rhel8 should be blocked (NeverContactSource)")
+
+		g.By("Step 3: Create an ImageTagMirrorSet")
+		workerSpec, masterSpec = getMCPSpecs(oc)
 		itms := &configv1.ImageTagMirrorSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: itmsName,
@@ -295,32 +164,17 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 				},
 			},
 		}
-
-		itmsInitialSpec := pool.currentSpec()
-
-		createdITMS, err := configClient.ImageTagMirrorSets().Create(ctx, itms, metav1.CreateOptions{})
+		_, err = configClient.ImageTagMirrorSets().Create(ctx, itms, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ImageTagMirrorSet")
-		e2e.Logf("ImageTagMirrorSet %q created successfully", createdITMS.Name)
+		e2e.Logf("ImageTagMirrorSet %q created successfully", itmsName)
 
-		g.By("Step 3: Wait for custom MCP to finish rolling out")
-		pool.waitForRollout(itmsInitialSpec)
-		e2e.Logf("Custom MCP %s finished rolling out after ITMS creation", pool.PoolName)
+		g.By("Step 4: Wait for MCP rollout and verify ITMS entries alongside IDMS")
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after ITMS creation")
 
-		g.By("Step 4: Verify /etc/containers/registries.conf on the custom pool node")
-		registriesConf := pool.readRegistriesConf(ctx)
-		e2e.Logf("registries.conf on %s: read %d bytes, asserting expected entries", pool.NodeName, len(registriesConf))
+		registriesConf = readRegistriesConfOnWorker(ctx, oc)
+		e2e.Logf("registries.conf after ITMS: read %d bytes", len(registriesConf))
 
-		g.By("Verify IDMS entries (digest-only mirrors)")
-		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.redhat.io/openshift4"`),
-			"registries.conf should contain the IDMS source for openshift4")
-		o.Expect(registriesConf).To(o.ContainSubstring(`location = "mirror.example.com/redhat"`),
-			"registries.conf should contain the IDMS mirror for openshift4")
-		o.Expect(registriesConf).To(o.ContainSubstring(`pull-from-mirror = "digest-only"`),
-			"registries.conf should have pull-from-mirror set to digest-only for IDMS mirrors")
-		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.redhat.io/rhel8"`),
-			"registries.conf should contain the IDMS source for rhel8")
-
-		g.By("Verify ITMS entries (tag-only mirrors)")
 		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi8/ubi-minimal"`),
 			"registries.conf should contain the ITMS source for ubi-minimal")
 		o.Expect(registriesConf).To(o.ContainSubstring(`location = "example.io/example/ubi-minimal"`),
@@ -329,12 +183,10 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			"registries.conf should have pull-from-mirror set to tag-only for ITMS mirrors")
 		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi8/ubi-minimal-1"`),
 			"registries.conf should contain the ITMS source for ubi-minimal-1")
-
-		g.By("Verify NeverContactSource entries are blocked")
 		o.Expect(registriesConf).To(o.ContainSubstring("location = \"registry.access.redhat.com/ubi8/ubi-minimal-1\"\n  blocked = true"),
 			"registry.access.redhat.com/ubi8/ubi-minimal-1 should be blocked (NeverContactSource)")
-		o.Expect(registriesConf).To(o.ContainSubstring("location = \"registry.redhat.io/rhel8\"\n  blocked = true"),
-			"registry.redhat.io/rhel8 should be blocked (NeverContactSource)")
+		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.redhat.io/openshift4"`),
+			"registries.conf should still contain IDMS entries after ITMS creation")
 	})
 
 	// author: asahay@redhat.com
@@ -347,8 +199,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 		icspName2 := fmt.Sprintf("ubi9repo-%s", suffix)
 
-		pool := newMirrorTestPool(oc, ctx)
-		g.DeferCleanup(pool.Teardown)
+		workerSpec, masterSpec := getMCPSpecs(oc)
 
 		g.By("Step 1: Create ICSP with digest mirrors for ubi8/ubi-minimal and openshift5")
 		icsp1 := &operatorv1alpha1.ImageContentSourcePolicy{
@@ -375,55 +226,51 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			},
 		}
 
-		initialSpec := pool.currentSpec()
-
 		_, err := operatorClient.ImageContentSourcePolicies().Create(ctx, icsp1, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ICSP %s", icspName1)
 		e2e.Logf("ICSP %s created successfully", icspName1)
 
 		g.DeferCleanup(func() {
-			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-			defer cancel()
-			g.By("Cleanup: Delete any remaining test resources and wait for custom MCP to settle")
-			cleanupSpec := pool.currentSpec()
+			g.By("Cleanup: Delete any remaining test resources and wait for pools to settle")
+			wSpec, mSpec := getMCPSpecs(oc)
 			toDelete := false
 
 			for _, name := range []string{icspName1, icspName2} {
-				if _, getErr := operatorClient.ImageContentSourcePolicies().Get(cleanupCtx, name, metav1.GetOptions{}); getErr == nil {
-					if delErr := operatorClient.ImageContentSourcePolicies().Delete(cleanupCtx, name, metav1.DeleteOptions{}); delErr == nil {
+				if _, getErr := operatorClient.ImageContentSourcePolicies().Get(context.Background(), name, metav1.GetOptions{}); getErr == nil {
+					if delErr := operatorClient.ImageContentSourcePolicies().Delete(context.Background(), name, metav1.DeleteOptions{}); delErr == nil {
 						e2e.Logf("Cleanup: deleted ICSP %s", name)
 						toDelete = true
 					} else {
-						e2e.Logf("Cleanup: warning - failed to delete ICSP %s: %v", name, delErr)
+						e2e.Logf("Warning: failed to delete ICSP %s: %v", name, delErr)
 					}
 				}
 			}
-			if _, getErr := configClient.ImageTagMirrorSets().Get(cleanupCtx, itmsName, metav1.GetOptions{}); getErr == nil {
-				if delErr := configClient.ImageTagMirrorSets().Delete(cleanupCtx, itmsName, metav1.DeleteOptions{}); delErr == nil {
+			if _, getErr := configClient.ImageTagMirrorSets().Get(context.Background(), itmsName, metav1.GetOptions{}); getErr == nil {
+				if delErr := configClient.ImageTagMirrorSets().Delete(context.Background(), itmsName, metav1.DeleteOptions{}); delErr == nil {
 					e2e.Logf("Cleanup: deleted ITMS %s", itmsName)
 					toDelete = true
 				} else {
-					e2e.Logf("Cleanup: warning - failed to delete ITMS %s: %v", itmsName, delErr)
+					e2e.Logf("Warning: failed to delete ITMS %s: %v", itmsName, delErr)
 				}
 			}
-			if _, getErr := configClient.ImageDigestMirrorSets().Get(cleanupCtx, idmsName, metav1.GetOptions{}); getErr == nil {
-				if delErr := configClient.ImageDigestMirrorSets().Delete(cleanupCtx, idmsName, metav1.DeleteOptions{}); delErr == nil {
+			if _, getErr := configClient.ImageDigestMirrorSets().Get(context.Background(), idmsName, metav1.GetOptions{}); getErr == nil {
+				if delErr := configClient.ImageDigestMirrorSets().Delete(context.Background(), idmsName, metav1.DeleteOptions{}); delErr == nil {
 					e2e.Logf("Cleanup: deleted IDMS %s", idmsName)
 					toDelete = true
 				} else {
-					e2e.Logf("Cleanup: warning - failed to delete IDMS %s: %v", idmsName, delErr)
+					e2e.Logf("Warning: failed to delete IDMS %s: %v", idmsName, delErr)
 				}
 			}
 			if toDelete {
-				pool.waitForRollout(cleanupSpec)
+				waitForPoolsRollout(oc, wSpec, mSpec)
 			}
 		})
 
-		g.By("Step 2: Wait for custom MCP rollout after ICSP creation and verify registries.conf")
-		pool.waitForRollout(initialSpec)
-		e2e.Logf("Custom MCP %s rollout complete after ICSP creation", pool.PoolName)
+		g.By("Step 2: Wait for MCP rollout after ICSP creation and verify registries.conf")
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after ICSP creation")
 
-		registriesConf := pool.readRegistriesConf(ctx)
+		registriesConf := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after ICSP creation: read %d bytes, asserting expected entries", len(registriesConf))
 
 		o.Expect(registriesConf).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi8/ubi-minimal"`),
@@ -440,7 +287,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			"registries.conf should have pull-from-mirror = digest-only for ICSP entries")
 
 		g.By("Step 3: Create IDMS with same registry/mirror config as ICSP (AllowContactingSource)")
-		specBeforeIDMS := pool.currentSpec()
+		workerSpecBeforeIDMS, masterSpecBeforeIDMS := getMCPSpecs(oc)
 		idms := &configv1.ImageDigestMirrorSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   idmsName,
@@ -471,29 +318,33 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		e2e.Logf("IDMS %s created successfully", idmsName)
 
 		g.By("Step 3 (verify): Confirm no new MC was generated after IDMS creation with same config as ICSP")
-		o.Expect(pollMCPSpecUnchanged(oc, pool.PoolName, specBeforeIDMS, 2*time.Minute)).
-			NotTo(o.HaveOccurred(), "unexpected MCP rollout after IDMS creation with same config as ICSP")
-		e2e.Logf("Confirmed: custom MCP %s stable for 2 minutes after IDMS creation", pool.PoolName)
+		o.Expect(pollMCPSpecUnchanged(oc, "worker", workerSpecBeforeIDMS, 2*time.Minute)).
+			NotTo(o.HaveOccurred(), "unexpected worker MCP rollout after IDMS creation with same config as ICSP")
+		o.Expect(pollMCPSpecUnchanged(oc, "master", masterSpecBeforeIDMS, 2*time.Minute)).
+			NotTo(o.HaveOccurred(), "unexpected master MCP rollout after IDMS creation with same config as ICSP")
+		e2e.Logf("Confirmed: both MCPs stable for 2 minutes after IDMS creation")
 
 		g.By("Step 4.1: Delete ICSP - IDMS covers the same config so no new MC should be triggered")
-		specBeforeICSPDelete := pool.currentSpec()
+		workerSpecBeforeICSPDel, masterSpecBeforeICSPDel := getMCPSpecs(oc)
 		err = operatorClient.ImageContentSourcePolicies().Delete(ctx, icspName1, metav1.DeleteOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete ICSP %s", icspName1)
 		e2e.Logf("ICSP %s deleted successfully", icspName1)
 
 		g.By("Step 4.2: Confirm no new MC was generated after ICSP deletion (IDMS still covers the same config)")
-		o.Expect(pollMCPSpecUnchanged(oc, pool.PoolName, specBeforeICSPDelete, 2*time.Minute)).
-			NotTo(o.HaveOccurred(), "unexpected MCP rollout after ICSP deletion when IDMS covers the same config")
-		e2e.Logf("Confirmed: custom MCP %s stable for 2 minutes after ICSP deletion", pool.PoolName)
+		o.Expect(pollMCPSpecUnchanged(oc, "worker", workerSpecBeforeICSPDel, 2*time.Minute)).
+			NotTo(o.HaveOccurred(), "unexpected worker MCP rollout after ICSP deletion when IDMS covers the same config")
+		o.Expect(pollMCPSpecUnchanged(oc, "master", masterSpecBeforeICSPDel, 2*time.Minute)).
+			NotTo(o.HaveOccurred(), "unexpected master MCP rollout after ICSP deletion when IDMS covers the same config")
+		e2e.Logf("Confirmed: both MCPs stable for 2 minutes after ICSP deletion")
 
 		g.By("Step 5: Verify registries.conf is unchanged after ICSP deletion (IDMS maintains same mirror config)")
-		registriesConfAfterICSPDelete := pool.readRegistriesConf(ctx)
+		registriesConfAfterICSPDelete := readRegistriesConfOnWorker(ctx, oc)
 		o.Expect(registriesConfAfterICSPDelete).To(o.Equal(registriesConf),
 			"registries.conf should be unchanged after ICSP deletion when IDMS covers the same mirror config")
 		e2e.Logf("Confirmed: registries.conf unchanged after ICSP deletion")
 
 		g.By("Step 6: Create ITMS with tag mirrors for ubi9/ubi-minimal (different source from IDMS)")
-		itmsInitialSpec := pool.currentSpec()
+		workerSpec, masterSpec = getMCPSpecs(oc)
 		itms := &configv1.ImageTagMirrorSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   itmsName,
@@ -516,11 +367,11 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ITMS %s", itmsName)
 		e2e.Logf("ITMS %s created successfully", itmsName)
 
-		pool.waitForRollout(itmsInitialSpec)
-		e2e.Logf("Custom MCP %s rollout complete after ITMS creation", pool.PoolName)
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after ITMS creation")
 
 		g.By("Step 7: Verify registries.conf updated with ITMS tag-only entries alongside IDMS digest entries")
-		registriesConfAfterITMS := pool.readRegistriesConf(ctx)
+		registriesConfAfterITMS := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after ITMS creation: read %d bytes, asserting expected entries", len(registriesConfAfterITMS))
 
 		o.Expect(registriesConfAfterITMS).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi9/ubi-minimal"`),
@@ -535,7 +386,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			"registries.conf should still contain IDMS entries for ubi8/ubi-minimal")
 
 		g.By("Step 8: Create second ICSP with digest mirrors for registry.example.com/example/myimage")
-		icsp2InitialSpec := pool.currentSpec()
+		workerSpec, masterSpec = getMCPSpecs(oc)
 		icsp2 := &operatorv1alpha1.ImageContentSourcePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   icspName2,
@@ -556,11 +407,11 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ICSP %s", icspName2)
 		e2e.Logf("ICSP %s created successfully", icspName2)
 
-		pool.waitForRollout(icsp2InitialSpec)
-		e2e.Logf("Custom MCP %s rollout complete after second ICSP creation", pool.PoolName)
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after second ICSP creation")
 
 		g.By("Step 9: Verify registries.conf updated with ICSP2 entries alongside IDMS and ITMS entries")
-		registriesConfAfterICSP2 := pool.readRegistriesConf(ctx)
+		registriesConfAfterICSP2 := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after second ICSP creation: read %d bytes, asserting expected entries", len(registriesConfAfterICSP2))
 
 		o.Expect(registriesConfAfterICSP2).To(o.ContainSubstring(`location = "registry.example.com/example/myimage"`),
@@ -572,17 +423,17 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(registriesConfAfterICSP2).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi9/ubi-minimal"`),
 			"registries.conf should still contain ITMS entries for ubi9/ubi-minimal")
 
-		g.By("Step 10: Delete IDMS and wait for custom MCP rollout")
-		idmsDeleteInitialSpec := pool.currentSpec()
+		g.By("Step 10: Delete IDMS and wait for MCP rollout")
+		workerSpec, masterSpec = getMCPSpecs(oc)
 		err = configClient.ImageDigestMirrorSets().Delete(ctx, idmsName, metav1.DeleteOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete IDMS %s", idmsName)
 		e2e.Logf("IDMS %s deleted successfully", idmsName)
 
-		pool.waitForRollout(idmsDeleteInitialSpec)
-		e2e.Logf("Custom MCP %s rollout complete after IDMS deletion", pool.PoolName)
+		waitForPoolsRollout(oc, workerSpec, masterSpec)
+		e2e.Logf("MCP rollout complete after IDMS deletion")
 
 		g.By("Step 11: Verify registries.conf - IDMS entries removed, ITMS and ICSP2 entries remain")
-		registriesConfAfterIDMSDelete := pool.readRegistriesConf(ctx)
+		registriesConfAfterIDMSDelete := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after IDMS deletion: read %d bytes, asserting expected entries", len(registriesConfAfterIDMSDelete))
 
 		o.Expect(registriesConfAfterIDMSDelete).NotTo(o.ContainSubstring(`location = "registry.access.redhat.com/ubi8/ubi-minimal"`),

--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -21,14 +21,25 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
+func getWorkerMCPSpec(oc *exutil.CLI) string {
+	return imagepolicy.GetMCPCurrentSpecConfigName(oc, "worker")
+}
+
 func getMCPSpecs(oc *exutil.CLI) (workerSpec, masterSpec string) {
 	return imagepolicy.GetMCPCurrentSpecConfigName(oc, "worker"),
 		imagepolicy.GetMCPCurrentSpecConfigName(oc, "master")
 }
 
-func waitForPoolsRollout(oc *exutil.CLI, workerSpec, masterSpec string) {
+// waitForWorkerRollout waits for the worker pool only. Used during test steps
+// since we only verify registries.conf on worker nodes; master drains in background.
+func waitForWorkerRollout(oc *exutil.CLI, workerSpec string) {
 	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "worker", workerSpec)
-	imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", masterSpec)
+}
+
+// waitForPoolsRollout waits for both worker and master pools to complete.
+// Used in cleanup to ensure the cluster is fully stable for the next test.
+func waitForPoolsRollout(oc *exutil.CLI, workerSpec, masterSpec string) {
+	imagepolicy.WaitForMCPsConfigSpecChangeAndUpdated(oc, workerSpec, masterSpec)
 }
 
 func readRegistriesConfOnWorker(ctx context.Context, oc *exutil.CLI) string {
@@ -71,7 +82,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		idmsName := fmt.Sprintf("digest-mirror-%s", suffix)
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 
-		workerSpec, masterSpec := getMCPSpecs(oc)
+		workerSpec := getWorkerMCPSpec(oc)
 
 		g.By("Step 1: Create an ImageDigestMirrorSet")
 		idms := &configv1.ImageDigestMirrorSet{
@@ -120,9 +131,9 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			}
 		})
 
-		g.By("Step 2: Wait for MCP rollout and verify IDMS entries in registries.conf")
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after IDMS creation")
+		g.By("Step 2: Wait for worker MCP rollout and verify IDMS entries in registries.conf")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after IDMS creation")
 
 		registriesConf := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after IDMS: read %d bytes", len(registriesConf))
@@ -139,7 +150,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			"registry.redhat.io/rhel8 should be blocked (NeverContactSource)")
 
 		g.By("Step 3: Create an ImageTagMirrorSet")
-		workerSpec, masterSpec = getMCPSpecs(oc)
+		workerSpec = getWorkerMCPSpec(oc)
 		itms := &configv1.ImageTagMirrorSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: itmsName,
@@ -168,9 +179,9 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ImageTagMirrorSet")
 		e2e.Logf("ImageTagMirrorSet %q created successfully", itmsName)
 
-		g.By("Step 4: Wait for MCP rollout and verify ITMS entries alongside IDMS")
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after ITMS creation")
+		g.By("Step 4: Wait for worker MCP rollout and verify ITMS entries alongside IDMS")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after ITMS creation")
 
 		registriesConf = readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after ITMS: read %d bytes", len(registriesConf))
@@ -199,7 +210,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		itmsName := fmt.Sprintf("tag-mirror-%s", suffix)
 		icspName2 := fmt.Sprintf("ubi9repo-%s", suffix)
 
-		workerSpec, masterSpec := getMCPSpecs(oc)
+		workerSpec := getWorkerMCPSpec(oc)
 
 		g.By("Step 1: Create ICSP with digest mirrors for ubi8/ubi-minimal and openshift5")
 		icsp1 := &operatorv1alpha1.ImageContentSourcePolicy{
@@ -266,9 +277,9 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			}
 		})
 
-		g.By("Step 2: Wait for MCP rollout after ICSP creation and verify registries.conf")
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after ICSP creation")
+		g.By("Step 2: Wait for worker MCP rollout after ICSP creation and verify registries.conf")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after ICSP creation")
 
 		registriesConf := readRegistriesConfOnWorker(ctx, oc)
 		e2e.Logf("registries.conf after ICSP creation: read %d bytes, asserting expected entries", len(registriesConf))
@@ -344,7 +355,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		e2e.Logf("Confirmed: registries.conf unchanged after ICSP deletion")
 
 		g.By("Step 6: Create ITMS with tag mirrors for ubi9/ubi-minimal (different source from IDMS)")
-		workerSpec, masterSpec = getMCPSpecs(oc)
+		workerSpec = getWorkerMCPSpec(oc)
 		itms := &configv1.ImageTagMirrorSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   itmsName,
@@ -367,8 +378,8 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ITMS %s", itmsName)
 		e2e.Logf("ITMS %s created successfully", itmsName)
 
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after ITMS creation")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after ITMS creation")
 
 		g.By("Step 7: Verify registries.conf updated with ITMS tag-only entries alongside IDMS digest entries")
 		registriesConfAfterITMS := readRegistriesConfOnWorker(ctx, oc)
@@ -386,7 +397,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			"registries.conf should still contain IDMS entries for ubi8/ubi-minimal")
 
 		g.By("Step 8: Create second ICSP with digest mirrors for registry.example.com/example/myimage")
-		workerSpec, masterSpec = getMCPSpecs(oc)
+		workerSpec = getWorkerMCPSpec(oc)
 		icsp2 := &operatorv1alpha1.ImageContentSourcePolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   icspName2,
@@ -407,8 +418,8 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create ICSP %s", icspName2)
 		e2e.Logf("ICSP %s created successfully", icspName2)
 
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after second ICSP creation")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after second ICSP creation")
 
 		g.By("Step 9: Verify registries.conf updated with ICSP2 entries alongside IDMS and ITMS entries")
 		registriesConfAfterICSP2 := readRegistriesConfOnWorker(ctx, oc)
@@ -423,14 +434,14 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		o.Expect(registriesConfAfterICSP2).To(o.ContainSubstring(`location = "registry.access.redhat.com/ubi9/ubi-minimal"`),
 			"registries.conf should still contain ITMS entries for ubi9/ubi-minimal")
 
-		g.By("Step 10: Delete IDMS and wait for MCP rollout")
-		workerSpec, masterSpec = getMCPSpecs(oc)
+		g.By("Step 10: Delete IDMS and wait for worker MCP rollout")
+		workerSpec = getWorkerMCPSpec(oc)
 		err = configClient.ImageDigestMirrorSets().Delete(ctx, idmsName, metav1.DeleteOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to delete IDMS %s", idmsName)
 		e2e.Logf("IDMS %s deleted successfully", idmsName)
 
-		waitForPoolsRollout(oc, workerSpec, masterSpec)
-		e2e.Logf("MCP rollout complete after IDMS deletion")
+		waitForWorkerRollout(oc, workerSpec)
+		e2e.Logf("Worker MCP rollout complete after IDMS deletion")
 
 		g.By("Step 11: Verify registries.conf - IDMS entries removed, ITMS and ICSP2 entries remain")
 		registriesConfAfterIDMSDelete := readRegistriesConfOnWorker(ctx, oc)


### PR DESCRIPTION
## Summary

Fixes PDB drain deadlock and suite timeout in `[OCP-57401]` and `[OCP-70203]` mirror-set tests on 2-worker clusters (vSphere, AWS 1of2 split).

## Root Cause

The tests previously used a custom `mirrorTestPool` MCP for a single worker node. Since IDMS/ITMS/ICSP are cluster-scoped, creating them triggered rollouts on **both** the custom MCP and the main worker MCP simultaneously. On 2-worker clusters, MCO attempted to drain both workers at once, but PodDisruptionBudgets prevented pod rescheduling — causing a deadlock where neither node could drain and MCP rollouts stalled indefinitely.

Additionally, since IDMS/ITMS are cluster-scoped, they also trigger master pool rollouts. On clusters with 3 master nodes, draining masters sequentially during cleanup adds significant time (~15-20 min), causing the overall disruptive test suite to timeout.

## Fix

1. **Remove custom MCP entirely** — Tests now operate directly on the worker pool, eliminating the concurrent drain scenario that caused the PDB deadlock.

2. **Pause master pool during test execution** — Since we only verify `registries.conf` on worker nodes, the master pool drain is unnecessary for test validation. Pausing the master at test start and unpausing in `DeferCleanup` prevents master drains from contributing to suite timeout.

3. **Use worker-only waits in test body** — Test steps use `waitForWorkerRollout` (calls `imagepolicy.WaitForMCPConfigSpecChangeAndUpdated`) to wait only for the worker pool during verification steps, reducing blocking time.

4. **Use parallel pool waits in cleanup** — Cleanup uses `waitForPoolsRollout` (calls `imagepolicy.WaitForMCPsConfigSpecChangeAndUpdated`) to wait for both worker and master pools in parallel, ensuring cluster stability before the next test.

## Changes

- Removed `mirrorTestPool` struct, methods, and all custom MCP lifecycle code
- Added `pauseMasterPool` / `unpauseMasterPool` helpers
- Added `getWorkerMCPSpec` / `waitForWorkerRollout` / `waitForPoolsRollout` / `readRegistriesConfOnWorker` helpers
- Both `OCP-57401` and `OCP-70203` tests updated to use new approach

## Testing

```
  Running Suite:  - /Users/cmaurya/go/src/github.com/openshift/origin
  ===================================================================
  Random Seed: 1784946045 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [sig-node][Suite:openshift/disruptive-longrunning][Disruptive][Serial] ImageTagMirrorSet and ImageDigestMirrorSet [OTP] Create ImageDigestMirrorSet and ImageTagMirrorSet and verify registries.conf [OCP-57401]
  github.com/openshift/origin/test/extended/node/node_e2e/image_mirror_set.go:91
    STEP: Creating a kubernetes client @ 07/25/26 07:50:50.968
  I0725 07:50:50.969803   52889 discovery.go:214] Invalidating discovery information
  I0725 07:50:50.970646 52889 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0725 07:50:51.284708 52889 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Pause master pool to avoid master drains during test @ 07/25/26 07:50:51.613
  machineconfigpool.machineconfiguration.openshift.io/master patched
  I0725 07:50:57.528691 52889 image_mirror_set.go:45] Master pool paused
    STEP: Step 1: Create an ImageDigestMirrorSet @ 07/25/26 07:50:57.863
  I0725 07:50:58.195755 52889 image_mirror_set.go:129] ImageDigestMirrorSet "digest-mirror-spcnk" created successfully
    STEP: Step 2: Wait for worker MCP rollout and verify IDMS entries in registries.conf @ 07/25/26 07:50:58.195
  I0725 07:50:58.195946 52889 imagepolicy.go:689] Waiting for pool worker to complete
  I0725 07:51:51.154750 52889 image_mirror_set.go:152] Worker MCP rollout complete after IDMS creation
  I0725 07:52:11.410017 52889 image_mirror_set.go:155] registries.conf after IDMS: read 668 bytes
    STEP: Step 3: Create an ImageTagMirrorSet @ 07/25/26 07:52:11.41
  I0725 07:52:12.348925 52889 image_mirror_set.go:196] ImageTagMirrorSet "tag-mirror-spcnk" created successfully
    STEP: Step 4: Wait for worker MCP rollout and verify ITMS entries alongside IDMS @ 07/25/26 07:52:12.349
  I0725 07:52:12.349152 52889 imagepolicy.go:689] Waiting for pool worker to complete
  I0725 07:55:09.269053 52889 image_mirror_set.go:200] Worker MCP rollout complete after ITMS creation
  I0725 07:55:14.606981 52889 image_mirror_set.go:203] registries.conf after ITMS: read 1177 bytes
    STEP: Cleanup: Delete IDMS and ITMS resources @ 07/25/26 07:55:14.609
  I0725 07:55:15.798240 52889 imagepolicy.go:689] Waiting for pool worker to complete
  machineconfigpool.machineconfiguration.openshift.io/master patched
  I0725 07:58:22.724754 52889 image_mirror_set.go:54] Master pool unpaused
  • [451.773 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 451.773 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped

```

## Bug Reference

https://redhat.atlassian.net/browse/OCPBUGS-99397