### PR TITLE
OCPBUGS-111581: Fix probe termination test to use pod status instead of kubelet event text

### DIFF
--- a/test/extended/node/node_e2e/probe_termination.go
+++ b/test/extended/node/node_e2e/probe_termination.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/utils/ptr"
 
 	nodeutils "github.com/openshift/origin/test/extended/node"
@@ -200,87 +201,81 @@ var _ = g.Describe("[sig-node] Probe configuration", func() {
 	})
 })
 
-// findLatestEventByReason finds the latest event matching the given reason and message filter
-func findLatestEventByReason(events *corev1.EventList, reason string, msgFilter func(string) bool) *corev1.Event {
-	var latestEvent *corev1.Event
-	for i := range events.Items {
-		event := &events.Items[i]
-		if event.Reason == reason && msgFilter(event.Message) {
-			if latestEvent == nil || event.LastTimestamp.Time.After(latestEvent.LastTimestamp.Time) {
-				latestEvent = event
-			}
-		}
-	}
-	return latestEvent
-}
-
-// findEarliestEventAfter finds the earliest event matching the reason and filter that occurred after the given time
-// Uses LastTimestamp to properly detect repeated events (container restarts)
-func findEarliestEventAfter(events *corev1.EventList, reason string, msgFilter func(string) bool, afterTime time.Time) *corev1.Event {
-	var earliestEvent *corev1.Event
-	for i := range events.Items {
-		event := &events.Items[i]
-		// Use LastTimestamp instead of FirstTimestamp to catch repeated events (e.g., container restarts)
-		// FirstTimestamp stays at the original event time, but LastTimestamp updates on each occurrence
-		if event.Reason == reason && msgFilter(event.Message) && event.LastTimestamp.Time.After(afterTime) {
-			if earliestEvent == nil || event.LastTimestamp.Time.Before(earliestEvent.LastTimestamp.Time) {
-				earliestEvent = event
-			}
-		}
-	}
-	return earliestEvent
-}
-
-// verifyProbeTermination verifies that the probe termination grace period is honored
-// by checking the time difference between probe failure (Killing) and container restart (Started) events
-// Returns the time difference in seconds, or an error if events are not found
+// verifyProbeTermination returns the seconds between the "Killing" event (FirstTimestamp) and
+// the container's restart (pod.Status, gated on RestartCount==1 for the same cycle) - avoids
+// matching the "Started" event's message text, which varies across kubelet versions.
 func verifyProbeTermination(ctx context.Context, oc *exutil.CLI, namespace, podName, containerName string, expectedTerminationSec int) (int, error) {
 	var timeDiff int
 	// Timeout needs to account for: pod start (~30s) + probe period (60s) + termination (up to 60s) + restart (~30s) = ~3 minutes minimum
 	// Use 6 minutes to be safe for tests with 60s termination grace period
-	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 6*time.Minute, true, func(ctx context.Context) (bool, error) {
-		// Get events using the Events API
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 6*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := oc.KubeClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Error getting pod %s: %v", podName, err)
+			return false, nil
+		}
+
+		status := e2epod.FindContainerStatusInPod(pod, containerName)
+		if status == nil {
+			e2e.Logf("Waiting for container status of %q to appear", containerName)
+			return false, nil
+		}
+
+		// Gate strictly on the first restart so the "Killing" event's FirstTimestamp below
+		// is guaranteed to correspond to the same cycle as this restart, not a later one.
+		if status.RestartCount != 1 {
+			e2e.Logf("Waiting for the first restart of %q (restartCount=%d)", containerName, status.RestartCount)
+			return false, nil
+		}
+
+		if status.State.Running == nil {
+			e2e.Logf("Waiting for container %q to be running again after restart", containerName)
+			return false, nil
+		}
+
 		events, err := oc.KubeClient().CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Killing", podName),
 		})
 		if err != nil {
-			e2e.Logf("Error getting events: %v", err)
+			e2e.Logf("Error listing events for pod %s: %v", podName, err)
 			return false, nil
 		}
 
-		// Find probe failure (Killing) event for the container
-		killingEvent := findLatestEventByReason(events, "Killing", func(msg string) bool {
-			return strings.Contains(msg, containerName) &&
-				strings.Contains(msg, "failed") &&
-				strings.Contains(msg, "probe")
-		})
-
+		killingEvent := findProbeKillingEvent(events, containerName)
 		if killingEvent == nil {
-			e2e.Logf("Waiting for probe failure (Killing) event")
+			e2e.Logf("Waiting for probe-failure (Killing) event for container %q", containerName)
 			return false, nil
 		}
 
-		// Find container restart (Started) event that occurred after the Killing event
-		startedEvent := findEarliestEventAfter(events, "Started", func(msg string) bool {
-			return strings.Contains(msg, "Container started")
-		}, killingEvent.LastTimestamp.Time)
-
-		if startedEvent == nil {
-			e2e.Logf("Waiting for container restart (Started) event after Killing event")
+		killedAt := killingEvent.FirstTimestamp.Time
+		startedAt := status.State.Running.StartedAt.Time
+		if !startedAt.After(killedAt) {
+			// The status hasn't caught up yet (e.g. reporting a stale running instance); keep polling.
+			e2e.Logf("Waiting for a fresh Running state after kill decision at %v", killedAt)
 			return false, nil
 		}
 
-		e2e.Logf("Killing event: %s at %v", killingEvent.Message, killingEvent.LastTimestamp)
-		e2e.Logf("Started event: %s at %v", startedEvent.Message, startedEvent.LastTimestamp)
-
-		// Calculate time difference using the helper function
-		timeDiff = int(nodeutils.CalculateEventTimeDiff(killingEvent, startedEvent).Seconds())
-		e2e.Logf("Time difference: %d seconds (expected: %d ±10 seconds)", timeDiff, expectedTerminationSec)
+		timeDiff = int(startedAt.Sub(killedAt).Seconds())
+		e2e.Logf("Container %q: probe failure detected at %v, restarted at %v, time difference: %d seconds (expected: %d seconds)",
+			containerName, killedAt, startedAt, timeDiff, expectedTerminationSec)
 
 		return true, nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to observe probe termination and restart for container %q: %w", containerName, err)
 	}
 	return timeDiff, nil
+}
+
+// findProbeKillingEvent finds the "Killing" event kubelet records when a probe failure
+// triggers container termination. The message format is "Container <name> failed
+// liveness/startup probe, will be restarted" (see kuberuntime_manager.go).
+func findProbeKillingEvent(events *corev1.EventList, containerName string) *corev1.Event {
+	for i := range events.Items {
+		event := &events.Items[i]
+		if strings.Contains(event.Message, containerName) && strings.Contains(event.Message, "failed") && strings.Contains(event.Message, "probe") {
+			return event
+		}
+	}
+	return nil
 }

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -917,23 +917,6 @@ func GetFirstReadyWorkerNode(oc *exutil.CLI) string {
 	return ""
 }
 
-// CalculateEventTimeDiff calculates the time difference between two Kubernetes events.
-// It uses LastTimestamp for both events to handle repeated events correctly.
-// For repeated events (like container restarts), Kubernetes reuses the event object and updates
-// LastTimestamp while keeping FirstTimestamp at the original occurrence.
-// Falls back to FirstTimestamp if LastTimestamp is zero.
-func CalculateEventTimeDiff(startEvent, endEvent *corev1.Event) time.Duration {
-	startTime := startEvent.LastTimestamp.Time
-	if startTime.IsZero() {
-		startTime = startEvent.FirstTimestamp.Time
-	}
-	endTime := endEvent.LastTimestamp.Time
-	if endTime.IsZero() {
-		endTime = endEvent.FirstTimestamp.Time
-	}
-	return endTime.Sub(startTime)
-}
-
 // GetPodNetNs retrieves the network namespace path for a pod using crictl.
 // It uses crictl to get the sandbox ID and then inspects it to extract the NetNS path.
 // Returns the NetNS path and an error if not found.


### PR DESCRIPTION
## Summary

Fixes the `[sig-node] Probe configuration [OTP]` `terminationGracePeriodSeconds` tests, which have been failing deterministically on `release-4.20`/`release-4.21` (and flaking to a lesser extent elsewhere) since their restart-detection logic depended on matching a hardcoded substring against the kubelet `Started` event's free-text message.

## Root cause

The test waited for a `Started` event containing the substring `"Container started"` to detect a container restart. That message text is **not stable across kubelet versions**:

| Branch | kubelet `Started` event message |
|---|---|
| `release-4.20` | `"Started container %v"` (e.g. `"Started container test"`) |
| `release-4.21` | `"Started container %v"` |
| `release-4.22` | `"Container started"` (no container name) |
| `main` (5.0) | `"Container started"` |

Because `"Started container test"` does not contain the substring `"Container started"`, the match can never succeed on 4.20/4.21, so the test always timed out waiting for a restart signal that would never match, eventually failing with `client rate limiter Wait returned an error: context deadline exceeded`. On `4.22`/`main`, the newer wording happens to satisfy the match, which is why those branches showed a much higher (but not 100%) pass rate.

## Fix

Replace the event-message matching with data read directly from the Kubernetes API instead of free-text log parsing:

- Use `pod.Status.ContainerStatuses[].State.Running.StartedAt` for the restart timestamp (authoritative, always current).
- Use the `Killing` event's `FirstTimestamp` for the kill-decision timestamp (immutable on first occurrence).
- Gate strictly on `RestartCount == 1` so both signals are guaranteed to correspond to the same restart cycle.

This has no dependency on kubelet event wording, so it is stable across kubelet versions and platforms.

Also removes `CalculateEventTimeDiff` from `node_utils.go`, which was added solely for the old event-message-matching approach and has no other callers in the repository.

## Testing

Verified on a live OCP 4.20 cluster (via `./openshift-tests run-test "<test name>"`) for all three affected tests:

| Test | Container | Expected | Measured | Result |
|---|---|---|---|---|
| Liveness probe should respect probe-level terminationGracePeriodSeconds | `test` | 10s (-3s/+10s) | 11s | PASS |
| Startup probe should respect probe-level terminationGracePeriodSeconds | `teststartup` | 10s (-3s/+10s) | 10s | PASS |
| Liveness probe should fall back to pod-level terminationGracePeriodSeconds when probe-level is not set | `test` | 60s (-3s/+10s) | 60s | PASS |

Sample output:

```
probe_termination.go:262] Container "test": probe failure detected at 2026-08-18 15:09:35 +0530 IST, restarted at 2026-08-18 15:09:46 +0530 IST, time difference: 11 seconds (expected: 10 seconds)
Ran 1 of 1 Specs in 91.249 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

```
probe_termination.go:262] Container "teststartup": probe failure detected at 2026-08-18 15:14:23 +0530 IST, restarted at 2026-08-18 15:14:33 +0530 IST, time difference: 10 seconds (expected: 10 seconds)
Ran 1 of 1 Specs in 91.434 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

```
probe_termination.go:262] Container "test": probe failure detected at 2026-08-18 15:16:57 +0530 IST, restarted at 2026-08-18 15:17:57 +0530 IST, time difference: 60 seconds (expected: 60 seconds)
Ran 1 of 1 Specs in 141.898 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```

No trace of the previous `Waiting for container restart (Started) event after Killing event` timeout loop or `context deadline exceeded` failure.

## Jira

[OCPBUGS-111581](https://issues.redhat.com/browse/OCPBUGS-111581)

## Backport plan

Once this merges to `main`, the same fix will be backported to `release-4.22`, `release-4.21`, and `release-4.20`, where these tests are currently failing/regressing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of probe-triggered container termination by correlating restart status with pod events.
  * More accurately measures termination and restart timing using event and container timestamps.
  * Removed outdated event-matching and timing logic to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->