### PR TITLE
OCPBUGS-100298: pin internal-lb-monitor pollers to worker nodes

### DIFF
--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
@@ -4,6 +4,12 @@ metadata:
   name: internal-lb-monitor
 spec:
   replicas: 1
+  # Recreate avoids a rollout deadlock when only a single node matches the
+  # nodeSelector below: the default RollingUpdate strategy (maxUnavailable=0,
+  # maxSurge=1) would surge a replacement pod that the required hostname
+  # anti-affinity can never schedule next to the old one.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: internal-lb-monitor

--- a/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
+++ b/pkg/monitortests/kubeapiserver/disruptioninclusterapiserver/manifests/dep-internal-lb.yaml
@@ -54,6 +54,21 @@ spec:
           securityContext:
             privileged: true
             runAsUser: 0
+      # Pin the internal-lb pollers to worker nodes. On cloud platforms with
+      # passthrough load balancers (notably GCP), a control-plane node cannot
+      # reach the api-int VIP through the LB fabric while its local
+      # kube-apiserver is shutting down: apiserver-watcher removes the local
+      # VIP redirect ~15s into the graceful shutdown, but the cloud LB health
+      # check only deprograms the backend ~25-30s in, and in between the
+      # node's own new connections to the VIP are blackholed (hairpin). A
+      # poller scheduled on a master therefore reports ~10s of internal-lb
+      # new-connections disruption on every kube-apiserver rollout of that
+      # node, which is a measurement artifact rather than user-perceived
+      # unavailability (OCPBUGS-100298, see also OCPBUGS-83523). The master
+      # toleration below is kept so the pods remain schedulable on compact
+      # clusters, where control-plane nodes also carry the worker role.
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       hostNetwork: true
       serviceAccountName: disruption-monitor-sa
       volumes:


### PR DESCRIPTION
Fixes the internal-LB new-connections "disruption regression" tracked in [OCPBUGS-100298](https://issues.redhat.com/browse/OCPBUGS-100298).

## What was happening

The `internal-lb-monitor` poller deployment tolerates the control-plane `NoSchedule` taint but has **no nodeSelector**. Its replicas normally land on workers, but when a replica is evicted mid-run — the `[sig-node] NoExecuteTaintManager Multiple Pods [Serial]` test taints the worker hosting it — the replacement is scheduled ~1s later while the taint is still active, and if no untainted worker is free (anti-affinity holds the others), it lands on a **control-plane node**.

On GCP that vantage point measures a platform hairpin gap instead of user-perceived availability. During every kube-apiserver graceful shutdown on that node:

1. `/readyz` goes red at T+1s
2. `apiserver-watcher` writes the VIP downfile at T+15s (8 × 2s failures) → `gcp-routes` removes the local VIP DNAT
3. GCP's passthrough-ILB health check only deprograms the backend at T+25–30s (`CheckIntervalSec: 5` × `UnhealthyThreshold: 6`)
4. In the ~10s gap, the node's **own new connections** to the api-int VIP are blackholed (a backend VM cannot reach its own VIP through the fabric); reused connections survive via conntrack

Result: 2–12 disruption events per internal-lb new-connections backend per run, in two bursts (the hosting master rolls twice during the `ensures external ip policy` test). Verified across 7 runs of `periodic-ci-openshift-release-main-nightly-5.0-e2e-gcp-ovn-serial`: disruption occurs **iff** the replacement replica landed on a master (audit-log source IPs, scheduling events, gcp-routes journals and apiserver-watcher logs all line up; full evidence in the Jira). The previously suspected cluster-kube-apiserver-operator#2247 and openshift/kubernetes#2713 are exonerated — the payload correlation was scheduler-placement luck.

## The fix

Pin the internal-lb pollers to worker nodes with a `nodeSelector`. The master toleration is kept so the pods remain schedulable on compact/SNO clusters where control-plane nodes also carry the worker role.

---
This PR was generated using AI (Assisted-By: Claude Fable 5). Please verify before acting on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal load-balancer polling reliability by scheduling pollers on worker nodes.
  * Preserved compatibility with compact clusters by allowing scheduling on control-plane nodes when necessary.
  * Prevented rollout deadlocks in single-worker environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->