### PR TITLE
OCPBUGS-106190: Make oc rsh test resilient

### DIFF
--- a/test/extended/cli/rsh.go
+++ b/test/extended/cli/rsh.go
@@ -37,12 +37,12 @@ var _ = g.Describe("[sig-cli] oc rsh", func() {
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("running the rsh command without specify container name")
-			out, err := oc.Run("rsh").Args(pods[0], "mkdir", "/tmp/test1").Output()
+			out, err := oc.Run("rsh").Args(pods[0], "sh", "-c", "mkdir /tmp/test1 && sleep 1").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(out).To(o.MatchRegexp(`Default.*container.*hello-busybox`))
 
 			g.By("running the rsh command with specify container name and shell")
-			_, err = oc.Run("rsh").Args("--container=hello-busybox-2", "--shell=/bin/sh", pods[0], "mkdir", "/tmp/test3").Output()
+			_, err = oc.Run("rsh").Args("--container=hello-busybox-2", "--shell=/bin/sh", pods[0], "sh", "-c", "mkdir /tmp/test3 && sleep 1").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
 		})
 	})


### PR DESCRIPTION
 When `ExtendWebSocketsToKubelet` is enabled (Beta in 1.36), WebSocket exec/attach connections are proxied through the API server's UpgradeAwareHandler to the kubelet. The proxy tears down both connections as soon as one direction's io.Copy completes. For fast-completing commands (e.g., mkdir), the kubelet's WebSocket close frame can be lost.

This PR updates the test to make it more resilient to the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated remote shell coverage to validate directory creation through a shell command.
  * Added a brief delay to improve reliability for both default and explicitly selected containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->