### PR TITLE
Revert: Fix APIs for openshift.io must have stable versions check

### DIFF
--- a/test/extended/operators/crd_must_be_stable.go
+++ b/test/extended/operators/crd_must_be_stable.go
@@ -89,6 +89,10 @@ var _ = g.Describe("[sig-arch][Early]", func() {
 						continue
 					}
 
+					if !versionSpec.Served {
+						continue
+					}
+
 					if !stableVersions.Has(versionSpec.Name) {
 						failures = append(failures,
 							fmt.Sprintf("crd/%v has an unstable version %q that is accessible-by-default. All CRDs accessible by default must be stable (v1, v2, etc) with guaranteed compatibility and upgradeability ~forever.",


### PR DESCRIPTION
After an API has stabilized to version v1, then o/api wants the earlier v1alpha1 version to be removed irrespective of the version's `served` value.

So, reverting back to the original way this test was implemented.

Reverting change introduced by https://github.com/openshift/origin/pull/31458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CRD stability validation to ignore versions that are not served, ensuring checks focus only on active CRD versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->