### PR TITLE
NE-2788: exempt ingress Upgradeable=False for deprecated HAProxy versions

### DIFF
--- a/test/extended/operators/operators.go
+++ b/test/extended/operators/operators.go
@@ -119,6 +119,14 @@ var _ = g.Describe("[sig-arch][Early] Managed cluster should [apigroup:config.op
 					continue
 				}
 
+				// The ingress operator sets Upgradeable=False when any
+				// IngressController uses a deprecated HAProxy version. CI jobs
+				// that test non-default HAProxy versions intentionally trigger
+				// this condition.
+				if name == "ingress" && isIngressUpgradableDeprecatedHAProxyCondition(worstCondition) {
+					continue
+				}
+
 				unready = append(unready, fmt.Sprintf("%s (%s=%s %s: %s)",
 					name,
 					worstCondition.Type,
@@ -344,4 +352,15 @@ func isNetworkOperatorUpgradableOpenShiftSDNConfiguredCondition(cond configv1.Cl
 	return cond.Reason == "OpenShiftSDNConfigured" &&
 		cond.Status == "False" &&
 		cond.Type == "Upgradeable"
+}
+
+// isIngressUpgradableDeprecatedHAProxyCondition returns true when the ingress
+// operator reports Upgradeable=False because an IngressController is using a
+// deprecated HAProxy version. This is expected in CI jobs that test non-default
+// HAProxy versions.
+func isIngressUpgradableDeprecatedHAProxyCondition(cond configv1.ClusterOperatorStatusCondition) bool {
+	return cond.Reason == "IngressControllersNotUpgradeable" &&
+		cond.Status == configv1.ConditionFalse &&
+		cond.Type == configv1.OperatorUpgradeable &&
+		strings.Contains(cond.Message, "spec.haproxyVersion")
 }


### PR DESCRIPTION
## Summary

Add an exemption in the `[sig-arch][Early] start all core operators` test to allow the ingress ClusterOperator to report `Upgradeable=False` when caused by a deprecated HAProxy version.

## Why

The ingress operator sets `Upgradeable=False` when any IngressController has `effectiveHAProxyVersion` set to a deprecated version (e.g. HAProxy 2.8 on OCP 5.0). CI jobs that test non-default HAProxy versions intentionally trigger this condition via the `ingress-conf-haproxy-version` CI step, which annotates `ingresses.config.openshift.io/cluster` to override the default HAProxy version cluster-wide.

Without this exemption, every haproxy28 CI job fails on the "start all core operators" test because the ingress ClusterOperator reports `Upgradeable=False` — even though the cluster is fully functional and the condition is expected.

Unblocks https://github.com/openshift/release/pull/83065 (presubmits) and https://github.com/openshift/release/pull/83066 (nightly periodics).

## Pattern

This follows the existing exemption pattern for:
- `kube-apiserver` / `config-operator` — TechPreviewNoUpgrade feature gates
- `cloud-controller-manager` — AlibabaCloud platform
- `network` — Kuryr / OpenShiftSDN deprecation

## Test plan

- [ ] Verify haproxy28 conformance job no longer fails on "start all core operators"
- [ ] Verify non-haproxy28 jobs still catch unexpected ingress `Upgradeable=False` conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated operator readiness checks to ignore known ingress conditions caused by deprecated HAProxy versions.
  * Improved test matching to recognize these conditions based on their status, type, reason, and message details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->