### PR TITLE
OCPBUGS-105399,OCPBUGS-105400: Remove TechPreview skips and event matchers from sigstore imagepolicy tests

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -550,18 +550,6 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 	vsphereConfigurationTestsRollOutTooOftenMatcher := newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(vsphereConfigurationTestsRollOutTooOftenMatcher)
 
-	newDeferringOperatorNodeUpdateTooOftenEventMatcher := newDeferringOperatorNodeUpdateTooOftenEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newDeferringOperatorNodeUpdateTooOftenEventMatcher)
-
-	newAnnotationChangeTooOftenEventMatcher := newAnnotationChangeTooOftenEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newAnnotationChangeTooOftenEventMatcher)
-
-	newSetDesiredConfigTooOftenEventMatcher := newSetDesiredConfigTooOftenEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newSetDesiredConfigTooOftenEventMatcher)
-
-	newCrioReloadedTooOftenEventMatcher := newCrioReloadedTooOftenEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newCrioReloadedTooOftenEventMatcher)
-
 	twoNodeEtcdEndpointsMatcher := newTwoNodeEtcdEndpointsConfigMissingEventMatcher(finalIntervals)
 	registry.AddPathologicalEventMatcherOrDie(twoNodeEtcdEndpointsMatcher)
 
@@ -578,15 +566,6 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 		messageReasonRegex: regexp.MustCompile(`^(SuccessfulCreate|SawCompletedJob)$`),
 		jira:               "https://issues.redhat.com/browse/OCPBUGS-81340",
 	})
-
-	newConfigDriftMonitorStoppedTooOftenEventMatcher := newConfigDriftMonitorStoppedTooOftenEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newConfigDriftMonitorStoppedTooOftenEventMatcher)
-
-	newAddSigtermProtectionEventMatcher := newAddSigtermProtectionEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newAddSigtermProtectionEventMatcher)
-
-	newRemoveSigtermProtectionEventMatcher := newRemoveSigtermProtectionEventMatcher(finalIntervals)
-	registry.AddPathologicalEventMatcherOrDie(newRemoveSigtermProtectionEventMatcher)
 
 	// OVN-Kuberentes EVPN e2e tests running in parallel incorrectly create
 	// multiple VTEP resources with the same CIDR. No further consequence other
@@ -1230,145 +1209,6 @@ func newSingleNodeKubeAPIProgressingEventMatcher(finalIntervals monitorapi.Inter
 			topology:          &snoTopology,
 		},
 		allowIfWithinIntervals: ocpKubeAPIServerProgressingInterval,
-	}
-}
-
-func newDeferringOperatorNodeUpdateTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	DeferringOperatorNodeUpdateIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "imagepolicy signature validation")
-	})
-	for i := range DeferringOperatorNodeUpdateIntervals {
-		DeferringOperatorNodeUpdateIntervals[i].To = DeferringOperatorNodeUpdateIntervals[i].To.Add(time.Minute * 2)
-		DeferringOperatorNodeUpdateIntervals[i].From = DeferringOperatorNodeUpdateIntervals[i].From.Add(time.Minute * -2)
-	}
-
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "DeferringOperatorNodeUpdateTooOften",
-			messageReasonRegex: regexp.MustCompile(`^DeferringOperatorNodeUpdate$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-52260",
-		},
-		allowIfWithinIntervals: DeferringOperatorNodeUpdateIntervals,
-	}
-}
-
-func newAnnotationChangeTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	AnnotationChangeIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "imagepolicy signature validation")
-	})
-	for i := range AnnotationChangeIntervals {
-		AnnotationChangeIntervals[i].To = AnnotationChangeIntervals[i].To.Add(time.Minute * 10)
-		AnnotationChangeIntervals[i].From = AnnotationChangeIntervals[i].From.Add(time.Minute * -10)
-	}
-
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "AnnotationChangeTooOften",
-			messageReasonRegex: regexp.MustCompile(`^AnnotationChange$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-58376",
-		},
-		allowIfWithinIntervals: AnnotationChangeIntervals,
-	}
-}
-
-func newSetDesiredConfigTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	SetDesiredConfigIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "imagepolicy signature validation")
-	})
-	for i := range SetDesiredConfigIntervals {
-		SetDesiredConfigIntervals[i].To = SetDesiredConfigIntervals[i].To.Add(time.Minute * 10)
-		SetDesiredConfigIntervals[i].From = SetDesiredConfigIntervals[i].From.Add(time.Minute * -10)
-	}
-
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "SetDesiredConfigTooOften",
-			messageReasonRegex: regexp.MustCompile(`^SetDesiredConfig$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-58376",
-		},
-		allowIfWithinIntervals: SetDesiredConfigIntervals,
-	}
-}
-
-func newCrioReloadedTooOftenEventMatcher(finalInternals monitorapi.Intervals) EventMatcher {
-	crioReloadedIntervals := finalInternals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "imagepolicy signature validation")
-	})
-	for i := range crioReloadedIntervals {
-		crioReloadedIntervals[i].To = crioReloadedIntervals[i].To.Add(time.Minute * 10)
-		crioReloadedIntervals[i].From = crioReloadedIntervals[i].From.Add(time.Minute * -10)
-	}
-
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "CrioReloadedTooOften",
-			messageReasonRegex: regexp.MustCompile(`^ServiceReload$`),
-			messageHumanRegex:  regexp.MustCompile(`Service crio.service was reloaded.`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-52260",
-		},
-		allowIfWithinIntervals: crioReloadedIntervals,
-	}
-}
-
-func newConfigDriftMonitorStoppedTooOftenEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	configDriftMonitorStoppedIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
-	})
-	for i := range configDriftMonitorStoppedIntervals {
-		configDriftMonitorStoppedIntervals[i].To = configDriftMonitorStoppedIntervals[i].To.Add(time.Second * 30)
-		configDriftMonitorStoppedIntervals[i].From = configDriftMonitorStoppedIntervals[i].From.Add(time.Second * -30)
-	}
-
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "ConfigDriftMonitorStoppedTooOften",
-			messageReasonRegex: regexp.MustCompile(`^ConfigDriftMonitorStopped$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-63307",
-		},
-		allowIfWithinIntervals: configDriftMonitorStoppedIntervals,
-	}
-}
-
-func newAddSigtermProtectionEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	AddSigtermProtectionIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
-	})
-	for i := range AddSigtermProtectionIntervals {
-		AddSigtermProtectionIntervals[i].To = AddSigtermProtectionIntervals[i].To.Add(time.Second * 30)
-		AddSigtermProtectionIntervals[i].From = AddSigtermProtectionIntervals[i].From.Add(time.Second * -30)
-	}
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "AddSigtermProtection",
-			messageReasonRegex: regexp.MustCompile(`^AddSigtermProtection$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-63307",
-		},
-		allowIfWithinIntervals: AddSigtermProtectionIntervals,
-	}
-}
-
-func newRemoveSigtermProtectionEventMatcher(finalIntervals monitorapi.Intervals) EventMatcher {
-	RemoveSigtermProtectionIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
-		return eventInterval.Source == monitorapi.SourceE2ETest &&
-			strings.Contains(eventInterval.Locator.Keys[monitorapi.LocatorE2ETestKey], "SigstoreImageVerification")
-	})
-	for i := range RemoveSigtermProtectionIntervals {
-		RemoveSigtermProtectionIntervals[i].To = RemoveSigtermProtectionIntervals[i].To.Add(time.Second * 30)
-		RemoveSigtermProtectionIntervals[i].From = RemoveSigtermProtectionIntervals[i].From.Add(time.Second * -30)
-	}
-	return &OverlapOtherIntervalsPathologicalEventMatcher{
-		delegate: &SimplePathologicalEventMatcher{
-			name:               "RemoveSigtermProtection",
-			messageReasonRegex: regexp.MustCompile(`^RemoveSigtermProtection$`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-63307",
-		},
-		allowIfWithinIntervals: RemoveSigtermProtectionIntervals,
 	}
 }
 

--- a/test/extended/imagepolicy/imagepolicy.go
+++ b/test/extended/imagepolicy/imagepolicy.go
@@ -59,9 +59,6 @@ var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Di
 	)
 
 	g.BeforeAll(func() {
-		if !exutil.IsTechPreviewNoUpgrade(tctx, oc.AdminConfigClient()) {
-			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-		}
 		// skip test on disconnected clusters.
 		networkConfig, err := oc.AdminConfigClient().ConfigV1().Networks().Get(context.Background(), "cluster", metav1.GetOptions{})
 		if err != nil {
@@ -163,12 +160,6 @@ var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Di
 		testClusterImagePolicies = generateClusterImagePolicies()
 		testImagePolicies        = generateImagePolicies()
 	)
-
-	g.BeforeAll(func() {
-		if !exutil.IsTechPreviewNoUpgrade(tctx, oc.AdminConfigClient()) {
-			g.Skip("skipping, this feature is only supported on TechPreviewNoUpgrade clusters")
-		}
-	})
 
 	g.DescribeTable("clusterimagepolicy signature validation tests",
 		func(policyName string, expectPass bool, imageSpec string, verifyFunc func(tctx context.Context, clif *e2e.Framework, expectPass bool, testPodName string, imageSpec string) error) {


### PR DESCRIPTION
Bug1: https://redhat.atlassian.net/browse/OCPBUGS-105399
 Bug2: https://redhat.atlassian.net/browse/OCPBUGS-105400
## Summary
The sigstore image policy tests have been moved to the`[Suite:openshift/disruptive-longrunning]` suite. This PR completes the cleanup by:
- Removing the `IsTechPreviewNoUpgrade` runtime skip checks from both `SigstoreImageVerification` and `SigstoreImageVerificationPKI` test   blocks (the `[OCPFeatureGate:...]` annotations already control test
  selection)
- Removing 7 pathological event matchers that were only needed when the tests ran in the normal serial suite (the disruptive suite does not flag these events as pathological)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Streamlined image policy validation by removing obsolete prerequisite checks.
  * Retained existing handling for disconnected platform environments.
  * Removed outdated monitoring expectations associated with image-policy signature validation and image verification intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->