### PR TITLE
STOR-2974: add OTE extensions for upstream e2e tests

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -214,6 +214,10 @@ var extensionBinaries = []TestBinary{
 
 	// Extensions in other payload images
 	{
+		imageTag:   "azure-disk-csi-driver",
+		binaryPath: "/usr/bin/azure-disk-csi-driver-test.gz",
+	},
+	{
 		imageTag:   "aws-machine-controllers",
 		binaryPath: "/machine-api-provider-aws-tests-ext.gz",
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the Azure Disk CSI driver extension binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->