### PR TITLE
OCPBUGS-63219: Remove NLB hairpin workaround from dual-stack test

### DIFF
--- a/test/extended/router/dualstack.go
+++ b/test/extended/router/dualstack.go
@@ -79,12 +79,6 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:AWSDualStackInstall][Featu
 		}()
 		o.Expect(err).NotTo(o.HaveOccurred(), "new router shard did not rollout")
 
-		g.By("Disabling client IP preservation on the NLB target group to avoid hairpin issues (OCPBUGS-63219)")
-		routerSvcName := "router-" + shardIngressCtrl.Name
-		err = oc.AsAdmin().Run("annotate").Args("service", "-n", "openshift-ingress", routerSvcName,
-			"service.beta.kubernetes.io/aws-load-balancer-target-group-attributes=preserve_client_ip.enabled=false").Execute()
-		o.Expect(err).NotTo(o.HaveOccurred())
-
 		g.By("Labelling the namespace for the shard")
 		err = oc.AsAdmin().Run("label").Args("namespace", oc.Namespace(), "type="+oc.Namespace()).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION
## Summary

Remove the manual `service.beta.kubernetes.io/aws-load-balancer-target-group-attributes=preserve_client_ip.enabled=false` annotation workaround from the dual-stack NLB e2e test.

New NLB IngressControllers now default to PROXY protocol ([openshift/cluster-ingress-operator#1426](https://github.com/openshift/cluster-ingress-operator/pull/1426)), which disables native client IP preservation and fixes hairpin connection failures without manual annotation.

**Affected test**: `[sig-network-edge][OCPFeatureGate:AWSDualStackInstall][Feature:Router] should be reachable via IPv4 and IPv6 through a dual-stack ingress controller`

## Dependencies

- openshift/cluster-ingress-operator#1426 must merge first