### PR TITLE
NO-ISSUE: Update agnhost image to 2.63.0 (mirrored version)

### DIFF
--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -90,7 +90,7 @@ var _ = g.Describe("[Skipped:Disconnected][Skipped:SingleReplicaTopology][apigro
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// Pre-populate test image in image store
-		testImage := "registry.k8s.io/e2e-test-images/agnhost:2.59"
+		testImage := "registry.k8s.io/e2e-test-images/agnhost:2.63.0"
 		framework.Logf("Pre-populating image %s to %s on node %s", testImage, imageStorePath, testNode)
 
 		_, err = ExecOnNodeWithChroot(ctx, oc, testNode, "podman", "--root", imageStorePath, "pull", testImage)


### PR DESCRIPTION
### Summary
Fix Additional Storage E2E test to use a mirrored agnhost image version, preventing "unmirrored image" warnings in CI jobs.
  
### Problem
The test was using `registry.k8s.io/e2e-test-images/agnhost:2.59` which is no longer in the mirrored images list, causing warnings:
```
Cluster accessed images that were not mirrored to the testing repository or already part of the cluster,
  see test/extended/util/image/README.md in the openshift/origin repo:
  
  registry.k8s.io/e2e-test-images/agnhost:2.59 from pods:
    namespace/e2e-test-additional-storage-e2e-mr7nl node/ip-10-0-100-216.us-west-2.compute.internal pod/imagestore-fallback-pod
    namespace/e2e-test-additional-storage-e2e-mr7nl node/ip-10-0-100-216.us-west-2.compute.internal pod/imagestore-prepop-pod
```
  
### Root Cause
commit [9ff6d6990f](https://github.com/openshift/origin/commit/9ff6d6990f513369a3d595313ec0356d4f0efd0d) updated mirrored images during a Kubernetes v1.36.2 bump:
  ```diff
  - "registry.k8s.io/e2e-test-images/agnhost:2.59":     2,
  + "registry.k8s.io/e2e-test-images/agnhost:2.63.0":   2,
```
Changes
File: test/extended/node/additional_storage_e2e.go
  - Changed: agnhost:2.59 → agnhost:2.63.0

Verification
  - agnhost:2.63.0 is in the current mirrored images list (test/extended/util/image/image.go line 53)
  - Test functionality unchanged (only version bump, same image base)
  - No more "unmirrored image" warnings in CI

Testcase ran locally
```
  ------------------------------
  [Skipped:Disconnected][Skipped:SingleReplicaTopology][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests should verify configuration of all storage types and functionally test image stores
  github.com/openshift/origin/test/extended/node/additional_storage_e2e.go:51
    STEP: Creating a kubernetes client @ 08/12/26 18:07:49.245
  I0812 18:07:54.392225 3741420 client.go:293] configPath is now "/tmp/configfile1994917446"
  I0812 18:07:54.392246 3741420 client.go:368] The user is now "e2e-test-additional-storage-e2e-cbgvd-user"
  I0812 18:07:54.392251 3741420 client.go:373] Creating project "e2e-test-additional-storage-e2e-cbgvd"
  I0812 18:07:55.840983 3741420 client.go:393] Waiting on permissions in project "e2e-test-additional-storage-e2e-cbgvd" ...
  I0812 18:07:57.587641 3741420 client.go:422] DeploymentConfig capability is enabled, adding 'deployer' SA to the list of default SAs
  I0812 18:07:59.977501 3741420 client.go:447] Waiting for ServiceAccount "default" to be provisioned...
  I0812 18:08:01.016416 3741420 client.go:447] Waiting for ServiceAccount "builder" to be provisioned...
  I0812 18:08:01.745953 3741420 client.go:447] Waiting for ServiceAccount "deployer" to be provisioned...
  I0812 18:08:03.096118 3741420 client.go:457] Waiting for RoleBinding "system:image-pullers" to be provisioned...
  I0812 18:08:03.526126 3741420 client.go:457] Waiting for RoleBinding "system:image-builders" to be provisioned...
  I0812 18:08:03.890614 3741420 client.go:457] Waiting for RoleBinding "system:deployers" to be provisioned...
  I0812 18:08:06.094679 3741420 client.go:494] Project "e2e-test-additional-storage-e2e-cbgvd" has been fully provisioned.
  I0812 18:08:06.096155 3741420 framework.go:2330] [precondition-check] checking if cluster is MicroShift
  I0812 18:08:06.497668 3741420 framework.go:2353] IsMicroShiftCluster: microshift-version configmap not found, not MicroShift
    STEP: Getting worker node for test @ 08/12/26 18:08:07.633
    STEP: Creating single-node MachineConfigPool for test isolation @ 08/12/26 18:08:08.218
  I0812 18:08:08.728426 3741420 node_mcp_helpers.go:75] Labeling node bgudi-2-n5lpk-worker-a-82p7j with node-role.kubernetes.io/combined-func-test
  I0812 18:08:09.241670 3741420 node_mcp_helpers.go:82] Creating custom MachineConfigPool combined-func-test
  I0812 18:08:09.604953 3741420 node_mcp_helpers.go:121] Waiting for custom MachineConfigPool combined-func-test to be ready
  I0812 18:08:09.605004 3741420 node_utils.go:621] Waiting for MCP combined-func-test to be ready (timeout: 5m0s)...
  I0812 18:08:09.920302 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=false degraded=false renderDegraded=false updated=false machines=0/0
  I0812 18:08:19.992795 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:08:29.934863 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:08:39.960767 3741420 node_utils.go:695] MachineConfigPool combined-func-test is ready: 1/1 machines ready
  I0812 18:08:39.960810 3741420 node_mcp_helpers.go:127] Custom MachineConfigPool combined-func-test created successfully
  I0812 18:08:39.960834 3741420 additional_storage_e2e.go:65] Custom MCP combined-func-test created, targeting node bgudi-2-n5lpk-worker-a-82p7j
    STEP: Phase 1: Creating storage directories and pre-populating test image @ 08/12/26 18:08:39.96
  I0812 18:08:52.259844 3741420 node_utils.go:1025] Node bgudi-2-n5lpk-worker-a-82p7j: directories created: [/var/lib/combined-imagestore /var/lib/combined-artifactstore /var/lib/stargz-store/store]
  I0812 18:08:52.259879 3741420 additional_storage_e2e.go:94] Pre-populating image registry.k8s.io/e2e-test-images/agnhost:2.63.0 to /var/lib/combined-imagestore on node bgudi-2-n5lpk-worker-a-82p7j
  I0812 18:09:05.414633 3741420 additional_storage_e2e.go:102] Image pre-populated successfully: registry.k8s.io/e2e-test-images/agnhost:2.63.0
  I0812 18:09:05.414666 3741420 additional_storage_e2e.go:105] Checking if image exists in primary CRI-O store BEFORE configuring additional stores
  I0812 18:09:09.009542 3741420 additional_storage_e2e.go:115] Verified: image registry.k8s.io/e2e-test-images/agnhost:2.63.0 is NOT in primary CRI-O store (only in /var/lib/combined-imagestore)
    STEP: Phase 2: Creating ContainerRuntimeConfig with all three storage types @ 08/12/26 18:09:09.009
    STEP: Applying ContainerRuntimeConfig and waiting for MCP rollout @ 08/12/26 18:09:09.009
  I0812 18:09:09.009628 3741420 node_kc_cc_helpers.go:111] Creating ContainerRuntimeConfig combined-func-test
  I0812 18:09:09.489284 3741420 node_kc_cc_helpers.go:147] Waiting for MCP combined-func-test to start updating
  I0812 18:09:20.408836 3741420 node_kc_cc_helpers.go:96] MCP combined-func-test has started updating
  I0812 18:09:20.408862 3741420 node_kc_cc_helpers.go:153] Waiting for MCP combined-func-test to complete rollout
  I0812 18:09:20.408872 3741420 node_utils.go:621] Waiting for MCP combined-func-test to be ready (timeout: 15m0s)...
  I0812 18:09:20.911167 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:09:30.877706 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:09:40.744381 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:09:50.891793 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:00.857719 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:11.017304 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:20.900830 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:30.755794 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:40.792539 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:10:51.017305 3741420 node_utils.go:698] MachineConfigPool combined-func-test not ready yet: updating=true degraded=false renderDegraded=false updated=false machines=0/1
  I0812 18:11:00.744962 3741420 node_utils.go:695] MachineConfigPool combined-func-test is ready: 1/1 machines ready
    STEP: Phase 3: Verifying storage.conf and CRI-O configuration @ 08/12/26 18:11:00.745
  I0812 18:11:05.376849 3741420 additional_storage_e2e.go:156] Image stores verified in storage.conf
  I0812 18:11:05.376893 3741420 additional_storage_e2e.go:164] Layer stores verified in storage.conf with path /var/lib/stargz-store/store:ref (MCO added :ref)
    STEP: Verifying CRI-O config contains artifact stores @ 08/12/26 18:11:05.376
  I0812 18:11:09.561025 3741420 additional_storage_e2e.go:172] Artifact stores verified in CRI-O config
    STEP: Verifying CRI-O is active with new configuration @ 08/12/26 18:11:09.561
  I0812 18:11:13.569166 3741420 additional_storage_e2e.go:178] CRI-O is active
    STEP: Phase 4: Creating pod using prepopulated image from additional store @ 08/12/26 18:11:13.569
  I0812 18:11:17.261832 3741420 additional_storage_e2e.go:190] Pod using prepopulated image started in 3.692611098s
    STEP: Phase 5: Testing fallback to registry when image removed from additional store @ 08/12/26 18:11:17.261
  I0812 18:11:17.262641 3741420 delete.go:78] Deleting pod "imagestore-prepop-pod" in namespace "e2e-test-additional-storage-e2e-cbgvd"
  I0812 18:11:17.653196 3741420 delete.go:86] Wait up to 5m0s for pod "imagestore-prepop-pod" to be fully deleted
  I0812 18:11:25.344739 3741420 additional_storage_e2e.go:200] Removed image from additional store to test fallback
  I0812 18:11:31.242097 3741420 additional_storage_e2e.go:215] Pod using registry fallback started in 5.897293794s
  I0812 18:11:31.573078 3741420 additional_storage_e2e.go:227] SUCCESS: Image pulled from registry - Successfully pulled image "registry.k8s.io/e2e-test-images/agnhost:2.63.0" in 2.308s (2.308s including waiting). Image size: 164184663 bytes.
  I0812 18:11:31.573132 3741420 additional_storage_e2e.go:234] Phase 5 PASSED: Fallback to registry works when image not in additional store
  I0812 18:11:31.573141 3741420 additional_storage_e2e.go:236] Test PASSED: Configuration verified for all storage types and image stores functionally tested
  I0812 18:11:31.921722 3741420 client.go:731] Deleted {user.openshift.io/v1, Resource=users  e2e-test-additional-storage-e2e-cbgvd-user}, err: <nil>
  I0812 18:11:32.505867 3741420 client.go:731] Deleted {oauth.openshift.io/v1, Resource=oauthclients  e2e-client-e2e-test-additional-storage-e2e-cbgvd}, err: <nil>
  I0812 18:11:32.506690 3741420 delete.go:78] Deleting pod "imagestore-fallback-pod" in namespace "e2e-test-additional-storage-e2e-cbgvd"
  I0812 18:11:32.891513 3741420 delete.go:86] Wait up to 5m0s for pod "imagestore-fallback-pod" to be fully deleted
  I0812 18:11:35.738362 3741420 node_kc_cc_helpers.go:121] Cleaning up ContainerRuntimeConfig combined-func-test
  I0812 18:11:36.097608 3741420 node_kc_cc_helpers.go:129] Waiting for MCP combined-func-test to become ready after ContainerRuntimeConfig deletion
  I0812 18:11:36.097649 3741420 node_utils.go:621] Waiting for MCP combined-func-test to be ready (timeout: 15m0s)...
  I0812 18:11:36.421024 3741420 node_utils.go:695] MachineConfigPool combined-func-test is ready: 1/1 machines ready
  I0812 18:11:36.421071 3741420 node_kc_cc_helpers.go:136] ContainerRuntimeConfig combined-func-test cleaned up successfully
  I0812 18:11:36.421084 3741420 node_mcp_helpers.go:140] Removing node label node-role.kubernetes.io/combined-func-test from node bgudi-2-n5lpk-worker-a-82p7j
  I0812 18:11:36.750890 3741420 node_mcp_helpers.go:148] Waiting for node bgudi-2-n5lpk-worker-a-82p7j to transition back to worker pool
  I0812 18:13:17.310997 3741420 node_mcp_helpers.go:167] Deleting custom MachineConfigPool combined-func-test
  I0812 18:13:17.662779 3741420 node_mcp_helpers.go:174] Waiting for worker MCP to stabilize after custom MCP deletion
  I0812 18:13:17.662848 3741420 node_utils.go:621] Waiting for MCP worker to be ready (timeout: 10m0s)...
  I0812 18:13:18.001592 3741420 node_utils.go:695] MachineConfigPool worker is ready: 3/3 machines ready
  I0812 18:13:18.001628 3741420 node_mcp_helpers.go:185] Custom MachineConfigPool combined-func-test cleaned up successfully
    STEP: Destroying namespace "e2e-test-additional-storage-e2e-cbgvd" for this suite. @ 08/12/26 18:13:22.809
  • [333.931 seconds]
  ------------------------------
  [ReportAfterSuite] [sig-testing] Log Check
  k8s.io/kubernetes@v1.36.2/test/e2e/invariants/logcheck/logcheck.go:179
  [ReportAfterSuite] PASSED [0.000 seconds]
  ------------------------------
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the pre-populated test image used by the additional storage end-to-end test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->