### PR TITLE
OCPBUGS-84491: Remove openshift-ingress terminationMessagePolicy exemption

### DIFF
--- a/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
+++ b/pkg/monitortests/clusterversionoperator/terminationmessagepolicy/monitortest.go
@@ -144,10 +144,6 @@ func (w *terminationMessagePolicyChecker) CollectData(ctx context.Context, stora
 		"openshift-deployment-validation-operator": sets.NewString("pods/deployment-validation-operator"), // filed OCPBUGS-84523 to fix
 		"openshift-etcd":    sets.NewString("pods/master-1ostesttestmetalkubeorg-debug"), // filed OCPBUGS-84514 to fix
 		"openshift-frr-k8s": sets.NewString("pods/frr-k8s"),                              // filed OCPBUGS-84524 to fix
-		"openshift-ingress": sets.NewString( // filed OCPBUGS-84491 to fix
-			"pods/gateway",
-			"pods/istiod-openshift-gateway",
-		),
 		"openshift-insights": sets.NewString( // filed OCPBUGS-84515 to fix
 			"pods/insights-runtime-extractor",
 			"pods/periodic-gathering",


### PR DESCRIPTION
## Summary
- Removes the `openshift-ingress` namespace exemption from the `terminationMessagePolicy` monitor test
- The upstream fix ([istio/istio#60102](https://github.com/istio/istio/pull/60102)) adding `terminationMessagePolicy=FallbackToLogsOnError` to the istiod pilot container has been cherry-picked into downstream [openshift-service-mesh/istio release-1.30.1](https://github.com/openshift-service-mesh/istio/commit/25c524ce093c592e8e945cf2532d0f2e8b4b7da0) (commit 25c524c), fixing the `pods/istiod-openshift-gateway` violation
- The Gateway API proxy containers (`pods/gateway`) were fixed in [openshift/cluster-ingress-operator#1428](https://github.com/openshift/cluster-ingress-operator/pull/1428)
- With both fixes in place, the exemption for `openshift-ingress` is no longer needed

## Test plan
- [ ] Verify CI passes without the exemption (the `[sig-arch] all containers in ns/openshift-ingress must have terminationMessagePolicy=FallbackToLogsOnError` test should now pass instead of flaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)