### PR TITLE
NO-JIRA: Update minio image to use source with all supported architectures

### DIFF
--- a/test/extended/util/image/image.go
+++ b/test/extended/util/image/image.go
@@ -74,11 +74,11 @@ var (
 		// used by artifact volume tests
 		"quay.io/crio/artifact:subpath": -1,
 
-		// used by cluster-image-registry-operator e2e tests (S3/Minio endpoint test)
-		"quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z": -1,
-
 		// used by cluster-authentication-operator e2e tests (Authentication proxy)
 		"registry.redhat.io/rhel10/squid:10.2-1784702318": -1,
+
+		// used by cluster-image-registry-operator e2e tests (S3/Minio endpoint test)
+		"quay.io/openshifttest/minio:latest": -1,
 	}
 )
 

--- a/test/extended/util/image/zz_generated.txt
+++ b/test/extended/util/image/zz_generated.txt
@@ -4,9 +4,9 @@ quay.io/crio/artifact:subpath quay.io/openshift/community-e2e-images:e2e-quay-io
 quay.io/crio/zstd-chunked:2 quay.io/openshift/community-e2e-images:e2e-quay-io-crio-zstd-chunked-2-8Uf42eAKe3YN2nwu
 quay.io/keycloak/keycloak:25.0 quay.io/openshift/community-e2e-images:e2e-quay-io-keycloak-keycloak-25-0-rEIw9B2Zcc3L1M6k
 quay.io/kubevirt/fedora-with-test-tooling-container-disk:20241024_891122a6fc quay.io/openshift/community-e2e-images:e2e-quay-io-kubevirt-fedora-with-test-tooling-container-disk-20241024_891122a6fc-IycYTh-87XrXse4E
-quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z quay.io/openshift/community-e2e-images:e2e-quay-io-minio-minio-RELEASE-2025-09-07T16-13-09Z-vEhi3VtwtVplkeun
 quay.io/olmtest/webhook-operator:v0.0.5 quay.io/openshift/community-e2e-images:e2e-quay-io-olmtest-webhook-operator-v0-0-5--2OhUsk-Xv-pLaTI
 quay.io/openshifttest/ldap:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-ldap-1-2-O3f5zPgtmWzEtasv
+quay.io/openshifttest/minio:latest quay.io/openshift/community-e2e-images:e2e-quay-io-openshifttest-minio-latest-p_yqYDk9rEgphwXT
 quay.io/redhat-developer/nfs-server:1.1 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-nfs-server-1-1-dlXGfzrk5aNo8EjC
 quay.io/redhat-developer/test-build-roots2i:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-test-build-roots2i-1-2-gLJ7WcnS2TSllJ32
 quay.io/redhat-developer/test-build-simples2i:1.2 quay.io/openshift/community-e2e-images:e2e-quay-io-redhat-developer-test-build-simples2i-1-2-thirLMR-JKplfkmE


### PR DESCRIPTION
* [quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z](http://quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z) - is the image we originally added in github.com/openshift/origin/pull/31241. However, since that image doesn't publish all architecture variants in its manifest list, ] we later created a custom image, [quay.io/openshifttest/minio:latest](http://quay.io/openshifttest/minio:latest) , which includes all supported architectures.
* However, https://github.com/openshift/origin/blob/main/test/extended/util/image/image.go#L78 still point to the first image - this isn't right and is causing problems when 
[quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z](http://quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z) [quay.io/openshift/community-e2e-images:e2e-quay-io-minio-minio-RELEASE-2025-09-07T16-13-09Z-vEhi3VtwtVplkeun](http://quay.io/openshift/community-e2e-images:e2e-quay-io-minio-minio-RELEASE-2025-09-07T16-13-09Z-vEhi3VtwtVplkeun)  is re-mirrored, since the mirrored image will again be based on the first source image, which is missing some architecture variants.
* Update minio image to use the correct source [quay.io/openshifttest/minio:latest](http://quay.io/openshifttest/minio:latest) with all supported architectures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the permitted MinIO test image reference to support the latest test environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->