### PR TITLE
OCPBUGS-100183: Always tear down upgrade tests after setup failures

### DIFF
--- a/test/extended/router/gatewayapi_upgrade.go
+++ b/test/extended/router/gatewayapi_upgrade.go
@@ -258,6 +258,11 @@ func (t *GatewayAPIUpgradeTest) validateCIOProvisioning(ctx context.Context, mig
 // Teardown cleans up Gateway API resources, Istio CR, and OSSM subscription
 // This runs even if the test fails, ensuring complete cleanup
 func (t *GatewayAPIUpgradeTest) Teardown(ctx context.Context, f *e2e.Framework) {
+	if t.oc == nil || t.gatewayName == "" {
+		e2e.Logf("Skipping Gateway API cleanup because setup did not initialize test resources")
+		return
+	}
+
 	g.By("Deleting the Gateway")
 	err := t.oc.AdminGatewayApiClient().GatewayV1().Gateways(ingressNamespace).Delete(ctx, t.gatewayName, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -177,6 +177,14 @@ type chaosMonkeyAdapter struct {
 	framework       *framework.Framework
 }
 
+func runUpgradeTest(ctx context.Context, test upgrades.Test, f *framework.Framework, ready func(), stopCh <-chan struct{}, upgradeType upgrades.UpgradeType) {
+	// upgrades.Test requires teardown to run even when setup fails.
+	defer test.Teardown(ctx, f)
+	test.Setup(ctx, f)
+	ready()
+	test.Test(ctx, f, stopCh, upgradeType)
+}
+
 func (cma *chaosMonkeyAdapter) Test(ctx context.Context, sem *chaosmonkey.Semaphore) {
 	start := time.Now()
 	var once sync.Once
@@ -198,10 +206,7 @@ func (cma *chaosMonkeyAdapter) Test(ctx context.Context, sem *chaosmonkey.Semaph
 		return
 	}
 	cma.framework.BeforeEach(ctx)
-	cma.test.Setup(ctx, cma.framework)
-	defer cma.test.Teardown(ctx, cma.framework)
-	ready()
-	cma.test.Test(ctx, cma.framework, sem.StopCh, cma.UpgradeType)
+	runUpgradeTest(ctx, cma.test, cma.framework, ready, sem.StopCh, cma.UpgradeType)
 }
 
 func finalizeTest(start time.Time, testName, className string, ts *junitapi.JUnitTestSuite, f *framework.Framework) {

--- a/test/extended/util/disruption/disruption.go
+++ b/test/extended/util/disruption/disruption.go
@@ -179,7 +179,20 @@ type chaosMonkeyAdapter struct {
 
 func runUpgradeTest(ctx context.Context, test upgrades.Test, f *framework.Framework, ready func(), stopCh <-chan struct{}, upgradeType upgrades.UpgradeType) {
 	// upgrades.Test requires teardown to run even when setup fails.
-	defer test.Teardown(ctx, f)
+	defer func() {
+		primaryPanic := recover()
+		if primaryPanic == nil {
+			test.Teardown(ctx, f)
+			return
+		}
+
+		// A teardown panic must not replace the setup or test failure.
+		defer func() {
+			_ = recover()
+			panic(primaryPanic)
+		}()
+		test.Teardown(ctx, f)
+	}()
 	test.Setup(ctx, f)
 	ready()
 	test.Test(ctx, f, stopCh, upgradeType)

--- a/test/extended/util/disruption/disruption_test.go
+++ b/test/extended/util/disruption/disruption_test.go
@@ -1,0 +1,98 @@
+package disruption
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/upgrades"
+)
+
+type recordingUpgradeTest struct {
+	calls      []string
+	setupPanic any
+	testPanic  any
+}
+
+func (t *recordingUpgradeTest) Name() string {
+	return "recording-upgrade-test"
+}
+
+func (t *recordingUpgradeTest) Setup(context.Context, *framework.Framework) {
+	t.calls = append(t.calls, "setup")
+	if t.setupPanic != nil {
+		panic(t.setupPanic)
+	}
+}
+
+func (t *recordingUpgradeTest) Test(context.Context, *framework.Framework, <-chan struct{}, upgrades.UpgradeType) {
+	t.calls = append(t.calls, "test")
+	if t.testPanic != nil {
+		panic(t.testPanic)
+	}
+}
+
+func (t *recordingUpgradeTest) Teardown(context.Context, *framework.Framework) {
+	t.calls = append(t.calls, "teardown")
+}
+
+func TestRunUpgradeTest(t *testing.T) {
+	testCases := []struct {
+		name          string
+		setupPanic    any
+		testPanic     any
+		expectedPanic any
+		expectedCalls []string
+	}{
+		{
+			name:          "successful test",
+			expectedCalls: []string{"setup", "ready", "test", "teardown"},
+		},
+		{
+			name:          "setup panic",
+			setupPanic:    "setup failed",
+			expectedPanic: "setup failed",
+			expectedCalls: []string{"setup", "teardown"},
+		},
+		{
+			name:          "test panic",
+			testPanic:     "test failed",
+			expectedPanic: "test failed",
+			expectedCalls: []string{"setup", "ready", "test", "teardown"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			upgradeTest := &recordingUpgradeTest{
+				setupPanic: testCase.setupPanic,
+				testPanic:  testCase.testPanic,
+			}
+
+			var recovered any
+			func() {
+				defer func() {
+					recovered = recover()
+				}()
+				runUpgradeTest(
+					context.Background(),
+					upgradeTest,
+					nil,
+					func() {
+						upgradeTest.calls = append(upgradeTest.calls, "ready")
+					},
+					nil,
+					upgrades.ClusterUpgrade,
+				)
+			}()
+
+			if recovered != testCase.expectedPanic {
+				t.Errorf("expected panic %v, got %v", testCase.expectedPanic, recovered)
+			}
+			if !reflect.DeepEqual(upgradeTest.calls, testCase.expectedCalls) {
+				t.Errorf("expected calls %v, got %v", testCase.expectedCalls, upgradeTest.calls)
+			}
+		})
+	}
+}

--- a/test/extended/util/disruption/disruption_test.go
+++ b/test/extended/util/disruption/disruption_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 type recordingUpgradeTest struct {
-	calls      []string
-	setupPanic any
-	testPanic  any
+	calls         []string
+	setupPanic    any
+	testPanic     any
+	teardownPanic any
 }
 
 func (t *recordingUpgradeTest) Name() string {
@@ -35,6 +36,9 @@ func (t *recordingUpgradeTest) Test(context.Context, *framework.Framework, <-cha
 
 func (t *recordingUpgradeTest) Teardown(context.Context, *framework.Framework) {
 	t.calls = append(t.calls, "teardown")
+	if t.teardownPanic != nil {
+		panic(t.teardownPanic)
+	}
 }
 
 func TestRunUpgradeTest(t *testing.T) {
@@ -42,6 +46,7 @@ func TestRunUpgradeTest(t *testing.T) {
 		name          string
 		setupPanic    any
 		testPanic     any
+		teardownPanic any
 		expectedPanic any
 		expectedCalls []string
 	}{
@@ -61,13 +66,34 @@ func TestRunUpgradeTest(t *testing.T) {
 			expectedPanic: "test failed",
 			expectedCalls: []string{"setup", "ready", "test", "teardown"},
 		},
+		{
+			name:          "teardown panic",
+			teardownPanic: "teardown failed",
+			expectedPanic: "teardown failed",
+			expectedCalls: []string{"setup", "ready", "test", "teardown"},
+		},
+		{
+			name:          "setup and teardown panic",
+			setupPanic:    "setup failed",
+			teardownPanic: "teardown failed",
+			expectedPanic: "setup failed",
+			expectedCalls: []string{"setup", "teardown"},
+		},
+		{
+			name:          "test and teardown panic",
+			testPanic:     "test failed",
+			teardownPanic: "teardown failed",
+			expectedPanic: "test failed",
+			expectedCalls: []string{"setup", "ready", "test", "teardown"},
+		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			upgradeTest := &recordingUpgradeTest{
-				setupPanic: testCase.setupPanic,
-				testPanic:  testCase.testPanic,
+				setupPanic:    testCase.setupPanic,
+				testPanic:     testCase.testPanic,
+				teardownPanic: testCase.teardownPanic,
 			}
 
 			var recovered any


### PR DESCRIPTION
These bugs and fixes were automatically generated by a payload-agent experiment to improve resilience and diagnostics for infrastructure failures. Please review the PR and either shepherd it to merge or close it. If the work is incorrect or unhelpful, a brief comment would help us improve. Thanks, and apologies if we missed the mark.

Bug: [OCPBUGS-100183](https://redhat.atlassian.net/browse/OCPBUGS-100183)

## What

- Register upgrade-test teardown before `Setup` runs.
- Add a lifecycle regression test covering successful runs and panics in both setup and test execution.
- Make the Gateway API upgrade teardown safe when its precheck fails before client/resource initialization.

## Why

`chaosMonkeyAdapter.Test` previously deferred `Teardown` only after `Setup` returned. If setup created resources and then failed—as the Gateway API connectivity check did in [this aggregated GCP upgrade run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregated-gcp-ovn-rt-upgrade-5.0-major-release-openshift-release-analysis-aggregator/2082432071682232320)—the panic skipped teardown and leaked the generated Gateway deployment into the upgrade. Registering teardown first restores the `upgrades.Test` contract while preserving the original panic.

## Testing

- `go test ./test/extended/util/disruption ./test/extended/router`
- `go vet ./test/extended/util/disruption ./test/extended/router`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling when upgrade test setup is incomplete.
  * Ensured teardown runs reliably after setup or test failures without masking the original error.

* **Tests**
  * Added coverage for successful execution, lifecycle ordering, and panic handling across upgrade test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->