### PR TITLE
OCPBUGS-104561: test: exclude NTO debug pods from best-effort QoS invariant

### DIFF
--- a/test/extended/operators/qos.go
+++ b/test/extended/operators/qos.go
@@ -16,6 +16,8 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
+const nodeTuningOperatorNamespace = "openshift-cluster-node-tuning-operator"
+
 var _ = Describe("[sig-arch] Managed cluster should", func() {
 	oc := exutil.NewCLIWithoutNamespace("operators")
 
@@ -70,24 +72,10 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 			if hasPrefixSet(pod.Name, excludePodPrefix) {
 				continue
 			}
-			// Exclude ephemeral oc debug node pods created by the
-			// node.ExecOnNode*() helper functions.
-			//
-			// These are privileged, transient pods with no resource requests.
-			// They are best-effort QoS by design. They are created by many
-			// other tests, and will cause this test to fail if one happens to
-			// be present while it executes.
-			if pod.Namespace == node.DebugNamespace && isEphemeralDebugPod(&pod) {
-				continue
-			}
-			// Exclude ephemeral oc debug pods in transient openshift-debug-*
-			// namespaces. `oc debug node/<node>` run without an explicit
-			// namespace creates a temporary namespace named
-			// openshift-debug-<random> for the debug pod (e.g. the
-			// [sig-auth][Feature:SecurityPenetration] tests do this while the
-			// parallel conformance suite runs). These are not control-plane
-			// workloads and are best-effort QoS by design. OCPBUGS-99916
-			if strings.HasPrefix(pod.Namespace, "openshift-debug-") && isEphemeralDebugPod(&pod) {
+			// Exclude only recognized transient oc debug pods in the namespaces
+			// used by test helpers. They are best-effort QoS by design rather
+			// than control-plane workloads.
+			if isKnownEphemeralDebugPod(&pod) {
 				continue
 			}
 			if pod.Status.QOSClass == v1.PodQOSBestEffort {
@@ -100,6 +88,13 @@ var _ = Describe("[sig-arch] Managed cluster should", func() {
 		}
 	})
 })
+
+func isKnownEphemeralDebugPod(pod *v1.Pod) bool {
+	return isEphemeralDebugPod(pod) &&
+		(pod.Namespace == node.DebugNamespace ||
+			pod.Namespace == nodeTuningOperatorNamespace ||
+			strings.HasPrefix(pod.Namespace, "openshift-debug-"))
+}
 
 func isEphemeralDebugPod(pod *v1.Pod) bool {
 	// Debug pods created by oc can be identified via:

--- a/test/extended/operators/qos_test.go
+++ b/test/extended/operators/qos_test.go
@@ -1,0 +1,77 @@
+package operators
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/origin/test/extended/node"
+)
+
+func TestIsKnownEphemeralDebugPod(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  v1.Pod
+		want bool
+	}{
+		{
+			name: "machine config operator debug pod",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: node.DebugNamespace,
+				Name:      "worker-a-debug-abcde",
+			}},
+			want: true,
+		},
+		{
+			name: "node tuning operator debug pod from older oc",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: nodeTuningOperatorNamespace,
+				Name:      "worker-a-debug-abcde",
+			}},
+			want: true,
+		},
+		{
+			name: "transient debug namespace pod",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-debug-abcde",
+				Labels: map[string]string{
+					"debug.openshift.io/managed-by": "oc-debug",
+				},
+			}},
+			want: true,
+		},
+		{
+			name: "ordinary node tuning operator pod",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: nodeTuningOperatorNamespace,
+				Name:      "tuned-abcde",
+			}},
+			want: false,
+		},
+		{
+			name: "debug named pod outside known namespaces",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-example-operator",
+				Name:      "worker-a-debug-abcde",
+			}},
+			want: false,
+		},
+		{
+			name: "ordinary pod in transient debug namespace",
+			pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "openshift-debug-abcde",
+				Name:      "controller-abcde",
+			}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKnownEphemeralDebugPod(&tt.pod); got != tt.want {
+				t.Fatalf("isKnownEphemeralDebugPod() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to OCPBUGS-99916 and #31437.

## Problem

The control-plane QoS invariant can race with transient `oc debug` pods in `openshift-cluster-node-tuning-operator`. These pods are best-effort by design, but the invariant currently recognizes equivalent pods only in `openshift-machine-config-operator` and transient `openshift-debug-*` namespaces.

Two OpenShift 5.0 runs show the same sequence:

- [2052486181521723392](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade/2052486181521723392)
- [2052954768447377408](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-ci-5.0-upgrade-from-stable-4.22-e2e-gcp-ovn-rt-upgrade/2052954768447377408)

In both runs, an NTO test created and started an `oc debug` pod immediately before the QoS assertion. The assertion reported that pod. The NTO test then deleted it, and the QoS retry passed.

## Fix

This change adds `openshift-cluster-node-tuning-operator` to the explicit list of namespaces that can contain known transient debug pods.

The exclusion still requires the existing `isEphemeralDebugPod` predicate. It does not exclude all NTO pods. It does not add a global `-debug-` name exclusion.

The new table test covers:

- Existing MCO debug pods.
- NTO debug pods.
- Transient `openshift-debug-*` pods.
- An ordinary NTO pod.
- A debug-named pod in an unrelated namespace.
- An ordinary pod in a transient debug namespace.

## Validation

```text
CGO_ENABLED=0 go test -p 2 -vet=off ./test/extended/operators -run '^TestIsKnownEphemeralDebugPod$' -count=1
ok github.com/openshift/origin/test/extended/operators 0.079s
```

The test used workspace-local temporary and cache paths. An independent review found no blocking issue.

Generated-by: AI (analysis and patch). A human must verify this change before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification of temporary debug pods across supported debug namespaces.
  * Prevented ordinary pods from being incorrectly classified as ephemeral debug pods.

* **Tests**
  * Added coverage for recognized debug pods and non-debug pods across multiple namespace patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->