### PR TITLE
CORENET-7431: Register network-tools OTE binary

### DIFF
--- a/pkg/test/extensions/binary.go
+++ b/pkg/test/extensions/binary.go
@@ -314,6 +314,10 @@ var extensionBinaries = []TestBinary{
 		binaryPath: "/usr/bin/machine-config-tests-ext.gz",
 	},
 	{
+		imageTag:   "network-tools",
+		binaryPath: "/usr/bin/network-tools-tests-ext.gz",
+	},
+	{
 		imageTag:   "oauth-apiserver",
 		binaryPath: "/usr/bin/oauth-apiserver-tests-ext.gz",
 	},


### PR DESCRIPTION
## Summary
- Add network-tools extension binary to the payload image registry in `pkg/test/extensions/binary.go`
- Enables openshift-tests to discover and run network-tools OTP test cases (55887, 55889, 67625, 67648, 67649)

## Dependencies
- openshift/network-tools#190

## Test plan
- [ ] Verify `go build ./...` passes
- [ ] Run `/testwith openshift/network-tools#190` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `network-tools` extension binary to the available extension registry.
  * Mapped the network tools image tag to its packaged test executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->