### PR TITLE
Migrate CRI-O annotations to v2 format

### DIFF
--- a/test/extended/node/nested_container.go
+++ b/test/extended/node/nested_container.go
@@ -57,7 +57,7 @@ func runNestedPod(ctx context.Context, oc *exutil.CLI) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				"io.kubernetes.cri-o.Devices": "/dev/fuse,/dev/net/tun",
+				"devices.crio.io": "/dev/fuse,/dev/net/tun",
 				"openshift.io/scc":            "nested-container",
 			},
 		},

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -120,7 +120,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		podName := "pod-devfuse"
 		ns := "devfuse-test"
 
-		// Skip on runc: io.kubernetes.cri-o.Devices annotation is only in crun's allowed_annotations.
+		// Skip on runc: devices.crio.io annotation is only in crun's allowed_annotations.
 		// We query crio config directly as ContainerRuntimeConfig API misses platform-default runc.
 		g.By("Skip if the default runtime is runc")
 		node, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(

--- a/test/extended/testdata/bindata.go
+++ b/test/extended/testdata/bindata.go
@@ -50688,7 +50688,7 @@ kind: Pod
 metadata:
   name: pod-devfuse
   annotations:
-    io.kubernetes.cri-o.Devices: "/dev/fuse"
+    devices.crio.io: "/dev/fuse"
 spec:
   securityContext:
     runAsNonRoot: true

--- a/test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml
+++ b/test/extended/testdata/node/node_e2e/pod-dev-fuse.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: pod-devfuse
   annotations:
-    io.kubernetes.cri-o.Devices: "/dev/fuse"
+    devices.crio.io: "/dev/fuse"
 spec:
   securityContext:
     runAsNonRoot: true

--- a/test/extended/util/compat_otp/testdata/bindata.go
+++ b/test/extended/util/compat_otp/testdata/bindata.go
@@ -51643,7 +51643,7 @@ objects:
     labels:
       name: pod-devfuse
     annotations:
-      io.kubernetes.cri-o.Devices: "/dev/fuse"
+      devices.crio.io: "/dev/fuse"
   spec:
     securityContext:
       runAsNonRoot: true
@@ -51950,7 +51950,7 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}" 
     annotations:
-      io.kubernetes.cri-o.LinkLogs: "logging-volume"
+      link-logs.crio.io: "logging-volume"
   spec:
     containers:
     - name: httpd
@@ -52166,7 +52166,7 @@ objects:
     namespace: "${NAMESPACE}"
     annotations:
       io.openshift.builder: "true"
-      io.kubernetes.cri-o.userns-mode: "auto"
+      userns-mode.crio.io: "auto"
   spec:
     securityContext:
       runAsUser: 1000

--- a/test/extended/util/compat_otp/testdata/node/pod-dev-fuse.yaml
+++ b/test/extended/util/compat_otp/testdata/node/pod-dev-fuse.yaml
@@ -11,7 +11,7 @@ objects:
     labels:
       name: pod-devfuse
     annotations:
-      io.kubernetes.cri-o.Devices: "/dev/fuse"
+      devices.crio.io: "/dev/fuse"
   spec:
     securityContext:
       runAsNonRoot: true

--- a/test/extended/util/compat_otp/testdata/node/pod-loglink.yaml
+++ b/test/extended/util/compat_otp/testdata/node/pod-loglink.yaml
@@ -9,7 +9,7 @@ objects:
     name: "${NAME}"
     namespace: "${NAMESPACE}" 
     annotations:
-      io.kubernetes.cri-o.LinkLogs: "logging-volume"
+      link-logs.crio.io: "logging-volume"
   spec:
     containers:
     - name: httpd

--- a/test/extended/util/compat_otp/testdata/node/pod-user-namespace.yaml
+++ b/test/extended/util/compat_otp/testdata/node/pod-user-namespace.yaml
@@ -10,7 +10,7 @@ objects:
     namespace: "${NAMESPACE}"
     annotations:
       io.openshift.builder: "true"
-      io.kubernetes.cri-o.userns-mode: "auto"
+      userns-mode.crio.io: "auto"
   spec:
     securityContext:
       runAsUser: 1000


### PR DESCRIPTION
CRI-O migrated its annotations from v1 (`io.kubernetes.cri-o.*`) to v2 (`*.crio.io`) in December 2025. The old format is deprecated.

Replacements:
- `io.kubernetes.cri-o.Devices` -> `devices.crio.io`
- `io.kubernetes.cri-o.LinkLogs` -> `link-logs.crio.io`
- `io.kubernetes.cri-o.userns-mode` -> `userns-mode.crio.io`

Tracking: https://github.com/cri-o/cri-o/issues/10194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod annotations to use the current CRI-O formats for device access, log linking, and user namespace configuration.
  * Preserved existing behavior and values for FUSE access, logging volume links, and automatic user namespace mode.

* **Tests**
  * Updated end-to-end test data and validation references to match the current annotation formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->