### PR TITLE
OCPBUGS-100385: MonitorTest: measure the union of ClusterOperator wait intervals

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -3,6 +3,7 @@ package legacycvomonitortests
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -639,10 +640,10 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			// CO have not shown up in CVO Progressing message
 			return fmt.Sprintf("%s completing its update so fast that CVO did not recogize any waiting", co)
 		}
-		from, to := fromAndTo(intervals)
-		if d := to.Sub(from); d < 3*time.Minute {
+		summary := summarizeWaitingIntervals(intervals)
+		if summary.total < 3*time.Minute {
 			// CO showed up in CVO Progressing message but the total duration is less than three minutes
-			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, d.String())
+			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, summary)
 		}
 		switch co {
 		case "baremetal":
@@ -684,8 +685,8 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			if exception != "" {
 				output = fmt.Sprintf("%s which is expected up to %s", output, exception)
 			} else {
-				from, to := fromAndTo(COWaiting[operatorName])
-				output = fmt.Sprintf("%s and CVO waited for it over 3 minutes from %s to %s", output, from.Format(time.RFC3339), to.Format(time.RFC3339))
+				summary := summarizeWaitingIntervals(COWaiting[operatorName])
+				output = fmt.Sprintf("%s and CVO waited for it at least three minutes: %s", output, summary)
 			}
 			mcTestCase.FailureOutput = &junitapi.FailureOutput{
 				Output: output,
@@ -911,17 +912,75 @@ func getUpgradeLevelFromClusterVersionHistory(history []configv1.UpdateHistory) 
 	return patchUpgradeLevel, nil
 }
 
-func fromAndTo(intervals monitorapi.Intervals) (time.Time, time.Time) {
-	var from, to time.Time
-	for _, interval := range intervals {
-		if from.IsZero() || interval.From.Before(from) {
-			from = interval.From
+type waitingIntervalSummary struct {
+	from     time.Time
+	to       time.Time
+	total    time.Duration
+	longest  time.Duration
+	episodes monitorapi.Intervals
+}
+
+func (s waitingIntervalSummary) String() string {
+	if len(s.episodes) == 0 {
+		return "no valid waiting intervals"
+	}
+
+	ranges := make([]string, 0, len(s.episodes))
+	for _, episode := range s.episodes {
+		ranges = append(ranges, fmt.Sprintf("%s..%s", episode.From.Format(time.RFC3339), episode.To.Format(time.RFC3339)))
+	}
+
+	return fmt.Sprintf(
+		"%s total across %d episode(s), longest %s, observation span %s from %s to %s; ranges: %s",
+		s.total,
+		len(s.episodes),
+		s.longest,
+		s.to.Sub(s.from),
+		s.from.Format(time.RFC3339),
+		s.to.Format(time.RFC3339),
+		strings.Join(ranges, ", "),
+	)
+}
+
+func summarizeWaitingIntervals(intervals monitorapi.Intervals) waitingIntervalSummary {
+	sorted := append(monitorapi.Intervals(nil), intervals...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].From.Equal(sorted[j].From) {
+			return sorted[i].To.Before(sorted[j].To)
 		}
-		if to.IsZero() || interval.To.After(to) {
-			to = interval.To
+		return sorted[i].From.Before(sorted[j].From)
+	})
+
+	var summary waitingIntervalSummary
+	for _, interval := range sorted {
+		if interval.From.IsZero() || interval.To.Before(interval.From) {
+			continue
+		}
+
+		if len(summary.episodes) == 0 || interval.From.After(summary.episodes[len(summary.episodes)-1].To) {
+			summary.episodes = append(summary.episodes, interval)
+			continue
+		}
+
+		last := &summary.episodes[len(summary.episodes)-1]
+		if interval.To.After(last.To) {
+			last.To = interval.To
 		}
 	}
-	return from, to
+
+	for _, episode := range summary.episodes {
+		duration := episode.To.Sub(episode.From)
+		summary.total += duration
+		if duration > summary.longest {
+			summary.longest = duration
+		}
+	}
+	if len(summary.episodes) > 0 {
+		summary.from = summary.episodes[0].From
+		summary.to = summary.episodes[len(summary.episodes)-1].To
+	}
+
+	return summary
 }
 
 func updateCOWaiting(interval monitorapi.Interval, waiting map[string]monitorapi.Intervals) {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -942,6 +942,7 @@ func (s waitingIntervalSummary) String() string {
 	)
 }
 
+// summarizeWaitingIntervals excludes gaps during which CVO did not report waiting on the operator.
 func summarizeWaitingIntervals(intervals monitorapi.Intervals) waitingIntervalSummary {
 	sorted := append(monitorapi.Intervals(nil), intervals...)
 	sort.SliceStable(sorted, func(i, j int) bool {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -311,9 +311,10 @@ func Test_summarizeWaitingIntervals(t *testing.T) {
 		expectedLongest  time.Duration
 		expectedSpan     time.Duration
 		expectedEpisodes int
+		expectedString   string
 	}{
 		{
-			name: "separated point does not fill healthy gap",
+			name: "separated point does not fill gap without CVO-reported waiting",
 			intervals: monitorapi.Intervals{
 				interval(0, 15*time.Second),
 				interval(45*time.Minute+14*time.Second, 45*time.Minute+14*time.Second),
@@ -358,6 +359,18 @@ func Test_summarizeWaitingIntervals(t *testing.T) {
 			expectedSpan:     30 * time.Second,
 			expectedEpisodes: 1,
 		},
+		{
+			name:           "empty input",
+			expectedString: "no valid waiting intervals",
+		},
+		{
+			name: "all invalid intervals",
+			intervals: monitorapi.Intervals{
+				interval(2*time.Minute, time.Minute),
+				interval(4*time.Minute, 3*time.Minute),
+			},
+			expectedString: "no valid waiting intervals",
+		},
 	}
 
 	for _, tt := range tests {
@@ -367,6 +380,9 @@ func Test_summarizeWaitingIntervals(t *testing.T) {
 			assert.Equal(t, tt.expectedLongest, summary.longest)
 			assert.Equal(t, tt.expectedSpan, summary.to.Sub(summary.from))
 			assert.Len(t, summary.episodes, tt.expectedEpisodes)
+			if tt.expectedString != "" {
+				assert.Equal(t, tt.expectedString, summary.String())
+			}
 		})
 	}
 }

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -259,14 +259,14 @@ func Test_updateCOWaiting(t *testing.T) {
 			d:       2 * time.Minute,
 			message: "working towards ${VERSION}: 106 of 841 done (12% complete), waiting on etcd, kube-apiserver",
 			waiting: map[string]monitorapi.Intervals{"etcd": {interval("some", now, 3*time.Minute)}},
-			expect:  map[string]time.Duration{"etcd": next + 2*time.Minute, "kube-apiserver": 2 * time.Minute},
+			expect:  map[string]time.Duration{"etcd": 5 * time.Minute, "kube-apiserver": 2 * time.Minute},
 		},
 		{
 			name:    "incremental all",
 			d:       2 * time.Minute,
 			message: "working towards ${VERSION}: 106 of 841 done (12% complete), waiting on etcd, kube-apiserver",
 			waiting: map[string]monitorapi.Intervals{"etcd": {interval("some", now, 3*time.Minute)}, "kube-apiserver": {interval("some", now, 6*time.Minute)}},
-			expect:  map[string]time.Duration{"etcd": next + 2*time.Minute, "kube-apiserver": next + 2*time.Minute},
+			expect:  map[string]time.Duration{"etcd": 5 * time.Minute, "kube-apiserver": 8 * time.Minute},
 		},
 		{
 			name:    "unknown message",
@@ -288,10 +288,85 @@ func Test_updateCOWaiting(t *testing.T) {
 			updateCOWaiting(i, tt.waiting)
 			actual := map[string]time.Duration{}
 			for co, intervals := range tt.waiting {
-				from, to := fromAndTo(intervals)
-				actual[co] = to.Sub(from)
+				actual[co] = summarizeWaitingIntervals(intervals).total
 			}
 			assert.Equal(t, tt.expect, actual)
+		})
+	}
+}
+
+func Test_summarizeWaitingIntervals(t *testing.T) {
+	base := time.Date(2026, time.July, 25, 11, 48, 50, 0, time.UTC)
+	interval := func(from, to time.Duration) monitorapi.Interval {
+		return monitorapi.Interval{
+			From: base.Add(from),
+			To:   base.Add(to),
+		}
+	}
+
+	tests := []struct {
+		name             string
+		intervals        monitorapi.Intervals
+		expectedTotal    time.Duration
+		expectedLongest  time.Duration
+		expectedSpan     time.Duration
+		expectedEpisodes int
+	}{
+		{
+			name: "separated point does not fill healthy gap",
+			intervals: monitorapi.Intervals{
+				interval(0, 15*time.Second),
+				interval(45*time.Minute+14*time.Second, 45*time.Minute+14*time.Second),
+			},
+			expectedTotal:    15 * time.Second,
+			expectedLongest:  15 * time.Second,
+			expectedSpan:     45*time.Minute + 14*time.Second,
+			expectedEpisodes: 2,
+		},
+		{
+			name: "overlapping and adjacent intervals form one union",
+			intervals: monitorapi.Intervals{
+				interval(2*time.Minute, 4*time.Minute),
+				interval(0, 3*time.Minute),
+				interval(4*time.Minute, 5*time.Minute),
+			},
+			expectedTotal:    5 * time.Minute,
+			expectedLongest:  5 * time.Minute,
+			expectedSpan:     5 * time.Minute,
+			expectedEpisodes: 1,
+		},
+		{
+			name: "multiple real episodes sum without double counting",
+			intervals: monitorapi.Intervals{
+				interval(10*time.Minute, 12*time.Minute),
+				interval(0, 2*time.Minute),
+				interval(time.Minute, 3*time.Minute),
+			},
+			expectedTotal:    5 * time.Minute,
+			expectedLongest:  3 * time.Minute,
+			expectedSpan:     12 * time.Minute,
+			expectedEpisodes: 2,
+		},
+		{
+			name: "invalid interval is ignored",
+			intervals: monitorapi.Intervals{
+				interval(2*time.Minute, time.Minute),
+				interval(0, 30*time.Second),
+			},
+			expectedTotal:    30 * time.Second,
+			expectedLongest:  30 * time.Second,
+			expectedSpan:     30 * time.Second,
+			expectedEpisodes: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := summarizeWaitingIntervals(tt.intervals)
+			assert.Equal(t, tt.expectedTotal, summary.total)
+			assert.Equal(t, tt.expectedLongest, summary.longest)
+			assert.Equal(t, tt.expectedSpan, summary.to.Sub(summary.from))
+			assert.Len(t, summary.episodes, tt.expectedEpisodes)
 		})
 	}
 }


### PR DESCRIPTION
These bugs and fixes were automatically generated by a payload-agent experiment to improve resilience and diagnostics for infrastructure failures. Please review the PR and either shepherd it to merge or close it. If the work is incorrect or unhelpful, a brief comment would help us improve. Thanks, and apologies if we missed the mark.

## What this fixes

The upgrade monitor decides whether CVO reported waiting at least three minutes for a ClusterOperator. Its input consists of constructed intervals representing periods when the `ClusterVersion` Progressing message named that operator.

The existing calculation subtracts the earliest interval start from the latest interval end. When CVO names an operator in multiple disjoint episodes, this counts all intervening time—even though CVO did not report waiting on that operator during the gap.

This change sorts and merges overlapping or adjacent intervals, then applies the threshold to the duration of their union. This restores the accumulation intended by [origin#30333](https://github.com/openshift/origin/pull/30333) without double-counting overlaps. Failure diagnostics now report:

- total CVO-reported waiting duration;
- episode count;
- longest episode;
- full observation span; and
- each merged episode range.

These intervals are a CVO status-message metric. They do **not** prove operator availability, pod readiness, or overall cluster health during the gaps.

Visualization of the new behavior is [here](https://htmlpreview.github.io/?https://gist.githubusercontent.com/stbenjam/b1f975b142883b561818aed935edd905/raw/index.html)

<img width="1218" height="323" alt="image" src="https://github.com/user-attachments/assets/9324a482-ab38-48a2-9ac6-dc72d46d7cab" />

## Payload and RCA context

The false attribution surfaced during the 4.22→5.0 regression introduced by [cluster-version-operator#1427](https://github.com/openshift/cluster-version-operator/pull/1427) and reverted by [cluster-version-operator#1431](https://github.com/openshift/cluster-version-operator/pull/1431). The old CVO could not render its 5.0 Deployment, never self-updated, and repeatedly restarted its sync between the embedded 4.22 payload and desired 5.0 payload. That produced several short `waiting on config-operator` episodes separated by unrelated payload work and restarts.

The CVO defect was the primary payload regression; this PR fixes a secondary monitor calculation that turned those disjoint episodes into a misleading `config-operator` failure. The CVO, etcd, alert, and disruption signals for the underlying product regression remain unaffected.

- [Evidence-backed RCA](https://gist.github.com/not-stbenjam/e7bc6959e6ff5345c5395d2972dcd761)
- [Failed Payload Agent analysis](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-claude-payload-agent/2080964771632386048/artifacts/claude-payload-agent/openshift-claude-payload-agent/artifacts/payload-analysis-5.0.0-0.ci-2026-07-25-102741-summary.html)
- [Representative AWS timeline artifact](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade/2080964774497095680/artifacts/e2e-aws-ovn-upgrade/openshift-e2e-test/artifacts/junit/e2e-timelines_spyglass_20260725-113839.json)
- [Representative Azure timeline artifact](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-azure-ovn-upgrade/2080964703600775168/artifacts/e2e-azure-ovn-upgrade/openshift-e2e-test/artifacts/junit/e2e-timelines_spyglass_20260725-113832.json)

For payload `5.0.0-0.ci-2026-07-25-102741`, 13 raw AWS/Azure child failures had CVO-reported interval unions of 13–150 seconds with no episode longer than 150 seconds, while the old calculation reported observation spans from 3m27s to 58m53s. One representative result combined a 15-second interval with a later point observation and reported 45m14s.

The Payload Agent consequently recommended reverting unrelated `openshift/api#2920` and `#2923` at 90 confidence. Experimental revert jobs continued failing, falsifying both recommendations.

- [Experimental revert #2953, AWS: 0/5 passed](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregator-periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade/2081157939309056000)
- [Experimental revert #2954, AWS: 3/5 passed](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/aggregator-periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-aws-ovn-upgrade/2081163819089924096)

## Validation

- `go test ./pkg/monitortests/clusterversionoperator/legacycvomonitortests`
- `go vet ./pkg/monitortests/clusterversionoperator/legacycvomonitortests`
- Added table-driven coverage for separated point observations, overlaps, adjacency, multiple episodes, unsorted input, and invalid intervals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade progress reporting by accurately summarizing operator waiting periods.
  * Combined overlapping or adjacent periods while keeping separate episodes distinct.
  * Enhanced failure messages with total waiting time, longest episode, observation span, and episode details for clearer diagnostics.
* **Tests**
  * Added coverage for overlapping, invalid, adjacent, separate, and empty waiting intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
