### PR TITLE
NO-JIRA: Scope HyperShift etcd leader metrics

### DIFF
--- a/test/extended/etcd/leader_changes.go
+++ b/test/extended/etcd/leader_changes.go
@@ -28,7 +28,10 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 	g.It("leader changes are not excessive [Late]", func(ctx g.SpecContext) {
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
+		etcdNamespace := "openshift-etcd"
 		if *controlPlaneTopology == configv1.ExternalTopologyMode {
+			_, etcdNamespace, err = exutil.GetHypershiftManagementClusterConfigAndNamespace()
+			o.Expect(err).NotTo(o.HaveOccurred())
 			oc = exutil.NewHypershiftManagementCLI("default").AsAdmin().WithoutNamespace()
 		}
 
@@ -39,11 +42,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		testDuration := exutil.DurationSinceStartInSeconds().String()
 
 		g.By("Examining the number of etcd leadership changes over the run")
-		etcdNamespace := "openshift-etcd"
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			etcdNamespace = "clusters-.*"
-		}
-		result, _, err := prometheus.Query(context.Background(), fmt.Sprintf(`max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace=~"%s"}[%s])))`, etcdNamespace, testDuration), time.Now())
+		result, _, err := prometheus.Query(context.Background(), leaderChangesQuery(etcdNamespace, testDuration), time.Now())
 		o.Expect(err).ToNot(o.HaveOccurred())
 
 		vec, ok := result.(model.Vector)
@@ -68,3 +67,7 @@ var _ = g.Describe("[sig-etcd] etcd", func() {
 		}
 	})
 })
+
+func leaderChangesQuery(namespace, duration string) string {
+	return fmt.Sprintf(`max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace=%q}[%s])))`, namespace, duration)
+}

--- a/test/extended/etcd/leader_changes_test.go
+++ b/test/extended/etcd/leader_changes_test.go
@@ -1,0 +1,10 @@
+package etcd
+
+import "testing"
+
+func TestLeaderChangesQueryUsesExactNamespace(t *testing.T) {
+	want := `max(max by (pod,job) (increase(etcd_server_leader_changes_seen_total{namespace="clusters-example"}[2h3m4s])))`
+	if got := leaderChangesQuery("clusters-example", "2h3m4s"); got != want {
+		t.Fatalf("unexpected query:\nwant: %s\n got: %s", want, got)
+	}
+}


### PR DESCRIPTION
## What

Scope the HyperShift etcd leader-change Prometheus query to the hosted control plane under test.

## Why

For external control planes, this test currently queries every etcd namespace matching `clusters-.*` on the management cluster. Aggregated HyperShift conformance runs place ten hosted clusters on the same management cluster, so each child observes the leader elections of all nine sibling control planes as well as its own. A sibling cluster's startup or rollout can therefore fail an otherwise healthy child's etcd stability test.

The retained 5.0 corpus contains 40 exact metric-based failures in this job across seven aggregate batches. After streaming the original JUnit artifacts and excluding passing retries and independent blockers, 25 child jobs had this test as their sole unrecovered blocker. Four aggregate parents also had no other blocking failure. The conservative historical counterfactual is therefore 29 Prow jobs that would have succeeded with this fix.

Retrieve the exact hosted control plane namespace already exposed by the HyperShift test environment and use an exact Prometheus label match. Standalone control planes continue to query `openshift-etcd`.

## Validation

- added a focused assertion that the generated Prometheus query uses the exact namespace
- `gofmt`
- `git diff --check`
- attempted `GOTOOLCHAIN=auto GOMAXPROCS=2 go test -p=2 ./test/extended/etcd`; the workspace exhausted its disk quota while compiling Kubernetes dependencies (bounded at 415 MiB peak RSS), before the test binary ran


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved etcd leader-change monitoring tests to use the configured management-cluster namespace.
  * Added coverage ensuring Prometheus queries include the exact namespace and time range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->