### PR TITLE
NO-ISSUE: Skip additional storage support E2E test for on single-node - MCP rollouts timeout

### DIFF
--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -23,7 +23,12 @@ import (
 
 // Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
 // and run in the disruptive-longrunning suite.
-var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+//
+// [Skipped:SingleReplicaTopology] - MCP rollouts don't work reliably on single-node
+// clusters due to context deadline timeouts. The test creates a custom MCP which
+// triggers node drains, but single-node cannot drain its only control plane node
+// without bringing down the cluster.
+var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("additional-storage-e2e")


### PR DESCRIPTION
Skip additional storage support E2E test for on single-node - MCP rollouts timeout  
MCP rollouts don't work reliably on single-node clusters. The test creates a custom MCP which triggers node drains, but single-node cannot drain its only control plane node without bringing down the cluster (context deadline exceeded).
  
Added `[Skipped:SingleReplicaTopology]` tag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the Additional Storage end-to-end test suite to skip automatically in single-replica environments.
  * Documented limitations related to MCP rollout timeouts and node-drain operations on single-node clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->