### PR TITLE
NE-2789: Add a guard to skip IngressControllerMultipleHAProxyVersions tests if IngressController CRD lacks haproxyVersion field

### DIFF
--- a/test/extended/router/multi-haproxy.go
+++ b/test/extended/router/multi-haproxy.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 
 	"github.com/openshift/origin/test/extended/router/shard"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -60,6 +61,26 @@ var _ = g.Describe("[sig-network-edge][Feature:Router][apigroup:route.openshift.
 	})
 
 	g.BeforeEach(func() {
+
+		apiExtClient, err := apiextensionsclient.NewForConfig(oc.AdminConfig())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		crd, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, "ingresscontrollers.operator.openshift.io", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		// Check if haproxyVersion field exists in the CRD schema
+		hasField := false
+		for _, v := range crd.Spec.Versions {
+			if v.Name == "v1" && v.Schema != nil && v.Schema.OpenAPIV3Schema != nil {
+				if _, ok := v.Schema.OpenAPIV3Schema.Properties["spec"].Properties["haproxyVersion"]; ok {
+					hasField = true
+				}
+			}
+		}
+		if !hasField {
+			g.Skip("IngressController CRD does not have haproxyVersion field — operator not yet updated")
+		}
+
 		defaultIC, err := operatorClient.OperatorV1().IngressControllers("openshift-ingress-operator").Get(ctx, "default", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(defaultIC.Status.EffectiveHAProxyVersion).NotTo(o.BeEmpty())


### PR DESCRIPTION
With the introduction of featuregate `IngressControllerMultipleHAProxyVersions` origin tests, we want to make sure the tests are backwards compatible and dont start to fail during featuregate promotion.

this change is adding a guard to check the IngressController CRD to confirm the haproxyVersion field is present before trying to run the tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a compatibility check to ensure the IngressController custom resource supports HAProxy version configuration.
  * Skips related validation when the installed operator does not yet provide this capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->