### PR TITLE
NO-JIRA: monitor: record observed update/recreation counts on the stored object

### DIFF
--- a/pkg/monitor/recorder.go
+++ b/pkg/monitor/recorder.go
@@ -66,24 +66,24 @@ func (m *recorder) RecordResource(resourceType string, obj runtime.Object) {
 		UID:       fmt.Sprintf("%v", newMetadata.GetUID()),
 	}
 
+	// annotations are set on the stored copy so that the caller's object, which may come straight
+	// from an informer cache, is never mutated.
 	toStore := obj.DeepCopyObject()
-	// without metadata, just stomp in the new value, we can't add annotations
-	if newMetadata == nil {
-		recordedResource[key] = toStore
-		return
+	storedMetadata, err := meta.Accessor(toStore)
+	if err != nil {
+		// coding error
+		panic(err)
 	}
 
-	newAnnotations := newMetadata.GetAnnotations()
+	newAnnotations := storedMetadata.GetAnnotations()
 	if newAnnotations == nil {
 		newAnnotations = map[string]string{}
 	}
 	existingResource, ok := recordedResource[key]
 	if !ok {
-		if newMetadata != nil {
-			newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
-			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = "0"
-			newMetadata.SetAnnotations(newAnnotations)
-		}
+		newAnnotations[monitorapi.ObservedUpdateCountAnnotation] = "1"
+		newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = "0"
+		storedMetadata.SetAnnotations(newAnnotations)
 		recordedResource[key] = toStore
 		return
 	}
@@ -107,7 +107,7 @@ func (m *recorder) RecordResource(resourceType string, obj runtime.Object) {
 	}
 
 	// set the recreate count. increment if the UIDs don't match
-	existingRecreateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
+	existingRecreateCountStr := existingAnnotations[monitorapi.ObservedRecreationCountAnnotation]
 	if existingMetadata.GetUID() != newMetadata.GetUID() {
 		if existingRecreateCount, err := strconv.ParseInt(existingRecreateCountStr, 10, 32); err != nil {
 			newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
@@ -118,7 +118,7 @@ func (m *recorder) RecordResource(resourceType string, obj runtime.Object) {
 		newAnnotations[monitorapi.ObservedRecreationCountAnnotation] = existingRecreateCountStr
 	}
 
-	newMetadata.SetAnnotations(newAnnotations)
+	storedMetadata.SetAnnotations(newAnnotations)
 	recordedResource[key] = toStore
 	return
 }

--- a/pkg/monitor/recorder_test.go
+++ b/pkg/monitor/recorder_test.go
@@ -1,0 +1,98 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func pod(uid string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-pod",
+			UID:       types.UID(uid),
+		},
+	}
+}
+
+func TestRecordResourceObservedCounts(t *testing.T) {
+	tests := []struct {
+		name                  string
+		recorded              []*corev1.Pod
+		expectedUpdateCount   string
+		expectedRecreateCount string
+	}{
+		{
+			name:                  "first observation seeds the counts",
+			recorded:              []*corev1.Pod{pod("uid-1")},
+			expectedUpdateCount:   "1",
+			expectedRecreateCount: "0",
+		},
+		{
+			name:                  "repeated observations increment the update count",
+			recorded:              []*corev1.Pod{pod("uid-1"), pod("uid-1"), pod("uid-1")},
+			expectedUpdateCount:   "3",
+			expectedRecreateCount: "0",
+		},
+		{
+			// the UID is part of monitorapi.InstanceKey, so a recreated pod is tracked under its
+			// own key and starts counting again from scratch
+			name:                  "a recreated pod is tracked separately from its predecessor",
+			recorded:              []*corev1.Pod{pod("uid-1"), pod("uid-1"), pod("uid-2")},
+			expectedUpdateCount:   "1",
+			expectedRecreateCount: "0",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := NewRecorder()
+			for _, p := range test.recorded {
+				recorder.RecordResource("pods", p)
+			}
+
+			// the key is derived from the most recently recorded pod, since the UID is part of it
+			last := test.recorded[len(test.recorded)-1]
+			key := monitorapi.InstanceKey{
+				Namespace: last.Namespace,
+				Name:      last.Name,
+				UID:       string(last.UID),
+			}
+
+			stored, ok := recorder.CurrentResourceState()["pods"][key]
+			if !ok {
+				t.Fatalf("no resource recorded for %v", key)
+			}
+			annotations := stored.(*corev1.Pod).Annotations
+
+			if actual := annotations[monitorapi.ObservedUpdateCountAnnotation]; actual != test.expectedUpdateCount {
+				t.Errorf("expected update count %q, got %q", test.expectedUpdateCount, actual)
+			}
+			if actual := annotations[monitorapi.ObservedRecreationCountAnnotation]; actual != test.expectedRecreateCount {
+				t.Errorf("expected recreation count %q, got %q", test.expectedRecreateCount, actual)
+			}
+		})
+	}
+}
+
+// TestRecordResourceDoesNotMutateInput ensures the caller's object is left alone. Callers hand in
+// objects straight from an informer cache, so annotating them in place would corrupt the cache.
+func TestRecordResourceDoesNotMutateInput(t *testing.T) {
+	recorder := NewRecorder()
+
+	first := pod("uid-1")
+	recorder.RecordResource("pods", first)
+	if first.Annotations != nil {
+		t.Errorf("expected the recorded object to be unmodified, got annotations %v", first.Annotations)
+	}
+
+	second := pod("uid-1")
+	recorder.RecordResource("pods", second)
+	if second.Annotations != nil {
+		t.Errorf("expected the recorded object to be unmodified, got annotations %v", second.Annotations)
+	}
+}


### PR DESCRIPTION
`RecorderWriter.RecordResource` is documented as:

> Annotations are added to indicate number of updates and the number of recreates.

In practice neither `monitor.openshift.io/observed-update-count` nor
`monitor.openshift.io/observed-recreation-count` ever reaches the stored object, so the
recorded-resource artifacts carry no counts at all.

### What's wrong

In `pkg/monitor/recorder.go`, `toStore := obj.DeepCopyObject()` is taken *before* the annotations are
computed, while `newMetadata` is `meta.Accessor(obj)` — an accessor over the **caller's** object. So
every `SetAnnotations` call writes into the argument and leaves `toStore` untouched.

Two consequences:

1. **The counts are always absent.** Since the stored copy has no annotations, the next observation
   reads an empty `observed-update-count`, `strconv.ParseInt` fails, and the count is pinned at `"1"`
   forever — except it is never actually stored, so it reads back as `""`.
2. **The caller's object is mutated.** The callers in `pkg/monitortestlibrary/monitoring_store.go`
   (`AddFunc`/`UpdateFunc`/`DeleteFunc`, lines 64/90/112) pass objects straight from an informer
   cache. Writing annotations into them modifies shared cache state.

Separately, at line 110 the recreation count was read from the *update-count* key:

```go
existingRecreateCountStr := existingAnnotations[monitorapi.ObservedUpdateCountAnnotation]
```

so on every repeat observation `observed-recreation-count` was overwritten with the update count.

### The fix

Take the metadata accessor over the stored copy, so the annotations land on the object that is
actually retained and the caller's object is left alone; and read the recreation count from its own
annotation.

The `if newMetadata == nil` branch is dropped: `meta.Accessor` never returns a nil accessor together
with a nil error, and the error case is already handled by the `panic` a few lines above, so that
branch was unreachable.

### How it regressed

`git log -S` pins this down precisely:

- **6a53f638f8** (Aug 2021, "track the final state of pods and events from e2e tests for later
  debugging") introduced the feature with `newMetadata, _ := meta.Accessor(toStore)` — the accessor
  was correctly taken over the stored copy. The recreation count was read from the update-count key
  from day one, though.
- **4bdf8c0628** (May 2022, "key resources by UID") needed the UID to build `InstanceKey`, so the
  accessor was hoisted above the `DeepCopyObject()` call and re-pointed at `obj`. That silently moved
  every `SetAnnotations` off the stored copy and onto the caller's object. The same commit put the
  UID into the key, which is what made the recreation-increment branch unreachable.

There is corroborating evidence checked into the repo: the fixture
`pkg/monitortests/node/watchpods/podTest/simple/podData.json` was captured in March 2022, i.e. after
the day-one recreation bug but *before* the May 2022 regression. It records
`observed-update-count: "5"` alongside `observed-recreation-count: "4"` — the recreation count
trailing the update count by exactly one, which is the precise signature of reading the recreation
count out of the update-count annotation.

### Scope note

I deliberately did **not** change the UID-mismatch branch that increments the recreation count.
`monitorapi.InstanceKey` includes the UID, so a recreated object is stored under a *different* key
and the `existingMetadata.GetUID() != newMetadata.GetUID()` comparison can never be true on a
successful lookup. Making recreation counting actually work would mean changing the map key, which is
a design change rather than a bug fix — happy to follow up separately if maintainers want it.

### Testing

Added `pkg/monitor/recorder_test.go` with table-driven cases covering the seeded counts, repeated
observations incrementing the update count, a recreated pod being tracked under its own key, and that
`RecordResource` does not mutate its argument.

Against `main` the new tests fail:

```
--- FAIL: TestRecordResourceObservedCounts/first_observation_seeds_the_counts
    recorder_test.go:77: expected update count "1", got ""
    recorder_test.go:80: expected recreation count "0", got ""
--- FAIL: TestRecordResourceDoesNotMutateInput
    recorder_test.go:94: expected the recorded object to be unmodified, got annotations
        map[monitor.openshift.io/observed-recreation-count:0 monitor.openshift.io/observed-update-count:1]
```

With the fix applied, the whole unit suite is green:

- `go test ./pkg/...` — all 58 packages pass
- `go test -race ./pkg/monitor/...` — pass
- `go build ./...`, `go vet ./pkg/monitor/...`, `gofmt -l` — clean

No cluster is required for any of this.
