### PR TITLE
OCPBUGS-100392: Exclude openshift-debug-* namespaces from CPU Partitioning annotation check

### DIFF
--- a/test/extended/cpu_partitioning/platform.go
+++ b/test/extended/cpu_partitioning/platform.go
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io] CPU Partitioning cl
 				if ignoreNamespaces.Has(project.Name) {
 					continue
 				}
-				if strings.HasPrefix(project.Name, "openshift-") && !strings.HasPrefix(project.Name, "openshift-e2e-") {
+				if strings.HasPrefix(project.Name, "openshift-") && !strings.HasPrefix(project.Name, "openshift-e2e-") && !strings.HasPrefix(project.Name, "openshift-debug-") {
 					if v, ok := project.Annotations[namespaceAnnotationKey]; !ok || v != "management" {
 						invalidNamespaces = append(invalidNamespaces, project.Name)
 					}


### PR DESCRIPTION
## Summary

- The CPU Partitioning test checks that all `openshift-*` namespaces have the `workload.openshift.io/allowed:management` annotation, but does not exclude ephemeral `openshift-debug-*` namespaces created by `oc debug node/`
- When `[Feature:SecurityPenetration]` tests run in parallel, they create these debug namespaces which lack the annotation, causing 100% consistent test failures
- This adds `openshift-debug-*` to the exclusion logic, matching the existing `openshift-e2e-*` exclusion

## Details

**Root cause**: `test/extended/cpu_partitioning/platform.go` iterates all `openshift-*` projects and expects them to have `workload.openshift.io/allowed:management`. It already skips `openshift-e2e-*` namespaces, but not `openshift-debug-*` namespaces. The SecurityPenetration tests use `oc debug node/` to inspect node security, creating temporary `openshift-debug-<random>` namespaces that get picked up by this check.

**Impact**: 8/8 tracked runs failed (permafail) in the `metal + techpreview + ipi + ovn + ha` variant since July 23. Component Readiness regression [#45377](https://sippy.dptools.openshift.org/api/component_readiness/regressions/45377).

**Fix**: Add `!strings.HasPrefix(project.Name, "openshift-debug-")` to the existing prefix check on line 84.

Bug: https://redhat.atlassian.net/browse/OCPBUGS-100392

## Test plan

- [ ] Verify test passes on clusters where SecurityPenetration tests run in parallel
- [ ] Verify test still catches real `openshift-*` namespaces missing the annotation
- [ ] Confirm `openshift-debug-*` namespaces are correctly excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated namespace validation to exclude both `openshift-e2e-*` and `openshift-debug-*` namespaces from management-annotation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->