### PR TITLE
OCPBUGS-109671: monitortests: allow image-registry node-ca Progressing on DualReplica

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -187,6 +187,42 @@ func isTNFJobClusterOperatorReason(reason string) bool {
 	return strings.HasPrefix(reason, "tnf-") || strings.HasPrefix(reason, "TNF")
 }
 
+// isNodeCADaemonProgressingReason matches image-registry ClusterOperator Progressing reasons
+// emitted while the node-ca DaemonSet rolls: the bare reason NodeCADaemonProgressing, or
+// composites that begin with NodeCADaemonProgressing:: (e.g. NodeCADaemonProgressing::Ready).
+func isNodeCADaemonProgressingReason(reason string) bool {
+	return reason == "NodeCADaemonProgressing" || strings.HasPrefix(reason, "NodeCADaemonProgressing::")
+}
+
+// nodeUpdateNodeCADaemonGrace covers brief NodeCADaemonProgressing blips that land just after
+// a node finishes its MCO update while node-ca is still catching up on the returning node.
+const nodeUpdateNodeCADaemonGrace = time.Minute
+
+// nodeUpdateIntervals returns overall node MCO update windows (phase=Update) from the
+// node-lifecycle constructor. Drain/OSUpdate/Reboot phase intervals are subsets of these.
+func nodeUpdateIntervals(events monitorapi.Intervals) monitorapi.Intervals {
+	return events.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Source == monitorapi.SourceNodeState &&
+			eventInterval.Message.Reason == monitorapi.NodeUpdateReason &&
+			eventInterval.Message.Annotations[monitorapi.AnnotationPhase] == "Update"
+	})
+}
+
+// overlapsNodeUpdate reports whether conditionInterval overlaps a node Update window,
+// including grace after the update ends.
+func overlapsNodeUpdate(conditionInterval monitorapi.Interval, nodeUpdates monitorapi.Intervals, grace time.Duration) bool {
+	for _, update := range nodeUpdates {
+		window := update
+		if !window.To.IsZero() {
+			window.To = window.To.Add(grace)
+		}
+		if utility.IntervalsOverlap(conditionInterval, window) {
+			return true
+		}
+	}
+	return false
+}
+
 // isInUpgradeWindow determines if the given eventInterval falls within an upgrade window.
 // UpgradeStart and UpgradeRollback events start upgrade windows and can end and already started upgrade window.
 // UpgradeComplete and UpgradeFailed events end upgrade windows; if there was not an already started upgrade window,
@@ -644,6 +680,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 	multiUpgrades := platformidentification.UpgradeNumberDuringCollection(events, time.Time{}, time.Time{}) > 1
 
 	isTwoNode := topology == configv1.HighlyAvailableArbiterMode || topology == configv1.DualReplicaTopologyMode
+	nodeUpdates := nodeUpdateIntervals(events)
 
 	var machineConfigProgressingStart time.Time
 	var eventsInUpgradeWindows monitorapi.Intervals
@@ -753,7 +790,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 		}
 	}
 
-	except = func(co string, reason string) string {
+	exceptWithEventIntervals := func(co string, reason string, eventInterval monitorapi.Interval) string {
 		switch co {
 		case "authentication":
 			if isTwoNode && (reason == "APIServerDeployment_NewGeneration" || reason == "APIServerDeployment_PodsUpdating") {
@@ -770,6 +807,15 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 				if isTNFJobClusterOperatorReason(reason) {
 					return "clusteroperator/etcd may report Progressing=True while a TNF batch Job is running during DualReplica topology upgrades (CEO JobRunning condition reasons)"
 				}
+			}
+		case "image-registry":
+			// node-ca is a DaemonSet; master reboot during MCO recreates node-ca pods and CIMO
+			// briefly reports NodeCADaemonProgressing while the registry stays Available.
+			// Require overlap with a node Update window so unrelated Progressing blips are not
+			// allowlisted for the whole DualReplica MCO Progressing period.
+			if isTwoNode && isNodeCADaemonProgressingReason(reason) &&
+				overlapsNodeUpdate(eventInterval, nodeUpdates, nodeUpdateNodeCADaemonGrace) {
+				return "clusteroperator/image-registry may report Progressing=True while the node-ca DaemonSet rolls during a DualReplica node update while machine-config is progressing (NodeCADaemonProgressing)"
 			}
 		case "console":
 			if reason == "SyncLoopRefresh_InProgress" {
@@ -866,7 +912,7 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			// if there was any switch, it was wrong/unexpected at some point
 			failure := fmt.Sprintf("%v", operatorEvent)
 
-			exception := except(operatorName, condition.Reason)
+			exception := exceptWithEventIntervals(operatorName, condition.Reason, operatorEvent)
 			if exception == "" {
 				fatal = append(fatal, failure)
 			} else {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -491,6 +491,116 @@ func TestIsTNFJobClusterOperatorReason(t *testing.T) {
 	}
 }
 
+func TestIsNodeCADaemonProgressingReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason string
+		want   bool
+	}{
+		{name: "composite Ready", reason: "NodeCADaemonProgressing::Ready", want: true},
+		{name: "bare reason", reason: "NodeCADaemonProgressing", want: true},
+		{name: "composite Unavailable", reason: "DeploymentNotCompleted::NodeCADaemonUnavailable", want: false},
+		{name: "embedded substring", reason: "Ready::NodeCADaemonProgressing", want: false},
+		{name: "suffix without separator", reason: "NodeCADaemonProgressingReady", want: false},
+		{name: "Ready alone", reason: "Ready", want: false},
+		{name: "empty", reason: "", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNodeCADaemonProgressingReason(tt.reason))
+		})
+	}
+}
+
+func TestOverlapsNodeUpdate(t *testing.T) {
+	base := time.Date(2026, 8, 13, 11, 34, 25, 0, time.UTC)
+	nodeUpdate := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNodeKey: "master-0",
+					monitorapi.LocatorRowKey:  "NodeUpdate",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: monitorapi.NodeUpdateReason,
+				Annotations: map[monitorapi.AnnotationKey]string{
+					monitorapi.AnnotationPhase:       "Update",
+					monitorapi.AnnotationConstructed: monitorapi.ConstructionOwnerNodeLifecycle,
+				},
+			},
+		},
+		Source: monitorapi.SourceNodeState,
+		From:   base,
+		To:     base.Add(6 * time.Minute), // ends 11:40:25
+	}
+	drainPhase := monitorapi.Interval{
+		Condition: monitorapi.Condition{
+			Locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNodeKey: "master-0",
+					monitorapi.LocatorRowKey:  "NodeUpdatePhases",
+				},
+			},
+			Message: monitorapi.Message{
+				Reason: monitorapi.NodeUpdateReason,
+				Annotations: map[monitorapi.AnnotationKey]string{
+					monitorapi.AnnotationPhase: "Drain",
+				},
+			},
+		},
+		Source: monitorapi.SourceNodeState,
+		From:   base,
+		To:     base.Add(5 * time.Minute),
+	}
+	nodeUpdates := nodeUpdateIntervals(monitorapi.Intervals{nodeUpdate, drainPhase})
+	assert.Len(t, nodeUpdates, 1)
+
+	tests := []struct {
+		name string
+		from time.Time
+		to   time.Time
+		want bool
+	}{
+		{
+			name: "during node update",
+			from: base.Add(3*time.Minute + 48*time.Second), // 11:38:13 blip
+			to:   base.Add(3*time.Minute + 48*time.Second + 44*time.Millisecond),
+			want: true,
+		},
+		{
+			name: "few seconds after update within grace",
+			from: base.Add(6*time.Minute + 3*time.Second),
+			to:   base.Add(6*time.Minute + 3*time.Second + 50*time.Millisecond),
+			want: true,
+		},
+		{
+			name: "just inside grace window",
+			from: base.Add(6*time.Minute + 59*time.Second),
+			to:   base.Add(7 * time.Minute),
+			want: true,
+		},
+		{
+			name: "after grace window",
+			from: base.Add(7*time.Minute + time.Second),
+			to:   base.Add(7*time.Minute + 2*time.Second),
+			want: false,
+		},
+		{
+			name: "before node update",
+			from: base.Add(-2 * time.Minute),
+			to:   base.Add(-time.Minute),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condition := monitorapi.Interval{From: tt.from, To: tt.to}
+			assert.Equal(t, tt.want, overlapsNodeUpdate(condition, nodeUpdates, nodeUpdateNodeCADaemonGrace))
+		})
+	}
+}
+
 func TestOverlapsNoExecuteTaintManagerTest(t *testing.T) {
 	base := time.Date(2026, 8, 10, 13, 55, 43, 0, time.UTC)
 	taintTest := monitorapi.Interval{


### PR DESCRIPTION
During TNF upgrades, MCO node reboots recreate the node-ca DaemonSet and CIMO briefly reports NodeCADaemonProgressing while the registry stays Available. Except that Progressing-while-MCO blip on two-node topologies.

monitortests: require NodeUpdate overlap for image-registry node-ca exception

Limit the DualReplica Progressing-while-MCO allowlist for NodeCADaemonProgressing to blips that overlap a node-lifecycle Update window (+1m grace), so unrelated registry Progressing is not excepted for the whole MCO Progressing period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved upgrade monitoring to correctly handle temporary node certificate authority progressing states during overlapping node updates.
  - Added a one-minute grace period after node updates to reduce false-positive upgrade alerts.

- **Tests**
  - Added coverage for recognized progressing reasons, overlapping update windows, grace-period boundaries, and events occurring outside update intervals.
  - Expanded validation of upgrade monitoring behavior during node update transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->