### PR TITLE
OCPBUGS-98576: Improve test output for nodes should be ready test

### DIFF
--- a/pkg/e2eanalysis/e2e_analysis.go
+++ b/pkg/e2eanalysis/e2e_analysis.go
@@ -567,14 +567,24 @@ func checkMachineNodeConsistency(clientset clientset.Interface, dc dynamic.Inter
 		return -1, err
 	}
 
-	notReadyNodes := getUnreadyOrUnschedulableNodeNames(nodeList)
+	notReadyNodes := getUnreadyOrUnschedulableNodes(nodeList)
 
 	if len(notReadyNodes) == 0 {
 		tm.AddTestCase(tc, "", "")
 	} else {
-		message := fmt.Sprintf("Found %d out of %d Nodes not Ready or unscheduable: ", len(notReadyNodes), len(nodeList.Items))
-		message += strings.Join(notReadyNodes, " ")
-		tm.AddTestCase(tc, message, "")
+		var b strings.Builder
+		fmt.Fprintf(&b, "Found %d out of %d Nodes not Ready or unschedulable:\n",
+			len(notReadyNodes), len(nodeList.Items))
+		for _, n := range notReadyNodes {
+			fmt.Fprintf(&b, "Node %s:\n", n.name)
+			if n.unschedulable {
+				b.WriteString("  Spec.Unschedulable=true (cordoned)\n")
+			}
+			for _, c := range n.conditions {
+				fmt.Fprintf(&b, "  %s=%s reason=%s: %s\n", c.Type, c.Status, c.Reason, c.Message)
+			}
+		}
+		tm.AddTestCase(tc, b.String(), "")
 	}
 
 	// ===== Case 3 =====
@@ -645,19 +655,39 @@ func GetReadyNodeCountByLabel(nodeList *k8sv1.NodeList, labelSelector string) (i
 	return readyNodeCount, nil
 }
 
-// GetUnreadyOrUnschedulableNodeNames returns a list of node names that are
-// either not ready or marked as unschedulable.
-func getUnreadyOrUnschedulableNodeNames(allNodes *k8sv1.NodeList) []string {
-	var badNodeNames []string
+type unreadyNode struct {
+	name          string
+	conditions    []k8sv1.NodeCondition
+	unschedulable bool
+}
+
+func getUnreadyOrUnschedulableNodes(allNodes *k8sv1.NodeList) []unreadyNode {
+	var result []unreadyNode
 	for _, node := range allNodes.Items {
-		// IsNodeSchedulable checks if the node is ready AND schedulable.
-		// If it returns false, the node is one we're interested in.
 		if !e2enode.IsNodeSchedulable(klog.TODO(), &node) {
-			badNodeNames = append(badNodeNames, node.Name)
+			bad := unreadyNode{
+				name:          node.Name,
+				unschedulable: node.Spec.Unschedulable,
+			}
+			for _, c := range node.Status.Conditions {
+				if isProblematicCondition(c) {
+					bad.conditions = append(bad.conditions, c)
+				}
+			}
+			result = append(result, bad)
 		}
 	}
+	return result
+}
 
-	return badNodeNames
+func isProblematicCondition(c k8sv1.NodeCondition) bool {
+	switch c.Type {
+	case k8sv1.NodeReady:
+		return c.Status != k8sv1.ConditionTrue
+	case k8sv1.NodeMemoryPressure, k8sv1.NodeDiskPressure, k8sv1.NodePIDPressure, k8sv1.NodeNetworkUnavailable:
+		return c.Status != k8sv1.ConditionFalse
+	}
+	return false
 }
 
 func recordInstallDurations() map[string]time.Duration {

--- a/pkg/e2eanalysis/e2e_analysis_test.go
+++ b/pkg/e2eanalysis/e2e_analysis_test.go
@@ -150,11 +150,11 @@ func TestTopologicalSort(t *testing.T) {
 	}
 }
 
-func TestGetUnreadyOrUnschedulableNodeNames(t *testing.T) {
+func TestGetUnreadyOrUnschedulableNodes(t *testing.T) {
 	tests := []struct {
 		name     string
 		nodes    *k8sv1.NodeList
-		expected []string
+		expected []unreadyNode
 	}{
 		{
 			name: "all nodes ready",
@@ -164,45 +164,135 @@ func TestGetUnreadyOrUnschedulableNodeNames(t *testing.T) {
 					{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
 				},
 			},
-			expected: []string{},
+			expected: nil,
 		},
 		{
-			name: "one node not ready",
+			name: "one node not ready includes problematic conditions",
 			nodes: &k8sv1.NodeList{
 				Items: []k8sv1.Node{
 					{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionFalse}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{
+						{Type: k8sv1.NodeReady, Status: k8sv1.ConditionFalse, Reason: "KubeletNotReady", Message: "container runtime not ready"},
+						{Type: k8sv1.NodeMemoryPressure, Status: k8sv1.ConditionFalse},
+					}}},
 				},
 			},
-			expected: []string{"node-2"},
+			expected: []unreadyNode{
+				{
+					name: "node-2",
+					conditions: []k8sv1.NodeCondition{
+						{Type: k8sv1.NodeReady, Status: k8sv1.ConditionFalse, Reason: "KubeletNotReady", Message: "container runtime not ready"},
+					},
+				},
+			},
 		},
 		{
-			name: "one node unschedulable",
+			name: "unschedulable node with no problematic conditions sets flag",
 			nodes: &k8sv1.NodeList{
 				Items: []k8sv1.Node{
 					{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
 					{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Spec: k8sv1.NodeSpec{Unschedulable: true}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
 				},
 			},
-			expected: []string{"node-2"},
+			expected: []unreadyNode{
+				{name: "node-2", unschedulable: true},
+			},
 		},
 		{
-			name: "mixed not ready and unschedulable",
+			name: "node with all conditions unknown",
 			nodes: &k8sv1.NodeList{
 				Items: []k8sv1.Node{
-					{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "node-2"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionFalse}}}},
-					{ObjectMeta: metav1.ObjectMeta{Name: "node-3"}, Spec: k8sv1.NodeSpec{Unschedulable: true}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue}}}},
+					{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}, Status: k8sv1.NodeStatus{Conditions: []k8sv1.NodeCondition{
+						{Type: k8sv1.NodeReady, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown", Message: "Kubelet stopped posting node status."},
+						{Type: k8sv1.NodeMemoryPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+						{Type: k8sv1.NodeDiskPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+						{Type: k8sv1.NodePIDPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+					}}},
 				},
 			},
-			expected: []string{"node-2", "node-3"},
+			expected: []unreadyNode{
+				{
+					name: "node-1",
+					conditions: []k8sv1.NodeCondition{
+						{Type: k8sv1.NodeReady, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown", Message: "Kubelet stopped posting node status."},
+						{Type: k8sv1.NodeMemoryPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+						{Type: k8sv1.NodeDiskPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+						{Type: k8sv1.NodePIDPressure, Status: k8sv1.ConditionUnknown, Reason: "NodeStatusUnknown"},
+					},
+				},
+			},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getUnreadyOrUnschedulableNodeNames(tc.nodes)
-			assert.ElementsMatch(t, tc.expected, actual)
+			actual := getUnreadyOrUnschedulableNodes(tc.nodes)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestIsProblematicCondition(t *testing.T) {
+	tests := []struct {
+		name     string
+		cond     k8sv1.NodeCondition
+		expected bool
+	}{
+		{
+			name:     "Ready=True is not problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeReady, Status: k8sv1.ConditionTrue},
+			expected: false,
+		},
+		{
+			name:     "Ready=False is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeReady, Status: k8sv1.ConditionFalse},
+			expected: true,
+		},
+		{
+			name:     "Ready=Unknown is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeReady, Status: k8sv1.ConditionUnknown},
+			expected: true,
+		},
+		{
+			name:     "MemoryPressure=False is not problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeMemoryPressure, Status: k8sv1.ConditionFalse},
+			expected: false,
+		},
+		{
+			name:     "MemoryPressure=True is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeMemoryPressure, Status: k8sv1.ConditionTrue},
+			expected: true,
+		},
+		{
+			name:     "DiskPressure=Unknown is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeDiskPressure, Status: k8sv1.ConditionUnknown},
+			expected: true,
+		},
+		{
+			name:     "PIDPressure=False is not problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodePIDPressure, Status: k8sv1.ConditionFalse},
+			expected: false,
+		},
+		{
+			name:     "PIDPressure=True is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodePIDPressure, Status: k8sv1.ConditionTrue},
+			expected: true,
+		},
+		{
+			name:     "NetworkUnavailable=False is not problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeNetworkUnavailable, Status: k8sv1.ConditionFalse},
+			expected: false,
+		},
+		{
+			name:     "NetworkUnavailable=True is problematic",
+			cond:     k8sv1.NodeCondition{Type: k8sv1.NodeNetworkUnavailable, Status: k8sv1.ConditionTrue},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isProblematicCondition(tc.cond))
 		})
 	}
 }


### PR DESCRIPTION
Now allows us to see the problematic conditions directly in test output instead of fishing through artifacts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine-node consistency failure messages with a multi-line, per-node breakdown of problematic conditions (type, status, reason, and message), including whether nodes are marked unschedulable.

* **Tests**
  * Updated node-condition assertions to validate full returned node details (including condition subsets and unschedulable flag) instead of only node names.
  * Added table-driven coverage for the logic that determines which node conditions are considered “problematic.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->