### PR TITLE
OCPBUGS-100045: Add openshift/disruptive-longrunning testsuite in release-4.19

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -450,4 +450,21 @@ var staticSuites = []ginkgo.TestSuite{
 		TestTimeout:                120 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
+	{
+		Name: "openshift/disruptive-longrunning",
+		Description: templates.LongDesc(`
+		Long-running disruptive test suite. Tests in this suite are disruptive (cause node reboots,
+		configuration changes, or cluster-wide disruptions) and take significant time to complete.
+		Multiple teams can use this suite for their long-running disruptive tests.
+		`),
+		Matches: func(name string) bool {
+			if isDisabled(name) {
+				return false
+			}
+			return strings.Contains(name, "[Suite:openshift/disruptive-longrunning")
+		},
+		Parallelism:                1,
+		TestTimeout:                40 * time.Minute,
+		ClusterStabilityDuringTest: ginkgo.Disruptive,
+	},
 }


### PR DESCRIPTION
## Cherry-pick of [#31334](https://github.com/openshift/origin/pull/31334) (release-4.20) to release-4.19

### What
Add the `openshift/disruptive-longrunning` test suite definition to `pkg/testsuites/standard_suites.go` on the `release-4.19` branch, enabling long-running disruptive tests to run on 4.19.

### Why
The `disruptive-longrunning` suite was added to `main`, `release-4.21`, and `release-4.20` but is missing in `release-4.19`. Adding it allows payload jobs to run long-running disruptive tests on 4.19 nightly builds.

### Implementation Note
The suite definition uses the `Matches` function pattern (4.19 style) instead of `Qualifiers` string slices (4.20+ style), as the `TestSuite` struct in `release-4.19` does not have the `Qualifiers` field. The matching logic is functionally identical.

### Changes
- `pkg/testsuites/standard_suites.go`: Added `openshift/disruptive-longrunning` suite definition with:
  - Serial execution (`Parallelism: 1`)
  - 40-minute test timeout
  - Disruptive cluster stability setting
  - Matches tests containing `[Suite:openshift/disruptive-longrunning`

### Related PRs
| Release | Origin PR | Release PR | Jira |
|---------|-----------|------------|------|
| main | [#30648](https://github.com/openshift/origin/pull/30648) | — | — |
| 4.21 | [#30976](https://github.com/openshift/origin/pull/30976) | [#77488](https://github.com/openshift/release/pull/77488) | OCPBUGS-81638 |
| 4.20 | [#31334](https://github.com/openshift/origin/pull/31334) | [#80958](https://github.com/openshift/release/pull/80958) | OCPBUGS-91996 |
| **4.19** | **This PR** | TBD | **OCPBUGS-100045** |

### Verification
- `go build ./pkg/testsuites/...` passes
- `gofmt` clean
- `go generate` produces no diff (no tests tagged with this suite in 4.19 yet)
