### PR TITLE
NO-JIRA: Retry transient load-balancer rollout test

### DIFF
--- a/pkg/test/ginkgo/retry_allowed_tests.yaml
+++ b/pkg/test/ginkgo/retry_allowed_tests.yaml
@@ -22,6 +22,7 @@
 #   HAVING COUNT(*) >= 5
 #   ORDER BY flake_count DESC
 tests:
+  - "[sig-apps] Deployment should not disrupt a cloud load-balancer's connectivity during rollout"
   - "[sig-api-machinery][Feature:APIServer] TestTLSDefaults [Suite:openshift/conformance/parallel]"
   - "[sig-api-machinery][Feature:ClusterResourceQuota] Cluster resource quota should control resource limits across namespaces [apigroup:quota.openshift.io][apigroup:image.openshift.io][apigroup:monitoring.coreos.com][apigroup:template.openshift.io] [Suite:openshift/conformance/parallel]"
   - "[sig-api-machinery][Feature:ResourceQuota] Object count check the quota after import-image with --all option [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"


### PR DESCRIPTION
## What

Allow one retry for the runtime OTE identity of Kubernetes' Deployment load-balancer rollout test.

## Why

The test has failed in nine retained 5.0 jobs since May 9. Deep artifact analysis of the July 29 aggregate found that all three failures timed out during the *initial* load-balancer reachability check, before any Deployment rollout. The same three clusters also failed an independent load-balancer availability probe, while six same-payload sibling clusters passed both checks; GCP CCM created the forwarding rules, target pools, health checks, and firewall rules without reporting provider errors.

This is a transient cloud load-balancer readiness failure rather than a failed rollout assertion. The runtime OTE test name has no `[Suite:...]` suffix and therefore does not match any existing exact-name retry entry. A single retry exercises fresh load-balancer resources and preserves a hard failure if the problem repeats.

Under a conservative historical counterfactual, this would likely have rescued two failed child Prow jobs where this was the only unrecovered blocking test and the independent load-balancer monitor did not show a cluster-wide reachability problem. Three July 29 children are deliberately not credited: their independent monitor had already spent ten minutes failing to reach a separate load balancer, so a fresh retry is not supported as a rescue for those clusters. No aggregate parent is credited.

Related upstream report: https://github.com/kubernetes/kubernetes/issues/140358

## Validation

- `git diff --check`
- parsed `retry_allowed_tests.yaml` and asserted the runtime identity occurs exactly once (124 total entries)
- attempted `GOTOOLCHAIN=auto GOMAXPROCS=2 go test -p=2 ./pkg/test/ginkgo`; compilation was bounded to 421 MiB peak RSS but the workspace exhausted its disk quota while compiling Kubernetes dependencies
