### PR TITLE
STOR-2968: Skip regional PD test on GCP Dedicated

### DIFF
--- a/test/extended/storage/gce_pd_regional.go
+++ b/test/extended/storage/gce_pd_regional.go
@@ -57,6 +57,14 @@ var _ = g.Describe(`[sig-storage][Jira:"Storage"][Driver: pd.csi.storage.gke.io]
 			g.Skip("skipping, this test is only expected to work with standalone clusters")
 		}
 
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if infra.Status.PlatformStatus != nil &&
+			infra.Status.PlatformStatus.GCP != nil &&
+			strings.HasPrefix(infra.Status.PlatformStatus.GCP.Region, "u-") {
+			g.Skip("skipping, pd-standard regional PD is not available on GCP Dedicated")
+		}
+
 		isStorageEnabled, err := exutil.IsCapabilityEnabled(oc, configv1.ClusterVersionCapabilityStorage)
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if !isStorageEnabled {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regional persistent disk tests now skip unsupported GCP Dedicated cluster regions, preventing false failures when `pd-standard` storage is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->