### PR TITLE
NOJIRA: fix(auditloganalyzer): increase cao watch limit

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/operator_watch_limits.json
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/operator_watch_limits.json
@@ -4,7 +4,7 @@
       "authentication-operator": 359,
       "aws-ebs-csi-driver-operator": 213,
       "cloud-credential-operator": 185,
-      "cluster-autoscaler-operator": 91,
+      "cluster-autoscaler-operator": 100,
       "cluster-baremetal-operator": 108,
       "cluster-capi-operator": 199,
       "cluster-image-registry-operator": 183,


### PR DESCRIPTION
According to [this thread](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1784152264958869) in slack, we agreed that will be necessary to increase the limits of the cluster-autoscaler-operator watcher. For more information, please, take a look into the thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the configured watch limit for highly available AWS clusters using the cluster autoscaler operator from 91 to 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->