### PR TITLE
NO-JIRA: test: poll final EgressFirewall DNS deny assertion

### DIFF
--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -2,8 +2,10 @@ package networking
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -199,13 +201,28 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	// Test curl to www.redhat.com should fail
 	// because we don't have allow dns rule for www.redhat.com
 	g.By("sending traffic that does not match allow dns rule")
-	lastRequestOutput := ""
+	lastRequestStderr := ""
+	lastRequestExitCode := 0
 	var lastRequestErr error
 	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		lastRequestOutput, lastRequestErr = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://www.redhat.com").Output()
-		return lastRequestErr != nil, nil
+		_, lastRequestStderr, lastRequestErr = oc.Run("exec").Args(pod, "--", "curl", "-q", "-sS", "-I", "-m15", "https://www.redhat.com").Outputs()
+		if lastRequestErr == nil {
+			return false, nil
+		}
+
+		var exitErr *exec.ExitError
+		if !errors.As(lastRequestErr, &exitErr) {
+			return false, lastRequestErr
+		}
+		lastRequestExitCode = exitErr.ExitCode()
+		switch lastRequestExitCode {
+		case 5, 6, 7, 28:
+			return true, nil
+		default:
+			return false, fmt.Errorf("unexpected oc exec or curl failure with exit code %d: %s", lastRequestExitCode, lastRequestStderr)
+		}
 	})
-	expectNoError(err, "curl to www.redhat.com should fail; last output: %s; last error: %v", lastRequestOutput, lastRequestErr)
+	expectNoError(err, "curl to www.redhat.com should fail; last exit code: %d; last stderr: %s", lastRequestExitCode, lastRequestStderr)
 
 	if nodeSelectorSupport {
 		// Access to control plane nodes should work

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -143,6 +143,36 @@ func doEgressFwTest(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI, man
 	return err
 }
 
+func waitForSuccessfulPodCurl(ctx context.Context, oc *exutil.CLI, pod, url string) error {
+	lastRequestStderr := ""
+	lastRequestExitCode := 0
+
+	// EgressFirewall status can be updated before its DNS address sets are populated.
+	err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		var err error
+		_, lastRequestStderr, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-sS", "-I", "-m15", url).Outputs()
+		if err == nil {
+			return true, nil
+		}
+
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return false, fmt.Errorf("unexpected oc exec or curl failure for %s: %w", url, err)
+		}
+		lastRequestExitCode = exitErr.ExitCode()
+		switch lastRequestExitCode {
+		case 5, 6, 7, 28:
+			return false, nil
+		default:
+			return false, fmt.Errorf("unexpected oc exec or curl failure for %s with exit code %d: %s", url, lastRequestExitCode, lastRequestStderr)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("curl to %s did not succeed; last exit code: %d; last stderr: %s: %w", url, lastRequestExitCode, lastRequestStderr, err)
+	}
+	return nil
+}
+
 func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI, pod string, nodeSelectorSupport, checkWildcard bool) error {
 	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to get cluster-wide infrastructure")
@@ -177,25 +207,21 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	// Test curl to redhat.com should pass
 	// because we have allow dns rule for redhat.com.
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://redhat.com").Output()
-	expectNoError(err)
+	expectNoError(waitForSuccessfulPodCurl(context.TODO(), oc, pod, "https://redhat.com"))
 
 	// Test curl to amazon.com should pass
 	// because we have allow dns rule for amazon.com
 	g.By("sending traffic that matches allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://amazon.com").Output()
-	expectNoError(err)
+	expectNoError(waitForSuccessfulPodCurl(context.TODO(), oc, pod, "https://amazon.com"))
 
 	if checkWildcard {
 		// Test curl to `www.google.com` and `translate.google.com` should pass
 		// because we have allow dns rule for `*.google.com`.
 		g.By("sending traffic to `www.google.com` that matches allow dns rule for `*.google.com`")
-		_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://www.google.com").Output()
-		expectNoError(err)
+		expectNoError(waitForSuccessfulPodCurl(context.TODO(), oc, pod, "https://www.google.com"))
 
 		g.By("sending traffic to `translate.google.com` that matches allow dns rule for `*.google.com`")
-		_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://translate.google.com").Output()
-		expectNoError(err)
+		expectNoError(waitForSuccessfulPodCurl(context.TODO(), oc, pod, "https://translate.google.com"))
 	}
 
 	// Test curl to www.redhat.com should fail

--- a/test/extended/networking/egress_firewall.go
+++ b/test/extended/networking/egress_firewall.go
@@ -199,8 +199,13 @@ func sendEgressFwTraffic(f *e2e.Framework, mgmtFw *e2e.Framework, oc *exutil.CLI
 	// Test curl to www.redhat.com should fail
 	// because we don't have allow dns rule for www.redhat.com
 	g.By("sending traffic that does not match allow dns rule")
-	_, err = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://www.redhat.com").Output()
-	expectError(err)
+	lastRequestOutput := ""
+	var lastRequestErr error
+	err = wait.PollUntilContextTimeout(context.TODO(), 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		lastRequestOutput, lastRequestErr = oc.Run("exec").Args(pod, "--", "curl", "-q", "-s", "-I", "-m15", "https://www.redhat.com").Output()
+		return lastRequestErr != nil, nil
+	})
+	expectNoError(err, "curl to www.redhat.com should fail; last output: %s; last error: %v", lastRequestOutput, lastRequestErr)
 
 	if nodeSelectorSupport {
 		// Access to control plane nodes should work


### PR DESCRIPTION
## What

Poll the final forbidden `www.redhat.com` request for up to 30 seconds.
Keep the deny requirement unchanged. If access remains possible, fail with the last request output and error.

## Why

Merged PR #31376 added bounded waits to other EgressFirewall checks, but this final deny check remained single-shot.
The OpenShift 5.0 study found 13 later failures at this assertion across eight aggregate parents. Ten of the 13 runs passed the same test on another attempt.

This is a test-convergence fix. The evidence does not prove an OVN product defect.

## Validation

- `gofmt -d test/extended/networking/egress_firewall.go`
- `git diff --check`
- `go test -mod=vendor -p 2 -vet=off ./test/extended/networking -run '^$' -count=1`

The focused package compile passed. A live-cluster e2e run is left to normal PR CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved egress firewall validation reliability by retrying expected network-related failures for up to 30 seconds.
  * Enhanced diagnostic reporting with command output and error details when validation fails or times out.
  * Reduced false failures caused by temporary DNS resolution, connection, timeout, or network availability issues during firewall checks.
  * Preserved specialized handling for expected denial responses when validating blocked network access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->