### PR TITLE
OCPBUGS-99899: add os name exception for runc jobs

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -273,6 +273,8 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName string) {
 		targetStream = "rhel-10"
 	} else if strings.Contains(jobName, "rhcos9") {
 		targetStream = "rhel-9"
+	} else if strings.Contains(jobName, "-runc") {
+		targetStream = "rhel-9"
 	} else if strings.Contains(jobName, "upgrade") {
 		installVersion := getInstallVersion(clusterVersion)
 		// In standalone a cluster installed using OCP 4.x preserves RHEL 9 even after upgrading to 5


### PR DESCRIPTION
[sig-ci] [Early] prow job name should match os version [Suite:openshift/conformance/parallel] test fails on runc jobs because 5.0 runc jobs use rhel-9 stream since runc is not in rhel-10.  This adds another conditional for jobs with runc in their name to the check in validateStandaloneNodeOS().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated standalone node job detection so jobs containing `-runc` are correctly associated with the RHEL 9 operating system stream.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->