### PR TITLE
OCPBUGS-99916: exclude openshift-debug-* namespaces from best-effort QoS invariant

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -80,6 +80,16 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 			if pod.Namespace == node.DebugNamespace && isEphemeralDebugPod(&pod) {
 				continue
 			}
+			// Exclude ephemeral oc debug pods in transient openshift-debug-*
+			// namespaces. `oc debug node/<node>` run without an explicit
+			// namespace creates a temporary namespace named
+			// openshift-debug-<random> for the debug pod (e.g. the
+			// [sig-auth][Feature:SecurityPenetration] tests do this while the
+			// parallel conformance suite runs). These are not control-plane
+			// workloads and are best-effort QoS by design. OCPBUGS-99916
+			if strings.HasPrefix(pod.Namespace, "openshift-debug-") && isEphemeralDebugPod(&pod) {
+				continue
+			}
 			if pod.Status.QOSClass == v1.PodQOSBestEffort {
 				invalidPodQoS.Insert(fmt.Sprintf("%s/%s is running in best-effort QoS", pod.Namespace, pod.Name))
 			}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OCPBUGS-99916 (mirror: https://redhat.atlassian.net/browse/OCPBUGS-99916)

`oc debug node/<node>` run without an explicit namespace creates a transient `openshift-debug-<random>` namespace for its debug pod. These pods have no resource requests/limits and are best-effort QoS **by design** — they are not control-plane workloads.

The `[sig-auth][Feature:SecurityPenetration]` tests (baremetal-gated) run `oc debug node/master-0` repeatedly during the parallel conformance suite. When the `[sig-arch] Managed cluster should ensure control plane pods do not run in best-effort QoS` invariant scan races with one of these pods, it fails:

```
fail [github.com/openshift/origin/test/extended/operators/qos.go:89]:
1 pods found in best-effort QoS:
openshift-debug-9m92k/master-0-debug-fl67x is running in best-effort QoS
```

Audit logs confirm causality: the flagged pod was created by `system:admin` via `oc/5.0.0` at 14:03:02, and the invariant test failed at 14:03:04 ([prow run 2079493268545998848](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-e2e-metal-ipi-ovn-upgrade-rhcos9-10-techpreview/2079493268545998848), Component Readiness regression 44948, [triage 658](https://sippy-auth.dptools.openshift.org/sippy-ng/component_readiness/triages/658)).

The test already excludes ephemeral debug pods in `node.DebugNamespace` (`openshift-machine-config-operator`); this PR extends the same `isEphemeralDebugPod` exclusion to pods in transient `openshift-debug-*` namespaces.

---
**AI-generated content:** This PR was created by AI as part of Component Readiness triage duty. Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated managed-cluster QoS validation to correctly exclude temporary debug pods.
  * Prevents transient debug workloads from being incorrectly flagged during best-effort QoS checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->