### PR TITLE
OCPBUGS-98719: retry GetVotingMemberNames on transient etcd client fails

### DIFF
--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -447,6 +447,7 @@ func EnsureUpdatedReplicasOnCPMS(ctx context.Context, t TestingT, expectedCount 
 func GetVotingMemberNames(ctx context.Context, t TestingT, etcdClientFactory EtcdClientCreator) ([]string, error) {
 	waitPollInterval := 15 * time.Second
 	waitPollTimeout := 10 * time.Minute
+	memberListTimeout := 15 * time.Second
 	var votingMemberNames []string
 
 	framework.Logf("Waiting up to %s to get current voting etcd member names", waitPollTimeout.String())
@@ -458,7 +459,7 @@ func GetVotingMemberNames(ctx context.Context, t TestingT, etcdClientFactory Etc
 		}
 		defer closeFn()
 
-		memberCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		memberCtx, cancel := context.WithTimeout(ctx, memberListTimeout)
 		defer cancel()
 		memberList, err := etcdClient.MemberList(memberCtx)
 		if err != nil {

--- a/test/extended/etcd/helpers/helpers.go
+++ b/test/extended/etcd/helpers/helpers.go
@@ -442,29 +442,43 @@ func EnsureUpdatedReplicasOnCPMS(ctx context.Context, t TestingT, expectedCount 
 	})
 }
 
-// GetVotingMemberNames returns the list of current voting etcd member names
+// GetVotingMemberNames returns the list of current voting etcd member names.
+// It retries transient etcd client failures (e.g. port-forward errors while etcd is restarting).
 func GetVotingMemberNames(ctx context.Context, t TestingT, etcdClientFactory EtcdClientCreator) ([]string, error) {
-	etcdClient, closeFn, err := etcdClientFactory.NewEtcdClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get etcd client: %w", err)
-	}
-	defer closeFn()
-
-	memberCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	memberList, err := etcdClient.MemberList(memberCtx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the member list: %w", err)
-	}
-
+	waitPollInterval := 15 * time.Second
+	waitPollTimeout := 10 * time.Minute
 	var votingMemberNames []string
-	for _, member := range memberList.Members {
-		if !member.IsLearner {
-			votingMemberNames = append(votingMemberNames, member.Name)
-		}
-	}
 
-	framework.Logf("Current voting etcd members: %v", votingMemberNames)
+	framework.Logf("Waiting up to %s to get current voting etcd member names", waitPollTimeout.String())
+	err := wait.PollUntilContextTimeout(ctx, waitPollInterval, waitPollTimeout, true, func(ctx context.Context) (done bool, err error) {
+		etcdClient, closeFn, err := etcdClientFactory.NewEtcdClient()
+		if err != nil {
+			framework.Logf("failed to get etcd client, will retry, err: %v", err)
+			return false, nil
+		}
+		defer closeFn()
+
+		memberCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		memberList, err := etcdClient.MemberList(memberCtx)
+		if err != nil {
+			framework.Logf("failed to get the member list, will retry, err: %v", err)
+			return false, nil
+		}
+
+		votingMemberNames = nil
+		for _, member := range memberList.Members {
+			if !member.IsLearner {
+				votingMemberNames = append(votingMemberNames, member.Name)
+			}
+		}
+
+		framework.Logf("Current voting etcd members: %v", votingMemberNames)
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get voting member names: %w", err)
+	}
 	return votingMemberNames, nil
 }
 


### PR DESCRIPTION
`GetVotingMemberNames` previously failed immediately when `NewEtcdClient` or `MemberList` errored, which is flaky during master replacement while etcd is restarting and port-forwards drop.
Poll and retry those transient errors instead of failing the CPMS OnDelete scaling test on the first attempt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving etcd voting member information during transient connection failures or restarts.
  * Added polling and retry behavior so temporary port-forward or client errors no longer cause immediate failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->