### PR TITLE
OCPBUGS-100308: Fix test  `APIs for openshift.io must have stable versions`

### DIFF
--- a/test/extended/operators/crd_must_be_stable.go
+++ b/test/extended/operators/crd_must_be_stable.go
@@ -89,6 +89,10 @@ var _ = g.Describe("[sig-arch][Early]", func() {
 						continue
 					}
 
+					if !versionSpec.Served {
+						continue
+					}
+
 					if !stableVersions.Has(versionSpec.Name) {
 						failures = append(failures,
 							fmt.Sprintf("crd/%v has an unstable version %q that is accessible-by-default. All CRDs accessible by default must be stable (v1, v2, etc) with guaranteed compatibility and upgradeability ~forever.",


### PR DESCRIPTION
Check if a CRD's version is served before checking if it the stable version. Sometimes, the older unstable versions are not deleted rightaway but these CRDs are not served by default either. That should not cause this test to flag a failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CRD version stability checks to ignore versions that are not served, preventing false failures from inactive version specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->