### PR TITLE
WIP: UPSTREAM: <carry>: Create TLS secret in PrepareTest when CapSnapshotMetadata is enabled

### DIFF
--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/csi.go
@@ -376,6 +376,12 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		if err := utils.CreateSnapshotMetadataTLSSecret(ctx, f, driverns); err != nil {
+			framework.Failf("creating snapshot metadata TLS secret: %v", err)
+		}
+	}
+
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/openshift_group_snapshot_driver.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/drivers/openshift_group_snapshot_driver.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -106,6 +107,9 @@ func InitGroupSnapshotHostpathCSIDriver() storageframework.TestDriver {
 		// added when patching the deployment.
 		storageframework.CapVolumeLimits: true,
 	}
+	if os.Getenv("CSI_PROW_ENABLE_SNAPSHOT_METADATA") == "true" {
+		capabilities[storageframework.CapSnapshotMetadata] = true
+	}
 	// OCP specific code: a different driver name (csi-hostpath-groupsnapshot)
 	return initGroupSnapshotHostpathCSIDriver("csi-hostpath-groupsnapshot",
 		capabilities,
@@ -115,6 +119,7 @@ func InitGroupSnapshotHostpathCSIDriver() storageframework.TestDriver {
 		},
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml",
+		"test/e2e/testing-manifests/storage-csi/external-snapshot-metadata/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-snapshotter/csi-snapshotter/rbac-csi-snapshotter.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-health-monitor/external-health-monitor-controller/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-resizer/rbac.yaml",
@@ -236,6 +241,13 @@ func (h *groupSnapshotHostpathCSIDriver) PrepareTest(ctx context.Context, f *fra
 		DriverContainerArguments: []string{"--feature-gates=CSIVolumeGroupSnapshot=true"},
 	})
 
+	if os.Getenv("CSI_PROW_ENABLE_SNAPSHOT_METADATA") == "true" {
+		patches = append(patches, utils.PatchCSIOptions{
+			DriverContainerName:      "hostpath",
+			DriverContainerArguments: []string{"--enable-snapshot-metadata"},
+		})
+	}
+
 	err = utils.CreateFromManifests(ctx, config.Framework, driverNamespace, func(item interface{}) error {
 		for _, o := range patches {
 			if err := utils.PatchCSIDeployment(config.Framework, o, item); err != nil {
@@ -287,6 +299,12 @@ func (h *groupSnapshotHostpathCSIDriver) PrepareTest(ctx context.Context, f *fra
 
 	if err != nil {
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
+	}
+
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		if err := utils.CreateSnapshotMetadataTLSSecret(ctx, f, driverns); err != nil {
+			framework.Failf("creating snapshot metadata TLS secret: %v", err)
+		}
 	}
 
 	cleanupFunc := generateDriverCleanupFunc(

--- a/vendor/k8s.io/kubernetes/test/e2e/storage/utils/snapshot-metadata.go
+++ b/vendor/k8s.io/kubernetes/test/e2e/storage/utils/snapshot-metadata.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -145,7 +146,11 @@ func createTLSSecret(ctx context.Context, f *framework.Framework, driverNamespac
 
 	client := f.ClientSet.CoreV1().Secrets(driverNamespace)
 	if _, err := client.Create(ctx, tlsSecret, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create or update TLS secret: %w", err)
+		if apierrors.IsAlreadyExists(err) {
+			framework.Logf("TLS secret already exists: %s", tlsSecret.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to create TLS secret: %w", err)
 	}
 
 	framework.Logf("TLS secret created successfully: %s", tlsSecret.Name)
@@ -211,6 +216,28 @@ func createSnapshotMetdataServiceCR(ctx context.Context, f *framework.Framework,
 
 	if _, err := f.DynamicClient.Resource(gvr).Create(ctx, sms, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create SnapshotMetadataService: %w", err)
+	}
+
+	return nil
+}
+
+// CreateSnapshotMetadataTLSSecret creates only the TLS secret needed by the
+// csi-snapshot-metadata sidecar. Use this in PrepareTest when CapSnapshotMetadata
+// is enabled so the driver pod can mount the secret without requiring the full
+// set of snapshot metadata resources (Service, SnapshotMetadataService CR).
+func CreateSnapshotMetadataTLSSecret(ctx context.Context, f *framework.Framework, driverNamespace string) error {
+	caCert, caPrivateKey, err := generateCA()
+	if err != nil {
+		return fmt.Errorf("failed to generate CA certificate: %w", err)
+	}
+
+	serverCertBytes, serverKeyBytes, err := generateServerCert(driverNamespace, caCert, caPrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate server certificate: %w", err)
+	}
+
+	if err := createTLSSecret(ctx, f, driverNamespace, serverCertBytes, serverKeyBytes); err != nil {
+		return fmt.Errorf("failed to create TLS secret: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

When `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true`, `PrepareTest()` in `csi.go` keeps the `csi-snapshot-metadata` sidecar container and its `csi-snapshot-metadata-server-certs` volume, but never creates the TLS secret the volume references. Only the 2 CBT-specific tests create it via `CreateSnapshotMetadataResources()`, so **all other CSI hostpath tests fail** with `FailedMount` on the missing secret.

### Changes

- **New helper `CreateSnapshotMetadataTLSSecret()`** in `snapshot-metadata.go` — creates only the TLS secret (CA + server cert + secret) without the Service and SnapshotMetadataService CR that only CBT tests need.
- **Call from `PrepareTest()`** in `csi.go` — after deploying manifests, creates the TLS secret when `CapSnapshotMetadata` is true.
- **Idempotent `createTLSSecret()`** — handles `AlreadyExists` so CBT tests calling `CreateSnapshotMetadataResources()` after `PrepareTest()` don't fail on the duplicate secret.

### Context

- Companion to [openshift/release#81061](https://github.com/openshift/release/pull/81061) which adds `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true` to TechPreview CI jobs.
- Root cause analysis: 64 CSI hostpath test failures all trace to `FailedMount: secret "csi-snapshot-metadata-server-certs" not found`.

## Test plan

- [ ] `/testwith` against openshift/release#81061 to validate TechPreview jobs pass with this fix
- [ ] Existing CBT snapshot-metadata tests still pass (idempotent secret creation)