### PR TITLE
Pause worker MCP for image mirror tests

### DIFF
--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -211,6 +211,11 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 	g.BeforeEach(func(ctx context.Context) {
 		nodeutils.SkipOnMicroShift(oc)
 		nodeutils.EnsureNodesReady(ctx, oc)
+		nodeutils.EnsureWorkerPoolPaused(ctx, oc)
+	})
+
+	g.AfterEach(func(ctx context.Context) {
+		nodeutils.EnsureWorkerPoolUnpaused(ctx, oc)
 	})
 
 	g.It("[OTP] Create ImageDigestMirrorSet and ImageTagMirrorSet and verify registries.conf [OCP-57401]", func(ctx context.Context) {

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -993,3 +993,34 @@ func EnsureNodesReady(ctx context.Context, oc *exutil.CLI) {
 	o.Expect(notReadyNodes).To(o.BeEmpty(),
 		"Cannot start test: nodes not Ready: %v. Cluster may be recovering from previous test.", notReadyNodes)
 }
+
+func EnsureWorkerPoolPaused(ctx context.Context, oc *exutil.CLI) {
+	ensureWorkerPoolPaused(ctx, oc, true)
+}
+
+func EnsureWorkerPoolUnpaused(ctx context.Context, oc *exutil.CLI) {
+	ensureWorkerPoolPaused(ctx, oc, false)
+}
+
+func ensureWorkerPoolPaused(ctx context.Context, oc *exutil.CLI, paused bool) {
+	mcClient, err := machineconfigclient.NewForConfig(oc.AdminConfig())
+	if err != nil {
+		framework.Logf("Warning: failed to create MC client: %v", err)
+	}
+	workerPool, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, "worker", metav1.GetOptions{})
+	if err != nil {
+		framework.Logf("Warning: failed to get worker pool: %v", err)
+	}
+	if workerPool.Spec.Paused == paused {
+		framework.Logf("Worker pool is already paused=%v", paused)
+		return
+	}
+
+	workerPool.Spec.Paused = paused
+	_, err = mcClient.MachineconfigurationV1().MachineConfigPools().Update(ctx, workerPool, metav1.UpdateOptions{})
+	if err != nil {
+		framework.Logf("Warning: failed to update worker pool: %v", err)
+	}
+
+	return
+}


### PR DESCRIPTION
These tests create IMDS which affects all MCPs. The worker pool rolling out is hindering the progress on this test when a cluster is created with just two workers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved node image mirror test isolation by pausing the worker pool during each test.
  - Automatically restores the worker pool to its active state during test cleanup.
  - Added safeguards to avoid disrupting test execution when worker pool state changes encounter setup or update issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->