### PR TITLE
OCPBUGS-99921: Dump istiod logs and gateway state on GatewayAPI test failure

### DIFF
--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -224,14 +224,20 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 
 		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gateways.gateway.networking.k8s.io", "-n", ingressNamespace, "-o", "yaml").Output(); err == nil {
 			e2e.Logf("Gateways in %s:\n%s", ingressNamespace, output)
+		} else {
+			e2e.Logf("Failed to get gateways in %s: %v", ingressNamespace, err)
 		}
 
 		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployments,services", "-n", ingressNamespace, "-o", "wide").Output(); err == nil {
 			e2e.Logf("Deployments and services in %s:\n%s", ingressNamespace, output)
+		} else {
+			e2e.Logf("Failed to get deployments/services in %s: %v", ingressNamespace, err)
 		}
 
 		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gatewayclasses.gateway.networking.k8s.io", gatewayClassName, "-o", "yaml").Output(); err == nil {
 			e2e.Logf("GatewayClass %s:\n%s", gatewayClassName, output)
+		} else {
+			e2e.Logf("Failed to get GatewayClass %s: %v", gatewayClassName, err)
 		}
 	})
 

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -218,7 +218,7 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		if g.CurrentSpecReport().Failed() {
 			e2e.Logf("=== Dumping Gateway API debug info after test failure ===")
 
-			exutil.DumpPodLogsStartingWithInNamespace("istiod-", ingressNamespace, oc)
+			exutil.DumpPodLogsStartingWithInNamespace(istiodDeployment, ingressNamespace, oc)
 
 			if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gateways.gateway.networking.k8s.io", "-n", ingressNamespace, "-o", "yaml").Output(); err == nil {
 				e2e.Logf("Gateways in %s:\n%s", ingressNamespace, output)

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -214,6 +214,27 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 		o.Expect(errCheck).NotTo(o.HaveOccurred(), "GatewayClass %q does not have the CRDsReady condition", gatewayClassName)
 	})
 
+	g.JustAfterEach(func() {
+		if !g.CurrentSpecReport().Failed() {
+			return
+		}
+		e2e.Logf("=== Dumping Gateway API debug info after test failure ===")
+
+		exutil.DumpPodLogsStartingWithInNamespace("istiod-", ingressNamespace, oc)
+
+		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gateways.gateway.networking.k8s.io", "-n", ingressNamespace, "-o", "yaml").Output(); err == nil {
+			e2e.Logf("Gateways in %s:\n%s", ingressNamespace, output)
+		}
+
+		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployments,services", "-n", ingressNamespace, "-o", "wide").Output(); err == nil {
+			e2e.Logf("Deployments and services in %s:\n%s", ingressNamespace, output)
+		}
+
+		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gatewayclasses.gateway.networking.k8s.io", gatewayClassName, "-o", "yaml").Output(); err == nil {
+			e2e.Logf("GatewayClass %s:\n%s", gatewayClassName, output)
+		}
+	})
+
 	g.It("[OCPFeatureGate:GatewayAPIWithoutOLM] Ensure GatewayClass contains sail finalizer after creation", func() {
 		defer markTestDone(oc, gatewayClassFinalizer)
 

--- a/test/extended/router/gatewayapicontroller.go
+++ b/test/extended/router/gatewayapicontroller.go
@@ -215,29 +215,28 @@ var _ = g.Describe("[sig-network-edge][OCPFeatureGate:GatewayAPIController][Feat
 	})
 
 	g.JustAfterEach(func() {
-		if !g.CurrentSpecReport().Failed() {
-			return
-		}
-		e2e.Logf("=== Dumping Gateway API debug info after test failure ===")
+		if g.CurrentSpecReport().Failed() {
+			e2e.Logf("=== Dumping Gateway API debug info after test failure ===")
 
-		exutil.DumpPodLogsStartingWithInNamespace("istiod-", ingressNamespace, oc)
+			exutil.DumpPodLogsStartingWithInNamespace("istiod-", ingressNamespace, oc)
 
-		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gateways.gateway.networking.k8s.io", "-n", ingressNamespace, "-o", "yaml").Output(); err == nil {
-			e2e.Logf("Gateways in %s:\n%s", ingressNamespace, output)
-		} else {
-			e2e.Logf("Failed to get gateways in %s: %v", ingressNamespace, err)
-		}
+			if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gateways.gateway.networking.k8s.io", "-n", ingressNamespace, "-o", "yaml").Output(); err == nil {
+				e2e.Logf("Gateways in %s:\n%s", ingressNamespace, output)
+			} else {
+				e2e.Logf("Failed to get gateways in %s: %v", ingressNamespace, err)
+			}
 
-		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployments,services", "-n", ingressNamespace, "-o", "wide").Output(); err == nil {
-			e2e.Logf("Deployments and services in %s:\n%s", ingressNamespace, output)
-		} else {
-			e2e.Logf("Failed to get deployments/services in %s: %v", ingressNamespace, err)
-		}
+			if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployments,services", "-n", ingressNamespace, "-o", "wide").Output(); err == nil {
+				e2e.Logf("Deployments and services in %s:\n%s", ingressNamespace, output)
+			} else {
+				e2e.Logf("Failed to get deployments/services in %s: %v", ingressNamespace, err)
+			}
 
-		if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gatewayclasses.gateway.networking.k8s.io", gatewayClassName, "-o", "yaml").Output(); err == nil {
-			e2e.Logf("GatewayClass %s:\n%s", gatewayClassName, output)
-		} else {
-			e2e.Logf("Failed to get GatewayClass %s: %v", gatewayClassName, err)
+			if output, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("gatewayclasses.gateway.networking.k8s.io", gatewayClassName, "-o", "yaml").Output(); err == nil {
+				e2e.Logf("GatewayClass %s:\n%s", gatewayClassName, output)
+			} else {
+				e2e.Logf("Failed to get GatewayClass %s: %v", gatewayClassName, err)
+			}
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Add a `JustAfterEach` hook to the GatewayAPI controller e2e tests that captures istiod pod logs, gateway status, deployments/services, and GatewayClass status when a test fails
- This fires before AfterEach cleanup, so the istiod pod and gateway resources are still alive when diagnostics are captured
- Without this, when istiod silently fails to reconcile a Gateway (as seen in [periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn-conformance-serial #2081545455786790912](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-hypershift-release-5.0-periodics-e2e-aws-ovn-conformance-serial/2081545455786790912)), the pod gets replaced before the cluster dump runs, making root cause analysis impossible

## Test plan
- [ ] Verify the test binary compiles: `go build ./test/extended/router/`
- [ ] On a test failure, confirm istiod logs, gateway YAML, deployments/services, and GatewayClass YAML appear in the test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure diagnostics for Gateway API test runs.
  * On spec failure, the test framework now automatically captures and logs relevant Istiod logs plus detailed YAML output for key Gateway API resources (including the targeted GatewayClass), with clearer messaging when any data collection step fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->