### PR TITLE
OCPBUGS-105461: allow baremetal to progress while MCO does

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -680,8 +680,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, summary)
 		}
 		switch co {
-		case "baremetal":
-			return "https://issues.redhat.com/browse/OCPBUGS-66101"
 		case "operator-lifecycle-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-65583"
 		case "openshift-samples":
@@ -738,6 +736,13 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 
 	except = func(co string, reason string) string {
 		switch co {
+		case "baremetal":
+			// Since OCPBUGS-66101 was fixed, the baremetal operator intentionally reports Progressing=True
+			// during upgrades (reason SyncingResources, "Applying metal3 resources") while it syncs its
+			// metal3 resources, which legitimately overlaps with the machine-config progressing window.
+			if reason == "SyncingResources" {
+				return "baremetal is allowed to be Progressing=True while machine-config is progressing, as it applies metal3 resources during upgrades"
+			}
 		case "authentication":
 			if isTwoNode && (reason == "APIServerDeployment_NewGeneration" || reason == "APIServerDeployment_PodsUpdating") {
 				return "authentication operator may roll oauth-apiserver (APIServerDeployment_NewGeneration or APIServerDeployment_PodsUpdating) during DualReplica upgrades while machine-config is progressing"


### PR DESCRIPTION
## What this PR does

Updates the `legacy-cvo-invariants` monitor test exceptions for the baremetal cluster operator following the fix for [OCPBUGS-66101](https://issues.redhat.com/browse/OCPBUGS-66101).

Previously, the baremetal operator never reported `Progressing=True` during upgrades. [OCPBUGS-66101](https://issues.redhat.com/browse/OCPBUGS-66101) (fixed by [cluster-baremetal-operator#629](https://github.com/openshift/cluster-baremetal-operator/pull/629)) corrected this so the operator now intentionally reports `Progressing=True` (reason `SyncingResources`, "Applying metal3 resources") while it syncs its metal3 resources during an update.

That intended behavior change trips the `clusteroperator/baremetal should stay Progressing=False while MCO is Progressing=True` invariant, causing the regression reported in [OCPBUGS-105461](https://issues.redhat.com/browse/OCPBUGS-105461).

This PR:

- **Removes** the now-obsolete `baremetal` → `OCPBUGS-66101` exception in the *"must go Progressing=True during an upgrade test"* check. With the operator now reporting progress correctly, that exception path is dead — baremetal passes the test on its own.
- **Adds** a `baremetal` exception, scoped to reason `SyncingResources`, in the *"should stay Progressing=False while MCO is Progressing=True"* check. Since the Progressing transition is now the intended product behavior rather than a defect, this is recorded as an accepted-behavior exception (descriptive string) rather than a Jira reference to a bug to keep tracking.

## Which issue(s) this PR fixes

Fixes [OCPBUGS-105461](https://issues.redhat.com/browse/OCPBUGS-105461)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade monitoring for bare-metal environments.
  * Prevents premature upgrade failures while machine configuration resources are synchronizing.
  * Correctly recognizes expected progress during upgrades, including resource synchronization activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->