### PR TITLE
OCPBUGS-99533: Add Additional Storage Support - API validation test cases

### DIFF
--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -54,6 +54,47 @@ This directory contains OpenShift end-to-end tests for node-related features.
   - Duplicate path detection within store types
   - Combined store configurations with invalid paths
 
+### Suite: openshift/conformance/parallel
+
+- **Additional Storage Support API Validation** - API validation tests for additionalArtifactStores, additionalImageStores, and additionalLayerStores CRI-O configuration
+  
+  **Availability:**
+  - **OCP 4.22:** TechPreview (requires TechPreviewNoUpgrade feature gate)
+  - **OCP 4.23+/5.0+:** GA (Generally Available)
+  
+  **Suite:** `openshift/conformance/parallel`  
+  **Feature Tag:** `[Feature:AdditionalStorageSupport]`  
+  **Sig Tag:** `[sig-node]`  
+  **OCPFeatureGate:** `AdditionalStorageConfig`
+  
+  **Test File:**
+  - **additional_storage_api.go** - 13 API validation tests using DryRun (non-disruptive, parallel execution)
+    - Combined Additional Stores (3 tests): invalid paths, max count enforcement, duplicate detection
+    - Additional Layer Stores (8 tests): comprehensive path validation (empty, relative, spaces, special chars, length, max count, consecutive slashes, duplicates)
+    - Additional Image Stores (1 smoke test): path validation wiring
+    - Additional Artifact Stores (1 smoke test): path validation wiring
+  
+  **Requirements:**
+  - AdditionalStorageConfig feature gate must be enabled
+  - API tests are non-disruptive (use DryRun)
+  - Run in parallel with other conformance tests
+  - Skip on MicroShift (no MachineConfig support)
+  - Skip on Microsoft Azure (known platform issues)
+  
+  **Running API validation tests:**
+  ```bash
+  # Run only Additional Storage API validation tests (fast, non-disruptive)
+  ./openshift-tests run "openshift/conformance/parallel" --dry-run | \
+    grep "\[Feature:AdditionalStorageSupport\]" | \
+    ./openshift-tests run -f -
+  ```
+  
+  **Test Coverage (13 tests, ~2-3 min total):**
+  - Path format validation (absolute paths, character restrictions, length limits)
+  - Count limits enforcement (5 for artifact/layer stores, 10 for image stores)
+  - Duplicate path detection within store types
+  - Combined store configurations with invalid paths
+
 ### Suite: openshift/usernamespace
 
 - **nested_container.go** - Tests running nested containers (podman-in-pod) with user namespaces and nested-container SCC

--- a/test/extended/node/README.md
+++ b/test/extended/node/README.md
@@ -9,6 +9,47 @@ This directory contains OpenShift end-to-end tests for node-related features.
 - **kubeletconfig_features.go** - Tests applying KubeletConfig to custom machine config pools, requires node reboots
 - **kubelet_secret_pulled_images.go** - Tests kubelet credential verification for image pulls (`KubeletEnsureSecretPulledImages` feature gate). Covers multi-tenancy isolation, credential rotation, ImagePullPolicy behavior, credential verification policy (NeverVerify/AlwaysVerify), and registry availability scenarios. Requires `TechPreviewNoUpgrade` or `CustomNoUpgrade` FeatureSet.
 
+### Suite: openshift/conformance/parallel
+
+- **Additional Storage Support API Validation** - API validation tests for additionalArtifactStores, additionalImageStores, and additionalLayerStores CRI-O configuration
+  
+  **Availability:**
+  - **OCP 4.22:** TechPreview (requires TechPreviewNoUpgrade feature gate)
+  - **OCP 4.23+/5.0+:** GA (Generally Available)
+  
+  **Suite:** `openshift/conformance/parallel`  
+  **Feature Tag:** `[Feature:AdditionalStorageSupport]`  
+  **Sig Tag:** `[sig-node]`  
+  **OCPFeatureGate:** `AdditionalStorageConfig`
+  
+  **Test File:**
+  - **additional_storage_api.go** - 13 API validation tests using DryRun (non-disruptive, parallel execution)
+    - Combined Additional Stores (3 tests): invalid paths, max count enforcement, duplicate detection
+    - Additional Layer Stores (8 tests): comprehensive path validation (empty, relative, spaces, special chars, length, max count, consecutive slashes, duplicates)
+    - Additional Image Stores (1 smoke test): path validation wiring
+    - Additional Artifact Stores (1 smoke test): path validation wiring
+  
+  **Requirements:**
+  - AdditionalStorageConfig feature gate must be enabled
+  - API tests are non-disruptive (use DryRun)
+  - Run in parallel with other conformance tests
+  - Skip on MicroShift (no MachineConfig support)
+  - Skip on Microsoft Azure (known platform issues)
+  
+  **Running API validation tests:**
+  ```bash
+  # Run only Additional Storage API validation tests (fast, non-disruptive)
+  ./openshift-tests run "openshift/conformance/parallel" --dry-run | \
+    grep "\[Feature:AdditionalStorageSupport\]" | \
+    ./openshift-tests run -f -
+  ```
+  
+  **Test Coverage (13 tests, ~2-3 min total):**
+  - Path format validation (absolute paths, character restrictions, length limits)
+  - Count limits enforcement (5 for artifact/layer stores, 10 for image stores)
+  - Duplicate path detection within store types
+  - Combined store configurations with invalid paths
+
 ### Suite: openshift/usernamespace
 
 - **nested_container.go** - Tests running nested containers (podman-in-pod) with user namespaces and nested-container SCC

--- a/test/extended/node/additional_storage_api.go
+++ b/test/extended/node/additional_storage_api.go
@@ -1,0 +1,515 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// IsAdditionalStorageConfigEnabled checks whether the AdditionalStorageConfig
+// feature gate is enabled on the cluster and the platform is supported.
+// Returns false with a reason string if the test should be skipped.
+func IsAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) (bool, string) {
+	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to detect MicroShift cluster")
+	if isMicroShift {
+		return false, "MicroShift cluster - MachineConfig resources are not available"
+	}
+
+	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get FeatureGate resource")
+	for _, fg := range fgs.Status.FeatureGates {
+		for _, enabledFG := range fg.Enabled {
+			if enabledFG.Name == "AdditionalStorageConfig" {
+				return true, ""
+			}
+		}
+	}
+	return false, "AdditionalStorageConfig feature gate is not enabled"
+}
+
+// API validation tests - use DryRun to avoid triggering MCO reconciliation
+var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Suite:openshift/conformance/parallel] Additional Storage API Validation", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("additional-storage-api")
+
+	g.BeforeEach(func(ctx context.Context) {
+		if enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc); !enabled {
+			g.Skip(reason)
+		}
+	})
+
+	// ========================================================================
+	// Combined Additional Stores API Validation
+	// ========================================================================
+	g.Context("Combined Additional Stores", func() {
+		// Reject if any store type has invalid path
+		g.It("should reject if any store type has invalid path in combined config", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with valid layer/artifact but invalid image path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-invalid-image-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("relative/invalid/path")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred(), "Expected API to reject invalid relative image path")
+			o.Expect(err.Error()).To(o.Or(
+				o.ContainSubstring("relative"),
+				o.ContainSubstring("absolute"),
+				o.ContainSubstring("path"),
+			), "Error message should mention path validation issue")
+			framework.Logf("Test PASSED: Combined config with invalid image path rejected: %v", err)
+		})
+
+		// Reject if layer stores exceed max while other stores are valid
+		g.It("should reject if layer stores exceed max even with valid image/artifact stores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with 6 layer stores (exceeds max of 5)")
+			layerStores := make([]machineconfigv1.AdditionalLayerStore, 6)
+			for i := 0; i < 6; i++ {
+				layerStores[i] = machineconfigv1.AdditionalLayerStore{
+					Path: machineconfigv1.StorePath(fmt.Sprintf("/var/lib/layer-store-%d", i)),
+				}
+			}
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-exceed-layer-max-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: layerStores,
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("must have at most 5 items"))
+			framework.Logf("Test PASSED: Exceeding layer store max rejected: %v", err)
+		})
+
+		// Reject duplicate paths within same store type in combined config
+		g.It("should reject duplicate paths within same store type in combined config", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with duplicate paths in image stores")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "combined-duplicate-image-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+							{Path: machineconfigv1.StorePath("/mnt/nfs-images")},
+						},
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/mnt/ssd-artifacts")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("duplicate"))
+			framework.Logf("Test PASSED: Duplicate paths in same store type rejected: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Layer Stores API Validation
+	// ========================================================================
+	g.Context("Additional Layer Stores", func() {
+		// Should fail if additionalLayerStores path is empty
+		// Note: Go API returns "Required value" while YAML returns "at least 1 chars long"
+		g.It("should reject empty path for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with empty path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-empty-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			framework.Logf("Expected substring: 'Required value' (Go API) or 'at least 1 chars long' (YAML)")
+			framework.Logf("Actual error: %v", err)
+			o.Expect(err.Error()).To(o.ContainSubstring("Required value"))
+			framework.Logf("Test PASSED: Empty path correctly rejected")
+		})
+
+		// Should fail if additionalLayerStores path is not absolute
+		g.It("should reject relative path for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with relative path")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-relative-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("var/lib/stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
+			framework.Logf("Test PASSED: Relative path correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains spaces
+		g.It("should reject path with spaces for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with path containing spaces")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-path-spaces-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("path must be absolute and contain only alphanumeric characters"))
+			framework.Logf("Test PASSED: Path with spaces correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains invalid characters
+		g.It("should reject path with invalid characters for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with path containing @ symbol")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-invalid-char-at-symbol-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected API to reject path with invalid character '@'")
+			framework.Logf("Path with '@' correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path is too long (>256 bytes)
+		g.It("should reject path exceeding 256 characters for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			longPath := "/" + strings.Repeat("a", 256)
+			g.By(fmt.Sprintf("Creating ContainerRuntimeConfig with path of %d characters", len(longPath)))
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-long-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath(longPath)},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.Or(o.ContainSubstring("256"), o.ContainSubstring("Too long")))
+			framework.Logf("Test PASSED: Long path correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores exceeds maximum of 5 items
+		g.It("should reject more than 5 additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with 6 layer stores (exceeds max of 5)")
+			layerStores := make([]machineconfigv1.AdditionalLayerStore, 6)
+			for i := 0; i < 6; i++ {
+				layerStores[i] = machineconfigv1.AdditionalLayerStore{Path: machineconfigv1.StorePath(fmt.Sprintf("/var/lib/store%d", i))}
+			}
+
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-exceed-limit-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: layerStores,
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("must have at most 5 items"))
+			framework.Logf("Test PASSED: 6 layer stores correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores path contains consecutive forward slashes
+		g.It("should reject path with consecutive forward slashes for additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with consecutive forward slashes")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-consecutive-slashes-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib//stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("consecutive"))
+			framework.Logf("Test PASSED: Consecutive slashes correctly rejected: %v", err)
+		})
+
+		// Should fail if additionalLayerStores contains duplicate paths
+		g.It("should reject duplicate paths in additionalLayerStores", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with duplicate paths")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "layer-duplicate-path-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+							{Path: machineconfigv1.StorePath("/var/lib/stargz-store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred())
+			o.Expect(err.Error()).To(o.ContainSubstring("duplicate"))
+			framework.Logf("Test PASSED: Duplicate paths correctly rejected: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Image Stores API Validation
+	// ========================================================================
+	g.Context("Additional Image Stores", func() {
+		// Smoke test - validates that path validation is wired up for additionalImageStores
+		g.It("should reject invalid additionalImageStores path [Validation Smoke Test]", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with invalid path (contains special character)")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "imagestore-validation-smoke-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+							{Path: machineconfigv1.StorePath("/var/lib/image@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
+		})
+	})
+
+	// ========================================================================
+	// Additional Artifact Stores API Validation
+	// ========================================================================
+	g.Context("Additional Artifact Stores", func() {
+		// Smoke test - validates that path validation is wired up for additionalArtifactStores
+		g.It("should reject invalid additionalArtifactStores path [Validation Smoke Test]", func(ctx context.Context) {
+			mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Creating ContainerRuntimeConfig with invalid path (contains special character)")
+			ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "artifactstore-validation-smoke-test",
+				},
+				Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+					MachineConfigPoolSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pools.operator.machineconfiguration.openshift.io/worker": "",
+						},
+					},
+					ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+						AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+							{Path: machineconfigv1.StorePath("/var/lib/artifact@store")},
+						},
+					},
+				},
+			}
+
+			_, err = mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(
+				ctx, ctrcfg, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+			)
+			o.Expect(err).To(o.HaveOccurred(), "Expected validation to reject invalid path")
+			framework.Logf("Smoke test PASSED: Validation correctly rejected invalid path: %v", err)
+		})
+	})
+})

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -1,0 +1,283 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/utils/ptr"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	mcclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+// Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
+// and run in the disruptive-longrunning suite.
+var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+	defer g.GinkgoRecover()
+
+	var oc = exutil.NewCLI("additional-storage-e2e")
+
+	g.BeforeEach(func(ctx context.Context) {
+		SkipOnMicroShift(oc)
+		SkipOnHyperShift(ctx, oc)
+
+		isSingleNode, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isSingleNode {
+			g.Skip("MCP rollouts don't work reliably on single-node clusters")
+		}
+
+		EnsureNodesReady(ctx, oc)
+
+		enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc)
+		if !enabled {
+			g.Skip(reason)
+		}
+	})
+
+	// This test verifies configuration for all three storage types (image, layer, artifact)
+	// and performs functional testing for image stores (pre-population and fallback).
+	// Artifact stores are tested with filesystem operations, and layer stores are verified
+	// via storage.conf :ref suffix configuration.
+	g.It("should verify configuration of all storage types and functionally test image stores", func(ctx context.Context) {
+		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// SETUP: Create single-node MachineConfigPool for faster rollouts
+		g.By("Getting worker node for test")
+		testNode := GetFirstReadyWorkerNode(oc)
+
+		mcpName := "combined-func-test"
+		var mcpConfig *CustomMCPConfig
+
+		g.By("Creating single-node MachineConfigPool for test isolation")
+		mcpConfig, err = CreateCustomMCPForNode(ctx, oc, mcClient, mcpName, testNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Custom MCP %s created, targeting node %s", mcpName, testNode)
+
+		testNamespace := oc.Namespace()
+
+		// Phase 1: Setup directories and prepare for testing
+		g.By("Phase 1: Creating storage directories and pre-populating test image")
+		imageStorePath := "/var/lib/combined-imagestore"
+		artifactStorePath := "/var/lib/combined-artifactstore"
+		layerStorePath := "/var/lib/stargz-store/store"
+		allDirs := []string{imageStorePath, artifactStorePath, layerStorePath}
+
+		g.DeferCleanup(cleanupDirectoriesOnNode, oc, testNode, allDirs)
+		g.DeferCleanup(func() {
+			cleanupCtx := context.Background()
+			if err := CleanupContainerRuntimeConfig(cleanupCtx, mcClient, "combined-func-test", mcpName); err != nil {
+				framework.Logf("Warning: failed to cleanup ContainerRuntimeConfig: %v", err)
+			}
+			if mcpConfig != nil {
+				if err := CleanupCustomMCP(cleanupCtx, mcpConfig); err != nil {
+					framework.Logf("Warning: failed to cleanup custom MCP: %v", err)
+				}
+			}
+		})
+
+		err = createDirectoriesOnNode(oc, testNode, allDirs)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Pre-populate test image in image store
+		testImage := "registry.k8s.io/e2e-test-images/agnhost:2.59"
+		framework.Logf("Pre-populating image %s to %s on node %s", testImage, imageStorePath, testNode)
+
+		_, err = ExecOnNodeWithChroot(ctx, oc, testNode, "podman", "--root", imageStorePath, "pull", testImage)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		lsOutput, err := ExecOnNodeWithChroot(ctx, oc, testNode, "podman", "--root", imageStorePath, "images", "--format", "{{.Repository}}:{{.Tag}}")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(lsOutput).To(o.ContainSubstring(testImage))
+		framework.Logf("Image pre-populated successfully: %s", lsOutput)
+
+		// Ensure image is NOT in primary CRI-O store (cleanup from previous tests)
+		framework.Logf("Checking if image exists in primary CRI-O store BEFORE configuring additional stores")
+		imageIDOutput, err := ExecOnNodeWithChroot(ctx, oc, testNode, "crictl", "images", "-q", testImage)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		if strings.TrimSpace(imageIDOutput) != "" {
+			framework.Logf("Image %s found in primary CRI-O store (from previous tests), removing it", testImage)
+			_, err = ExecOnNodeWithChroot(ctx, oc, testNode, "crictl", "rmi", strings.TrimSpace(imageIDOutput))
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Image removed from primary CRI-O store")
+		}
+		framework.Logf("Verified: image %s is NOT in primary CRI-O store (only in %s)", testImage, imageStorePath)
+
+		// Phase 2: Create ContainerRuntimeConfig with all three storage types
+		g.By("Phase 2: Creating ContainerRuntimeConfig with all three storage types")
+		ctrcfg := &machineconfigv1.ContainerRuntimeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "combined-func-test",
+			},
+			Spec: machineconfigv1.ContainerRuntimeConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"machineconfiguration.openshift.io/pool": mcpName,
+					},
+				},
+				ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
+					AdditionalLayerStores: []machineconfigv1.AdditionalLayerStore{
+						{Path: machineconfigv1.StorePath(layerStorePath)},
+					},
+					AdditionalImageStores: []machineconfigv1.AdditionalImageStore{
+						{Path: machineconfigv1.StorePath(imageStorePath)},
+					},
+					AdditionalArtifactStores: []machineconfigv1.AdditionalArtifactStore{
+						{Path: machineconfigv1.StorePath(artifactStorePath)},
+					},
+				},
+			},
+		}
+
+		g.By("Applying ContainerRuntimeConfig and waiting for MCP rollout")
+		err = ApplyContainerRuntimeConfigAndWaitForMCP(ctx, mcClient, ctrcfg, mcpName, 15*time.Minute)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// CONFIGURATION VERIFICATION - verify configs without usage
+
+		// Phase 3: Verify storage configuration
+		g.By("Phase 3: Verifying storage.conf and CRI-O configuration")
+		storageConfOutput, err := ExecOnNodeWithChroot(ctx, oc, testNode, "cat", "/etc/containers/storage.conf")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Verify image stores
+		o.Expect(storageConfOutput).To(o.ContainSubstring(imageStorePath))
+		framework.Logf("Image stores verified in storage.conf")
+
+		// Verify layer stores with :ref suffix (MCO automatically appends :ref)
+		expectedPathWithRef := layerStorePath + ":ref"
+		o.Expect(storageConfOutput).To(o.ContainSubstring("additionallayerstores"),
+			"storage.conf should contain additionallayerstores on node %s", testNode)
+		o.Expect(storageConfOutput).To(o.ContainSubstring(expectedPathWithRef),
+			"storage.conf should contain %s with :ref suffix on node %s", expectedPathWithRef, testNode)
+		framework.Logf("Layer stores verified in storage.conf with path %s (MCO added :ref)", expectedPathWithRef)
+
+		g.By("Verifying CRI-O config contains artifact stores")
+		crioOutput, err := ExecOnNodeWithChroot(ctx, oc, testNode, "cat", "/etc/crio/crio.conf.d/01-ctrcfg-additionalArtifactStores")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		expectedArtifactConfig := fmt.Sprintf(`additional_artifact_stores = ["%s"]`, artifactStorePath)
+		o.Expect(crioOutput).To(o.ContainSubstring(expectedArtifactConfig))
+		framework.Logf("Artifact stores verified in CRI-O config")
+
+		g.By("Verifying CRI-O is active with new configuration")
+		crioStatus, err := ExecOnNodeWithChroot(ctx, oc, testNode, "systemctl", "is-active", "crio")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(strings.TrimSpace(crioStatus)).To(o.Equal("active"))
+		framework.Logf("CRI-O is active")
+
+		// FUNCTIONAL VERIFICATION - actually use the stores
+
+		// Phase 4: Test image store functionality - prepopulation and fallback
+		// Test prepopulated image by creating a pod
+		// Use ImagePullPolicy: Never to force using only local stores (proves additional store is used)
+		g.By("Phase 4: Creating pod using prepopulated image from additional store")
+		testPod1 := createTestPod("imagestore-prepop-pod", testNamespace, testImage, testNode, corev1.PullNever)
+		startTime1 := time.Now()
+		_ = CreatePodAndWaitForRunning(ctx, oc, testPod1)
+		pod1Time := time.Since(startTime1)
+		framework.Logf("Pod using prepopulated image started in %v", pod1Time)
+
+		// Test fallback to registry
+		g.By("Phase 5: Testing fallback to registry when image removed from additional store")
+		err = e2epod.DeletePodWithWaitByName(ctx, oc.AdminKubeClient(), testPod1.Name, testNamespace)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Remove image from additional store
+		_, err = ExecOnNodeWithChroot(ctx, oc, testNode, "podman", "--root", imageStorePath, "rmi", testImage)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Removed image from additional store to test fallback")
+
+		// Create second pod - should fall back to registry
+		// Use ImagePullPolicy: IfNotPresent to test actual CRI-O fallback path
+		// CRI-O checks local stores (empty), then falls back to registry
+		testPod2 := createTestPod("imagestore-fallback-pod", testNamespace, testImage, testNode, corev1.PullIfNotPresent)
+		g.DeferCleanup(func() {
+			err := e2epod.DeletePodWithWaitByName(context.Background(), oc.AdminKubeClient(), testPod2.Name, testNamespace)
+			if err != nil {
+				framework.Logf("Warning: failed to cleanup pod %s: %v", testPod2.Name, err)
+			}
+		})
+		startTime2 := time.Now()
+		_ = CreatePodAndWaitForRunning(ctx, oc, testPod2)
+		pod2Time := time.Since(startTime2)
+		framework.Logf("Pod using registry fallback started in %v", pod2Time)
+
+		// Verify pod pulled from registry
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+			events, err := oc.AdminKubeClient().CoreV1().Events(testNamespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("involvedObject.name=%s", testPod2.Name),
+			})
+			if err != nil {
+				return false, err
+			}
+			for _, event := range events.Items {
+				if event.Reason == "Pulled" && strings.Contains(event.Message, "Successfully pulled") {
+					framework.Logf("SUCCESS: Image pulled from registry - %s", event.Message)
+					return true, nil
+				}
+			}
+			return false, nil
+		})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("Phase 5 PASSED: Fallback to registry works when image not in additional store")
+
+		framework.Logf("Test PASSED: Configuration verified for all storage types and image stores functionally tested")
+	})
+})
+
+func createTestPod(name, namespace, image, nodeName string, pullPolicy corev1.PullPolicy) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Tolerations: []corev1.Toleration{
+				{
+					Operator: corev1.TolerationOpExists,
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsUser:    ptr.To[int64](1000),
+				RunAsNonRoot: ptr.To(true),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            "test",
+					Image:           image,
+					Command:         []string{"/agnhost", "pause"},
+					ImagePullPolicy: pullPolicy,
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: ptr.To(false),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{"ALL"},
+						},
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
+				},
+			},
+			RestartPolicy: corev1.RestartPolicyNever,
+		},
+	}
+}

--- a/test/extended/node/node_kc_cc_helpers.go
+++ b/test/extended/node/node_kc_cc_helpers.go
@@ -1,0 +1,155 @@
+package node
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+)
+
+// CreateKubeletConfig creates a KubeletConfig resource.
+func CreateKubeletConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, kubeletConfig *machineconfigv1.KubeletConfig) (*machineconfigv1.KubeletConfig, error) {
+	framework.Logf("Creating KubeletConfig %s", kubeletConfig.Name)
+	created, err := mcClient.MachineconfigurationV1().KubeletConfigs().Create(ctx, kubeletConfig, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// CreateOrUpdateKubeletConfig creates a KubeletConfig or updates it if it already exists.
+func CreateOrUpdateKubeletConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, kubeletConfig *machineconfigv1.KubeletConfig) (*machineconfigv1.KubeletConfig, error) {
+	existing, err := mcClient.MachineconfigurationV1().KubeletConfigs().Get(ctx, kubeletConfig.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		framework.Logf("Creating KubeletConfig %s", kubeletConfig.Name)
+		return mcClient.MachineconfigurationV1().KubeletConfigs().Create(ctx, kubeletConfig, metav1.CreateOptions{})
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	framework.Logf("Updating existing KubeletConfig %s", kubeletConfig.Name)
+	existing.Spec = kubeletConfig.Spec
+	return mcClient.MachineconfigurationV1().KubeletConfigs().Update(ctx, existing, metav1.UpdateOptions{})
+}
+
+// CleanupKubeletConfig deletes a KubeletConfig. If mcpName is non-empty, waits for that MCP to stabilize.
+func CleanupKubeletConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, kcName, mcpName string) error {
+	framework.Logf("Cleaning up KubeletConfig %s", kcName)
+
+	deleteErr := mcClient.MachineconfigurationV1().KubeletConfigs().Delete(ctx, kcName, metav1.DeleteOptions{})
+	if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		return deleteErr
+	}
+
+	if mcpName != "" && (deleteErr == nil || apierrors.IsNotFound(deleteErr)) {
+		framework.Logf("Waiting for MCP %s to become ready after KubeletConfig deletion", mcpName)
+		waitErr := WaitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		if waitErr != nil && !apierrors.IsNotFound(waitErr) {
+			return waitErr
+		}
+	}
+
+	framework.Logf("KubeletConfig %s cleaned up successfully", kcName)
+	return nil
+}
+
+// ApplyKubeletConfigAndWaitForMCP creates a KubeletConfig and waits for the MCP rollout to complete.
+func ApplyKubeletConfigAndWaitForMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, kubeletConfig *machineconfigv1.KubeletConfig, mcpName string, rolloutTimeout time.Duration) error {
+	_, err := CreateKubeletConfig(ctx, mcClient, kubeletConfig)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting for MCP %s to start updating", mcpName)
+	err = WaitForMCPUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting for MCP %s to complete rollout", mcpName)
+	return WaitForMCP(ctx, mcClient, mcpName, rolloutTimeout)
+}
+
+// WaitForMCPUpdating waits for an MCP to enter the "Updating" state.
+func WaitForMCPUpdating(ctx context.Context, mcClient *machineconfigclient.Clientset, mcpName string, timeout time.Duration) error {
+	startTime := time.Now()
+	for {
+		mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, mcpName, metav1.GetOptions{})
+		if err != nil {
+			if time.Since(startTime) > timeout {
+				return err
+			}
+			framework.Logf("Error getting MCP %s: %v, retrying...", mcpName, err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+
+		for _, condition := range mcp.Status.Conditions {
+			if condition.Type == "Updating" && condition.Status == "True" {
+				framework.Logf("MCP %s has started updating", mcpName)
+				return nil
+			}
+		}
+
+		if time.Since(startTime) > timeout {
+			return fmt.Errorf("timeout waiting for MCP %s to start updating", mcpName)
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+}
+
+// CreateContainerRuntimeConfig creates a ContainerRuntimeConfig resource.
+func CreateContainerRuntimeConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, ctrcfg *machineconfigv1.ContainerRuntimeConfig) (*machineconfigv1.ContainerRuntimeConfig, error) {
+	framework.Logf("Creating ContainerRuntimeConfig %s", ctrcfg.Name)
+	created, err := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Create(ctx, ctrcfg, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return created, nil
+}
+
+// CleanupContainerRuntimeConfig deletes a ContainerRuntimeConfig. If mcpName is non-empty, waits for that MCP to stabilize.
+func CleanupContainerRuntimeConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, ctrcfgName, mcpName string) error {
+	framework.Logf("Cleaning up ContainerRuntimeConfig %s", ctrcfgName)
+
+	deleteErr := mcClient.MachineconfigurationV1().ContainerRuntimeConfigs().Delete(ctx, ctrcfgName, metav1.DeleteOptions{})
+	if deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+		return deleteErr
+	}
+
+	if mcpName != "" && (deleteErr == nil || apierrors.IsNotFound(deleteErr)) {
+		framework.Logf("Waiting for MCP %s to become ready after ContainerRuntimeConfig deletion", mcpName)
+		waitErr := WaitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
+		if waitErr != nil && !apierrors.IsNotFound(waitErr) {
+			return waitErr
+		}
+	}
+
+	framework.Logf("ContainerRuntimeConfig %s cleaned up successfully", ctrcfgName)
+	return nil
+}
+
+// ApplyContainerRuntimeConfigAndWaitForMCP creates a ContainerRuntimeConfig and waits for the MCP rollout to complete.
+func ApplyContainerRuntimeConfigAndWaitForMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, ctrcfg *machineconfigv1.ContainerRuntimeConfig, mcpName string, rolloutTimeout time.Duration) error {
+	_, err := CreateContainerRuntimeConfig(ctx, mcClient, ctrcfg)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting for MCP %s to start updating", mcpName)
+	err = WaitForMCPUpdating(ctx, mcClient, mcpName, 5*time.Minute)
+	if err != nil {
+		return err
+	}
+
+	framework.Logf("Waiting for MCP %s to complete rollout", mcpName)
+	return WaitForMCP(ctx, mcClient, mcpName, rolloutTimeout)
+}

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
@@ -992,4 +993,43 @@ func EnsureNodesReady(ctx context.Context, oc *exutil.CLI) {
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to check node readiness")
 	o.Expect(notReadyNodes).To(o.BeEmpty(),
 		"Cannot start test: nodes not Ready: %v. Cluster may be recovering from previous test.", notReadyNodes)
+}
+
+func SkipOnHyperShift(ctx context.Context, oc *exutil.CLI) {
+	isHyperShift, err := exutil.IsHypershift(ctx, oc.AdminConfigClient())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if isHyperShift {
+		g.Skip("Skipping test on HyperShift cluster - MachineConfig API not available")
+	}
+}
+
+func CreatePodAndWaitForRunning(ctx context.Context, oc *exutil.CLI, pod *corev1.Pod) *corev1.Pod {
+	_, err := oc.AdminKubeClient().CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	err = e2epod.WaitForPodRunningInNamespace(ctx, oc.AdminKubeClient(), pod)
+	o.Expect(err).NotTo(o.HaveOccurred())
+
+	created, err := oc.AdminKubeClient().CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return created
+}
+
+func createDirectoriesOnNode(oc *exutil.CLI, nodeName string, dirs []string) error {
+	args := append([]string{"mkdir", "-p"}, dirs...)
+	_, err := ExecOnNodeWithChroot(context.Background(), oc, nodeName, args...)
+	if err != nil {
+		return fmt.Errorf("failed to create directories %v on node %s: %v", dirs, nodeName, err)
+	}
+	framework.Logf("Node %s: directories created: %v", nodeName, dirs)
+	return nil
+}
+
+func cleanupDirectoriesOnNode(oc *exutil.CLI, nodeName string, dirs []string) error {
+	args := append([]string{"rm", "-rf"}, dirs...)
+	_, err := ExecOnNodeWithChroot(context.Background(), oc, nodeName, args...)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup directories %v on node %s: %w", dirs, nodeName, err)
+	}
+	return nil
 }


### PR DESCRIPTION
Manual cherry-pick of PR https://github.com/openshift/origin/pull/31384
Summary:
Add comprehensive API validation tests for Additional Storage Support (additionalArtifactStores, additionalImageStores, additionalLayerStores) feature. These tests validate ContainerRuntimeConfig API behavior
using DryRun, ensuring proper validation without triggering MCO reconciliation.

`test/extended/node/additional_storage_api.go` - 13 API validation tests