### PR TITLE
OCPBUGS-111074: Expect TNF node-lost taint alert in DualReplica tests

### DIFF
--- a/test/extended/edge_topologies/tnf_taint.go
+++ b/test/extended/edge_topologies/tnf_taint.go
@@ -143,6 +143,8 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		o.Expect(alertOutput).To(o.ContainSubstring(services.TaintAlertID),
 			fmt.Sprintf("Expected pacemaker alert %s to be registered", services.TaintAlertID))
+		o.Expect(alertOutput).To(o.ContainSubstring(services.TaintLostAlertID),
+			fmt.Sprintf("Expected pacemaker alert %s to be registered", services.TaintLostAlertID))
 		o.Expect(alertOutput).To(o.ContainSubstring(services.UntaintAlertID),
 			fmt.Sprintf("Expected pacemaker alert %s to be registered", services.UntaintAlertID))
 		framework.Logf("Pacemaker alert config:\n%s", alertOutput)

--- a/test/extended/edge_topologies/utils/services/taint.go
+++ b/test/extended/edge_topologies/utils/services/taint.go
@@ -40,8 +40,10 @@ const (
 	// UntaintAlertRejoinLog is the message logged when the untaint alert fires on node rejoin.
 	UntaintAlertRejoinLog = "rejoined cluster (membership)"
 
-	// TaintAlertID is the pacemaker alert ID for the taint agent.
+	// TaintAlertID is the pacemaker alert ID for the STONITH taint agent.
 	TaintAlertID = "tnf-taint-alert"
+	// TaintLostAlertID is the pacemaker alert ID for graceful/node-lost taint.
+	TaintLostAlertID = "tnf-taint-lost-alert"
 	// UntaintAlertID is the pacemaker alert ID for the untaint agent.
 	UntaintAlertID = "tnf-untaint-alert"
 


### PR DESCRIPTION
The pacemaker taint path now registers tnf-taint-lost-alert for graceful shutdown. Assert it is present alongside the existing fencing and untaint alerts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying alerts when a node’s taint is gracefully or unexpectedly lost.

* **Tests**
  * Expanded alert-registration coverage to verify that node-lost taint alerts are included in the Pacemaker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->