### PR TITLE
NO-ISSUE: Skip Additional Storage tests on HyperShift - MachineConfig API not available

### DIFF
--- a/test/extended/node/additional_storage_api.go
+++ b/test/extended/node/additional_storage_api.go
@@ -16,15 +16,8 @@ import (
 )
 
 // IsAdditionalStorageConfigEnabled checks whether the AdditionalStorageConfig
-// feature gate is enabled on the cluster and the platform is supported.
-// Returns false with a reason string if the test should be skipped.
+// feature gate is enabled on the cluster.
 func IsAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) (bool, string) {
-	isMicroShift, err := exutil.IsMicroShiftCluster(oc.AdminKubeClient())
-	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to detect MicroShift cluster")
-	if isMicroShift {
-		return false, "MicroShift cluster - MachineConfig resources are not available"
-	}
-
 	fgs, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get FeatureGate resource")
 	for _, fg := range fgs.Status.FeatureGates {
@@ -44,6 +37,9 @@ var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration
 	var oc = exutil.NewCLI("additional-storage-api")
 
 	g.BeforeEach(func(ctx context.Context) {
+		SkipOnMicroShift(oc)
+		SkipOnHyperShift(ctx, oc)
+
 		if enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc); !enabled {
 			g.Skip(reason)
 		}

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -35,6 +35,7 @@ var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigro
 
 	g.BeforeEach(func(ctx context.Context) {
 		SkipOnMicroShift(oc)
+		SkipOnHyperShift(ctx, oc)
 		EnsureNodesReady(ctx, oc)
 
 		enabled, reason := IsAdditionalStorageConfigEnabled(ctx, oc)

--- a/test/extended/node/kubeletconfig_tls.go
+++ b/test/extended/node/kubeletconfig_tls.go
@@ -27,19 +27,14 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		testMCPName       = "kubelet-tls-test"
 	)
 
-	skipUnsupportedTopologies := func() {
+	skipUnsupportedTopologies := func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc)
 		skipOnTwoNodeTopology(oc)
-
-		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			g.Skip("Skipping test on External (Hypershift) topology - MachineConfig API not available")
-		}
+		SkipOnHyperShift(ctx, oc)
 	}
 
 	g.It("should upgrade kubelet TLS from 1.2 to 1.3 on a custom pool [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
-		skipUnsupportedTopologies()
+		skipUnsupportedTopologies(ctx)
 
 		mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating machine configuration client")

--- a/test/extended/node/node_swap.go
+++ b/test/extended/node/node_swap.go
@@ -95,12 +95,7 @@ var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func
 	})
 
 	g.It("should reject user override of swap settings via KubeletConfig API [OCP-86395]", ote.Informing(), func(ctx context.Context) {
-		// Skip on Hypershift - MachineConfig API is not available
-		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			g.Skip("Skipping test on Hypershift - MachineConfig API not available")
-		}
+		SkipOnHyperShift(ctx, oc)
 
 		g.By("Creating machine config client")
 		mcClient, err := mcclient.NewForConfig(oc.KubeFramework().ClientConfig())

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -37,6 +37,15 @@ func SkipOnMicroShift(oc *exutil.CLI) {
 	}
 }
 
+// SkipOnHyperShift skips the current test if the cluster is HyperShift (External topology).
+func SkipOnHyperShift(ctx context.Context, oc *exutil.CLI) {
+	isHyperShift, err := exutil.IsHypershift(ctx, oc.AdminConfigClient())
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if isHyperShift {
+		g.Skip("Skipping test on HyperShift cluster - MachineConfig API not available")
+	}
+}
+
 // getNodesByLabel returns nodes matching the specified label selector
 func getNodesByLabel(ctx context.Context, oc *exutil.CLI, labelSelector string) ([]corev1.Node, error) {
 	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{

--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -74,11 +74,10 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 			g.Skip("Skipping on MicroShift cluster: runc cannot be configured")
 		}
 
+		SkipOnHyperShift(ctx, oc)
+
 		controlPlaneTopology, err := exutil.GetControlPlaneTopology(oc)
 		o.Expect(err).NotTo(o.HaveOccurred())
-		if *controlPlaneTopology == configv1.ExternalTopologyMode {
-			g.Skip("Skipping on external control plane (Hypershift) cluster")
-		}
 		if *controlPlaneTopology == configv1.SingleReplicaTopologyMode {
 			g.Skip("Skipping on single-replica topology: requires a pure worker node")
 		}


### PR DESCRIPTION
  ### Summary
  Add HyperShift detection to Additional Storage tests and consolidate HyperShift skip logic across all node tests into a reusable helper function.
  
  ### Problem
  Additional Storage E2E and API validation tests were failing on HyperShift clusters with:
  the server could not find the requested resource (post containerruntimeconfigs.machineconfiguration.openshift.io)
  
  **Root cause:** HyperShift clusters use External topology mode where the control plane runs outside the cluster. These clusters do not have the MachineConfig API (ContainerRuntimeConfig, MachineConfigPool,
  etc.) available.

  ### Changes
  
  #### 1. Added `SkipOnHyperShift()` helper in `node_utils.go`
  - Uses context-aware `exutil.IsHypershift(ctx, configClient)`
  - Follows the same pattern as existing `SkipOnMicroShift()`
  - Accepts `context.Context` to allow API call cancellation
  
  #### 2. Updated 5 node test files to use the helper
  Replaced inline HyperShift detection with the reusable helper:
  - `additional_storage_api.go` - API validation tests 
  - `additional_storage_e2e.go` - E2E functional tests
  - `kubeletconfig_tls.go` - TLS config tests
  - `node_swap.go` - Swap configuration tests
  - `runc_upgrade_cases.go` - Runtime upgrade tests
  
  ### Benefits
 **DRY principle** - Eliminates duplicate HyperShift detection code (5 instances → 1 helper)
 **Context-aware** - API calls can be canceled if test context is canceled
**Consistent** - All node tests use the same skip pattern
**Maintainable** - Future HyperShift detection changes only need to update one function
  
  ### Testing
  - Additional Storage tests will now be skipped on HyperShift clusters
  - Existing tests on HA/Single-Node topologies continue to run normally

  ### Related
  - Addresses reviewer feedback from @saschagrunert and @ngopalak-redhat
  - Part of AdditionalStorageConfig feature gate promotion effort (TechPreview → GA)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved extended test compatibility by consistently skipping tests on HyperShift clusters where required APIs are unavailable.
  - Refined additional storage feature-gate checks to evaluate only the relevant feature gate.
  - Standardized topology detection and skip behavior across node-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->