### PR TITLE
OCPBUGS-99536: Raise status polling timeout and write bound

### DIFF
--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -210,7 +210,11 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for sufficient routes to have a status")
-			err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+
+			// The leader election lease lasts 1 minute. Normally all route statuses are written
+			// within 1-2 lease cycles when handling conflicts. Under heavier contention a replica
+			// may need to re-acquire the lease 3 or more times until all routes are updated.
+			err = wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
 				routes, err := client.List(context.Background(), metav1.ListOptions{})
 				if err != nil {
 					return false, err
@@ -249,10 +253,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			// Next, we expect 1-2 more writes per route until per-route contention activates.
 			// Next, we expect the maxContention logic to activate and stop all updates when the routers detect > 5
 			// contentions.
-			// In total, we expect around 30-35 writes, but we generously allow for up to 50 writes to accommodate for
-			// minor discrepancies in contention tracker logic.
+			// In total, we expect around 30-35 writes. The actual count can be higher when the
+			// asynchronous contention detector lags behind update events, allowing a few extra
+			// writes before updates are suppressed. The previous limit of 50 caused intermittent
+			// failures; 75 is a more conservative bound.
 			o.Expect(writes).To(o.BeNumerically(">=", numOfRoutes))
-			o.Expect(writes).To(o.BeNumerically("<=", 50))
+			o.Expect(writes).To(o.BeNumerically("<=", 75))
 
 			// the os_http_be.map file will vary, so only check the haproxy config
 			verifyCommandEquivalent(oc.KubeClient(), rs, "md5sum /var/lib/haproxy/conf/haproxy.config")


### PR DESCRIPTION
The 3-replica conflicting router stress test was intermittently failing in two independent places.

1. Polling timeout 2m -> 5m: the leader election lease lasts 1 minute. Under normal conditions all route statuses are written within 1-2 lease cycles, which fit in the previous 2-minute timeout. Under heavier contention a router replica may need to re-acquire the lease 3 or more times until all routes are updated.

2. Write upper bound 50 -> 75: the per-route contention detector runs asynchronously and can lag behind update events, allowing a few extra writes before suppressing further updates. The previous limit of 50 caused intermittent failures; 75 is a more conservative ceiling.

https://redhat.atlassian.net/browse/OCPBUGS-99536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended the conflicting-router convergence test timeout to accommodate asynchronous status updates.
  * Increased the permitted number of status updates for more reliable stress-test validation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->