### PR TITLE
CORENET-6714: Adding netobserv namespace exception for prometheus endpoint auth

### DIFF
--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -84,6 +84,8 @@ var _ = g.Describe("[sig-instrumentation][Late] Platform Prometheus targets", fu
 		namespacesToSkip := []string{
 			"openshift-image-registry",           // https://issues.redhat.com/browse/OCPBUGS-59767
 			"openshift-cluster-samples-operator", // https://issues.redhat.com/browse/OCPBUGS-59769
+			"netobserv",                          // https://redhat.atlassian.net/browse/NETOBSERV-2877
+			"netobserv-privileged",               // https://redhat.atlassian.net/browse/NETOBSERV-2877
 		}
 
 		expectedStatusCodes := []int{http.StatusUnauthorized, http.StatusForbidden}


### PR DESCRIPTION
Network Observability operator is GA itself for some years now and is part of the RH catalog but is not part of the payload.

We have been working on enabling it by default. To do this we have agreed to have the CNO create the ClusterExtension object which will trigger an OLM install.

Having Network observability installed by default triggered a lot of tests and requirements linked to payload elements which Network Observability is not. (We still have to investigate some of them because we are not sure if this is appropriate to annotate the Network Observability component with payload associated annotations.)

For some of them not deploying to an openshift- cluster was enough to not trigger them, and we have aggreed to come back to them before going GA for this feature.

The last ones are linked to the metric endpoints of some of the components, for now this components have network policies and we support enabling TLS but we do not support authentication.

I am asking if we could add exception to this authentication rule while this feature is still in techpreview to no block the release of the techpreview of this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Prometheus authentication coverage to account for additional monitoring namespaces during access checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->