### PR TITLE
OCPBUGS-105876: tolerate brief olm Available=False during upgrades

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -370,6 +370,11 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
+		case "olm":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
+				condition.Reason == "CatalogdDeploymentCatalogdControllerManager_Deploying" {
+				return "https://issues.redhat.com/browse/OCPBUGS-105876"
+			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
 				if isTwoNode && condition.Reason == "APIServices_PreconditionNotReady" {


### PR DESCRIPTION
clusteroperator/olm can briefly flip to Available=False (about 1 second) during upgrades when MCO drains a node hosting catalogd pods, reported as CatalogdDeploymentCatalogdControllerManager_Deploying. This is a known, harmless blip with no real service disruption; except it the same way other operators' known transient blips are handled here.

This is a temporary tolerance. The real fix is a grace period on the Available condition, tracked in OCPBUGS-105876; once that lands this exception can be removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a false upgrade-state failure while the `olm` operator is deploying its catalog controller.
  * Improved upgrade monitoring for this transitional deployment state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->