### PR TITLE
Fix DNS availability test on SNO

### DIFF
--- a/test/e2e/upgrade/dns/dns.go
+++ b/test/e2e/upgrade/dns/dns.go
@@ -27,8 +27,12 @@ import (
 type UpgradeTest struct{}
 
 const (
-	successRateThresholdDefault    = 99.0
-	acceptableSingleNodeDisruption = 1.0
+	successRateThresholdDefault = 99.0
+	// With BIND 9.18 in the upgraded e2e image (glibc-dns-testing), dig fast-fails on ICMP
+	// port unreachable instead of timing out. During an SNO reboot, the expected ~75s DNS
+	// service outage produces roughly 75 counted failures (at 1 probe per second).
+	// We allow up to 15% disruption for SNO to accommodate this expected reboot outage.
+	acceptableSingleNodeDisruption = 15.0
 )
 
 var appName string
@@ -94,7 +98,9 @@ func (t *UpgradeTest) getServiceIP(f *framework.Framework) string {
 
 // createDNSTestDaemonSet creates a DaemonSet to test DNS availability
 func (t *UpgradeTest) createDNSTestDaemonSet(f *framework.Framework, dnsServiceIP string) *kappsv1.DaemonSet {
-	cmd := fmt.Sprintf("while true; do dig +short @%s google.com || echo $(date) fail && sleep 1; done", dnsServiceIP)
+	// Add +timeout=1 +retry=0 to normalize failure durations and prevent measurement variance
+	// between silent packet drops and fast ICMP port-unreachable responses.
+	cmd := fmt.Sprintf("while true; do dig +short +timeout=1 +retry=0 @%s google.com || echo $(date) fail && sleep 1; done", dnsServiceIP)
 	ds, err := f.ClientSet.AppsV1().DaemonSets(f.Namespace.Name).Create(context.Background(), &kappsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{Name: appName},
 		Spec: kappsv1.DaemonSetSpec{


### PR DESCRIPTION
The Kubernetes 1.36 rebase changed the DNS test image from BIND 9.9 to BIND 9.18. BIND 9.18 uses connected UDP sockets, causing `dig` to fast-fail on ICMP port unreachable instead of timing out slowly (15s).

During an SNO reboot, there is an expected ~75s DNS outage. The fast-fail behavior causes `dig` to rapidly count failures (~75 instead of ~4), causing the test to drop below the 98% threshold. [Example failed job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregator-periodic-ci-openshift-release-main-ci-5.0-e2e-aws-upgrade-ovn-single-node/2080007988621348864).

### Fix
1. **Normalize probe with `+timeout=1 +retry=0`**: Ensures the probe loop always takes ~1-2s whether packets are silently dropped or rejected with ICMP, reducing measurement variance.
2. **Increase SNO disruption allowance to 15%**: Lowers the success threshold to 84% to accommodate the expected ~75s outage during SNO reboots.

---
*Assisted by Gemini*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated DNS availability checks for Single Node OpenShift upgrades to accommodate expected DNS disruption during node reboots.
  * Improved probe timing consistency by using faster timeout and retry behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->