### PR TITLE
CNTRLPLANE-3789: images: Add squid image used in CAO e2e tests

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -76,6 +76,9 @@ var (
 
 		// used by cluster-image-registry-operator e2e tests (S3/Minio endpoint test)
 		"quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z": -1,
+
+		// used by cluster-authentication-operator e2e tests (Authentication proxy)
+		"registry.redhat.io/rhel10/squid:10.2-1784702318": -1,
 	}
 )
 

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -51,5 +51,6 @@ registry.k8s.io/sig-storage/hostpathplugin:v1.17.1 quay.io/openshift/community-e
 registry.k8s.io/sig-storage/livenessprobe:v2.18.0 quay.io/openshift/community-e2e-images:e2e-33-registry-k8s-io-sig-storage-livenessprobe-v2-18-0-4jPBr4ceyZgd2qR7
 registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8 quay.io/openshift/community-e2e-images:e2e-14-registry-k8s-io-sig-storage-nfs-provisioner-v4-0-8-W5pbwDbNliDm1x4k
 registry.k8s.io/sig-storage/volume-data-source-validator:v1.0.0 quay.io/openshift/community-e2e-images:e2e-29-registry-k8s-io-sig-storage-volume-data-source-validator-v1-0-0-pJwTeQGTDmAV8753
+registry.redhat.io/rhel10/squid:10.2-1784702318 quay.io/openshift/community-e2e-images:e2e-registry-redhat-io-rhel10-squid-10-2-1784702318-xaA8NbKhmNRam1k2
 registry.k8s.io/e2e-test-images/jessie-dnsutils:1.7 quay.io/openshift/community-e2e-images:e2e-11-registry-k8s-io-e2e-test-images-jessie-dnsutils-1-7-bJ-yvCS2MUBlnXm1
 registry.k8s.io/e2e-test-images/nginx:1.14-4 quay.io/openshift/community-e2e-images:e2e-15-registry-k8s-io-e2e-test-images-nginx-1-14-4-20h7A1tgJp0m0c1_


### PR DESCRIPTION
The tests themselves are gonna be OTE tests hosted in the CAO repository, so this is the only change needed in origin.

This is needed to be able to run the tests in a disconnected environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an approved authentication proxy container image for end-to-end test validation.
  * Expanded the set of container images recognized during image lookup and pull-spec checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->