### PR TITLE
OCPBUGS-99492: remove storage NetworkPolicies from validation skip list

### DIFF
--- a/test/extended/networking/networkpolicy_validation.go
+++ b/test/extended/networking/networkpolicy_validation.go
@@ -29,10 +29,6 @@ var _ = g.Describe("[sig-network] NetworkPolicy", func() {
 		networkPoliciesToSkip := []string{
 			// https://redhat.atlassian.net/browse/OCPBUGS-99494
 			"openshift-ingress/router-default",
-			// https://redhat.atlassian.net/browse/OCPBUGS-99492
-			"openshift-cluster-csi-drivers/allow-to-dns",
-			// https://redhat.atlassian.net/browse/OCPBUGS-99492
-			"openshift-cluster-storage-operator/allow-to-dns",
 			// https://redhat.atlassian.net/browse/OCPBUGS-99493
 			"openshift-cluster-olm-operator/allow-egress-to-openshift-dns",
 			// https://redhat.atlassian.net/browse/OCPBUGS-99493


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-99492

/hold for https://github.com/openshift/cluster-storage-operator/pull/720

/cc @openshift/storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated NetworkPolicy validation coverage to include additional platform policies.
  * Named-port violations in these policies are now detected instead of being skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->