### PR TITLE
OCPNODE-4623: e2e for Block runc on RHEL 10 via OSImageURL stream class inspection

### DIFF
--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -14,12 +14,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	configv1 "github.com/openshift/api/config/v1"
+	imagev1 "github.com/openshift/api/image/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
 	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	v1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
@@ -27,18 +29,26 @@ import (
 )
 
 const (
-	runcRHCOS10GuardPool   = "runc-rhcos10-guard"
-	crunRHCOS10UpgradePool = "crun-rhcos10-upgrade"
-	streamRHEL9            = "rhel-9"
-	streamRHEL10           = "rhel-10"
+	runcRHCOS10GuardPool    = "runc-rhcos10-guard"
+	runcRHCOS10URLGuardPool = "runc-rhcos10-url-guard"
+	crunRHCOS10UpgradePool  = "crun-rhcos10-upgrade"
+	streamRHEL9             = "rhel-9"
+	streamRHEL10            = "rhel-10"
 
 	runcGuardCRCName          = "99-runc-rhcos10-guard-runc"
+	runcURLGuardCRCName       = "99-runc-rhcos10-url-guard-runc"
+	runcURLGuardMCName        = "99-runc-rhcos10-url-guard"
+	runcURLGuardImageStream   = "test-rhcos10-url-guard"
 	runcCRCDefaultRuntimePath = "/etc/crio/crio.conf.d/01-ctrcfg-defaultRuntime"
 
 	machineConfigClusterOperator = "machine-config"
 
 	degradedPoolUpgradeableReason  = "DegradedPool"
 	degradedPoolUpgradeableMessage = "One or more machine config pools are degraded"
+
+	// Render guard message when a pool targets a RHEL 10 OS image (via osImageStream or a
+	// genuinely overriding osImageURL) while runc is configured as the default runtime (OCPNODE-4518).
+	runcRHEL10GuardMessage = "targets a RHEL 10 OS image where runc is not available"
 )
 
 var rhelMajorOSImagePattern = regexp.MustCompile(`Linux\s+([0-9]+)`)
@@ -54,14 +64,18 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 		mcClient             *machineconfigclient.Clientset
 		nodeName             string
 		testPoolName         string
-		cleanupCRC           bool
+		cleanupCRCName       string
+		cleanupURLGuardMC    bool
+		cleanupURLGuardIS    bool
 		clusterDefaultStream string
 	)
 
 	g.BeforeEach(func(ctx context.Context) {
 		nodeName = ""
 		testPoolName = ""
-		cleanupCRC = false
+		cleanupCRCName = ""
+		cleanupURLGuardMC = false
+		cleanupURLGuardIS = false
 
 		var err error
 		mcClient, err = machineconfigclient.NewForConfig(oc.AdminConfig())
@@ -88,7 +102,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 
 	g.It("blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
 		testPoolName = runcRHCOS10GuardPool
-		cleanupCRC = true
+		cleanupCRCName = runcGuardCRCName
 
 		g.By("Creating custom MachineConfigPool pinned to rhel-9 with runc ContainerRuntimeConfig")
 		o.Expect(createRuncGuardPool(ctx, mcClient)).To(o.Succeed())
@@ -147,7 +161,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 			o.Expect(priorRenderedConfig).NotTo(o.BeEmpty(), "node should have a stable rendered config before CRC removal")
 
 			o.Expect(deleteContainerRuntimeConfig(ctx, mcClient, runcGuardCRCName)).To(o.Succeed())
-			o.Expect(waitForPoolConfigRolloutAfterCRCRemoval(ctx, oc, mcClient, runcRHCOS10GuardPool, nodeName, priorRenderedConfig, 30*time.Minute)).To(o.Succeed(),
+			o.Expect(waitForPoolConfigRollout(ctx, oc, mcClient, runcRHCOS10GuardPool, nodeName, priorRenderedConfig, 30*time.Minute)).To(o.Succeed(),
 				"pool should re-render and roll out on the node without runc ContainerRuntimeConfig before moving to rhel-10")
 			o.Expect(waitForRuncRemovedFromNode(ctx, oc, nodeName, 15*time.Minute)).To(o.Succeed(),
 				"CRC removal should drop the runc CRI-O drop-in before moving to rhel-10")
@@ -203,6 +217,113 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 			"cluster upgradeability should not be blocked by runc guard when pool uses crun")
 	})
 
+	g.It("blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
+		// This pool intentionally never sets spec.osImageStream (setting it alongside an
+		// osImageURL override is a separate, mutually-exclusive configuration error -- see
+		// assertMCPHasNoOSImageStream below), so it inherits its default stream from the
+		// worker pool, which falls back to the cluster's OSImageStream default when unset.
+		//
+		// A single MachineConfig pins the pool to RHCOS 9 via osImageURL first, then that
+		// same MachineConfig is updated in place -- not deleted and recreated -- to point at
+		// the RHEL 10 stream image. Using one MachineConfig for both steps avoids MCO's
+		// alphabetical "last MC wins" merge behavior that would otherwise apply if two
+		// separate osImageURL MachineConfigs briefly coexisted.
+		//
+		// MCO only treats osImageURL as a genuine override -- and only then runs the
+		// osImageURL stream-class-inspection guard (OCPNODE-4518) -- when it differs from
+		// the pool's resolved osImageStream default. On a rhel-10-default cluster, pointing
+		// osImageURL directly at the rhel-10 stream image would be indistinguishable from
+		// that default and silently fall through to the pre-existing osImageStream-based
+		// guard instead, which would not actually exercise this guard. To guarantee a
+		// genuine override on any cluster, the RHEL 10 image is re-imported into an
+		// in-cluster ImageStream (importOSImageToInternalRegistry) and that mirrored pull
+		// spec -- textually distinct from the upstream OSImageStream pull spec, but the
+		// identical image by digest -- is used as the osImageURL instead.
+		testPoolName = runcRHCOS10URLGuardPool
+		cleanupCRCName = runcURLGuardCRCName
+
+		g.By("Creating custom MachineConfigPool without osImageStream")
+		o.Expect(createOSImageURLUpgradeMCP(ctx, mcClient, runcRHCOS10URLGuardPool)).To(o.Succeed())
+
+		g.By("Pinning pool to RHCOS 9 via a single MachineConfig osImageURL")
+		rhel9Image, err := osImageFromStream(ctx, mcClient, streamRHEL9)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(createPoolOSImageURLMachineConfig(ctx, mcClient, runcURLGuardMCName, runcRHCOS10URLGuardPool, rhel9Image)).To(o.Succeed())
+		cleanupURLGuardMC = true
+
+		g.By("Labeling one worker into the custom pool")
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10URLGuardPool)
+		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
+
+		g.By("Waiting for pool rollout on RHCOS 9")
+		o.Expect(waitForMCPWithLabeledNode(ctx, oc, mcClient, runcRHCOS10URLGuardPool, nodeName, 45*time.Minute)).To(o.Succeed(),
+			"node did not join custom MCP on RHCOS 9")
+		o.Expect(waitForNodeRHELMajorVersion(ctx, oc, nodeName, "9", 10*time.Minute)).To(o.Succeed(),
+			"node should be on RHCOS 9 before configuring runc")
+
+		g.By("Creating runc ContainerRuntimeConfig for the custom pool")
+		// Snapshot the currently-rolled-out rendered config before creating the CRC: checking
+		// only Updated/machine-count immediately afterward can spuriously report "ready" using
+		// the pool's still-steady pre-CRC status, before the render controller has regenerated a
+		// new rendered config for the CRC. waitForPoolConfigRollout requires the node to actually
+		// converge onto a different rendered config than this snapshot.
+		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		priorRenderedConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
+		o.Expect(priorRenderedConfig).NotTo(o.BeEmpty(), "node should have a stable rendered config before configuring runc")
+
+		o.Expect(createRuncGuardCRC(ctx, mcClient, runcRHCOS10URLGuardPool, runcURLGuardCRCName)).To(o.Succeed())
+		o.Expect(waitForPoolConfigRollout(ctx, oc, mcClient, runcRHCOS10URLGuardPool, nodeName, priorRenderedConfig, 30*time.Minute)).To(o.Succeed(),
+			"pool did not roll out runc ContainerRuntimeConfig")
+
+		g.By("Checking default runtime is runc on RHCOS 9")
+		o.Expect(waitForRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed())
+		rhelMajor, err := nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "pool should be on RHCOS 9 before attempting rhel-10 osImageURL override")
+
+		g.By("Verifying MCP does not set osImageStream (required for osImageURL override path)")
+		o.Expect(assertMCPHasNoOSImageStream(ctx, mcClient, runcRHCOS10URLGuardPool)).To(o.Succeed())
+
+		g.By("Updating the same MachineConfig's osImageURL to target RHCOS 10 via a mirrored, guaranteed-override pull spec")
+		rhel10Image, err := osImageFromStream(ctx, mcClient, streamRHEL10)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		mirroredRHEL10Image, err := importOSImageToInternalRegistry(ctx, oc, rhel10Image, runcURLGuardImageStream)
+		// Set before asserting err: the ImageStream may have been created even if the import
+		// later failed (e.g. while inspecting import status), so cleanup should still run.
+		cleanupURLGuardIS = true
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(updateMachineConfigOSImageURL(ctx, mcClient, runcURLGuardMCName, mirroredRHEL10Image)).To(o.Succeed())
+		o.Expect(waitForMCPRenderDegraded(ctx, mcClient, runcRHCOS10URLGuardPool, 10*time.Minute)).To(o.Succeed())
+
+		g.By("Verifying cluster upgrade is blocked via CO and CVO Upgradeable=False")
+		o.Expect(waitForUpgradeBlockedByDegradedPool(ctx, oc)).To(o.Succeed())
+
+		g.By("Verifying node remains ready, not rolling out, on RHCOS 9 with runc after guard blocks rollout")
+		o.Expect(assertNodeReadyAndNotRollingOut(ctx, oc, nodeName)).To(o.Succeed())
+		rhelMajor, err = nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "node should remain on RHCOS 9 after guard blocks osImageURL rollout")
+		o.Expect(waitForRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed(),
+			"node should keep runc as default runtime after guard blocks osImageURL rollout")
+
+		g.By("Recovering pool by reverting MachineConfig osImageURL back to RHCOS 9")
+		o.Expect(updateMachineConfigOSImageURL(ctx, mcClient, runcURLGuardMCName, rhel9Image)).To(o.Succeed())
+		o.Expect(WaitForMCP(ctx, mcClient, runcRHCOS10URLGuardPool, 10*time.Minute, WaitMCPAllowDegraded())).To(o.Succeed())
+
+		g.By("Verifying cluster upgradeability recovers after pool returns to RHCOS 9")
+		// MCO may take up to ~30 minutes to propagate Upgradeable after RenderDegraded clears.
+		o.Expect(waitForClusterUpgradeable(ctx, oc, 30*time.Minute)).To(o.Succeed())
+
+		g.By("Verifying node remains ready, not rolling out, on RHCOS 9 with runc after recovery")
+		o.Expect(assertNodeReadyAndNotRollingOut(ctx, oc, nodeName)).To(o.Succeed())
+		rhelMajor, err = nodeRHELMajorVersion(ctx, oc, nodeName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(rhelMajor).To(o.Equal("9"), "node should remain on RHCOS 9 after recovery")
+		o.Expect(waitForRuncRuntimeOnNode(ctx, oc, nodeName, 2*time.Minute)).To(o.Succeed(),
+			"node should keep runc as default runtime after recovery")
+	})
+
 	g.AfterEach(func(ctx context.Context) {
 		// Do not use Expect here; a failed assertion would skip subsequent cleanup steps.
 		if nodeName != "" && testPoolName != "" {
@@ -211,9 +332,19 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 				framework.Logf("cleanup: failed to remove node label %s from %s: %v", roleLabel, nodeName, err)
 			}
 		}
-		if cleanupCRC {
-			if err := deleteContainerRuntimeConfig(ctx, mcClient, runcGuardCRCName); err != nil {
-				framework.Logf("cleanup: failed to delete ContainerRuntimeConfig %s: %v", runcGuardCRCName, err)
+		if cleanupCRCName != "" {
+			if err := deleteContainerRuntimeConfig(ctx, mcClient, cleanupCRCName); err != nil {
+				framework.Logf("cleanup: failed to delete ContainerRuntimeConfig %s: %v", cleanupCRCName, err)
+			}
+		}
+		if cleanupURLGuardMC {
+			if err := deleteMachineConfig(ctx, mcClient, runcURLGuardMCName); err != nil {
+				framework.Logf("cleanup: failed to delete MachineConfig %s: %v", runcURLGuardMCName, err)
+			}
+		}
+		if cleanupURLGuardIS {
+			if err := deleteImageStream(ctx, oc, "openshift", runcURLGuardImageStream); err != nil {
+				framework.Logf("cleanup: failed to delete ImageStream openshift/%s: %v", runcURLGuardImageStream, err)
 			}
 		}
 		if nodeName != "" && testPoolName != "" {
@@ -493,22 +624,22 @@ func createRuncGuardPool(ctx context.Context, mcClient *machineconfigclient.Clie
 	if err := createRuncGuardMCP(ctx, mcClient); err != nil {
 		return err
 	}
-	return createRuncGuardCRC(ctx, mcClient)
+	return createRuncGuardCRC(ctx, mcClient, runcRHCOS10GuardPool, runcGuardCRCName)
 }
 
 func createRuncGuardMCP(ctx context.Context, mcClient *machineconfigclient.Clientset) error {
 	return createRHEL9UpgradeMCP(ctx, mcClient, runcRHCOS10GuardPool)
 }
 
-func createRuncGuardCRC(ctx context.Context, mcClient *machineconfigclient.Clientset) error {
+func createRuncGuardCRC(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName, crcName string) error {
 	crc := &machineconfigv1.ContainerRuntimeConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: runcGuardCRCName,
+			Name: crcName,
 		},
 		Spec: machineconfigv1.ContainerRuntimeConfigSpec{
 			MachineConfigPoolSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					poolOperatorLabel(runcRHCOS10GuardPool): "",
+					poolOperatorLabel(poolName): "",
 				},
 			},
 			ContainerRuntimeConfig: &machineconfigv1.ContainerRuntimeConfiguration{
@@ -657,9 +788,7 @@ func waitForMCPRenderDegraded(ctx context.Context, mcClient *machineconfigclient
 
 		// The runc guard is enforced in the render controller; RenderDegraded is the
 		// authoritative signal. Degraded may propagate later via the node controller.
-		if renderDegraded &&
-			strings.Contains(renderMessage, "runc") &&
-			strings.Contains(renderMessage, streamRHEL10) {
+		if renderDegraded && strings.Contains(renderMessage, runcRHEL10GuardMessage) {
 			framework.Logf("MCP %s render degraded as expected: %s", poolName, renderMessage)
 			return true, nil
 		}
@@ -668,6 +797,18 @@ func waitForMCPRenderDegraded(ctx context.Context, mcClient *machineconfigclient
 			poolName, renderDegraded, renderMessage)
 		return false, nil
 	})
+}
+
+func assertMCPHasNoOSImageStream(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string) error {
+	mcp, err := mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, poolName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if mcp.Spec.OSImageStream.Name != "" {
+		return fmt.Errorf("MachineConfigPool %s must not set spec.osImageStream when testing osImageURL override (got %q); osImageURL and osImageStream are mutually exclusive",
+			poolName, mcp.Spec.OSImageStream.Name)
+	}
+	return nil
 }
 
 func hasRuncRuntimeOnNode(ctx context.Context, oc *exutil.CLI, nodeName string) (bool, error) {
@@ -751,14 +892,16 @@ func isTransientNodeDebugError(err error) bool {
 		strings.Contains(msg, "node is not ready")
 }
 
-// waitForPoolConfigRolloutAfterCRCRemoval waits for MCO to re-render the pool without the CRC and
-// roll the new config out to the labeled node. MCP can report ready with the old rendered config
-// briefly after CRC deletion; node annotations are the authoritative rollout signal.
-func waitForPoolConfigRolloutAfterCRCRemoval(ctx context.Context, oc *exutil.CLI, mcClient *machineconfigclient.Clientset, poolName, nodeName, priorRenderedConfig string, timeout time.Duration) error {
+// waitForPoolConfigRollout waits for a pool to converge onto a newly rendered config that
+// differs from priorRenderedConfig, rather than just checking Updated/machine-count, which can
+// spuriously report "ready" immediately after a config-source change (e.g. adding/removing a
+// ContainerRuntimeConfig) if the render controller has not yet regenerated a new rendered
+// config. Node annotations are the authoritative rollout signal.
+func waitForPoolConfigRollout(ctx context.Context, oc *exutil.CLI, mcClient *machineconfigclient.Clientset, poolName, nodeName, priorRenderedConfig string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		node, err := oc.AdminKubeClient().CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			return false, fmt.Errorf("node %s was removed from the cluster during pool re-render after CRC removal", nodeName)
+			return false, fmt.Errorf("node %s was removed from the cluster during pool config rollout", nodeName)
 		}
 		if err != nil {
 			return false, err
@@ -773,10 +916,10 @@ func waitForPoolConfigRolloutAfterCRCRemoval(ctx context.Context, oc *exutil.CLI
 		}
 		updated, degraded, renderDegraded, updating := mcpPoolConditions(mcp)
 		if degraded {
-			return false, fmt.Errorf("MachineConfigPool %s is degraded during post-CRC rollout", poolName)
+			return false, fmt.Errorf("MachineConfigPool %s is degraded during pool config rollout", poolName)
 		}
 		if renderDegraded {
-			return false, fmt.Errorf("MachineConfigPool %s render is degraded during post-CRC rollout", poolName)
+			return false, fmt.Errorf("MachineConfigPool %s render is degraded during pool config rollout", poolName)
 		}
 
 		poolReady := !updating && updated &&
@@ -786,11 +929,11 @@ func waitForPoolConfigRolloutAfterCRCRemoval(ctx context.Context, oc *exutil.CLI
 		synced := currentConfig != "" && currentConfig == desiredConfig
 
 		if poolReady && rerendered && synced {
-			framework.Logf("Node %s rolled out post-CRC rendered config %s (was %s)", nodeName, currentConfig, priorRenderedConfig)
+			framework.Logf("Node %s rolled out new rendered config %s (was %s)", nodeName, currentConfig, priorRenderedConfig)
 			return true, nil
 		}
 
-		framework.Logf("Node %s waiting for post-CRC pool rollout: current=%q desired=%q prior=%q poolReady=%v updating=%v",
+		framework.Logf("Node %s waiting for pool config rollout: current=%q desired=%q prior=%q poolReady=%v updating=%v",
 			nodeName, currentConfig, desiredConfig, priorRenderedConfig, poolReady, updating)
 		return false, nil
 	})
@@ -911,6 +1054,152 @@ func deleteMachineConfigPool(ctx context.Context, mcClient *machineconfigclient.
 		return nil
 	}
 	return err
+}
+
+func deleteMachineConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, name string) error {
+	err := mcClient.MachineconfigurationV1().MachineConfigs().Delete(ctx, name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func createOSImageURLUpgradeMCP(ctx context.Context, mcClient *machineconfigclient.Clientset, poolName string) error {
+	mcp := &machineconfigv1.MachineConfigPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: poolName,
+			Labels: map[string]string{
+				poolOperatorLabel(poolName): "",
+			},
+		},
+		Spec: machineconfigv1.MachineConfigPoolSpec{
+			// Do not set OSImageStream here. osImageURL override on a pool MachineConfig is
+			// mutually exclusive with MCP spec.osImageStream; setting both fails render with a
+			// conflict error, not the runc-on-RHEL-10 guard.
+			MachineConfigSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{{
+					Key:      machineconfigv1.MachineConfigRoleLabelKey,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"worker", poolName},
+				}},
+			},
+			NodeSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					poolNodeRoleLabel(poolName): "",
+				},
+			},
+		},
+	}
+	_, err := mcClient.MachineconfigurationV1().MachineConfigPools().Create(ctx, mcp, metav1.CreateOptions{})
+	return err
+}
+
+func osImageFromStream(ctx context.Context, mcClient *machineconfigclient.Clientset, streamName string) (string, error) {
+	osi, err := mcClient.MachineconfigurationV1().OSImageStreams().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, stream := range osi.Status.AvailableStreams {
+		if stream.Name == streamName {
+			if stream.OSImage == "" {
+				return "", fmt.Errorf("OSImageStream stream %q has empty osImage", streamName)
+			}
+			return string(stream.OSImage), nil
+		}
+	}
+	return "", fmt.Errorf("OSImageStream does not contain stream %q", streamName)
+}
+
+// importOSImageToInternalRegistry imports sourceImage into a fresh ImageStream named isName in
+// the openshift namespace via ImageStreamImport, and returns a pull spec through the cluster's
+// internal registry (e.g. image-registry.openshift-image-registry.svc:5000/openshift/<isName>@sha256:...)
+// that resolves to the identical image by digest but is textually distinct from sourceImage.
+// ImageStreamImport only fetches image manifest/config metadata, not the full image layers, so
+// this is fast even for multi-GB OS images.
+func importOSImageToInternalRegistry(ctx context.Context, oc *exutil.CLI, sourceImage, isName string) (string, error) {
+	isi := &imagev1.ImageStreamImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      isName,
+			Namespace: "openshift",
+		},
+		Spec: imagev1.ImageStreamImportSpec{
+			Import: true,
+			Images: []imagev1.ImageImportSpec{{
+				From: corev1.ObjectReference{
+					Kind: "DockerImage",
+					Name: sourceImage,
+				},
+				To: &corev1.LocalObjectReference{Name: "latest"},
+			}},
+		},
+	}
+
+	result, err := oc.AdminImageClient().ImageV1().ImageStreamImports(isi.Namespace).Create(ctx, isi, metav1.CreateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to create ImageStreamImport openshift/%s for %s: %w", isName, sourceImage, err)
+	}
+	if len(result.Status.Images) == 0 {
+		return "", fmt.Errorf("ImageStreamImport openshift/%s returned no image import status", isName)
+	}
+	imgStatus := result.Status.Images[0]
+	if imgStatus.Status.Status != metav1.StatusSuccess {
+		return "", fmt.Errorf("failed to import %s into ImageStream openshift/%s: %s", sourceImage, isName, imgStatus.Status.Message)
+	}
+	if imgStatus.Image == nil {
+		return "", fmt.Errorf("ImageStreamImport openshift/%s succeeded but returned no image metadata", isName)
+	}
+	if result.Status.Import == nil || result.Status.Import.Status.DockerImageRepository == "" {
+		return "", fmt.Errorf("ImageStream openshift/%s has no internal registry repository after import", isName)
+	}
+
+	mirrored := fmt.Sprintf("%s@%s", result.Status.Import.Status.DockerImageRepository, imgStatus.Image.Name)
+	framework.Logf("Imported %s into ImageStream openshift/%s as %s", sourceImage, isName, mirrored)
+	return mirrored, nil
+}
+
+func deleteImageStream(ctx context.Context, oc *exutil.CLI, namespace, isName string) error {
+	err := oc.AdminImageClient().ImageV1().ImageStreams(namespace).Delete(ctx, isName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func createPoolOSImageURLMachineConfig(ctx context.Context, mcClient *machineconfigclient.Clientset, mcName, poolName, osImageURL string) error {
+	mc := &machineconfigv1.MachineConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: mcName,
+			Labels: map[string]string{
+				machineconfigv1.MachineConfigRoleLabelKey: poolName,
+			},
+		},
+		Spec: machineconfigv1.MachineConfigSpec{
+			OSImageURL: osImageURL,
+			Config:     minimalIgnitionConfig(),
+		},
+	}
+	_, err := mcClient.MachineconfigurationV1().MachineConfigs().Create(ctx, mc, metav1.CreateOptions{})
+	return err
+}
+
+// updateMachineConfigOSImageURL patches an existing MachineConfig's osImageURL in place.
+// Reusing a single MachineConfig object (rather than deleting one osImageURL MC and
+// creating another) avoids MCO's alphabetical "last MC wins" merge behavior, which would
+// otherwise apply if two separate osImageURL-setting MachineConfigs briefly coexisted.
+func updateMachineConfigOSImageURL(ctx context.Context, mcClient *machineconfigclient.Clientset, mcName, osImageURL string) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		mc, err := mcClient.MachineconfigurationV1().MachineConfigs().Get(ctx, mcName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		mc.Spec.OSImageURL = osImageURL
+		_, err = mcClient.MachineconfigurationV1().MachineConfigs().Update(ctx, mc, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+func minimalIgnitionConfig() runtime.RawExtension {
+	return runtime.RawExtension{Raw: []byte(`{"ignition":{"version":"3.4.0"}}`)}
 }
 
 func createCrunUpgradeMCP(ctx context.Context, mcClient *machineconfigclient.Clientset) error {

--- a/test/extended/node/runc_upgrade_cases.md
+++ b/test/extended/node/runc_upgrade_cases.md
@@ -8,6 +8,9 @@ E2e coverage for MCO behavior when a `MachineConfigPool` moves from `rhel-9` to
 - **UC6A (guard):** runc via `ContainerRuntimeConfig` → blocked with `RenderDegraded`
 - **UC5/UC14 (happy path):** crun default runtime → upgrade succeeds
 
+A separate e2e in the same suite covers the **osImageURL** guard path (OCPNODE-4518);
+see below — that is **not** UC6A.
+
 ## Test Environment
 
 - OpenShift 5.0–5.3 (dual stream cluster)
@@ -44,6 +47,23 @@ cd origin && make WHAT=cmd/openshift-tests
   "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard allows RHCOS 9 to 10 osImageStream upgrade when default runtime is crun"
 ```
 
+### osImageURL guard (OCPNODE-4518) — separate from UC6A
+
+- **Case:** `blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime`
+- MCP must **not** set `spec.osImageStream` — if both `osImageURL` and `osImageStream` are set, render fails with `cannot override MachineConfig osImageURL and set MachineConfigPool spec.osImageStream.name simultaneously` (configuration conflict, **not** the runc guard)
+- Expected guard `RenderDegraded` message contains `targets a RHEL 10 OS image where runc is not available`
+- **Single MachineConfig, updated in place.** A single MachineConfig is created with `osImageURL` pointing at the `rhel-9` stream image to pin the pool, then that same MachineConfig object is updated (not deleted/recreated) to point at the `rhel-10` stream image. Reusing one MachineConfig avoids MCO's alphabetical "last MC wins" merge behavior that would otherwise apply if two separate `osImageURL` MachineConfigs briefly coexisted.
+- **Runs on any cluster `OSImageStream` default — no skip.** On a `rhel-9`-default cluster the update is a genuine override and exercises the `osImageURL` stream-class-inspection guard (OCPNODE-4518) directly. On a `rhel-10`-default cluster, MCO resolves the updated `osImageURL` as identical to the pool's already-resolved default and falls through to the pre-existing `osImageStream`-based guard instead. Both guards raise the same `RenderDegraded` message and produce identical observable blocking behavior, which is what this test actually asserts, so the scenario runs end-to-end either way.
+- Requires MCO with osImageURL stream-class inspection (OCPNODE-4518 / MCO #6238)
+
+Run:
+
+```bash
+cd origin && make WHAT=cmd/openshift-tests
+./openshift-tests run-test \
+  "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime"
+```
+
 Suggested CI: `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-disruptive-longrunning-techpreview-1of2` (with MCO payload)
 
 ## Notes
@@ -52,10 +72,13 @@ Suggested CI: `periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-disruptive
 - CO/CVO `Degraded=True` can take ~30 minutes on a stuck pool; the test asserts
   `Upgradeable=False` within 5 minutes and recovers before delayed Degraded propagation.
 - Typical runtime: UC6A ~15–30 minutes (optional RHCOS 10 recovery on 5.0 clusters); UC5/UC14 ~15–30 minutes (includes node reboot onto RHCOS 10).
-- MCP is pinned to `rhel-9` at creation so it does not inherit cluster default `rhel-10`.
+- UC6A MCP is pinned to `rhel-9` at creation so it does not inherit cluster default `rhel-10`.
+- osImageURL guard MCP omits `spec.osImageStream` entirely (do not pin `rhel-9` on the pool — that conflicts with `osImageURL`). It is instead pinned to `rhel-9` via a MachineConfig `osImageURL`, which is later updated in place to `rhel-10` to trigger the guard.
 - Runtime is configured via **ContainerRuntimeConfig** (supported path), not a hand-crafted MC drop-in.
+- After applying a CRC (or any config-source change) to an already-steady pool, wait via `waitForPoolConfigRollout` (which requires the node's rendered config to actually change) rather than a plain Updated/machine-count check — the latter can report "ready" using the stale pre-change status before the render controller regenerates a new rendered config.
 
 ## References
 
 - [openshift/enhancements#2032](https://github.com/openshift/enhancements/blob/master/enhancements/machine-config/block-runc-on-rhcos10-upgrade.md)
 - [OCPSTRAT-3154](https://issues.redhat.com/browse/OCPSTRAT-3154) — runc deprecation warning (separate)
+- [OCPNODE-4518](https://issues.redhat.com/browse/OCPNODE-4518) — osImageURL guard (separate from UC6A stream path)


### PR DESCRIPTION
**Summary**

This PR adds disruptive e2e coverage for the osImageURL runc-on-RHEL-10 guard ([OCPNODE-4518](https://issues.redhat.com/browse/OCPNODE-4518) / MCO stream-class inspection), in the existing runc RHCOS 10 upgrade guard suite alongside the osImageStream cases.

The new test verifies that when a pool uses runc via ContainerRuntimeConfig and targets RHCOS 10 through a MachineConfig osImageURL override (with no MachineConfigPool.spec.osImageStream), MCO blocks at render time (RenderDegraded), sets cluster upgradeability to Upgradeable=False, and leaves the node on RHCOS 9 with runc.

**Key design points:**

- MCP omits osImageStream entirely — osImageURL and osImageStream on the same pool are mutually exclusive and produce a different render error, not the runc guard.
- Guard assertion matches MCO’s message: targets a RHEL 10 OS image where runc is not available; fails fast if the stream+URL conflict message appears instead.
- On clusters whose OSImageStream default is rhel-10, the test temporarily pins RHCOS 9 via a baseline osImageURL MC, removes it, then applies the RHEL 10 URL so only one user URL MC is active at guard time.

**Output**
Ran locally and it passed:
```
./openshift-tests run-test \
  "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime"
  Running Suite:  - /Users/asahay/rhcos/origin
  ============================================
  Random Seed: 1786428557 - will randomize all specs

  Will run 1 of 1 specs
  ------------------------------
  [Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime [Lifecycle:informing]
  github.com/openshift/origin/test/extended/node/runc_upgrade_cases.go:220
    STEP: Creating a kubernetes client @ 08/11/26 11:39:22.74
    .........................................................................
  Ran 1 of 1 Specs in 649.087 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
[
  {
    "name": "[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime",
    "lifecycle": "informing",
    "duration": 649087,
    "startTime": "2026-08-11 06:09:22.718089 UTC",
    "endTime": "2026-08-11 06:20:11.805103 UTC",
    "result": "passed",
    "output": "  STEP:
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for RHEL 9-to-10 upgrades using a custom OS image URL with `runc`.
  * Verifies conflicting image settings are rejected, rendering enters the expected degraded state, upgrades are blocked, and nodes remain stable without unintended rollouts.
  * Added validation for runtime configuration, recovery, rollout behavior, and cleanup of temporary upgrade settings.

* **Documentation**
  * Documented the upgrade scenario, configuration constraints, expected behavior, rollout considerations, and distinction from related coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->