### PR TITLE
OCPBUGS-111704: router/metrics: enable proxy protocol for client on AWS clusters

### DIFF
--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -53,19 +53,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		platformType := infra.Status.Platform
-		dualStackIPFamily := false
-		if infra.Status.PlatformStatus != nil {
-			platformType = infra.Status.PlatformStatus.Type
-			if infra.Status.PlatformStatus.AWS != nil {
-				ipFamily := infra.Status.PlatformStatus.AWS.IPFamily
-				if ipFamily == configv1.DualStackIPv4Primary || ipFamily == configv1.DualStackIPv6Primary {
-					dualStackIPFamily = true
-				}
-			}
-		}
-		// Dual-stack installations on AWS are forced to use NLB type, which
-		// doesn't accept proxy protocol (yet).
-		proxyProtocol = (platformType == configv1.AWSPlatformType) && !dualStackIPFamily
+		proxyProtocol = platformType == configv1.AWSPlatformType
 
 		// This test needs to make assertions against a single router pod, so all access
 		// to the router should happen through a single endpoint.


### PR DESCRIPTION
The `cluster-ingress-operator` now supports `PROXY` protocol for NLB by default (OCPBUGS-63219) on AWS. Thus, we need to partially revert [NE-2422](https://redhat.atlassian.net/browse/NE-2422) (https://github.com/openshift/origin/pull/30934), specifically https://github.com/openshift/origin/commit/a97b2ad5bdf12577ae5d45858a9d783eeb1b9e14, to use proxy protocol for the client.

This addresses the below failed e2e test in AWS dualstack periodic jobs:

`[sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route [apigroup:route.openshift.io] [Suite:openshift/conformance/parallel]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated router metrics testing to validate proxy protocol behavior across all AWS platform configurations.
  * Expanded coverage to include AWS dual-stack environments.
  * Removed outdated platform-specific checks from the test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->