### PR TITLE
OCPNODE-4470: Add DRA consumable capacity e2e tests

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/openshift/origin/test/extended/machines"
 	_ "github.com/openshift/origin/test/extended/networking"
 	_ "github.com/openshift/origin/test/extended/node"
+	_ "github.com/openshift/origin/test/extended/node/dra/consumable"
 	_ "github.com/openshift/origin/test/extended/node/dra/example"
 	_ "github.com/openshift/origin/test/extended/node/dra/nvidia"
 	_ "github.com/openshift/origin/test/extended/node/dra/partitionable"

--- a/test/extended/node/dra/common/capacity_validator.go
+++ b/test/extended/node/dra/common/capacity_validator.go
@@ -1,0 +1,207 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// CapacityValidator provides helpers for validating consumable capacity
+// structures on DRA devices — per-device Capacity maps, AllowMultipleAllocations,
+// RequestPolicy, and ConsumedCapacity in allocation results.
+type CapacityValidator struct {
+	client     kubernetes.Interface
+	driverName string
+}
+
+func NewCapacityValidator(client kubernetes.Interface, driverName string) *CapacityValidator {
+	return &CapacityValidator{
+		client:     client,
+		driverName: driverName,
+	}
+}
+
+func (cv *CapacityValidator) listOptions() metav1.ListOptions {
+	return metav1.ListOptions{
+		FieldSelector: resourceapi.ResourceSliceSelectorDriver + "=" + cv.driverName,
+	}
+}
+
+// HasCapacityDevices reports whether the driver publishes devices with non-empty
+// Capacity maps.  It returns the result and any API error so callers can
+// distinguish "no devices yet" from "cannot list ResourceSlices".
+func (cv *CapacityValidator) HasCapacityDevices(ctx context.Context) (bool, error) {
+	count, err := cv.GetTotalDeviceCount(ctx)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// ValidateDeviceCapacity verifies that every device published by the driver has
+// the expected capacity entries with non-zero values and a RequestPolicy set.
+func (cv *CapacityValidator) ValidateDeviceCapacity(ctx context.Context, expectedCapacities []string) error {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
+	if err != nil {
+		return fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+
+	deviceCount := 0
+	for _, slice := range sliceList.Items {
+		for _, device := range slice.Spec.Devices {
+			if len(device.Capacity) == 0 {
+				continue
+			}
+			deviceCount++
+			for _, name := range expectedCapacities {
+				cap, exists := device.Capacity[resourceapi.QualifiedName(name)]
+				if !exists {
+					return fmt.Errorf("device %s in slice %s missing capacity %q", device.Name, slice.Name, name)
+				}
+				if cap.Value.IsZero() {
+					return fmt.Errorf("device %s capacity %q has zero value", device.Name, name)
+				}
+				if cap.RequestPolicy == nil {
+					return fmt.Errorf("device %s capacity %q has no RequestPolicy", device.Name, name)
+				}
+				framework.Logf("Device %s: %s=%s (has RequestPolicy)", device.Name, name, cap.Value.String())
+			}
+		}
+	}
+
+	if deviceCount == 0 {
+		return fmt.Errorf("no devices with Capacity found for driver %s", cv.driverName)
+	}
+	framework.Logf("Validated capacity across %d device(s) for driver %s", deviceCount, cv.driverName)
+	return nil
+}
+
+// ValidateAllowMultipleAllocations verifies that every device published by the
+// driver has AllowMultipleAllocations set to true.
+func (cv *CapacityValidator) ValidateAllowMultipleAllocations(ctx context.Context) error {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
+	if err != nil {
+		return fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+
+	deviceCount := 0
+	for _, slice := range sliceList.Items {
+		for _, device := range slice.Spec.Devices {
+			if len(device.Capacity) == 0 {
+				continue
+			}
+			deviceCount++
+			if device.AllowMultipleAllocations == nil || !*device.AllowMultipleAllocations {
+				return fmt.Errorf("device %s in slice %s does not have AllowMultipleAllocations=true", device.Name, slice.Name)
+			}
+		}
+	}
+
+	if deviceCount == 0 {
+		return fmt.Errorf("no devices with Capacity found for driver %s", cv.driverName)
+	}
+	framework.Logf("Validated AllowMultipleAllocations=true on %d device(s)", deviceCount)
+	return nil
+}
+
+// ValidateConsumedCapacity verifies that the allocation result for a ResourceClaim
+// has ConsumedCapacity entries for each of the expected capacity names.
+func (cv *CapacityValidator) ValidateConsumedCapacity(ctx context.Context, namespace, claimName string, expectedCapacities []string) error {
+	claim, err := cv.client.ResourceV1().ResourceClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get ResourceClaim %s/%s: %w", namespace, claimName, err)
+	}
+	if claim.Status.Allocation == nil {
+		return fmt.Errorf("ResourceClaim %s/%s is not allocated", namespace, claimName)
+	}
+
+	if len(claim.Status.Allocation.Devices.Results) == 0 {
+		return fmt.Errorf("ResourceClaim %s/%s has no device results in allocation", namespace, claimName)
+	}
+
+	for i, result := range claim.Status.Allocation.Devices.Results {
+		if len(result.ConsumedCapacity) == 0 {
+			return fmt.Errorf("device result %d (%s) has no ConsumedCapacity", i, result.Device)
+		}
+		for _, name := range expectedCapacities {
+			qty, exists := result.ConsumedCapacity[resourceapi.QualifiedName(name)]
+			if !exists {
+				return fmt.Errorf("device result %d (%s) missing ConsumedCapacity for %q", i, result.Device, name)
+			}
+			if qty.IsZero() {
+				return fmt.Errorf("device result %d (%s) ConsumedCapacity %q is zero", i, result.Device, name)
+			}
+			framework.Logf("Device result %d (%s): ConsumedCapacity[%s]=%s", i, result.Device, name, qty.String())
+		}
+	}
+	return nil
+}
+
+// GetNodeWithDevices returns the name of a schedulable worker node where the
+// driver is publishing devices with capacity. Avoids master/control-plane nodes.
+func (cv *CapacityValidator) GetNodeWithDevices(ctx context.Context) (string, error) {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
+	if err != nil {
+		return "", fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+
+	nodeList, err := cv.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	taintedNodes := make(map[string]bool)
+	for _, node := range nodeList.Items {
+		for _, taint := range node.Spec.Taints {
+			if taint.Effect == corev1.TaintEffectNoSchedule || taint.Effect == corev1.TaintEffectNoExecute {
+				taintedNodes[node.Name] = true
+				break
+			}
+		}
+	}
+
+	for _, slice := range sliceList.Items {
+		if slice.Spec.NodeName == nil || *slice.Spec.NodeName == "" {
+			continue
+		}
+		hasCapacityDevices := false
+		for _, device := range slice.Spec.Devices {
+			if len(device.Capacity) > 0 {
+				hasCapacityDevices = true
+				break
+			}
+		}
+		if !hasCapacityDevices {
+			continue
+		}
+
+		name := *slice.Spec.NodeName
+		if !taintedNodes[name] {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no untainted node found publishing capacity devices for driver %s", cv.driverName)
+}
+
+// GetTotalDeviceCount returns the total number of devices with capacity
+// published by the driver.
+func (cv *CapacityValidator) GetTotalDeviceCount(ctx context.Context) (int, error) {
+	sliceList, err := cv.client.ResourceV1().ResourceSlices().List(ctx, cv.listOptions())
+	if err != nil {
+		return 0, fmt.Errorf("failed to list ResourceSlices: %w", err)
+	}
+	count := 0
+	for _, slice := range sliceList.Items {
+		for _, device := range slice.Spec.Devices {
+			if len(device.Capacity) > 0 {
+				count++
+			}
+		}
+	}
+	return count, nil
+}

--- a/test/extended/node/dra/common/crud_helpers.go
+++ b/test/extended/node/dra/common/crud_helpers.go
@@ -2,9 +2,13 @@ package common
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -39,4 +43,49 @@ func CreateResourceClaimTemplate(ctx context.Context, client kubernetes.Interfac
 // DeleteResourceClaimTemplate deletes a ResourceClaimTemplate
 func DeleteResourceClaimTemplate(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
 	return client.ResourceV1().ResourceClaimTemplates(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// DeleteResourceClaimAndWait deletes a ResourceClaim and polls until it is
+// gone.  This is important in Ordered Ginkgo contexts where later specs depend
+// on capacity being fully released before they run.
+func DeleteResourceClaimAndWait(ctx context.Context, client kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	if err := client.ResourceV1().ResourceClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.ResourceV1().ResourceClaims(namespace).Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("error waiting for ResourceClaim %s/%s deletion: %w", namespace, name, err)
+		}
+		return false, nil
+	})
+}
+
+// DeletePodAndWait deletes a Pod with a short grace period and polls until it
+// is gone.  Mirrors DeleteResourceClaimAndWait for Ordered contexts where
+// capacity must be fully released between specs.
+func DeletePodAndWait(ctx context.Context, client kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	gracePeriod := int64(10)
+	if err := client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	return wait.PollUntilContextTimeout(ctx, 1*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, fmt.Errorf("error waiting for Pod %s/%s deletion: %w", namespace, name, err)
+		}
+		return false, nil
+	})
 }

--- a/test/extended/node/dra/common/resource_builder.go
+++ b/test/extended/node/dra/common/resource_builder.go
@@ -5,6 +5,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
@@ -80,6 +81,21 @@ func (rb *ResourceBuilder) BuildResourceClaim(name, deviceClassName string, coun
 			},
 		},
 	}
+}
+
+// BuildResourceClaimWithCapacity creates a ResourceClaim with capacity requests.
+// Each entry in capacityRequests maps a capacity name (e.g. "ingressBandwidth")
+// to a quantity string (e.g. "10G").
+func (rb *ResourceBuilder) BuildResourceClaimWithCapacity(name, deviceClassName string, count int, capacityRequests map[string]string) *resourceapi.ResourceClaim {
+	claim := rb.BuildResourceClaim(name, deviceClassName, count)
+	requests := make(map[resourceapi.QualifiedName]resource.Quantity, len(capacityRequests))
+	for k, v := range capacityRequests {
+		requests[resourceapi.QualifiedName(k)] = resource.MustParse(v)
+	}
+	claim.Spec.Devices.Requests[0].Exactly.Capacity = &resourceapi.CapacityRequirements{
+		Requests: requests,
+	}
+	return claim
 }
 
 // BuildPodWithClaim creates a Pod that uses a ResourceClaim

--- a/test/extended/node/dra/consumable/consumable_dra.go
+++ b/test/extended/node/dra/consumable/consumable_dra.go
@@ -135,6 +135,9 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 		})
 
 		g.AfterAll(func(ctx context.Context) {
+			if prereqInstaller == nil {
+				return
+			}
 			framework.Logf("Restoring DRA example driver to default gpu profile")
 			err := prereqInstaller.HelmUpgrade(ctx,
 				"deviceProfile=gpu",
@@ -200,7 +203,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumeClaim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumeClaimName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaimAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), consumeClaimName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), consumeClaimName, delErr)
 				}
 			}()
@@ -211,7 +214,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			consumePod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, consumePod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumePodName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), consumePodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), consumePodName, delErr)
 				}
 			}()
@@ -232,7 +235,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaimName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaimAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaimName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), overflowClaimName, delErr)
 				}
 			}()
@@ -243,7 +246,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			overflowPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, overflowPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), overflowPodName, delErr)
 				}
 			}()
@@ -279,7 +282,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitClaim)
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitClaimName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeleteResourceClaimAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), fitClaimName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), fitClaimName, delErr)
 				}
 			}()
@@ -290,7 +293,7 @@ var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:opensh
 			fitPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, fitPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitPodName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), fitPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), fitPodName, delErr)
 				}
 			}()

--- a/test/extended/node/dra/consumable/consumable_dra.go
+++ b/test/extended/node/dra/consumable/consumable_dra.go
@@ -1,0 +1,310 @@
+package consumable
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	nodeutils "github.com/openshift/origin/test/extended/node"
+	dracommon "github.com/openshift/origin/test/extended/node/dra/common"
+	draexample "github.com/openshift/origin/test/extended/node/dra/example"
+	exutil "github.com/openshift/origin/test/extended/util"
+	"github.com/openshift/origin/test/extended/util/image"
+)
+
+const (
+	netDriverName  = "net.example.com"
+	netDeviceClass = "net.example.com"
+
+	// numNICs is the number of NIC devices per node. Kept low so the
+	// capacity-exhaustion test can deterministically consume all bandwidth
+	// without requiring an excessive number of claims.
+	numNICs = 2
+)
+
+var (
+	prerequisitesOnce      sync.Once
+	prerequisitesInstalled bool
+	prerequisitesError     error
+	cachedInstaller        *draexample.PrerequisitesInstaller
+)
+
+var _ = g.Describe("[sig-scheduling][Feature:DRAConsumableCapacity][Suite:openshift/dra-example][Serial][Skipped:Disconnected]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("dra-consumable", admissionapi.LevelPrivileged)
+
+	var (
+		prereqInstaller   *draexample.PrerequisitesInstaller
+		capacityValidator *dracommon.CapacityValidator
+		builder           *dracommon.ResourceBuilder
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		builder = dracommon.NewResourceBuilder(oc.Namespace(), dracommon.DriverConfig{
+			DriverName:       netDriverName,
+			DefaultClass:     netDeviceClass,
+			RequestName:      "nic",
+			ContainerImage:   image.ShellImage(),
+			ContainerCommand: []string{"sh", "-c", "echo DRA NIC device allocated && sleep infinity"},
+			LongRunCommand:   []string{"sh", "-c", "while true; do echo DRA NIC active; sleep 60; done"},
+		})
+	})
+
+	g.Context("Consumable Capacity", g.Ordered, func() {
+		var targetNodeName string
+
+		g.BeforeAll(func(ctx context.Context) {
+			nodeutils.SkipOnMicroShift(oc)
+
+			capacityValidator = dracommon.NewCapacityValidator(oc.KubeFramework().ClientSet, netDriverName)
+			if cachedInstaller == nil {
+				cachedInstaller = draexample.NewPrerequisitesInstaller(oc.KubeFramework())
+			}
+			prereqInstaller = cachedInstaller
+
+			prerequisitesOnce.Do(func() {
+				framework.Logf("Checking DRA example driver prerequisites for consumable capacity tests")
+
+				if prereqInstaller.IsDriverInstalled(ctx) {
+					framework.Logf("DRA example driver already installed")
+					prerequisitesInstalled = true
+					return
+				}
+
+				framework.Logf("Installing DRA example driver...")
+				if err := prereqInstaller.InstallAll(ctx); err != nil {
+					prerequisitesError = err
+					framework.Logf("ERROR: Failed to install DRA example driver: %v", err)
+					return
+				}
+
+				prerequisitesInstalled = true
+				framework.Logf("DRA example driver installation completed successfully")
+			})
+
+			if prerequisitesError != nil {
+				if stderrors.Is(prerequisitesError, draexample.ErrToolingUnavailable) {
+					g.Skip(fmt.Sprintf("Required tooling unavailable: %v", prerequisitesError))
+				}
+				g.Fail(fmt.Sprintf("DRA example driver prerequisites failed: %v", prerequisitesError))
+			}
+			if !prerequisitesInstalled {
+				g.Fail("DRA example driver prerequisites not installed")
+			}
+
+			framework.Logf("Upgrading DRA example driver to net profile with numDevices=%d", numNICs)
+			err := prereqInstaller.HelmUpgrade(ctx,
+				"deviceProfile=net",
+				fmt.Sprintf("kubeletPlugin.numDevices=%d", numNICs),
+			)
+			framework.ExpectNoError(err, "Failed to helm upgrade driver to net profile")
+
+			framework.Logf("Waiting for driver to stabilize after upgrade...")
+			err = prereqInstaller.WaitForDriver(ctx, 5*time.Minute)
+			framework.ExpectNoError(err, "Driver failed to stabilize after helm upgrade")
+
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
+				return capacityValidator.HasCapacityDevices(ctx)
+			})
+			if err != nil {
+				if wait.Interrupted(err) {
+					g.Skip("DRAConsumableCapacity not available — no devices with Capacity published after upgrade")
+				}
+				framework.Failf("Failed to check for capacity devices: %v", err)
+			}
+
+			framework.Logf("Capacity devices detected — DRAConsumableCapacity is active")
+
+			targetNodeName, err = capacityValidator.GetNodeWithDevices(ctx)
+			framework.ExpectNoError(err, "Failed to find a node with published devices")
+			framework.Logf("Using node %s for consumable capacity tests", targetNodeName)
+		})
+
+		g.AfterAll(func(ctx context.Context) {
+			framework.Logf("Restoring DRA example driver to default gpu profile")
+			err := prereqInstaller.HelmUpgrade(ctx,
+				"deviceProfile=gpu",
+				"kubeletPlugin.numDevices=8",
+			)
+			if err != nil {
+				framework.Logf("Warning: failed to restore driver to default mode: %v", err)
+				return
+			}
+			if waitErr := prereqInstaller.WaitForDriver(ctx, 5*time.Minute); waitErr != nil {
+				framework.Logf("Warning: driver did not stabilize after restore: %v", waitErr)
+			}
+		})
+
+		g.It("should publish ResourceSlices with device Capacity and AllowMultipleAllocations", func(ctx context.Context) {
+			g.By("Validating device capacity entries")
+			err := capacityValidator.ValidateDeviceCapacity(ctx, []string{"ingressBandwidth", "egressBandwidth", "vfs"})
+			framework.ExpectNoError(err, "Device capacity validation failed")
+
+			g.By("Validating AllowMultipleAllocations is set on all devices")
+			err = capacityValidator.ValidateAllowMultipleAllocations(ctx)
+			framework.ExpectNoError(err, "AllowMultipleAllocations validation failed")
+
+			g.By("Verifying NIC device count")
+			count, err := capacityValidator.GetTotalDeviceCount(ctx)
+			framework.ExpectNoError(err, "Failed to count capacity devices")
+			o.Expect(count).To(o.BeNumerically(">", 0),
+				"Expected capacity devices after switching to net profile")
+			framework.Logf("Found %d NIC device(s) with capacity across all nodes", count)
+		})
+
+		g.It("should reject a request exceeding remaining capacity while accepting one that fits", func(ctx context.Context) {
+			nodeName := targetNodeName
+
+			deviceClassName := "test-consumable-partial-" + oc.Namespace()
+			consumeClaimName := "test-partial-consume-claim"
+			overflowClaimName := "test-partial-overflow-claim"
+			fitClaimName := "test-partial-fit-claim"
+			consumePodName := "test-partial-consume-pod"
+			overflowPodName := "test-partial-overflow-pod"
+			fitPodName := "test-partial-fit-pod"
+
+			g.By("Creating DeviceClass")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := dracommon.CreateDeviceClass(ctx, oc.KubeFramework().ClientSet, deviceClass)
+			framework.ExpectNoError(err)
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+				defer cancel()
+				if delErr := dracommon.DeleteDeviceClass(cleanupCtx, oc.KubeFramework().ClientSet, deviceClassName); delErr != nil {
+					framework.Logf("Warning: failed to delete DeviceClass %s: %v", deviceClassName, delErr)
+				}
+			}()
+
+			// Each NIC has 100G bandwidth. Consuming 90G on each of the 2
+			// NICs leaves 10G free per NIC. A 15G request cannot fit on any
+			// NIC, while a 10G request fits exactly.
+			g.By(fmt.Sprintf("Creating ResourceClaim requesting %d NICs with 90G bandwidth to partially exhaust capacity", numNICs))
+			consumeClaim := builder.BuildResourceClaimWithCapacity(consumeClaimName, deviceClassName, numNICs, map[string]string{
+				"ingressBandwidth": "90G",
+				"egressBandwidth":  "90G",
+			})
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumeClaim)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumeClaimName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), consumeClaimName, delErr)
+				}
+			}()
+
+			g.By("Creating pod pinned to target node to consume 90G per NIC")
+			consumePod := builder.BuildLongRunningPodWithClaim(consumePodName, consumeClaimName, "")
+			consumePod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+			consumePod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, consumePod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), consumePodName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), consumePodName, delErr)
+				}
+			}()
+
+			g.By("Waiting for consumption pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, consumePod)
+			framework.ExpectNoError(err, "Consumption pod failed to start")
+
+			g.By("Validating 90G bandwidth was consumed")
+			err = capacityValidator.ValidateConsumedCapacity(ctx, oc.Namespace(), consumeClaimName, []string{"ingressBandwidth", "egressBandwidth"})
+			framework.ExpectNoError(err)
+
+			g.By("Creating overflow claim requesting 15G — exceeds remaining 10G on every NIC")
+			overflowClaim := builder.BuildResourceClaimWithCapacity(overflowClaimName, deviceClassName, 1, map[string]string{
+				"ingressBandwidth": "15G",
+				"egressBandwidth":  "15G",
+			})
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaim)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowClaimName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), overflowClaimName, delErr)
+				}
+			}()
+
+			g.By("Creating overflow pod pinned to same node — should be unschedulable")
+			overflowPod := builder.BuildPodWithClaim(overflowPodName, overflowClaimName, "")
+			overflowPod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+			overflowPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, overflowPod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), overflowPodName, delErr)
+				}
+			}()
+
+			g.By("Verifying 15G overflow pod stays Pending with DRA-related Unschedulable condition")
+			err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+				p, getErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, overflowPodName, metav1.GetOptions{})
+				if getErr != nil {
+					return false, getErr
+				}
+				if p.Status.Phase != corev1.PodPending {
+					return false, fmt.Errorf("expected overflow pod to stay Pending but got %s", p.Status.Phase)
+				}
+				for _, cond := range p.Status.Conditions {
+					if cond.Type == corev1.PodScheduled && cond.Status == corev1.ConditionFalse {
+						msg := strings.ToLower(cond.Message)
+						if strings.Contains(msg, "claim") || strings.Contains(msg, "insufficient") || strings.Contains(msg, "unresolvable") {
+							framework.Logf("15G overflow pod correctly unschedulable: %s", cond.Message)
+							return true, nil
+						}
+					}
+				}
+				framework.Logf("Overflow pod is Pending but no DRA-related Unschedulable condition yet")
+				return false, nil
+			})
+			framework.ExpectNoError(err, "15G request should be unschedulable when only 10G remains per NIC")
+
+			g.By("Creating fit claim requesting 10G — fits within remaining capacity")
+			fitClaim := builder.BuildResourceClaimWithCapacity(fitClaimName, deviceClassName, 1, map[string]string{
+				"ingressBandwidth": "10G",
+				"egressBandwidth":  "10G",
+			})
+			err = dracommon.CreateResourceClaim(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitClaim)
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeleteResourceClaimAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitClaimName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete ResourceClaim %s/%s: %v", oc.Namespace(), fitClaimName, delErr)
+				}
+			}()
+
+			g.By("Creating fit pod pinned to same node — should succeed")
+			fitPod := builder.BuildPodWithClaim(fitPodName, fitClaimName, "")
+			fitPod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": nodeName}
+			fitPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, fitPod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer func() {
+				if delErr := dracommon.DeletePodAndWait(ctx, oc.KubeFramework().ClientSet, oc.Namespace(), fitPodName, 1*time.Minute); delErr != nil {
+					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), fitPodName, delErr)
+				}
+			}()
+
+			g.By("Waiting for 10G fit pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, fitPod)
+			framework.ExpectNoError(err, "10G request should succeed when 10G remains per NIC — fine-grained accounting may be broken")
+
+			g.By("Validating ConsumedCapacity on the fit allocation")
+			err = capacityValidator.ValidateConsumedCapacity(ctx, oc.Namespace(), fitClaimName, []string{"ingressBandwidth", "egressBandwidth"})
+			framework.ExpectNoError(err, "ConsumedCapacity validation failed on 10G fit allocation")
+
+			framework.Logf("Partial exhaustion validated: 15G rejected, 10G accepted with 10G remaining per NIC")
+		})
+
+	})
+})

--- a/test/extended/node/dra/example/prerequisites_installer.go
+++ b/test/extended/node/dra/example/prerequisites_installer.go
@@ -2,6 +2,7 @@ package example
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,6 +29,10 @@ const (
 	helmChartRelPath = "deployments/helm/dra-example-driver"
 )
 
+// ErrToolingUnavailable indicates that a required CLI tool (helm, git) is not
+// installed or not functional on the test runner.
+var ErrToolingUnavailable = stderrors.New("required tooling unavailable")
+
 // PrerequisitesInstaller manages dra-example-driver installation and cleanup
 type PrerequisitesInstaller struct {
 	client    kubernetes.Interface
@@ -47,8 +52,8 @@ func NewPrerequisitesInstaller(f *framework.Framework) *PrerequisitesInstaller {
 func (pi *PrerequisitesInstaller) InstallAll(ctx context.Context) error {
 	framework.Logf("=== Installing DRA Example Driver Prerequisites ===")
 
-	if err := pi.ensureHelm(ctx); err != nil {
-		return fmt.Errorf("helm not available: %w", err)
+	if err := pi.ensureTooling(ctx); err != nil {
+		return fmt.Errorf("required tooling not available: %w", err)
 	}
 
 	if pi.IsDriverInstalled(ctx) {
@@ -88,18 +93,18 @@ func (pi *PrerequisitesInstaller) InstallAll(ctx context.Context) error {
 	return nil
 }
 
-func (pi *PrerequisitesInstaller) ensureHelm(ctx context.Context) error {
+func (pi *PrerequisitesInstaller) ensureTooling(ctx context.Context) error {
 	cmd := exec.CommandContext(ctx, "helm", "version", "--short")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("helm command not found or failed: %w\nOutput: %s", err, string(output))
+		return fmt.Errorf("%w: helm: %w\nOutput: %s", ErrToolingUnavailable, err, string(output))
 	}
 	framework.Logf("Helm version: %s", strings.TrimSpace(string(output)))
 
 	gitCmd := exec.CommandContext(ctx, "git", "version")
 	gitOutput, gitErr := gitCmd.CombinedOutput()
 	if gitErr != nil {
-		return fmt.Errorf("git command not found or failed: %w\nOutput: %s", gitErr, string(gitOutput))
+		return fmt.Errorf("%w: git: %w\nOutput: %s", ErrToolingUnavailable, gitErr, string(gitOutput))
 	}
 	framework.Logf("Git version: %s", strings.TrimSpace(string(gitOutput)))
 	return nil

--- a/test/extended/node/dra/partitionable/partitionable_dra.go
+++ b/test/extended/node/dra/partitionable/partitionable_dra.go
@@ -209,9 +209,7 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Failed to create pod")
 			defer func() {
-				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
-				defer cancel()
-				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), podName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), podName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), podName, delErr)
 				}
 			}()
@@ -283,9 +281,7 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			exhaustPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, exhaustPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
-				defer cancel()
-				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), exhaustPodName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), exhaustPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), exhaustPodName, delErr)
 				}
 			}()
@@ -318,9 +314,7 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			overflowPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, overflowPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
-				defer cancel()
-				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
+				if delErr := dracommon.DeletePodAndWait(context.WithoutCancel(ctx), oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), overflowPodName, delErr)
 				}
 			}()

--- a/test/extended/node/dra/partitionable/partitionable_dra.go
+++ b/test/extended/node/dra/partitionable/partitionable_dra.go
@@ -2,6 +2,7 @@ package partitionable
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	o "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 		})
 
 		if prerequisitesError != nil {
-			if strings.Contains(prerequisitesError.Error(), "not found or failed") {
+			if stderrors.Is(prerequisitesError, draexample.ErrToolingUnavailable) {
 				g.Skip(fmt.Sprintf("Required tooling unavailable: %v", prerequisitesError))
 			}
 			g.Fail(fmt.Sprintf("DRA example driver prerequisites failed: %v", prerequisitesError))
@@ -209,7 +209,9 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
 			framework.ExpectNoError(err, "Failed to create pod")
 			defer func() {
-				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, podName, metav1.DeleteOptions{}); delErr != nil && !errors.IsNotFound(delErr) {
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+				defer cancel()
+				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), podName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), podName, delErr)
 				}
 			}()
@@ -281,8 +283,9 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			exhaustPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, exhaustPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				gracePeriod := int64(10)
-				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, exhaustPodName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); delErr != nil && !errors.IsNotFound(delErr) {
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+				defer cancel()
+				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), exhaustPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), exhaustPodName, delErr)
 				}
 			}()
@@ -315,8 +318,9 @@ var _ = g.Describe("[sig-scheduling][OCPFeatureGate:DRAPartitionableDevices][Fea
 			overflowPod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, overflowPod, metav1.CreateOptions{})
 			framework.ExpectNoError(err)
 			defer func() {
-				gracePeriod := int64(10)
-				if delErr := oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, overflowPodName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); delErr != nil && !errors.IsNotFound(delErr) {
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+				defer cancel()
+				if delErr := dracommon.DeletePodAndWait(cleanupCtx, oc.KubeFramework().ClientSet, oc.Namespace(), overflowPodName, 1*time.Minute); delErr != nil {
 					framework.Logf("Warning: failed to delete pod %s/%s: %v", oc.Namespace(), overflowPodName, delErr)
 				}
 			}()


### PR DESCRIPTION
Add DRA consumable capacity e2e tests scoped to OpenShift-specific coverage
    
    Add e2e tests for DRA consumable capacity that focus on OpenShift
    platform integration, avoiding duplication with upstream Kubernetes
    DRA e2e tests (basic allocation, multiple allocations,
    full exhaustion, and capacity release lifecycle are already covered
    upstream).
    
    The two retained tests target gaps in upstream coverage:
    - ResourceSlice structure validation: verifies the driver publishes
      correct Capacity maps, AllowMultipleAllocations, and device counts
      through OpenShift's stack (SCC, CRI-O, PSA)
    - Fine-grained partial capacity accounting: partially exhausts NIC
      bandwidth (90G/100G), verifies a 15G request is rejected while a
      10G request fitting exact remaining capacity is accepted
    
    Also adds shared test infrastructure (capacity validator, CRUD helpers,
    resource builder extensions) and updates the partitionable device tests
    and prerequisites installer for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extended end-to-end coverage for consumable device capacity.
  * Validates capacity publication, multiple allocations, capacity consumption, exhaustion, and capacity release.
  * Added support for creating resource claims with requested capacity values.
  * Added validation for device capacity, allocation behavior, schedulable nodes, and device counts.
* **Bug Fixes**
  * Improved cleanup reliability when removing test pods and resource claims.
  * Improved handling and reporting when required tooling is unavailable.
* **Tests**
  * Registered the consumable capacity test suite in the extended test package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->