### PR TITLE
OCPNODE-4521: Use programmatic skip for single-node instead of test name tag

### DIFF
--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -23,18 +23,20 @@ import (
 
 // Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
 // and run in the disruptive-longrunning suite.
-//
-// [Skipped:SingleReplicaTopology] - MCP rollouts don't work reliably on single-node
-// clusters due to context deadline timeouts. The test creates a custom MCP which
-// triggers node drains, but single-node cannot drain its only control plane node
-// without bringing down the cluster.
-var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("additional-storage-e2e")
 
 	g.BeforeEach(func(ctx context.Context) {
 		SkipOnMicroShift(oc)
+
+		isSingleNode, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isSingleNode {
+			g.Skip("MCP rollouts don't work reliably on single-node clusters")
+		}
+
 		EnsureNodesReady(ctx, oc)
 
 		enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc)

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -23,12 +23,7 @@ import (
 
 // Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
 // and run in the disruptive-longrunning suite.
-//
-// [Skipped:SingleReplicaTopology] - MCP rollouts don't work reliably on single-node
-// clusters due to context deadline timeouts. The test creates a custom MCP which
-// triggers node drains, but single-node cannot drain its only control plane node
-// without bringing down the cluster.
-var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("additional-storage-e2e")
@@ -36,6 +31,13 @@ var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigro
 	g.BeforeEach(func(ctx context.Context) {
 		SkipOnMicroShift(oc)
 		SkipOnHyperShift(ctx, oc)
+
+		isSingleNode, err := exutil.IsSingleNode(ctx, oc.AdminConfigClient())
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if isSingleNode {
+			g.Skip("MCP rollouts don't work reliably on single-node clusters")
+		}
+
 		EnsureNodesReady(ctx, oc)
 
 		enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc)


### PR DESCRIPTION
Remove `[Skipped:SingleReplicaTopology]` from the `Describe` string and use a programmatic skip via `IsSingleNode()` in `BeforeEach` instead.

The tag in the test name changed the SHA-256 hash used for deterministic sharding (`pkg/test/ginkgo/sharder.go`), which moved the test from shard `2of2` to `1of2` and reset all Sippy run counts to zero. This blocks the feature gate promotion in https://github.com/openshift/api/pull/2858.

This reverts the test name to its original form (from openshift/origin#31439) while preserving the single-node skip behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated storage end-to-end tests to explicitly skip on single-node clusters.
  * Added a clear message explaining when the required topology is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->