### PR TITLE
NO-JIRA: Remove exception OCPBUGS-86009

### DIFF
--- a/test/extended/machines/scale.go
+++ b/test/extended/machines/scale.go
@@ -261,8 +261,6 @@ var _ = g.Describe("[sig-cluster-lifecycle][Feature:Machines][Serial] Managed cl
 			switch co {
 			case "authentication":
 				return "https://issues.redhat.com/browse/OCPBUGS-65896"
-			case "dns":
-				return "https://redhat.atlassian.net/browse/OCPBUGS-86009"
 			case "image-registry":
 				return "https://redhat.atlassian.net/browse/OCPBUGS-86308"
 			case "network":


### PR DESCRIPTION
/hold

wait for 5.1 cut.

I will verify by running pull-ci-openshift-origin-main-e2e-aws-ovn-serial-2of2 a few times the same way as we spot the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scale test cleanup validation to apply standard cluster operator checks without a DNS-specific exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->