### PR TITLE
NO-JIRA: Remove exception OCPBUGS-66225

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -354,14 +354,6 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-23744"
 			}
 		case "image-registry":
-			if condition.Type == configv1.OperatorDegraded &&
-				condition.Status == configv1.ConditionTrue &&
-				(condition.Reason == "NodeCADaemonControllerError" ||
-					condition.Reason == "ProgressDeadlineExceeded" ||
-					condition.Reason == "ImageConfigControllerError" ||
-					condition.Reason == "Unavailable") {
-				return "https://issues.redhat.com/browse/OCPBUGS-66225"
-			}
 			// this won't handle the replicaCount==2 serial test where both pods are on nodes that get tainted.
 			// need to consider how we detect that or modify the job to set replicaCount==3
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {


### PR DESCRIPTION
They are [fixed in 5.0](https://redhat.atlassian.net/browse/OCPBUGS-66225?focusedCommentId=17817903).

/hold

wait for 5.1 cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitoring behavior so image-registry degradation conditions with specific error reasons are no longer exempted.
  * Preserved existing exception handling for other image-registry conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->