### PR TITLE
OCPBUGS-100386: test: scope hosted etcd leader metrics by namespace

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -28,7 +28,10 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	g.It("leader changes are not excessive [Late]", func(ctx g.SpecContext) {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		etcdNamespace := "openshift-etcd"
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			_, etcdNamespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
+			o.Expect(err).NotTo(o.HaveOccurred())
 			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
 		}
 
@@ -39,11 +42,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
 		g.By("Examining the number of etcd leadership changes over the run")
-		etcdNamespace := "openshift-etcd"
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			etcdNamespace = "clusters-.*"
-		}
-		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf(`max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace=~"%s"}[%s])))`, etcdNamespace, testDuration), time.Now())
+		result, _, err := prometheus.Query(context.Background(), etcdLeaderChangesQuery(etcdNamespace, testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		vec, ok := result.(model.Vector)
@@ -68,3 +67,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		}
 	})
 })
+
+func etcdLeaderChangesQuery(namespace, testDuration string) string {
+	return fmt.Sprintf(`max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace=%q}[%s])))`, namespace, testDuration)
+}

--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -42,7 +42,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
 		g.By("Examining the number of etcd leadership changes over the run")
-		result, _, err := prometheus.Query(context.Background(), etcdLeaderChangesQuery(etcdNamespace, testDuration), time.Now())
+		result, _, err := prometheus.Query(ctx, etcdLeaderChangesQuery(etcdNamespace, testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		vec, ok := result.(model.Vector)

--- a/test/extended/etcd/leader_changes_test.go
+++ b/test/extended/etcd/leader_changes_test.go
@@ -1,0 +1,31 @@
+package etcd
+
+import "testing"
+
+func TestEtcdLeaderChangesQueryScopesNamespaceExactly(t *testing.T) {
+	testCases := []struct {
+		name      string
+		namespace string
+		expected  string
+	}{
+		{
+			name:      "standalone control plane",
+			namespace: "openshift-etcd",
+			expected:  `max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace="openshift-etcd"}[1h])))`,
+		},
+		{
+			name:      "hosted control plane",
+			namespace: "clusters-example",
+			expected:  `max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace="clusters-example"}[1h])))`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := etcdLeaderChangesQuery(testCase.namespace, "1h")
+			if actual != testCase.expected {
+				t.Fatalf("expected %q, got %q", testCase.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These bugs and fixes were automatically generated by a payload-agent experiment to improve resilience and diagnostics for infrastructure failures. Please review the PR and either shepherd it to merge or close it. If the work is incorrect or unhelpful, a brief comment would help us improve. Thanks, and apologies if we missed the mark.

## Summary

Scope the etcd leader-change invariant to the HostedCluster under test.

External-topology runs currently query `namespace=~"clusters-.*"` on a shared HyperShift management cluster. The query then aggregates by pod and job while dropping namespace identity. An election from any concurrent HostedCluster can therefore fail every test sharing that management cluster.

This change:

- reads `HYPERSHIFT_MANAGEMENT_CLUSTER_NAMESPACE` through the existing management-cluster helper;
- uses an exact namespace selector for external and standalone control planes;
- adds regression coverage proving that generated PromQL stays scoped to one namespace.

## Evidence

The audited HostedCluster etcd pod started with the new TLS arguments, had `restartCount=0`, and experienced only its normal initial election. A sibling with identical flags passed. The broad shared-cluster query nevertheless attributed another `clusters-*` namespace election to 7/10 target runs and drove an unsupported revert recommendation against `openshift/hypershift#8871`.

This fix removes cross-tenant metric contamination without relaxing the leader-change threshold.

## Validation

- `go test ./test/extended/etcd`
- `gofmt`
- `git diff --check`

## AI disclosure

Generated with AI from retained OpenShift payload, Prow, pod, and Prometheus evidence. The patch changes only query scoping and includes focused unit coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved etcd leader-change monitoring for external topologies by selecting the correct namespace.
  * Ensured Prometheus queries are scoped precisely to the intended namespace.

* **Tests**
  * Added coverage validating namespace-specific etcd leader-change queries for standalone and hosted control plane configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->