### PR TITLE
Run long running tests in parallel

### DIFF
--- a/pkg/test/ginkgo/cmd_runsuite.go
+++ b/pkg/test/ginkgo/cmd_runsuite.go
@@ -567,6 +567,9 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		return err
 	}
 
+	nodeResourceTests, primaryTests := splitTests(primaryTests, isNodeResourceTest)
+	logrus.Infof("Found %d node resource tests", len(nodeResourceTests))
+
 	kubeTests, openshiftTests := splitTests(primaryTests, func(t *testCase) bool {
 		return k8sTestNames[t.name]
 	})
@@ -622,6 +625,7 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		originalNetpol := netpolTests
 		originalBuilds := buildsTests
 		originalMustGather := mustGatherTests
+		originalNodeResource := nodeResourceTests
 
 		for i := 1; i < count; i++ {
 			kubeTests = append(kubeTests, copyTests(originalKube)...)
@@ -633,9 +637,10 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 			netpolTests = append(netpolTests, copyTests(originalNetpol)...)
 			buildsTests = append(buildsTests, copyTests(originalBuilds)...)
 			mustGatherTests = append(mustGatherTests, copyTests(originalMustGather)...)
+			nodeResourceTests = append(nodeResourceTests, copyTests(originalNodeResource)...)
 		}
 	}
-	expectedTestCount += len(openshiftTests) + len(kubeTests) + len(storageTests) + len(networkK8sTests) + len(orderedNamespaceDeletionTests) + len(networkTests) + len(netpolTests) + len(buildsTests) + len(mustGatherTests)
+	expectedTestCount += len(openshiftTests) + len(kubeTests) + len(storageTests) + len(networkK8sTests) + len(orderedNamespaceDeletionTests) + len(networkTests) + len(netpolTests) + len(buildsTests) + len(mustGatherTests) + len(nodeResourceTests)
 
 	abortFn := neverAbort
 	testCtx := ctx
@@ -728,6 +733,15 @@ func (o *GinkgoRunSuiteOptions) Run(suite *TestSuite, clusterConfig *clusterdisc
 		monitorEventRecorder.EndInterval(mustGatherIntervalID, time.Now())
 		logrus.Infof("Completed MustGather test bucket in %v", time.Since(mustGatherStartTime))
 		tests = append(tests, mustGatherTestsCopy...)
+
+		if len(nodeResourceTests) > 0 {
+			nodeResourceTestsCopy := copyTests(nodeResourceTests)
+			nodeResourceIntervalID, nodeResourceStartTime := recordTestBucketInterval(monitorEventRecorder, "NodeResource")
+			executeNodeResourceTests(testCtx, nodeResourceTestsCopy, testRunnerContext, testOutputConfig, abortFn, restConfig)
+			monitorEventRecorder.EndInterval(nodeResourceIntervalID, time.Now())
+			logrus.Infof("Completed NodeResource test bucket in %v", time.Since(nodeResourceStartTime))
+			tests = append(tests, nodeResourceTestsCopy...)
+		}
 	}
 
 	// TODO: will move to the monitor

--- a/pkg/test/ginkgo/node_resource_runner.go
+++ b/pkg/test/ginkgo/node_resource_runner.go
@@ -131,6 +131,12 @@ func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCas
 	nrs.mu.Lock()
 	defer nrs.mu.Unlock()
 
+	// Watch for context cancellation to wake blocked workers
+	go func() {
+		<-ctx.Done()
+		nrs.cond.Broadcast()
+	}()
+
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -143,6 +149,12 @@ func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCas
 
 		for i, test := range nrs.tests {
 			cfg := nrs.configs[test.name]
+
+			// Skip if this label is already reserved by a running test
+			if nrs.isLabelReservedLocked(cfg.label) {
+				continue
+			}
+
 			needed := cfg.numNodes
 			if cfg.isAll {
 				needed = len(nrs.workerNodes)
@@ -158,8 +170,11 @@ func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCas
 			reserved := freeNodes[:needed]
 
 			if err := labelNodes(ctx, nrs.kubeClient, reserved, cfg.label); err != nil {
-				logrus.Errorf("Failed to label nodes for test %s: %v", test.name, err)
-				continue
+				logrus.Errorf("Failed to label nodes for test %s: %v, marking test failed", test.name, err)
+				test.failed = true
+				test.testOutputBytes = []byte(fmt.Sprintf("NodeResource scheduler failed to label nodes: %v", err))
+				nrs.tests = append(nrs.tests[:i], nrs.tests[i+1:]...)
+				return test
 			}
 
 			for _, nodeName := range reserved {
@@ -172,6 +187,15 @@ func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCas
 
 		nrs.cond.Wait()
 	}
+}
+
+func (nrs *nodeResourceScheduler) isLabelReservedLocked(label string) bool {
+	for _, reservedLabel := range nrs.reservedBy {
+		if reservedLabel == label {
+			return true
+		}
+	}
+	return false
 }
 
 func (nrs *nodeResourceScheduler) MarkTestComplete(test *testCase) {
@@ -213,7 +237,9 @@ func labelNodes(ctx context.Context, kubeClient kubernetes.Interface, nodeNames 
 		_, err := kubeClient.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
 		if err != nil {
 			for j := 0; j < i; j++ {
-				_ = unlabelNode(ctx, kubeClient, nodeNames[j])
+				if rollbackErr := unlabelNode(ctx, kubeClient, nodeNames[j]); rollbackErr != nil {
+					logrus.Errorf("Failed to rollback label on node %s during cleanup: %v", nodeNames[j], rollbackErr)
+				}
 			}
 			return fmt.Errorf("failed to label node %s: %w", nodeName, err)
 		}
@@ -288,7 +314,9 @@ func executeNodeResourceTests(
 	cleanupCtx := context.Background()
 	for nodeName := range scheduler.reservedBy {
 		logrus.Warnf("Cleaning up orphaned NodeResource label on node %s", nodeName)
-		_ = unlabelNode(cleanupCtx, scheduler.kubeClient, nodeName)
+		if err := unlabelNode(cleanupCtx, scheduler.kubeClient, nodeName); err != nil {
+			logrus.Errorf("Failed to clean up orphaned NodeResource label on node %s: %v", nodeName, err)
+		}
 	}
 }
 

--- a/pkg/test/ginkgo/node_resource_runner.go
+++ b/pkg/test/ginkgo/node_resource_runner.go
@@ -1,0 +1,297 @@
+package ginkgo
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const nodeResourceLabelKey = "noderesource.test.openshift.io/name"
+
+var nodeResourceTagRe = regexp.MustCompile(`\[NodeResource:numNodes=([^,]+),label=([^\]]+)\]`)
+
+type nodeResourceConfig struct {
+	numNodes int
+	label    string
+	isAll    bool
+}
+
+func parseNodeResourceTag(testName string) (*nodeResourceConfig, error) {
+	match := nodeResourceTagRe.FindStringSubmatch(testName)
+	if match == nil {
+		return nil, fmt.Errorf("no [NodeResource:...] tag found in %q", testName)
+	}
+	numNodesStr := match[1]
+	label := match[2]
+
+	cfg := &nodeResourceConfig{label: label}
+	if numNodesStr == "all" {
+		cfg.isAll = true
+		cfg.numNodes = -1
+	} else {
+		n, err := strconv.Atoi(numNodesStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid numNodes %q in test %q: %w", numNodesStr, testName, err)
+		}
+		if n <= 0 {
+			return nil, fmt.Errorf("numNodes must be positive or 'all', got %q in test %q", numNodesStr, testName)
+		}
+		cfg.numNodes = n
+	}
+	return cfg, nil
+}
+
+type nodeResourceScheduler struct {
+	mu          sync.Mutex
+	cond        *sync.Cond
+	kubeClient  kubernetes.Interface
+	workerNodes []string
+	reservedBy  map[string]string
+	tests       []*testCase
+	configs     map[string]*nodeResourceConfig
+}
+
+func newNodeResourceScheduler(ctx context.Context, kubeClient kubernetes.Interface, tests []*testCase) (*nodeResourceScheduler, error) {
+	nodeList, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: "node-role.kubernetes.io/worker",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worker nodes: %w", err)
+	}
+
+	var workerNames []string
+	for _, node := range nodeList.Items {
+		if _, has := node.Labels["node-role.kubernetes.io/control-plane"]; has {
+			continue
+		}
+		if _, has := node.Labels["node-role.kubernetes.io/master"]; has {
+			continue
+		}
+		workerNames = append(workerNames, node.Name)
+	}
+	sort.Strings(workerNames)
+
+	if len(workerNames) == 0 {
+		return nil, fmt.Errorf("no pure worker nodes available for NodeResource tests")
+	}
+
+	configs := make(map[string]*nodeResourceConfig, len(tests))
+	for _, t := range tests {
+		cfg, err := parseNodeResourceTag(t.name)
+		if err != nil {
+			return nil, err
+		}
+		needed := cfg.numNodes
+		if cfg.isAll {
+			needed = len(workerNames)
+		}
+		if needed > len(workerNames) {
+			return nil, fmt.Errorf("test %q requires %d nodes but only %d workers available", t.name, needed, len(workerNames))
+		}
+		configs[t.name] = cfg
+	}
+
+	for _, nodeName := range workerNames {
+		node, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+		if _, hasLabel := node.Labels[nodeResourceLabelKey]; hasLabel {
+			logrus.Warnf("Removing stale %s label from node %s", nodeResourceLabelKey, nodeName)
+			if err := unlabelNode(ctx, kubeClient, nodeName); err != nil {
+				return nil, fmt.Errorf("failed to remove stale label from node %s: %w", nodeName, err)
+			}
+		}
+	}
+
+	nrs := &nodeResourceScheduler{
+		kubeClient:  kubeClient,
+		workerNodes: workerNames,
+		reservedBy:  make(map[string]string),
+		tests:       tests,
+		configs:     configs,
+	}
+	nrs.cond = sync.NewCond(&nrs.mu)
+
+	logrus.Infof("NodeResource scheduler initialized: %d tests, %d worker nodes available", len(tests), len(workerNames))
+	return nrs, nil
+}
+
+func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCase {
+	nrs.mu.Lock()
+	defer nrs.mu.Unlock()
+
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if len(nrs.tests) == 0 {
+			return nil
+		}
+
+		freeNodes := nrs.getFreeNodesLocked()
+
+		for i, test := range nrs.tests {
+			cfg := nrs.configs[test.name]
+			needed := cfg.numNodes
+			if cfg.isAll {
+				needed = len(nrs.workerNodes)
+				if len(freeNodes) != len(nrs.workerNodes) {
+					continue
+				}
+			}
+
+			if len(freeNodes) < needed {
+				continue
+			}
+
+			reserved := freeNodes[:needed]
+
+			if err := labelNodes(ctx, nrs.kubeClient, reserved, cfg.label); err != nil {
+				logrus.Errorf("Failed to label nodes for test %s: %v", test.name, err)
+				continue
+			}
+
+			for _, nodeName := range reserved {
+				nrs.reservedBy[nodeName] = cfg.label
+			}
+
+			nrs.tests = append(nrs.tests[:i], nrs.tests[i+1:]...)
+			return test
+		}
+
+		nrs.cond.Wait()
+	}
+}
+
+func (nrs *nodeResourceScheduler) MarkTestComplete(test *testCase) {
+	nrs.mu.Lock()
+	defer nrs.mu.Unlock()
+
+	cfg := nrs.configs[test.name]
+
+	var nodesToRelease []string
+	for nodeName, reservedLabel := range nrs.reservedBy {
+		if reservedLabel == cfg.label {
+			nodesToRelease = append(nodesToRelease, nodeName)
+		}
+	}
+
+	for _, nodeName := range nodesToRelease {
+		if err := unlabelNode(context.Background(), nrs.kubeClient, nodeName); err != nil {
+			logrus.Errorf("Failed to remove NodeResource label from node %s after test %s: %v", nodeName, test.name, err)
+		}
+		delete(nrs.reservedBy, nodeName)
+	}
+
+	nrs.cond.Broadcast()
+}
+
+func (nrs *nodeResourceScheduler) getFreeNodesLocked() []string {
+	var free []string
+	for _, name := range nrs.workerNodes {
+		if _, reserved := nrs.reservedBy[name]; !reserved {
+			free = append(free, name)
+		}
+	}
+	return free
+}
+
+func labelNodes(ctx context.Context, kubeClient kubernetes.Interface, nodeNames []string, label string) error {
+	for i, nodeName := range nodeNames {
+		patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, nodeResourceLabelKey, label))
+		_, err := kubeClient.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+		if err != nil {
+			for j := 0; j < i; j++ {
+				_ = unlabelNode(ctx, kubeClient, nodeNames[j])
+			}
+			return fmt.Errorf("failed to label node %s: %w", nodeName, err)
+		}
+	}
+	return nil
+}
+
+func unlabelNode(ctx context.Context, kubeClient kubernetes.Interface, nodeName string) error {
+	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:null}}}`, nodeResourceLabelKey))
+	_, err := kubeClient.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+	return err
+}
+
+func executeNodeResourceTests(
+	ctx context.Context,
+	tests []*testCase,
+	commandContext *commandContext,
+	testOutput testOutputConfig,
+	maybeAbortOnFailureFn testAbortFunc,
+	restConfig *rest.Config,
+) {
+	if len(tests) == 0 {
+		return
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		logrus.Errorf("Failed to create kubernetes client for NodeResource tests: %v", err)
+		for _, test := range tests {
+			test.failed = true
+			test.testOutputBytes = []byte(fmt.Sprintf("NodeResource scheduler initialization failed: %v", err))
+		}
+		return
+	}
+
+	scheduler, err := newNodeResourceScheduler(ctx, kubeClient, tests)
+	if err != nil {
+		logrus.Errorf("Failed to initialize NodeResource scheduler: %v", err)
+		for _, test := range tests {
+			test.failed = true
+			test.testOutputBytes = []byte(fmt.Sprintf("NodeResource scheduler initialization failed: %v", err))
+		}
+		return
+	}
+
+	parallelism := len(scheduler.workerNodes)
+	if parallelism > len(tests) {
+		parallelism = len(tests)
+	}
+
+	testSuiteProgress := newTestSuiteProgress(len(tests))
+	testSuiteRunner := &testSuiteRunnerImpl{
+		commandContext:        commandContext,
+		testOutput:            testOutput,
+		testSuiteProgress:     testSuiteProgress,
+		maybeAbortOnFailureFn: maybeAbortOnFailureFn,
+	}
+
+	logrus.Infof("Starting NodeResource test execution: %d tests, %d workers, parallelism=%d",
+		len(tests), len(scheduler.workerNodes), parallelism)
+
+	var wg sync.WaitGroup
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runTestsUntilDone(ctx, scheduler, testSuiteRunner)
+		}()
+	}
+	wg.Wait()
+
+	cleanupCtx := context.Background()
+	for nodeName := range scheduler.reservedBy {
+		logrus.Warnf("Cleaning up orphaned NodeResource label on node %s", nodeName)
+		_ = unlabelNode(cleanupCtx, scheduler.kubeClient, nodeName)
+	}
+}
+
+func isNodeResourceTest(test *testCase) bool {
+	return strings.Contains(test.name, "[NodeResource:")
+}

--- a/pkg/test/ginkgo/node_resource_runner.go
+++ b/pkg/test/ginkgo/node_resource_runner.go
@@ -8,8 +8,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -101,16 +103,29 @@ func newNodeResourceScheduler(ctx context.Context, kubeClient kubernetes.Interfa
 		configs[t.name] = cfg
 	}
 
-	for _, nodeName := range workerNames {
-		node, err := kubeClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		if err != nil {
-			return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
-		}
-		if _, hasLabel := node.Labels[nodeResourceLabelKey]; hasLabel {
-			logrus.Warnf("Removing stale %s label from node %s", nodeResourceLabelKey, nodeName)
-			if err := unlabelNode(ctx, kubeClient, nodeName); err != nil {
-				return nil, fmt.Errorf("failed to remove stale label from node %s: %w", nodeName, err)
+	staleErrs := make([]error, len(workerNames))
+	var staleWg sync.WaitGroup
+	for i, nodeName := range workerNames {
+		staleWg.Add(1)
+		go func(idx int, name string) {
+			defer staleWg.Done()
+			node, err := kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				staleErrs[idx] = fmt.Errorf("failed to get node %s: %w", name, err)
+				return
 			}
+			if _, hasLabel := node.Labels[nodeResourceLabelKey]; hasLabel {
+				logrus.Warnf("Removing stale %s label from node %s", nodeResourceLabelKey, name)
+				if err := unlabelNode(ctx, kubeClient, name); err != nil {
+					staleErrs[idx] = fmt.Errorf("failed to remove stale label from node %s: %w", name, err)
+				}
+			}
+		}(i, nodeName)
+	}
+	staleWg.Wait()
+	for _, err := range staleErrs {
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -145,7 +160,7 @@ func (nrs *nodeResourceScheduler) GetNextTestToRun(ctx context.Context) *testCas
 			return nil
 		}
 
-		freeNodes := nrs.getFreeNodesLocked()
+		freeNodes := nrs.getReadyFreeNodesLocked(ctx)
 
 		for i, test := range nrs.tests {
 			cfg := nrs.configs[test.name]
@@ -231,18 +246,67 @@ func (nrs *nodeResourceScheduler) getFreeNodesLocked() []string {
 	return free
 }
 
-func labelNodes(ctx context.Context, kubeClient kubernetes.Interface, nodeNames []string, label string) error {
-	for i, nodeName := range nodeNames {
-		patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, nodeResourceLabelKey, label))
-		_, err := kubeClient.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
+func (nrs *nodeResourceScheduler) getReadyFreeNodesLocked(ctx context.Context) []string {
+	free := nrs.getFreeNodesLocked()
+	var ready []string
+	for _, name := range free {
+		node, err := nrs.kubeClient.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			for j := 0; j < i; j++ {
-				if rollbackErr := unlabelNode(ctx, kubeClient, nodeNames[j]); rollbackErr != nil {
-					logrus.Errorf("Failed to rollback label on node %s during cleanup: %v", nodeNames[j], rollbackErr)
-				}
-			}
-			return fmt.Errorf("failed to label node %s: %w", nodeName, err)
+			logrus.Warnf("Failed to check readiness of node %s, skipping: %v", name, err)
+			continue
 		}
+		if isNodeReady(node) {
+			ready = append(ready, name)
+		}
+	}
+	return ready
+}
+
+func isNodeReady(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func labelNodes(ctx context.Context, kubeClient kubernetes.Interface, nodeNames []string, label string) error {
+	errs := make([]error, len(nodeNames))
+	var wg sync.WaitGroup
+	for i, nodeName := range nodeNames {
+		wg.Add(1)
+		go func(idx int, name string) {
+			defer wg.Done()
+			patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:%q}}}`, nodeResourceLabelKey, label))
+			_, errs[idx] = kubeClient.CoreV1().Nodes().Patch(ctx, name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		}(i, nodeName)
+	}
+	wg.Wait()
+
+	var firstErr error
+	var successNodes []string
+	for i, err := range errs {
+		if err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("failed to label node %s: %w", nodeNames[i], err)
+		}
+		if err == nil {
+			successNodes = append(successNodes, nodeNames[i])
+		}
+	}
+	if firstErr != nil {
+		var rollbackWg sync.WaitGroup
+		for _, name := range successNodes {
+			rollbackWg.Add(1)
+			go func(n string) {
+				defer rollbackWg.Done()
+				if rollbackErr := unlabelNode(ctx, kubeClient, n); rollbackErr != nil {
+					logrus.Errorf("Failed to rollback label on node %s during cleanup: %v", n, rollbackErr)
+				}
+			}(name)
+		}
+		rollbackWg.Wait()
+		return firstErr
 	}
 	return nil
 }
@@ -300,6 +364,21 @@ func executeNodeResourceTests(
 
 	logrus.Infof("Starting NodeResource test execution: %d tests, %d workers, parallelism=%d",
 		len(tests), len(scheduler.workerNodes), parallelism)
+
+	// Periodic wakeup so blocked workers re-check node readiness
+	// after disruptive tests leave nodes temporarily NotReady.
+	ticker := time.NewTicker(30 * time.Second)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				scheduler.cond.Broadcast()
+			}
+		}
+	}()
 
 	var wg sync.WaitGroup
 	for i := 0; i < parallelism; i++ {

--- a/pkg/test/ginkgo/node_resource_runner_test.go
+++ b/pkg/test/ginkgo/node_resource_runner_test.go
@@ -1,0 +1,182 @@
+package ginkgo
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseNodeResourceTag(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantNum     int
+		wantLabel   string
+		wantIsAll   bool
+		wantErr     bool
+	}{
+		{
+			name:      "single node",
+			input:     "[NodeResource:numNodes=1,label=foo]",
+			wantNum:   1,
+			wantLabel: "foo",
+		},
+		{
+			name:      "all nodes",
+			input:     "[NodeResource:numNodes=all,label=bar]",
+			wantNum:   -1,
+			wantLabel: "bar",
+			wantIsAll: true,
+		},
+		{
+			name:      "multiple nodes",
+			input:     "[NodeResource:numNodes=3,label=multi_node]",
+			wantNum:   3,
+			wantLabel: "multi_node",
+		},
+		{
+			name:      "embedded in full test name",
+			input:     "[sig-node][Disruptive][NodeResource:numNodes=1,label=test_embed] some test description",
+			wantNum:   1,
+			wantLabel: "test_embed",
+		},
+		{
+			name:    "zero nodes",
+			input:   "[NodeResource:numNodes=0,label=bad]",
+			wantErr: true,
+		},
+		{
+			name:    "negative nodes",
+			input:   "[NodeResource:numNodes=-1,label=bad]",
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric nodes",
+			input:   "[NodeResource:numNodes=abc,label=bad]",
+			wantErr: true,
+		},
+		{
+			name:    "no tag",
+			input:   "no tag here",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseNodeResourceTag(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.numNodes != tt.wantNum {
+				t.Errorf("numNodes = %d, want %d", cfg.numNodes, tt.wantNum)
+			}
+			if cfg.label != tt.wantLabel {
+				t.Errorf("label = %q, want %q", cfg.label, tt.wantLabel)
+			}
+			if cfg.isAll != tt.wantIsAll {
+				t.Errorf("isAll = %v, want %v", cfg.isAll, tt.wantIsAll)
+			}
+		})
+	}
+}
+
+func TestIsNodeResourceTest(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"[NodeResource:numNodes=1,label=x] test", true},
+		{"[sig-node][NodeResource:numNodes=all,label=y] test", true},
+		{"[sig-node] regular test", false},
+		{"", false},
+		{"NodeResource without brackets", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &testCase{name: tt.name}
+			got := isNodeResourceTest(tc)
+			if got != tt.want {
+				t.Errorf("isNodeResourceTest(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsNodeReady(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []corev1.NodeCondition
+		want       bool
+	}{
+		{
+			name: "ready true",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+			want: true,
+		},
+		{
+			name: "ready false",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionFalse},
+			},
+			want: false,
+		},
+		{
+			name: "ready unknown",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionUnknown},
+			},
+			want: false,
+		},
+		{
+			name:       "no conditions",
+			conditions: nil,
+			want:       false,
+		},
+		{
+			name: "other conditions only",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+			},
+			want: false,
+		},
+		{
+			name: "ready true among other conditions",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeMemoryPressure, Status: corev1.ConditionFalse},
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+				{Type: corev1.NodeDiskPressure, Status: corev1.ConditionFalse},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Status:     corev1.NodeStatus{Conditions: tt.conditions},
+			}
+			got := isNodeReady(node)
+			if got != tt.want {
+				t.Errorf("isNodeReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/extended/node/additional_storage_api.go
+++ b/test/extended/node/additional_storage_api.go
@@ -31,7 +31,7 @@ func IsAdditionalStorageConfigEnabled(ctx context.Context, oc *exutil.CLI) (bool
 }
 
 // API validation tests - use DryRun to avoid triggering MCO reconciliation
-var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Suite:openshift/conformance/parallel] Additional Storage API Validation", func() {
+var _ = g.Describe("[apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Suite:openshift/conformance/parallel][NodeResource:numNodes=1,label=additional_storage_api] Additional Storage API Validation", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("additional-storage-api")

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -23,7 +23,7 @@ import (
 
 // Additional Storage E2E Tests - trigger MCO reconciliation (MCP rollouts)
 // and run in the disruptive-longrunning suite.
-var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Additional Storage E2E Tests", func() {
+var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigroup:machineconfiguration.openshift.io][Jira:Node/CRI-O][sig-node][Feature:AdditionalStorageSupport][OCPFeatureGate:AdditionalStorageConfig][Serial][Disruptive][Suite:openshift/disruptive-longrunning][NodeResource:numNodes=1,label=additional_storage_e2e] Additional Storage E2E Tests", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("additional-storage-e2e")
@@ -56,7 +56,8 @@ var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigrou
 
 		// SETUP: Create single-node MachineConfigPool for faster rollouts
 		g.By("Getting worker node for test")
-		testNode := GetFirstReadyWorkerNode(oc)
+		testNode, nodeErr := GetFirstNodeResourceNode(ctx, oc, "additional_storage_e2e")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no worker node found")
 
 		mcpName := "combined-func-test"
 		var mcpConfig *CustomMCPConfig

--- a/test/extended/node/additional_storage_e2e.go
+++ b/test/extended/node/additional_storage_e2e.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[Skipped:Disconnected][apigroup:config.openshift.io][apigrou
 
 		// SETUP: Create single-node MachineConfigPool for faster rollouts
 		g.By("Getting worker node for test")
-		testNode, nodeErr := GetFirstNodeResourceNode(ctx, oc, "additional_storage_e2e")
+		testNode, nodeErr := GetNodeResource(ctx, oc, "additional_storage_e2e")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no worker node found")
 
 		mcpName := "combined-func-test"

--- a/test/extended/node/crio_goroutinedump.go
+++ b/test/extended/node/crio_goroutinedump.go
@@ -71,7 +71,7 @@ var _ = g.Describe("[sig-node][Late][NodeResource:numNodes=all,label=crio_gorout
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("crio-goroutine-dump")
 
-	g.It("CRI-O goroutine dump via SIGUSR1 should contain no stuck image pulls on any node",
+	g.It("CRI-O goroutine dump via SIGUSR1 should contain no stuck image pulls on any worker node",
 		ote.Informing(), func(ctx g.SpecContext) {
 
 			nodes, err := GetNodeResourceNodes(ctx, oc, "crio_goroutinedump")

--- a/test/extended/node/crio_goroutinedump.go
+++ b/test/extended/node/crio_goroutinedump.go
@@ -67,14 +67,14 @@ func findStuckImagePulls(dump string) []string {
 	return stuck
 }
 
-var _ = g.Describe("[sig-node][Late]", func() {
+var _ = g.Describe("[sig-node][Late][NodeResource:numNodes=all,label=crio_goroutinedump]", func() {
 	defer g.GinkgoRecover()
 	oc := exutil.NewCLIWithoutNamespace("crio-goroutine-dump")
 
 	g.It("CRI-O goroutine dump via SIGUSR1 should contain no stuck image pulls on any node",
 		ote.Informing(), func(ctx g.SpecContext) {
 
-			nodes, err := exutil.GetAllClusterNodes(oc)
+			nodes, err := GetNodeResourceNodes(ctx, oc, "crio_goroutinedump")
 			o.Expect(err).NotTo(o.HaveOccurred())
 			o.Expect(nodes).NotTo(o.BeEmpty(), "expected at least one node")
 

--- a/test/extended/node/criocredentialprovider.go
+++ b/test/extended/node/criocredentialprovider.go
@@ -31,7 +31,7 @@ const (
 	dummypodImage                       = "docker.io/library/nginx@sha256:7f2f2b29e70f2785a697e2364718c6dbbe198ee7e17ae736a9da80bdd85ce843"
 )
 
-var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:CRIOCredentialProviderConfig][Serial][NodeResource:numNodes=1,label=crio_credential_provider]", g.Ordered, func() {
+var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:CRIOCredentialProviderConfig][Serial][NodeResource:numNodes=all,label=crio_credential_provider]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                           = exutil.NewCLIWithoutNamespace("crio-credential-provider")
@@ -52,7 +52,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			g.Skip("skipping, error determining expected credential provider config path")
 		}
 		var err error
-		workerNodeName, err = GetFirstNodeResourceNode(tctx, oc, "crio_credential_provider")
+		workerNodeName, err = GetNodeResource(tctx, oc, "crio_credential_provider")
 		if err != nil {
 			g.Skip("skipping, no worker nodes found")
 		}

--- a/test/extended/node/criocredentialprovider.go
+++ b/test/extended/node/criocredentialprovider.go
@@ -31,13 +31,13 @@ const (
 	dummypodImage                       = "docker.io/library/nginx@sha256:7f2f2b29e70f2785a697e2364718c6dbbe198ee7e17ae736a9da80bdd85ce843"
 )
 
-var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:CRIOCredentialProviderConfig][Serial]", g.Ordered, func() {
+var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:CRIOCredentialProviderConfig][Serial][NodeResource:numNodes=1,label=crio_credential_provider]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 	var (
 		oc                           = exutil.NewCLIWithoutNamespace("crio-credential-provider")
 		tctx                         = context.Background()
 		credentialProviderConfigPath string
-		workerNodes                  []corev1.Node
+		workerNodeName               string
 		cli                          = exutil.NewCLIWithPodSecurityLevel("criocp-mynamespace", admissionapi.LevelBaseline)
 		clif                         = cli.KubeFramework()
 	)
@@ -52,8 +52,8 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			g.Skip("skipping, error determining expected credential provider config path")
 		}
 		var err error
-		workerNodes, err = getWorkerNodes(oc)
-		if err != nil || len(workerNodes) == 0 {
+		workerNodeName, err = GetFirstNodeResourceNode(tctx, oc, "crio_credential_provider")
+		if err != nil {
 			g.Skip("skipping, no worker nodes found")
 		}
 
@@ -64,16 +64,16 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			updateCRIOCredentialProviderConfig(oc, expectedMatchImages, false)
 			g.DeferCleanup(updateCRIOCredentialProviderConfig, oc, []string{}, false)
 
-			verifyWorkerNodeCRIOCredentialProviderConfig(oc, expectedMatchImages, nil, workerNodes[0], credentialProviderConfigPath, true)
+			verifyWorkerNodeCRIOCredentialProviderConfig(oc, expectedMatchImages, nil, workerNodeName, credentialProviderConfigPath, true)
 
 			if updatedMatchImages != nil && expectProviderAfterUpdate {
 				updateCRIOCredentialProviderConfig(oc, updatedMatchImages, false)
-				verifyWorkerNodeCRIOCredentialProviderConfig(oc, updatedMatchImages, excludedMatchImages, workerNodes[0], credentialProviderConfigPath, expectProviderAfterUpdate)
+				verifyWorkerNodeCRIOCredentialProviderConfig(oc, updatedMatchImages, excludedMatchImages, workerNodeName, credentialProviderConfigPath, expectProviderAfterUpdate)
 			}
 
 			if !expectProviderAfterUpdate {
 				updateCRIOCredentialProviderConfig(oc, updatedMatchImages, false)
-				verifyWorkerNodeCRIOCredentialProviderConfig(oc, updatedMatchImages, excludedMatchImages, workerNodes[0], credentialProviderConfigPath, expectProviderAfterUpdate)
+				verifyWorkerNodeCRIOCredentialProviderConfig(oc, updatedMatchImages, excludedMatchImages, workerNodeName, credentialProviderConfigPath, expectProviderAfterUpdate)
 			}
 
 		},
@@ -102,7 +102,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		matchImages := []string{"docker.io"}
 		updateCRIOCredentialProviderConfig(oc, matchImages, false)
 		g.DeferCleanup(updateCRIOCredentialProviderConfig, oc, []string{}, false)
-		verifyWorkerNodeCRIOCredentialProviderConfig(oc, matchImages, nil, workerNodes[0], credentialProviderConfigPath, true)
+		verifyWorkerNodeCRIOCredentialProviderConfig(oc, matchImages, nil, workerNodeName, credentialProviderConfigPath, true)
 
 		// namespace rbac
 		createNamespaceRBAC(clif, clif.Namespace.Name)
@@ -118,7 +118,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 
 		logSince := time.Now().UTC().Format("2006-01-02 15:04:05")
 
-		pod, err := launchTestPod(context.Background(), clif, "dummy-pod", dummypodImage, workerNodes[0].Name)
+		pod, err := launchTestPod(context.Background(), clif, "dummy-pod", dummypodImage, workerNodeName)
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to launch test pod")
 		g.DeferCleanup(func() {
 			clif.ClientSet.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
@@ -138,7 +138,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		var lastErr error
 		o.Eventually(func() (string, error) {
 			out, err := oc.AsAdmin().Run("debug").Args(
-				"-n", debugNamespaceDefault, "node/"+workerNodes[0].Name, "--", "chroot", "/host", "sh", "-c",
+				"-n", debugNamespaceDefault, "node/"+workerNodeName, "--", "chroot", "/host", "sh", "-c",
 				fmt.Sprintf("journalctl --since '%s' _COMM=crio-credential | grep 'Wrote auth file to /etc/crio/auth/'", logSince),
 			).Output()
 			lastOut = out
@@ -208,8 +208,7 @@ func getWorkerNodes(oc *exutil.CLI) ([]corev1.Node, error) {
 	return workerNodes.Items, nil
 }
 
-func verifyWorkerNodeCRIOCredentialProviderConfig(oc *exutil.CLI, expectedMatchImages, excludedMatchImages []string, node corev1.Node, path string, expectCRIOProviderEntry bool) {
-	nodeName := node.Name
+func verifyWorkerNodeCRIOCredentialProviderConfig(oc *exutil.CLI, expectedMatchImages, excludedMatchImages []string, nodeName string, path string, expectCRIOProviderEntry bool) {
 	out, err := oc.AsAdmin().Run("debug").Args("-n", debugNamespaceDefault, "node/"+nodeName, "--", "chroot", "/host", "cat", path).Output()
 	e2e.Logf("%s", out)
 

--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -66,32 +66,39 @@ func describeImageVolumeTests(config imageVolumeTestConfig) bool {
 		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 
 		var (
-			oc      = exutil.NewCLI(config.frameworkName)
-			podName = config.frameworkName + "-test"
+			oc       = exutil.NewCLI(config.frameworkName)
+			podName  = config.frameworkName + "-test"
+			nodeName string
 		)
 
 		g.BeforeEach(func(ctx context.Context) {
 			SkipOnMicroShift(oc)
 			EnsureNodesReady(ctx, oc)
+
+			if nodeName == "" {
+				var err error
+				nodeName, err = GetFirstNodeResourceNode(ctx, oc, config.nodeResourceLabel)
+				o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node for label %s", config.nodeResourceLabel)
+			}
 		})
 
 		g.It("should succeed with pod and pull policy of Always", func(ctx context.Context) {
 			ref := config.getVolumeRef(ctx, oc, f.Namespace.Name)
-			pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, ref)
+			pod := buildPodWithImageVolume(f.Namespace.Name, nodeName, podName, ref)
 			CreatePodAndWaitForRunning(ctx, oc, pod)
 			verifyPathsExist(f, pod, "/mnt/image", config.pathsToVerify)
 		})
 
 		g.It("should handle multiple image volumes", func(ctx context.Context) {
 			ref := config.getVolumeRef(ctx, oc, f.Namespace.Name)
-			pod := buildPodWithMultipleImageVolumes(f.Namespace.Name, "", podName, ref, ref)
+			pod := buildPodWithMultipleImageVolumes(f.Namespace.Name, nodeName, podName, ref, ref)
 			CreatePodAndWaitForRunning(ctx, oc, pod)
 			verifyPathsExist(f, pod, "/mnt/image", config.pathsToVerify)
 			verifyPathsExist(f, pod, "/mnt/image2", config.pathsToVerify)
 		})
 
 		g.It("should fail when image does not exist", func(ctx context.Context) {
-			pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, "nonexistent:latest")
+			pod := buildPodWithImageVolume(f.Namespace.Name, nodeName, podName, "nonexistent:latest")
 
 			g.By("Creating a pod with non-existent image volume")
 			_, err := oc.AdminKubeClient().CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
@@ -109,7 +116,7 @@ func describeImageVolumeTests(config imageVolumeTestConfig) bool {
 		})
 
 		g.It("should succeed if image volume is not existing but unused", func(ctx context.Context) {
-			pod := buildPodWithImageVolume(f.Namespace.Name, "", podName, "nonexistent:latest")
+			pod := buildPodWithImageVolume(f.Namespace.Name, nodeName, podName, "nonexistent:latest")
 			pod.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{}
 			CreatePodAndWaitForRunning(ctx, oc, pod)
 			// The container has no image volume mount, so just checking running is enough
@@ -118,7 +125,7 @@ func describeImageVolumeTests(config imageVolumeTestConfig) bool {
 		g.It("should succeed with multiple pods and same image on the same node", func(ctx context.Context) {
 			ref := config.getVolumeRef(ctx, oc, f.Namespace.Name)
 
-			pod1 := buildPodWithImageVolume(f.Namespace.Name, "", podName, ref)
+			pod1 := buildPodWithImageVolume(f.Namespace.Name, nodeName, podName, ref)
 			pod1 = CreatePodAndWaitForRunning(ctx, oc, pod1)
 
 			pod2 := buildPodWithImageVolume(f.Namespace.Name, pod1.Spec.NodeName, podName+"-2", ref)
@@ -133,14 +140,14 @@ func describeImageVolumeTests(config imageVolumeTestConfig) bool {
 				ref := config.getVolumeRef(ctx, oc, f.Namespace.Name)
 				// Use the top-level directory of the first path as the subPath
 				subPath := strings.Split(config.pathsToVerify[0], "/")[0]
-				pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, "", podName, ref, subPath)
+				pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, nodeName, podName, ref, subPath)
 				CreatePodAndWaitForRunning(ctx, oc, pod)
 				verifyPathsExist(f, pod, "/mnt/image", trimSubPath(config.pathsToVerify, subPath))
 			})
 
 			g.It("should fail to mount image volume with invalid subPath", func(ctx context.Context) {
 				ref := config.getVolumeRef(ctx, oc, f.Namespace.Name)
-				pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, "", podName, ref, "noexist")
+				pod := buildPodWithImageVolumeSubPath(f.Namespace.Name, nodeName, podName, ref, "noexist")
 				g.By("Creating a pod with image volume and subPath")
 				_, err := oc.AdminKubeClient().CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -77,7 +77,7 @@ func describeImageVolumeTests(config imageVolumeTestConfig) bool {
 
 			if nodeName == "" {
 				var err error
-				nodeName, err = GetFirstNodeResourceNode(ctx, oc, config.nodeResourceLabel)
+				nodeName, err = GetNodeResource(ctx, oc, config.nodeResourceLabel)
 				o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node for label %s", config.nodeResourceLabel)
 			}
 		})

--- a/test/extended/node/image_volume.go
+++ b/test/extended/node/image_volume.go
@@ -24,6 +24,8 @@ import (
 type imageVolumeTestConfig struct {
 	// describeLabel is appended to "[sig-node] [FeatureGate:ImageVolume] "
 	describeLabel string
+	// nodeResourceLabel is used in the [NodeResource:numNodes=1,label=...] tag
+	nodeResourceLabel string
 	// frameworkName is used for framework.NewDefaultFramework and exutil.NewCLI
 	frameworkName string
 	// getVolumeRef returns the reference for the image/artifact volume.
@@ -36,8 +38,9 @@ type imageVolumeTestConfig struct {
 
 // Register image volume tests
 var _ = describeImageVolumeTests(imageVolumeTestConfig{
-	describeLabel: "ArtifactVolume",
-	frameworkName: "artifact-volume",
+	describeLabel:     "ArtifactVolume",
+	nodeResourceLabel: "image_volume_artifact",
+	frameworkName:     "artifact-volume",
 	getVolumeRef: func(_ context.Context, _ *exutil.CLI, _ string) string {
 		return image.LocationFor("quay.io/crio/artifact:subpath")
 	},
@@ -45,8 +48,9 @@ var _ = describeImageVolumeTests(imageVolumeTestConfig{
 })
 
 var _ = describeImageVolumeTests(imageVolumeTestConfig{
-	describeLabel: "ImageVolume",
-	frameworkName: "image-volume",
+	describeLabel:     "ImageVolume",
+	nodeResourceLabel: "image_volume",
+	frameworkName:     "image-volume",
 	getVolumeRef: func(_ context.Context, _ *exutil.CLI, _ string) string {
 		return "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest"
 	},
@@ -55,7 +59,7 @@ var _ = describeImageVolumeTests(imageVolumeTestConfig{
 
 // describeImageVolumeTests generates a full test suite for image or artifact volumes.
 func describeImageVolumeTests(config imageVolumeTestConfig) bool {
-	return g.Describe("[sig-node] [FeatureGate:ImageVolume] "+config.describeLabel, func() {
+	return g.Describe("[sig-node] [FeatureGate:ImageVolume] "+config.describeLabel+"[NodeResource:numNodes=1,label="+config.nodeResourceLabel+"]", func() {
 		defer g.GinkgoRecover()
 
 		f := framework.NewDefaultFramework(config.frameworkName)

--- a/test/extended/node/kubelet_secret_pulled_images.go
+++ b/test/extended/node/kubelet_secret_pulled_images.go
@@ -56,7 +56,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		}
 
 		var err error
-		workerNode, err = GetFirstNodeResourceNode(ctx, oc, "kubelet_secret_images")
+		workerNode, err = GetNodeResource(ctx, oc, "kubelet_secret_images")
 		if err != nil {
 			g.Skip("no worker nodes available")
 		}
@@ -192,6 +192,7 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 	// effect after kubelet restart triggered by the MCO rollout.
 	g.It("Case 4: Credential verification policy [Slow]", func() {
 		kcName := "cred-verify-policy"
+		mcpName := "cred-verify-policy"
 		ns := "cred-verify-policy"
 		credVerifyEnsureNamespace(ctx, oc, ns)
 		g.DeferCleanup(credVerifyDeleteNamespace, context.Background(), oc, ns)
@@ -202,27 +203,37 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 		credVerifyGrantImagePuller(oc, sourceNS, ns)
 		credVerifyCreateSecret(ctx, oc, ns, "pull-secret", pullSecret)
 
+		err = EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		var mcpConfig *CustomMCPConfig
 		g.DeferCleanup(func() {
 			cleanupCtx := context.Background()
-			_ = CleanupKubeletConfig(cleanupCtx, mcClient, kcName, "worker")
+			_ = CleanupKubeletConfig(cleanupCtx, mcClient, kcName, mcpName)
+			if err := CleanupCustomMCP(cleanupCtx, mcpConfig); err != nil {
+				e2e.Logf("WARNING: cleanup had errors: %v", err)
+			}
 		})
+
+		mcpConfig, err = CreateCustomMCPForNode(ctx, oc, mcClient, mcpName, workerNode)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create custom MCP")
 
 		g.By("Pre-caching private image on the node with a valid secret")
 		credVerifyRunPod(ctx, oc, credVerifyPod(ns, "pod-seed", privateImage, workerNode, corev1.PullIfNotPresent, "pull-secret"))
 
 		g.By("Applying NeverVerify policy and waiting for MCO rollout")
-		credVerifyApplyPolicy(ctx, mcClient, kcName, `{"imagePullCredentialsVerificationPolicy":"NeverVerify"}`)
-		credVerifyWaitForMCPUpdating(ctx, mcClient, "worker")
-		err = WaitForMCP(ctx, mcClient, "worker", 15*time.Minute)
+		credVerifyApplyPolicy(ctx, mcClient, kcName, mcpName, `{"imagePullCredentialsVerificationPolicy":"NeverVerify"}`)
+		credVerifyWaitForMCPUpdating(ctx, mcClient, mcpName)
+		err = WaitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Verifying NeverVerify policy allows pod without secret to use cached image")
 		credVerifyRunPod(ctx, oc, credVerifyPod(ns, "pod-neververify", privateImage, workerNode, corev1.PullNever))
 
 		g.By("Switching to AlwaysVerify policy and waiting for MCO rollout")
-		credVerifyApplyPolicy(ctx, mcClient, kcName, `{"imagePullCredentialsVerificationPolicy":"AlwaysVerify"}`)
-		credVerifyWaitForMCPUpdating(ctx, mcClient, "worker")
-		err = WaitForMCP(ctx, mcClient, "worker", 15*time.Minute)
+		credVerifyApplyPolicy(ctx, mcClient, kcName, mcpName, `{"imagePullCredentialsVerificationPolicy":"AlwaysVerify"}`)
+		credVerifyWaitForMCPUpdating(ctx, mcClient, mcpName)
+		err = WaitForMCP(ctx, mcClient, mcpName, 15*time.Minute)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		// This pod also re-caches the image after MCO rollout since pull records are cleared
@@ -393,14 +404,14 @@ func credVerifyExpectImagePullError(ctx context.Context, oc *exutil.CLI, pod *co
 	o.Expect(err).NotTo(o.HaveOccurred())
 }
 
-// credVerifyApplyPolicy creates or updates a KubeletConfig targeting workers with the given raw JSON.
-func credVerifyApplyPolicy(ctx context.Context, mcClient *mcclient.Clientset, name, kubeletConfigJSON string) {
+// credVerifyApplyPolicy creates or updates a KubeletConfig targeting the given MCP with the given raw JSON.
+func credVerifyApplyPolicy(ctx context.Context, mcClient *mcclient.Clientset, name, mcpName, kubeletConfigJSON string) {
 	kc := &machineconfigv1.KubeletConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: machineconfigv1.KubeletConfigSpec{
 			MachineConfigPoolSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"pools.operator.machineconfiguration.openshift.io/worker": "",
+					"pools.operator.machineconfiguration.openshift.io/" + mcpName: "",
 				},
 			},
 			KubeletConfig: &runtime.RawExtension{

--- a/test/extended/node/kubelet_secret_pulled_images.go
+++ b/test/extended/node/kubelet_secret_pulled_images.go
@@ -30,7 +30,7 @@ const (
 	credVerifyPublicImage = internalRegistryPrefix + "/openshift/tools:latest"
 )
 
-var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:KubeletEnsureSecretPulledImages][Serial]", g.Ordered, func() {
+var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][OCPFeatureGate:KubeletEnsureSecretPulledImages][Serial][NodeResource:numNodes=1,label=kubelet_secret_images]", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -55,11 +55,11 @@ var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptiv
 			g.Skip("requires TechPreviewNoUpgrade or CustomNoUpgrade feature set")
 		}
 
-		nodes, err := getWorkerNodes(oc)
-		if err != nil || len(nodes) == 0 {
+		var err error
+		workerNode, err = GetFirstNodeResourceNode(ctx, oc, "kubelet_secret_images")
+		if err != nil {
 			g.Skip("no worker nodes available")
 		}
-		workerNode = nodes[0].Name
 		e2e.Logf("Worker node: %s", workerNode)
 
 		// Tag the cluster-hosted openshift/tools image into a namespace-scoped imagestream

--- a/test/extended/node/kubeletconfig_features.go
+++ b/test/extended/node/kubeletconfig_features.go
@@ -29,7 +29,7 @@ var (
 // These tests verify KubeletConfig application with various kubelet configuration features.
 // The primary purpose is to test applying KubeletConfig objects to nodes and verifying that
 // the kubelet configuration changes are properly applied and take effect.
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive]", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] [NodeResource:numNodes=1,label=kubeletconfig_features]", func() {
 	defer g.GinkgoRecover()
 	var (
 		NodeKubeletConfigBaseDir = exutil.FixturePath("testdata", "node", "kubeletconfig")
@@ -50,7 +50,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		kubeClient, err := kubernetes.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting kube client: %v", err))
 
-		testNode := GetFirstReadyWorkerNode(oc)
+		testNode, err := GetFirstNodeResourceNode(ctx, oc, "kubeletconfig_features")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating machine config client")

--- a/test/extended/node/kubeletconfig_features.go
+++ b/test/extended/node/kubeletconfig_features.go
@@ -50,7 +50,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		kubeClient, err := kubernetes.NewForConfig(oc.KubeFramework().ClientConfig())
 		o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting kube client: %v", err))
 
-		testNode, err := GetFirstNodeResourceNode(ctx, oc, "kubeletconfig_features")
+		testNode, err := GetNodeResource(ctx, oc, "kubeletconfig_features")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		mcClient, err := machineconfigclient.NewForConfig(oc.KubeFramework().ClientConfig())

--- a/test/extended/node/kubeletconfig_tls.go
+++ b/test/extended/node/kubeletconfig_tls.go
@@ -20,7 +20,7 @@ import (
 // from TLS 1.2 to TLS 1.3 via a KubeletConfig resource applied to a custom
 // MachineConfigPool containing a single worker node. Using a custom pool
 // avoids rebooting all workers and makes the test significantly faster.
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Kubelet TLS configuration", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] [NodeResource:numNodes=1,label=kubeletconfig_tls] Kubelet TLS configuration", func() {
 	var (
 		oc                = exutil.NewCLIWithoutNamespace("node-kubeletconfig-tls")
 		kubeletConfigName = "tls13-kubelet-config"
@@ -40,13 +40,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating machine configuration client")
 
 		g.By("Selecting a worker node for testing")
-		allWorkers, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
-		o.Expect(err).NotTo(o.HaveOccurred(), "Error listing worker nodes")
-		workerNodes := getPureWorkerNodes(allWorkers)
-		o.Expect(len(workerNodes)).To(o.BeNumerically(">", 0), "No pure worker nodes found in the cluster")
-
-		testNode := workerNodes[0].Name
-		o.Expect(isNodeInReadyState(&workerNodes[0])).To(o.BeTrue(), "Worker node %s is not in Ready state", testNode)
+		testNode, err := GetFirstNodeResourceNode(ctx, oc, "kubeletconfig_tls")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Selected node %s for TLS upgrade test", testNode)
 
 		g.By("Checking default TLS configuration")

--- a/test/extended/node/kubeletconfig_tls.go
+++ b/test/extended/node/kubeletconfig_tls.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error creating machine configuration client")
 
 		g.By("Selecting a worker node for testing")
-		testNode, err := GetFirstNodeResourceNode(ctx, oc, "kubeletconfig_tls")
+		testNode, err := GetNodeResource(ctx, oc, "kubeletconfig_tls")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Selected node %s for TLS upgrade test", testNode)
 

--- a/test/extended/node/nested_container.go
+++ b/test/extended/node/nested_container.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] nested container", func() {
+var _ = g.Describe("[Suite:openshift/usernamespace] [sig-node] [FeatureGate:ProcMountType] [FeatureGate:UserNamespacesSupport] [NodeResource:numNodes=1,label=nested_container] nested container", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("nested-podman", admissionapi.LevelBaseline)
 	g.It("should pass podman localsystem test in baseline mode",
 		func(ctx context.Context) {

--- a/test/extended/node/node_e2e/container_runtime_config.go
+++ b/test/extended/node/node_e2e/container_runtime_config.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive][NodeResource:numNodes=1,label=container_runtime_config] ContainerRuntimeConfig", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("ctrcfg")
 	)
@@ -35,13 +35,13 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 	// Validates that ContainerRuntimeConfig pidsLimit setting is correctly applied
 	// by MCO to a single worker node and that manual crio.conf edits are overwritten.
 	//author: cmaurya@redhat.com
-	g.It("[OTP] Verify pidsLimit and MCO overwrite behavior [OCP-45351]", func() {
+	g.It("[NodeResource:numNodes=1,label=ctrcfg_pidslimit][OTP] Verify pidsLimit and MCO overwrite behavior [OCP-45351]", func() {
 		ctx := context.Background()
 		ctrcfgName := "set-pids-limit"
 		mcpName := "ctrcfg-pids"
 
 		g.By("Get a ready worker node")
-		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "container_runtime_config")
+		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "ctrcfg_pidslimit")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -115,7 +115,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 	// Validates that setting overlaySize in ContainerRuntimeConfig is applied to
 	// storage.conf on a single worker node and the overlay size is reflected inside a container.
 	//author: cmaurya@redhat.com
-	g.It("[OTP] Verify overlaySize is applied to node and container [OCP-46313]", func() {
+	g.It("[NodeResource:numNodes=1,label=ctrcfg_overlaysize][OTP] Verify overlaySize is applied to node and container [OCP-46313]", func() {
 		oc.SetupProject()
 		ctx := context.Background()
 		ctrcfgName := "ctrcfg-46313"
@@ -123,7 +123,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		overlaySize := "9G"
 
 		g.By("Get a ready worker node")
-		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "container_runtime_config")
+		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "ctrcfg_overlaysize")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/node/node_e2e/container_runtime_config.go
+++ b/test/extended/node/node_e2e/container_runtime_config.go
@@ -41,7 +41,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		mcpName := "ctrcfg-pids"
 
 		g.By("Get a ready worker node")
-		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "ctrcfg_pidslimit")
+		workerNode, nodeErr := nodeutils.GetNodeResource(ctx, oc, "ctrcfg_pidslimit")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -123,7 +123,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		overlaySize := "9G"
 
 		g.By("Get a ready worker node")
-		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "ctrcfg_overlaysize")
+		workerNode, nodeErr := nodeutils.GetNodeResource(ctx, oc, "ctrcfg_overlaysize")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/node/node_e2e/container_runtime_config.go
+++ b/test/extended/node/node_e2e/container_runtime_config.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] ContainerRuntimeConfig", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive][NodeResource:numNodes=1,label=container_runtime_config] ContainerRuntimeConfig", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("ctrcfg")
 	)
@@ -41,8 +41,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		mcpName := "ctrcfg-pids"
 
 		g.By("Get a ready worker node")
-		workerNode := nodeutils.GetFirstReadyWorkerNode(oc)
-		o.Expect(workerNode).NotTo(o.BeEmpty(), "no ready worker node found")
+		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "container_runtime_config")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
@@ -123,8 +123,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		overlaySize := "9G"
 
 		g.By("Get a ready worker node")
-		workerNode := nodeutils.GetFirstReadyWorkerNode(oc)
-		o.Expect(workerNode).NotTo(o.BeEmpty(), "no ready worker node found")
+		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "container_runtime_config")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 		err := nodeutils.EnsureNodeHasNoCustomRole(ctx, oc, workerNode)
 		o.Expect(err).NotTo(o.HaveOccurred())
 

--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -55,7 +55,7 @@ func unpauseMasterPool(oc *exutil.CLI) {
 }
 
 func readRegistriesConfOnWorker(ctx context.Context, oc *exutil.CLI) string {
-	nodeName, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "image_mirror_set")
+	nodeName, nodeErr := nodeutils.GetNodeResource(ctx, oc, "image_mirror_set")
 	o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 	registriesConf, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, nodeName, "cat", "/etc/containers/registries.conf")
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to read registries.conf from node %s", nodeName)

--- a/test/extended/node/node_e2e/image_mirror_set.go
+++ b/test/extended/node/node_e2e/image_mirror_set.go
@@ -55,8 +55,8 @@ func unpauseMasterPool(oc *exutil.CLI) {
 }
 
 func readRegistriesConfOnWorker(ctx context.Context, oc *exutil.CLI) string {
-	nodeName := nodeutils.GetFirstReadyWorkerNode(oc)
-	o.Expect(nodeName).NotTo(o.BeEmpty(), "no ready worker node found")
+	nodeName, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "image_mirror_set")
+	o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 	registriesConf, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, nodeName, "cat", "/etc/containers/registries.conf")
 	o.Expect(err).NotTo(o.HaveOccurred(), "failed to read registries.conf from node %s", nodeName)
 	return registriesConf
@@ -78,7 +78,7 @@ func pollMCPSpecUnchanged(oc *exutil.CLI, pool, baselineSpec string, duration ti
 }
 
 // author: asahay@redhat.com
-var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][Serial] ImageTagMirrorSet and ImageDigestMirrorSet", func() {
+var _ = g.Describe("[sig-node][Suite:openshift/disruptive-longrunning][Disruptive][Serial][NodeResource:numNodes=all,label=image_mirror_set] ImageTagMirrorSet and ImageDigestMirrorSet", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("image-mirror-set")
 	)

--- a/test/extended/node/node_e2e/image_registry_config.go
+++ b/test/extended/node/node_e2e/image_registry_config.go
@@ -19,7 +19,7 @@ import (
 	operator "github.com/openshift/origin/test/extended/util/operator"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Image registry config", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive][NodeResource:numNodes=all,label=image_registry_config] Image registry config", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("imgcfg")
 	)
@@ -92,14 +92,13 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", initialMasterSpec)
 
 		g.By("Verify search registries config on a worker node")
-		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
-		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get ready schedulable worker nodes")
-		o.Expect(workers).NotTo(o.BeEmpty(), "no ready worker nodes found")
+		workerNodeName, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "image_registry_config")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 
 		var registriesConf string
 		o.Eventually(func() error {
 			var execErr error
-			registriesConf, execErr = nodeutils.ExecOnNodeWithChroot(ctx, oc, workers[0].Name,
+			registriesConf, execErr = nodeutils.ExecOnNodeWithChroot(ctx, oc, workerNodeName,
 				"cat", "/etc/containers/registries.conf.d/01-image-searchRegistries.conf")
 			if execErr != nil {
 				return execErr
@@ -109,14 +108,14 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 			}
 			return nil
 		}, 30*time.Second, 5*time.Second).Should(o.Succeed(),
-			"search registry %s not found in registries config on node %s", searchRegistry, workers[0].Name)
-		e2e.Logf("Registries config on %s:\n%s", workers[0].Name, registriesConf)
+			"search registry %s not found in registries config on node %s", searchRegistry, workerNodeName)
+		e2e.Logf("Registries config on %s:\n%s", workerNodeName, registriesConf)
 
 		g.By("Verify policy.json is updated with allowed registries")
-		policyJSON, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, workers[0].Name,
+		policyJSON, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, workerNodeName,
 			"cat", "/etc/containers/policy.json")
-		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read policy.json on node %s", workers[0].Name)
-		e2e.Logf("policy.json on %s:\n%s", workers[0].Name, policyJSON)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to read policy.json on node %s", workerNodeName)
+		e2e.Logf("policy.json on %s:\n%s", workerNodeName, policyJSON)
 		o.Expect(policyJSON).To(o.ContainSubstring(searchRegistry),
 			"policy.json should contain allowed registry %s", searchRegistry)
 	})

--- a/test/extended/node/node_e2e/image_registry_config.go
+++ b/test/extended/node/node_e2e/image_registry_config.go
@@ -92,7 +92,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		imagepolicy.WaitForMCPConfigSpecChangeAndUpdated(oc, "master", initialMasterSpec)
 
 		g.By("Verify search registries config on a worker node")
-		workerNodeName, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "image_registry_config")
+		workerNodeName, nodeErr := nodeutils.GetNodeResource(ctx, oc, "image_registry_config")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "no ready worker node found")
 
 		var registriesConf string

--- a/test/extended/node/node_e2e/initcontainer.go
+++ b/test/extended/node/node_e2e/initcontainer.go
@@ -18,7 +18,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] NODE initContainer policy,volume,readiness,quota", func() {
+var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label=initcontainer] NODE initContainer policy,volume,readiness,quota", func() {
 	defer g.GinkgoRecover()
 
 	var (

--- a/test/extended/node/node_e2e/initcontainer.go
+++ b/test/extended/node/node_e2e/initcontainer.go
@@ -46,7 +46,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 		ctx := context.Background()
 
 		g.By("Resolve NodeResource node for pod placement")
-		assignedNode, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "initcontainer")
+		assignedNode, err := nodeutils.GetNodeResource(ctx, oc, "initcontainer")
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node")
 
 		g.By("Create a pod with init container")

--- a/test/extended/node/node_e2e/initcontainer.go
+++ b/test/extended/node/node_e2e/initcontainer.go
@@ -45,6 +45,10 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 		namespace := oc.Namespace()
 		ctx := context.Background()
 
+		g.By("Resolve NodeResource node for pod placement")
+		assignedNode, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "initcontainer")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node")
+
 		g.By("Create a pod with init container")
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -52,6 +56,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 				Namespace: namespace,
 			},
 			Spec: corev1.PodSpec{
+				NodeName: assignedNode,
 				InitContainers: []corev1.Container{
 					{
 						Name:    "inittest",
@@ -90,7 +95,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 			},
 		}
 
-		_, err := oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		_, err = oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		defer func() {
 			oc.KubeClient().CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})

--- a/test/extended/node/node_e2e/netns_cleanup.go
+++ b/test/extended/node/node_e2e/netns_cleanup.go
@@ -39,6 +39,10 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 		namespace := oc.Namespace()
 		podName := "pod-56266"
 
+		g.By("Resolve NodeResource node for pod placement")
+		assignedNode, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "netns_cleanup")
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node")
+
 		g.By("Create a test pod")
 		pod := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -46,6 +50,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 				Namespace: namespace,
 			},
 			Spec: corev1.PodSpec{
+				NodeName: assignedNode,
 				Containers: []corev1.Container{
 					{
 						Name:    "hello-openshift",
@@ -55,7 +60,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 				},
 			},
 		}
-		pod, err := oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		pod, err = oc.KubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to create pod")
 
 		g.By("Wait for pod to be ready")

--- a/test/extended/node/node_e2e/netns_cleanup.go
+++ b/test/extended/node/node_e2e/netns_cleanup.go
@@ -19,7 +19,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Network namespace cleanup", func() {
+var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label=netns_cleanup] Network namespace cleanup", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("netns-cleanup")
 	)

--- a/test/extended/node/node_e2e/netns_cleanup.go
+++ b/test/extended/node/node_e2e/netns_cleanup.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet][NodeResource:numNodes=1,label
 		podName := "pod-56266"
 
 		g.By("Resolve NodeResource node for pod placement")
-		assignedNode, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "netns_cleanup")
+		assignedNode, err := nodeutils.GetNodeResource(ctx, oc, "netns_cleanup")
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get NodeResource node")
 
 		g.By("Create a test pod")

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -81,7 +81,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] [NodeResource:numNodes=1,labe
 
 	//author: cmaurya@redhat.com
 	g.It("[OTP] validate cgroupv2 is default [OCP-80983]", func(ctx context.Context) {
-		g.By("Check cgroup version on all Ready worker nodes")
+		g.By("Check cgroup version on NodeResource worker nodes")
 		resourceNodes, err := nodeutils.GetNodeResourceNodes(ctx, oc, "node_e2e")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -16,7 +16,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager", func() {
+var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] [NodeResource:numNodes=1,label=node_e2e] Kubelet, CRI-O, CPU manager", func() {
 	var (
 		oc             = exutil.NewCLIWithoutNamespace("node")
 		nodeE2EBaseDir = exutil.FixturePath("testdata", "node", "node_e2e")
@@ -82,18 +82,11 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 	//author: cmaurya@redhat.com
 	g.It("[OTP] validate cgroupv2 is default [OCP-80983]", func(ctx context.Context) {
 		g.By("Check cgroup version on all Ready worker nodes")
-		nodeNames, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("nodes", "-l", "node-role.kubernetes.io/worker", "-o=jsonpath={.items[*].metadata.name}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		workers := strings.Fields(nodeNames)
-		o.Expect(workers).NotTo(o.BeEmpty(), "No worker nodes found")
+		resourceNodes, err := nodeutils.GetNodeResourceNodes(ctx, oc, "node_e2e")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 
-		for _, worker := range workers {
-			nodeStatus, err := oc.AsAdmin().Run("get").Args("nodes", worker, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if nodeStatus != "True" {
-				e2e.Logf("Skipping worker node %s (not Ready)", worker)
-				continue
-			}
+		for _, resourceNode := range resourceNodes {
+			worker := resourceNode.Name
 			cgroupV, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, worker, "/bin/bash", "-c", "stat -c %T -f /sys/fs/cgroup")
 			o.Expect(err).NotTo(o.HaveOccurred())
 			e2e.Logf("cgroup version on node %s: [%v]", worker, cgroupV)
@@ -114,10 +107,8 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] Kubelet, CRI-O, CPU manager",
 		// Skip on runc: io.kubernetes.cri-o.Devices annotation is only in crun's allowed_annotations.
 		// We query crio config directly as ContainerRuntimeConfig API misses platform-default runc.
 		g.By("Skip if the default runtime is runc")
-		node, err := oc.AsAdmin().WithoutNamespace().Run("get").Args(
-			"nodes", "-l", "node-role.kubernetes.io/worker", "-o=jsonpath={.items[0].metadata.name}").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(node).NotTo(o.BeEmpty())
+		node, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "node_e2e")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		runtime, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c",
 			"crio status config 2>/dev/null | awk -F'\"' '/default_runtime/{print $2}'")
 		o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -107,7 +107,7 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] [NodeResource:numNodes=1,labe
 		// Skip on runc: io.kubernetes.cri-o.Devices annotation is only in crun's allowed_annotations.
 		// We query crio config directly as ContainerRuntimeConfig API misses platform-default runc.
 		g.By("Skip if the default runtime is runc")
-		node, err := nodeutils.GetFirstNodeResourceNode(ctx, oc, "node_e2e")
+		node, err := nodeutils.GetNodeResource(ctx, oc, "node_e2e")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		runtime, err := nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c",
 			"crio status config 2>/dev/null | awk -F'\"' '/default_runtime/{print $2}'")

--- a/test/extended/node/node_e2e/node.go
+++ b/test/extended/node/node_e2e/node.go
@@ -34,41 +34,25 @@ var _ = g.Describe("[sig-node] [Jira:Node/Kubelet] [NodeResource:numNodes=1,labe
 		var kubelet string
 		var err error
 
-		g.By("Polling to check kubelet log level on ready nodes")
+		node, err := nodeutils.GetNodeResource(ctx, oc, "node_e2e")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
+
+		g.By("Polling to check kubelet log level on node " + node)
 		waitErr := wait.Poll(10*time.Second, 1*time.Minute, func() (bool, error) {
-			g.By("Getting all node names in the cluster")
-			nodeName, nodeErr := oc.AsAdmin().Run("get").Args("nodes", "-o=jsonpath={.items[*].metadata.name}").Output()
-			o.Expect(nodeErr).NotTo(o.HaveOccurred())
-			e2e.Logf("\nNode Names are %v", nodeName)
-			nodes := strings.Fields(nodeName)
+			g.By("Checking KUBELET_LOG_LEVEL in kubelet.service on node " + node)
+			kubeservice, err = nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c", "systemctl show kubelet.service | grep KUBELET_LOG_LEVEL")
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			for _, node := range nodes {
-				g.By("Checking if node " + node + " is Ready")
-				nodeStatus, statusErr := oc.AsAdmin().Run("get").Args("nodes", node, "-o=jsonpath={.status.conditions[?(@.type=='Ready')].status}").Output()
-				o.Expect(statusErr).NotTo(o.HaveOccurred())
-				e2e.Logf("\nNode %s Status is %s\n", node, nodeStatus)
+			g.By("Checking kubelet process for --v=2 flag on node " + node)
+			kubelet, err = nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c", "ps aux | grep [k]ubelet")
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-				if nodeStatus == "True" {
-					g.By("Checking KUBELET_LOG_LEVEL in kubelet.service on node " + node)
-					kubeservice, err = nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c", "systemctl show kubelet.service | grep KUBELET_LOG_LEVEL")
-					o.Expect(err).NotTo(o.HaveOccurred())
-
-					g.By("Checking kubelet process for --v=2 flag on node " + node)
-					kubelet, err = nodeutils.ExecOnNodeWithChroot(ctx, oc, node, "/bin/bash", "-c", "ps aux | grep [k]ubelet")
-					o.Expect(err).NotTo(o.HaveOccurred())
-
-					g.By("Verifying KUBELET_LOG_LEVEL is set and kubelet is running with --v=2")
-					if strings.Contains(kubeservice, "KUBELET_LOG_LEVEL") && strings.Contains(kubelet, "--v=2") {
-						e2e.Logf("KUBELET_LOG_LEVEL is 2.\n")
-						return true, nil
-					} else {
-						e2e.Logf("KUBELET_LOG_LEVEL is not 2.\n")
-						return false, nil
-					}
-				} else {
-					e2e.Logf("\nNode %s is not Ready, Skipping\n", node)
-				}
+			g.By("Verifying KUBELET_LOG_LEVEL is set and kubelet is running with --v=2")
+			if strings.Contains(kubeservice, "KUBELET_LOG_LEVEL") && strings.Contains(kubelet, "--v=2") {
+				e2e.Logf("KUBELET_LOG_LEVEL is 2.\n")
+				return true, nil
 			}
+			e2e.Logf("KUBELET_LOG_LEVEL is not 2.\n")
 			return false, nil
 		})
 

--- a/test/extended/node/node_e2e/pdb_drain.go
+++ b/test/extended/node/node_e2e/pdb_drain.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/operator"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] PodDisruptionBudget", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive][NodeResource:numNodes=1,label=pdb_drain] PodDisruptionBudget", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("pdb-drain")
 	)
@@ -48,10 +48,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		namespace := oc.Namespace()
 
 		g.By("Get a worker node to schedule pods on")
-		workers, err := exutil.GetReadySchedulableWorkerNodes(ctx, oc.AdminKubeClient())
-		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get worker nodes")
-		o.Expect(workers).NotTo(o.BeEmpty(), "no ready schedulable worker nodes found")
-		workerNode := workers[0].Name
+		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "pdb_drain")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "failed to get worker node")
 		e2e.Logf("Selected worker node: %s", workerNode)
 
 		g.By("Create 6 pods on the selected worker node")

--- a/test/extended/node/node_e2e/pdb_drain.go
+++ b/test/extended/node/node_e2e/pdb_drain.go
@@ -48,7 +48,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		namespace := oc.Namespace()
 
 		g.By("Get a worker node to schedule pods on")
-		workerNode, nodeErr := nodeutils.GetFirstNodeResourceNode(ctx, oc, "pdb_drain")
+		workerNode, nodeErr := nodeutils.GetNodeResource(ctx, oc, "pdb_drain")
 		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "failed to get worker node")
 		e2e.Logf("Selected worker node: %s", workerNode)
 

--- a/test/extended/node/node_e2e/probe_termination.go
+++ b/test/extended/node/node_e2e/probe_termination.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/image"
 )
 
-var _ = g.Describe("[sig-node] Probe configuration", func() {
+var _ = g.Describe("[sig-node][NodeResource:numNodes=1,label=probe_termination] Probe configuration", func() {
 	var (
 		oc = exutil.NewCLIWithoutNamespace("probe-termination")
 	)

--- a/test/extended/node/node_sizing.go
+++ b/test/extended/node/node_sizing.go
@@ -16,7 +16,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] Node sizing", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] [NodeResource:numNodes=1,label=node_sizing] Node sizing", func() {
 	defer g.GinkgoRecover()
 
 	oc := exutil.NewCLIWithoutNamespace("node-sizing")
@@ -37,15 +37,8 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		// Verify the default state (NODE_SIZING_ENABLED=false)
 		// This feature is added in OCP 4.21
 		g.By("Getting a worker node to test")
-		nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
-			LabelSelector: "node-role.kubernetes.io/worker",
-		})
-		o.Expect(err).NotTo(o.HaveOccurred(), "Should be able to list worker nodes")
-		o.Expect(len(nodes.Items)).To(o.BeNumerically(">", 0), "Should have at least one worker node")
-
-		pureWorkers := getPureWorkerNodes(nodes.Items)
-		o.Expect(len(pureWorkers)).To(o.BeNumerically(">", 0), "No worker nodes without custom roles found")
-		nodeName := pureWorkers[0].Name
+		nodeName, err := GetFirstNodeResourceNode(ctx, oc, "node_sizing")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Testing on node: %s", nodeName)
 
 		// Register cleanup BEFORE MCP creation so it always runs

--- a/test/extended/node/node_sizing.go
+++ b/test/extended/node/node_sizing.go
@@ -37,7 +37,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptiv
 		// Verify the default state (NODE_SIZING_ENABLED=false)
 		// This feature is added in OCP 4.21
 		g.By("Getting a worker node to test")
-		nodeName, err := GetFirstNodeResourceNode(ctx, oc, "node_sizing")
+		nodeName, err := GetNodeResource(ctx, oc, "node_sizing")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Testing on node: %s", nodeName)
 

--- a/test/extended/node/node_swap.go
+++ b/test/extended/node/node_swap.go
@@ -98,19 +98,23 @@ var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create machine config client")
 
 		g.By("Getting initial machine config resourceVersion")
-		// Get the initial resourceVersion of the worker machine config before creating KubeletConfig
 		workerGeneratedKubeletMC, err := getWorkerGeneratedKubeletMC(ctx, mcClient)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to find worker-generated-kubelet MachineConfig")
 		initialResourceVersion := workerGeneratedKubeletMC.ResourceVersion
 		framework.Logf("Initial %s resourceVersion: %s", workerGeneratedKubeletMC.Name, initialResourceVersion)
 
-		g.By("Creating a KubeletConfig with swap settings")
+		g.By("Creating a KubeletConfig with swap settings targeting worker pool")
 		kcName := fmt.Sprintf("test-swap-override-%d", time.Now().UnixNano())
 		kubeletConfig := &machineconfigv1.KubeletConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: kcName,
 			},
 			Spec: machineconfigv1.KubeletConfigSpec{
+				MachineConfigPoolSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"pools.operator.machineconfiguration.openshift.io/worker": "",
+					},
+				},
 				KubeletConfig: &runtime.RawExtension{
 					Raw: []byte(`{
 						"failSwapOn": true,

--- a/test/extended/node/node_swap.go
+++ b/test/extended/node/node_swap.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func() {
+var _ = g.Describe("[Jira:Node][sig-node] [NodeResource:numNodes=1,label=node_swap] Node non-cnv swap configuration", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("node-swap")
@@ -40,12 +40,8 @@ var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func
 	// the kubelet will not use it for memory management, maintaining consistent behavior across the cluster.
 	g.It("should have correct default kubelet swap settings with worker nodes failSwapOn=false, control plane nodes failSwapOn=true, and both swapBehavior=NoSwap [OCP-86394]", ote.Informing(), func(ctx context.Context) {
 		g.By("Getting worker nodes")
-		allWorkerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(allWorkerNodes)).Should(o.BeNumerically(">", 0), "Expected at least one worker node")
-
-		// Filter out nodes that are also control plane (e.g., SNO)
-		workerNodes := getPureWorkerNodes(allWorkerNodes)
+		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 
 		g.By("Validating kubelet configuration on each worker node")
 		for _, node := range workerNodes {
@@ -179,12 +175,8 @@ var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func
 		framework.Logf("Verified: %s was not updated (resourceVersion: %s)", workerMCAfter.Name, workerMCAfter.ResourceVersion)
 
 		g.By("Verifying worker nodes still have correct swap settings")
-		allWorkerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(len(allWorkerNodes)).Should(o.BeNumerically(">", 0), "Expected at least one worker node")
-
-		// Filter out nodes that are also control plane (e.g., SNO)
-		workerNodes := getPureWorkerNodes(allWorkerNodes)
+		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 
 		for _, node := range workerNodes {
 			config, err := getKubeletConfigFromNode(ctx, oc, node.Name)

--- a/test/extended/node/node_swap.go
+++ b/test/extended/node/node_swap.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Jira:Node][sig-node] [NodeResource:numNodes=1,label=node_swap] Node non-cnv swap configuration", func() {
+var _ = g.Describe("[Jira:Node][sig-node] Node non-cnv swap configuration", func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("node-swap")
@@ -38,9 +38,9 @@ var _ = g.Describe("[Jira:Node][sig-node] [NodeResource:numNodes=1,label=node_sw
 	// - All nodes have swapBehavior=NoSwap to ensure kubelet does not utilize swap even if available at OS level
 	// The swapBehavior=NoSwap configuration ensures that even if swap is manually enabled on a worker node,
 	// the kubelet will not use it for memory management, maintaining consistent behavior across the cluster.
-	g.It("should have correct default kubelet swap settings with worker nodes failSwapOn=false, control plane nodes failSwapOn=true, and both swapBehavior=NoSwap [OCP-86394]", ote.Informing(), func(ctx context.Context) {
+	g.It("[NodeResource:numNodes=1,label=node_swap_defaults] should have correct default kubelet swap settings with worker nodes failSwapOn=false, control plane nodes failSwapOn=true, and both swapBehavior=NoSwap [OCP-86394]", ote.Informing(), func(ctx context.Context) {
 		g.By("Getting worker nodes")
-		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap")
+		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap_defaults")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 
 		g.By("Validating kubelet configuration on each worker node")
@@ -90,7 +90,7 @@ var _ = g.Describe("[Jira:Node][sig-node] [NodeResource:numNodes=1,label=node_sw
 		framework.Logf("Test PASSED: All nodes have correct default swap settings")
 	})
 
-	g.It("should reject user override of swap settings via KubeletConfig API [OCP-86395]", ote.Informing(), func(ctx context.Context) {
+	g.It("[NodeResource:numNodes=1,label=node_swap_reject] should reject user override of swap settings via KubeletConfig API [OCP-86395]", ote.Informing(), func(ctx context.Context) {
 		SkipOnHyperShift(ctx, oc)
 
 		g.By("Creating machine config client")
@@ -175,7 +175,7 @@ var _ = g.Describe("[Jira:Node][sig-node] [NodeResource:numNodes=1,label=node_sw
 		framework.Logf("Verified: %s was not updated (resourceVersion: %s)", workerMCAfter.Name, workerMCAfter.ResourceVersion)
 
 		g.By("Verifying worker nodes still have correct swap settings")
-		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap")
+		workerNodes, err := GetNodeResourceNodes(ctx, oc, "node_swap_reject")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource nodes")
 
 		for _, node := range workerNodes {

--- a/test/extended/node/node_swap_cnv.go
+++ b/test/extended/node/node_swap_cnv.go
@@ -38,7 +38,7 @@ var (
 	cnvNoSwapConfigPath = exutil.FixturePath("testdata", "node", "cnv-swap", "kubelet-noswap-dropin.yaml")
 )
 
-var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disruptive][Suite:openshift/disruptive-longrunning] Kubelet LimitedSwap Drop-in Configuration for CNV", g.Ordered, func() {
+var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disruptive][Suite:openshift/disruptive-longrunning] [NodeResource:numNodes=1,label=node_swap_cnv] Kubelet LimitedSwap Drop-in Configuration for CNV", g.Ordered, func() {
 	defer g.GinkgoRecover()
 
 	var oc = exutil.NewCLI("cnv-swap")
@@ -95,8 +95,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// Per MCO PR #6044: directory is mandatory on ALL nodes (masters, workers)
 	g.It("TC1: should verify drop-in directory exists on all nodes with correct ownership", func(ctx context.Context) {
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Using CNV worker node for tests: %s", cnvWorkerNode)
 
 		g.By("Getting worker nodes")
@@ -185,8 +186,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC2: should verify kubelet starts normally with empty directory", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Using CNV worker node for tests: %s", cnvWorkerNode)
 
 		g.By("Checking if drop-in directory exists and is empty")
@@ -213,8 +215,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC3: should apply LimitedSwap configuration from drop-in file", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC3: Testing LimitedSwap configuration via drop-in file ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -278,8 +281,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC4: should revert to NoSwap when drop-in file is removed", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC4: Testing revert to NoSwap when drop-in file is removed ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -327,8 +331,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC5: should validate security and permissions of drop-in directory", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC5: Testing security and permissions of drop-in directory ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -401,8 +406,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC6: should verify cluster stability with LimitedSwap enabled", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC6: Testing cluster stability with LimitedSwap enabled ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -487,8 +493,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 		framework.Logf("=== TC7: Testing non-CNV workers have no swap configuration ===")
 
 		// Get a CNV worker node and temporarily remove its CNV label
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		cnvLabel := "kubevirt.io/schedulable"
 		framework.Logf("Selected worker node: %s", cnvWorkerNode)
@@ -558,8 +565,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC8: should apply correct precedence with multiple files", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC8: Testing file precedence with multiple drop-in files ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -778,8 +786,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 		framework.Logf("=== TC10: Testing LimitedSwap config when OS swap is disabled ===")
 
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
 
 		g.By("Checking initial OS-level swap status")
@@ -939,8 +948,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC11: should work correctly with various swap sizes", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC11: Testing LimitedSwap with various swap sizes ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -1115,8 +1125,9 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC12: should expose swap metrics correctly via Prometheus", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		// Get a CNV worker node for tests
-		cnvWorkerNode = getCNVWorkerNodeName(ctx, oc)
-		o.Expect(cnvWorkerNode).NotTo(o.BeEmpty(), "No CNV worker nodes available")
+		var nodeErr error
+		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC12: Testing swap metrics and observability via Prometheus ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)

--- a/test/extended/node/node_swap_cnv.go
+++ b/test/extended/node/node_swap_cnv.go
@@ -59,7 +59,7 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 		}
 
 		// Resolve the NodeResource node once for all tests
-		cnvWorkerNode, err = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		cnvWorkerNode, err = GetNodeResource(ctx, oc, "node_swap_cnv")
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Using CNV worker node for all tests: %s", cnvWorkerNode)
 

--- a/test/extended/node/node_swap_cnv.go
+++ b/test/extended/node/node_swap_cnv.go
@@ -58,6 +58,11 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 			g.Skip("Skipping test on MicroShift cluster")
 		}
 
+		// Resolve the NodeResource node once for all tests
+		cnvWorkerNode, err = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
+		o.Expect(err).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
+		framework.Logf("Using CNV worker node for all tests: %s", cnvWorkerNode)
+
 		// Check if CNV is already installed
 		if !isCNVInstalled(ctx, oc) {
 			framework.Logf("CNV operator not installed, installing...")
@@ -94,12 +99,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC1: Verify drop-in directory exists on all nodes (created by MCO for kubelet config)
 	// Per MCO PR #6044: directory is mandatory on ALL nodes (masters, workers)
 	g.It("TC1: should verify drop-in directory exists on all nodes with correct ownership", func(ctx context.Context) {
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
-		framework.Logf("Using CNV worker node for tests: %s", cnvWorkerNode)
-
 		g.By("Getting worker nodes")
 		allWorkerNodes, err := getNodesByLabel(ctx, oc, "node-role.kubernetes.io/worker")
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -185,11 +184,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC2: Verify kubelet starts normally with empty or missing directory
 	g.It("TC2: should verify kubelet starts normally with empty directory", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
-		framework.Logf("Using CNV worker node for tests: %s", cnvWorkerNode)
 
 		g.By("Checking if drop-in directory exists and is empty")
 		output, err := ExecOnNodeWithChroot(ctx, oc, cnvWorkerNode, "ls", "-la", cnvDropInDir)
@@ -214,10 +208,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC3: Verify LimitedSwap configuration is applied from drop-in file
 	g.It("TC3: should apply LimitedSwap configuration from drop-in file", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC3: Testing LimitedSwap configuration via drop-in file ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -280,10 +270,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC4: Verify revert behavior when drop-in file is removed
 	g.It("TC4: should revert to NoSwap when drop-in file is removed", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC4: Testing revert to NoSwap when drop-in file is removed ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -330,10 +316,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC5: Validate security and permissions of drop-in directory
 	g.It("TC5: should validate security and permissions of drop-in directory", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC5: Testing security and permissions of drop-in directory ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -405,10 +387,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC6: Validate cluster stability and performance
 	g.It("TC6: should verify cluster stability with LimitedSwap enabled", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC6: Testing cluster stability with LimitedSwap enabled ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -492,11 +470,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC7: should verify non-CNV workers have no swap configuration", func(ctx context.Context) {
 		framework.Logf("=== TC7: Testing non-CNV workers have no swap configuration ===")
 
-		// Get a CNV worker node and temporarily remove its CNV label
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
-
 		cnvLabel := "kubevirt.io/schedulable"
 		framework.Logf("Selected worker node: %s", cnvWorkerNode)
 
@@ -564,10 +537,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC8: Validate behavior with multiple conflicting drop-in files
 	g.It("TC8: should apply correct precedence with multiple files", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC8: Testing file precedence with multiple drop-in files ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -784,11 +753,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	g.It("TC10: should handle LimitedSwap config gracefully when OS swap is disabled", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
 		framework.Logf("=== TC10: Testing LimitedSwap config when OS swap is disabled ===")
-
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
 
 		g.By("Checking initial OS-level swap status")
@@ -947,10 +911,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// It requires sufficient disk space and may take longer to complete
 	g.It("TC11: should work correctly with various swap sizes", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC11: Testing LimitedSwap with various swap sizes ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)
@@ -1124,10 +1084,6 @@ var _ = g.Describe("[Jira:Node/Kubelet][sig-node][Feature:NodeSwap][Serial][Disr
 	// TC12: Validate swap metrics and observability via Prometheus
 	g.It("TC12: should expose swap metrics correctly via Prometheus", func(ctx context.Context) {
 		skipOnSingleNodeTopology(oc) //skip this test for SNO
-		// Get a CNV worker node for tests
-		var nodeErr error
-		cnvWorkerNode, nodeErr = GetFirstNodeResourceNode(ctx, oc, "node_swap_cnv")
-		o.Expect(nodeErr).NotTo(o.HaveOccurred(), "Error getting NodeResource node")
 
 		framework.Logf("=== TC12: Testing swap metrics and observability via Prometheus ===")
 		framework.Logf("Executing on node: %s", cnvWorkerNode)

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -1044,11 +1044,15 @@ func cleanupDirectoriesOnNode(oc *exutil.CLI, nodeName string, dirs []string) er
 	return nil
 }
 
+// NodeResourceLabelKey is the label key used by the NodeResource scheduler
+// to mark worker nodes as assigned to a specific test.
+const NodeResourceLabelKey = "noderesource.test.openshift.io/name"
+
 // GetNodeResourceNodes returns worker nodes assigned to a NodeResource test by label.
 // Tests tagged with [NodeResource:numNodes=N,label=X] should use this to find their
 // assigned nodes instead of manually selecting worker nodes.
 func GetNodeResourceNodes(ctx context.Context, oc *exutil.CLI, label string) ([]corev1.Node, error) {
-	labelSelector := fmt.Sprintf("noderesource.test.openshift.io/name=%s", label)
+	labelSelector := fmt.Sprintf("%s=%s", NodeResourceLabelKey, label)
 	nodes, err := getNodesByLabel(ctx, oc, labelSelector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get NodeResource nodes with label %s: %w", label, err)

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -1063,8 +1063,8 @@ func GetNodeResourceNodes(ctx context.Context, oc *exutil.CLI, label string) ([]
 	return nodes, nil
 }
 
-// GetFirstNodeResourceNode returns the name of the first node assigned to a NodeResource test.
-func GetFirstNodeResourceNode(ctx context.Context, oc *exutil.CLI, label string) (string, error) {
+// GetNodeResource returns the name of the first node assigned to a NodeResource test.
+func GetNodeResource(ctx context.Context, oc *exutil.CLI, label string) (string, error) {
 	nodes, err := GetNodeResourceNodes(ctx, oc, label)
 	if err != nil {
 		return "", err

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -1043,3 +1043,27 @@ func cleanupDirectoriesOnNode(oc *exutil.CLI, nodeName string, dirs []string) er
 	}
 	return nil
 }
+
+// GetNodeResourceNodes returns worker nodes assigned to a NodeResource test by label.
+// Tests tagged with [NodeResource:numNodes=N,label=X] should use this to find their
+// assigned nodes instead of manually selecting worker nodes.
+func GetNodeResourceNodes(ctx context.Context, oc *exutil.CLI, label string) ([]corev1.Node, error) {
+	labelSelector := fmt.Sprintf("noderesource.test.openshift.io/name=%s", label)
+	nodes, err := getNodesByLabel(ctx, oc, labelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get NodeResource nodes with label %s: %w", label, err)
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes found with NodeResource label %s", label)
+	}
+	return nodes, nil
+}
+
+// GetFirstNodeResourceNode returns the name of the first node assigned to a NodeResource test.
+func GetFirstNodeResourceNode(ctx context.Context, oc *exutil.CLI, label string) (string, error) {
+	nodes, err := GetNodeResourceNodes(ctx, oc, label)
+	if err != nil {
+		return "", err
+	}
+	return nodes[0].Name, nil
+}

--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -723,7 +723,7 @@ func mcpPoolConditions(mcp *machineconfigv1.MachineConfigPool) (updated, degrade
 }
 
 func labelFirstPureWorker(ctx context.Context, oc *exutil.CLI, poolName, nodeResourceLabel string) (string, error) {
-	nodeName, err := GetFirstNodeResourceNode(ctx, oc, nodeResourceLabel)
+	nodeName, err := GetNodeResource(ctx, oc, nodeResourceLabel)
 	if err != nil {
 		return "", err
 	}

--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -56,7 +56,7 @@ var rhelMajorOSImagePattern = regexp.MustCompile(`Linux\s+([0-9]+)`)
 // When a pool targets osImageStream rhel-10, MCO behavior depends on runtime:
 // - runc  → RenderDegraded blocks rollout; Upgradeable=False (DegradedPool)
 // - crun  → rollout succeeds to RHCOS 10 without guard errors
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams][NodeResource:numNodes=1,label=runc_upgrade] runc RHCOS 10 upgrade guard", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -99,7 +99,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 		clusterDefaultStream = requireOSImageStreams(ctx, mcClient)
 	})
 
-	g.It("blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
+	g.It("[NodeResource:numNodes=1,label=runc_upgrade_block] blocks RHCOS 9 to 10 osImageStream upgrade when ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
 		testPoolName = runcRHCOS10GuardPool
 		cleanupCRCName = runcGuardCRCName
 
@@ -108,7 +108,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 
 		g.By("Labeling one worker into the custom pool")
 		var err error
-		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10GuardPool, "runc_upgrade")
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10GuardPool, "runc_upgrade_block")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on rhel-9 with runc")
@@ -178,7 +178,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 		}
 	})
 
-	g.It("allows RHCOS 9 to 10 osImageStream upgrade when default runtime is crun", ote.Informing(), func(ctx context.Context) {
+	g.It("[NodeResource:numNodes=1,label=runc_upgrade_allow] allows RHCOS 9 to 10 osImageStream upgrade when default runtime is crun", ote.Informing(), func(ctx context.Context) {
 		testPoolName = crunRHCOS10UpgradePool
 
 		g.By("Creating custom MachineConfigPool pinned to rhel-9 with default runtime crun")
@@ -186,7 +186,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 
 		g.By("Labeling one worker into the custom pool")
 		var err error
-		nodeName, err = labelFirstPureWorker(ctx, oc, crunRHCOS10UpgradePool, "runc_upgrade")
+		nodeName, err = labelFirstPureWorker(ctx, oc, crunRHCOS10UpgradePool, "runc_upgrade_allow")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on rhel-9 with crun default runtime")
@@ -216,7 +216,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 			"cluster upgradeability should not be blocked by runc guard when pool uses crun")
 	})
 
-	g.It("blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
+	g.It("[NodeResource:numNodes=1,label=runc_upgrade_block_mc] blocks RHCOS 9 to 10 upgrade when MachineConfig osImageURL targets RHEL 10 and ContainerRuntimeConfig sets runc default runtime", ote.Informing(), func(ctx context.Context) {
 		// This pool intentionally never sets spec.osImageStream (setting it alongside an
 		// osImageURL override is a separate, mutually-exclusive configuration error -- see
 		// assertMCPHasNoOSImageStream below), so it inherits its default stream from the
@@ -251,7 +251,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 		cleanupURLGuardMC = true
 
 		g.By("Labeling one worker into the custom pool")
-		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10URLGuardPool, "runc_upgrade")
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10URLGuardPool, "runc_upgrade_block_mc")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on RHCOS 9")

--- a/test/extended/node/runc_upgrade_cases.go
+++ b/test/extended/node/runc_upgrade_cases.go
@@ -56,7 +56,7 @@ var rhelMajorOSImagePattern = regexp.MustCompile(`Linux\s+([0-9]+)`)
 // When a pool targets osImageStream rhel-10, MCO behavior depends on runtime:
 // - runc  → RenderDegraded blocks rollout; Upgradeable=False (DegradedPool)
 // - crun  → rollout succeeds to RHCOS 10 without guard errors
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams] runc RHCOS 10 upgrade guard", func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][Disruptive][OCPFeatureGate:OSStreams][NodeResource:numNodes=1,label=runc_upgrade] runc RHCOS 10 upgrade guard", func() {
 	defer g.GinkgoRecover()
 
 	var (
@@ -108,7 +108,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 
 		g.By("Labeling one worker into the custom pool")
 		var err error
-		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10GuardPool)
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10GuardPool, "runc_upgrade")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on rhel-9 with runc")
@@ -186,7 +186,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 
 		g.By("Labeling one worker into the custom pool")
 		var err error
-		nodeName, err = labelFirstPureWorker(ctx, oc, crunRHCOS10UpgradePool)
+		nodeName, err = labelFirstPureWorker(ctx, oc, crunRHCOS10UpgradePool, "runc_upgrade")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on rhel-9 with crun default runtime")
@@ -251,7 +251,7 @@ var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Serial][D
 		cleanupURLGuardMC = true
 
 		g.By("Labeling one worker into the custom pool")
-		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10URLGuardPool)
+		nodeName, err = labelFirstPureWorker(ctx, oc, runcRHCOS10URLGuardPool, "runc_upgrade")
 		o.Expect(err).NotTo(o.HaveOccurred(), "need a worker node for the custom pool")
 
 		g.By("Waiting for pool rollout on RHCOS 9")
@@ -722,27 +722,23 @@ func mcpPoolConditions(mcp *machineconfigv1.MachineConfigPool) (updated, degrade
 	return updated, degraded, renderDegraded, updating
 }
 
-func labelFirstPureWorker(ctx context.Context, oc *exutil.CLI, poolName string) (string, error) {
-	workers, err := getPureWorkerNodesFromCluster(ctx, oc)
+func labelFirstPureWorker(ctx context.Context, oc *exutil.CLI, poolName, nodeResourceLabel string) (string, error) {
+	nodeName, err := GetFirstNodeResourceNode(ctx, oc, nodeResourceLabel)
 	if err != nil {
 		return "", err
 	}
-	if len(workers) == 0 {
-		return "", fmt.Errorf("no pure worker nodes without custom roles available")
-	}
 
-	node := workers[0]
 	label := poolNodeRoleLabel(poolName)
 	patchData := []byte(fmt.Sprintf(`{"metadata":{"labels":{%q:""}}}`, label))
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		_, patchErr := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, node.Name, types.MergePatchType, patchData, metav1.PatchOptions{})
+		_, patchErr := oc.AdminKubeClient().CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchData, metav1.PatchOptions{})
 		return patchErr
 	})
 	if err != nil {
 		return "", err
 	}
-	framework.Logf("Labeled node %s with %s", node.Name, label)
-	return node.Name, nil
+	framework.Logf("Labeled node %s with %s", nodeName, label)
+	return nodeName, nil
 }
 
 func removeNodeLabel(ctx context.Context, oc *exutil.CLI, nodeName, label string) error {

--- a/test/extended/node/system_compressible.go
+++ b/test/extended/node/system_compressible.go
@@ -22,7 +22,7 @@ import (
 	exutil "github.com/openshift/origin/test/extended/util"
 )
 
-var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] System Compressible CPU", g.Serial, func() {
+var _ = g.Describe("[Suite:openshift/disruptive-longrunning][sig-node][Disruptive] [NodeResource:numNodes=1,label=system_compressible] System Compressible CPU", g.Serial, func() {
 	defer g.GinkgoRecover()
 
 	oc := exutil.NewCLIWithoutNamespace("system-compressible")
@@ -288,48 +288,15 @@ func isReservedCPUEnabled(config *kubeletconfigv1beta1.KubeletConfiguration) boo
 	return false
 }
 
-// selectTestNode selects a worker node with at least minCPUs CPU cores
+// selectTestNode selects a NodeResource-labeled worker node with at least minCPUs CPU cores
 // Returns node name and actual CPU count
 func selectTestNode(ctx context.Context, oc *exutil.CLI, minCPUs int) (string, int, error) {
-	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx, metav1.ListOptions{
-		LabelSelector: "node-role.kubernetes.io/worker",
-	})
+	nodes, err := GetNodeResourceNodes(ctx, oc, "system_compressible")
 	if err != nil {
 		return "", 0, err
 	}
 
-	for _, node := range nodes.Items {
-		// Skip unschedulable nodes
-		if node.Spec.Unschedulable {
-			framework.Logf("Skipping node %s: unschedulable", node.Name)
-			continue
-		}
-
-		// Check if node is Ready
-		isReady := false
-		for _, condition := range node.Status.Conditions {
-			if condition.Type == corev1.NodeReady && condition.Status == corev1.ConditionTrue {
-				isReady = true
-				break
-			}
-		}
-		if !isReady {
-			framework.Logf("Skipping node %s: not Ready", node.Name)
-			continue
-		}
-
-		if role, found := NodeHasCustomRole(node); found {
-			framework.Logf("Skipping node %s: already has custom role %q", node.Name, role)
-			continue
-		}
-
-		currentConfig := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
-		desiredConfig := node.Annotations["machineconfiguration.openshift.io/desiredConfig"]
-		if currentConfig == "" || desiredConfig == "" || currentConfig != desiredConfig {
-			framework.Logf("Skipping node %s: MCP not stable (current=%s, desired=%s)", node.Name, currentConfig, desiredConfig)
-			continue
-		}
-
+	for _, node := range nodes {
 		// Check CPU count
 		cpuQuantity := node.Status.Capacity[corev1.ResourceCPU]
 		cpuCount := int(cpuQuantity.Value())
@@ -338,7 +305,7 @@ func selectTestNode(ctx context.Context, oc *exutil.CLI, minCPUs int) (string, i
 			return node.Name, cpuCount, nil
 		}
 	}
-	return "", 0, fmt.Errorf("no suitable worker node found with at least %d CPUs (schedulable, ready, MCP stable)", minCPUs)
+	return "", 0, fmt.Errorf("no suitable worker node found with at least %d CPUs among NodeResource nodes", minCPUs)
 }
 
 // readCgroupCPUWeight reads cpu.weight file for a cgroup slice

--- a/test/extended/node/zstd_chunked.go
+++ b/test/extended/node/zstd_chunked.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/origin/test/extended/util/image"
 )
 
-var _ = g.Describe("[sig-node] zstd:chunked Image", func() {
+var _ = g.Describe("[sig-node][NodeResource:numNodes=1,label=zstd_chunked] zstd:chunked Image", func() {
 	defer g.GinkgoRecover()
 	var (
 		oc = exutil.NewCLI("zstd-chunked-image")


### PR DESCRIPTION
cc: @Chandan9112 @asahay19 @QiWang19  @BhargaviGudi 

Status: Design Review. Draft implementation done

Introduces a [NodeResource:numNodes=N,label=X] tag for tests that need exclusive access to worker nodes. A nodeResourceScheduler (implementing the existing TestScheduler interface) labels N worker nodes before each test runs and removes labels after completion. Tests use GetNodeResource(ctx, oc, label) to discover their assigned node. The scheduler uses the same sync.Cond wait/broadcast pattern as the existing conflict-based scheduler — workers block when no free nodes are available and wake when a test completes. numNodes=all requires every worker node to be free, naturally serializing cluster-wide tests like image_mirror_set.

  All tests under test/extended/node/ (except dra/) are tagged and run in a dedicated "NodeResource" execution bucket after MustGather. Tests that previously picked an arbitrary worker now target their labeled node, preventing concurrent tests from interfering with each other on the same node.

### After this PR
- Encapsulation of tests so that they cannot cross the node boundry.
- MachineConfigs created by tests should be restricted to the nodes they are allocated

### Time Savings

| Metric | Value |
|---|---|
| Serial baseline (sum of all test durations) | **3h52m** |
| Wall-clock with NodeResource scheduler | **2h29m** |
| Time saved | **1h23m** |
| Speedup | **1.56x** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added node-resource-aware test scheduling for selecting, labeling, and releasing eligible worker nodes.
  * Enabled concurrent execution across available worker-node capacity.
  * Added support for tests requiring a specific number of nodes or all matching nodes.
* **Bug Fixes**
  * Improved handling of node allocation failures, stale labels, initialization errors, and cleanup.
  * Updated node-focused validation suites to consistently run on their assigned resources.
* **Tests**
  * Added coverage for resource-tag parsing, test detection, and node readiness evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->