### PR TITLE
OCPBUGS-99535: Skip Squid proxy configuration

### DIFF
--- a/test/extended/router/config_manager_ingress.go
+++ b/test/extended/router/config_manager_ingress.go
@@ -729,7 +729,9 @@ func innerExecPodReadURL(execPod execPodRef, host string, secure bool, abspath s
 		port = 443
 	}
 	uri := fmt.Sprintf("%s://%s:%d%s", proto, host, port, abspath)
-	cmd := fmt.Sprintf("curl -ksS --max-time %d -w '\n%%{http_code}' --resolve %s:%d:%s %q", fastTimeoutSeconds, host, port, execPod.ipAddress, uri)
+	// Skipping Squid if configured by dropping its envvars: we are running from inside the router pod,
+	// using the loopback address, and resolving a hostname not known by neither the local DNS nor the Squid proxy.
+	cmd := fmt.Sprintf("env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u ALL_PROXY -u all_proxy curl -ksS --max-time %d -w '\n%%{http_code}' --resolve %s:%d:%s %q", fastTimeoutSeconds, host, port, execPod.ipAddress, uri)
 	output, err = e2eoutput.RunHostCmd(execPod.Namespace, execPod.Name, cmd)
 
 	// Checking for curl's "(52) empty response from server", this means a FIN or RST from the server side.


### PR DESCRIPTION
Requests made to the Router pod during its e2e tests happen from inside its own container, using the loopback interface, and resolving a non-existent hostname via curl's --resolve. This is not working when the cluster has Squid proxy running and configured, since Squid does not know the hostname, and cannot use the one curl is resolving since it runs from another pod and cannot reach router's loopback.

This update is overriding the curl environment, by dropping the HTTP/s_PROXY envvars inherited from the router pod, which makes curl not to use Squid when making a request to HAProxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router connectivity tests by preventing proxy settings from interfering with requests to local loopback addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->