### PR TITLE
OCPBUGS-111997: Add Degraded=True exception for authentication operator during upgrade

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -373,9 +373,11 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if checkAuthenticationAvailableExceptions(condition) {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056"
 			}
-			if isTwoNode && condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
-				strings.Contains(condition.Reason, "OAuthServerDeployment_UnavailablePod") {
-				return "authentication may report Degraded while oauth-openshift pods roll out during DualReplica disruptive upgrades"
+			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
+				(condition.Reason == "APIServerDeployment_UnavailablePod" ||
+					condition.Reason == "APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod" ||
+					condition.Reason == "OAuthServerDeployment_UnavailablePod") {
+				return "https://issues.redhat.com/browse/OCPBUGS-111997"
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -308,6 +308,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 	upgradeWindows := getUpgradeWindows(events)
 
 	isTwoNode := topology == configv1.HighlyAvailableArbiterMode || topology == configv1.DualReplicaTopologyMode
+	isOKD := isOKDCluster(clientConfig)
 	upgradeFailed := hasUpgradeFailedEvent(events)
 
 	except := func(operator string, condition *configv1.ClusterOperatorStatusCondition, eventInterval monitorapi.Interval) string {
@@ -373,9 +374,15 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if checkAuthenticationAvailableExceptions(condition) {
 				return "https://issues.redhat.com/browse/OCPBUGS-20056"
 			}
-			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
+			if isTwoNode && condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
 				strings.Contains(condition.Reason, "OAuthServerDeployment_UnavailablePod") {
-				return "authentication transiently reports Degraded while oauth-apiserver/oauth-server pods roll out during upgrade (OCPBUGS-111997)"
+				return "authentication may report Degraded while oauth-openshift pods roll out during DualReplica disruptive upgrades"
+			}
+			// Temporary exception for OKD SCOS upgrades until the auth operator
+			// stops reporting Degraded during pod rollout.
+			if isOKD && condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
+				strings.Contains(condition.Reason, "OAuthServerDeployment_UnavailablePod") {
+				return "https://issues.redhat.com/browse/OCPBUGS-111997"
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {
@@ -488,6 +495,21 @@ func isVSphere(config *rest.Config) (bool, error) {
 		return false, err
 	}
 	return infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.VSpherePlatformType, nil
+}
+
+func isOKDCluster(config *rest.Config) bool {
+	if config == nil {
+		return false
+	}
+	client, err := clientconfigv1.NewForConfig(config)
+	if err != nil {
+		return false
+	}
+	cv, err := client.ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+	return strings.Contains(cv.Status.Desired.Version, "okd-scos")
 }
 
 // getArchitecture checks if the cluster is running on an alternative architecture

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -374,10 +374,8 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				return "https://issues.redhat.com/browse/OCPBUGS-20056"
 			}
 			if condition.Type == configv1.OperatorDegraded && condition.Status == configv1.ConditionTrue &&
-				(condition.Reason == "APIServerDeployment_UnavailablePod" ||
-					condition.Reason == "APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod" ||
-					condition.Reason == "OAuthServerDeployment_UnavailablePod") {
-				return "https://issues.redhat.com/browse/OCPBUGS-111997"
+				strings.Contains(condition.Reason, "OAuthServerDeployment_UnavailablePod") {
+				return "authentication transiently reports Degraded while oauth-apiserver/oauth-server pods roll out during upgrade (OCPBUGS-111997)"
 			}
 		case "ingress":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "IngressUnavailable" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -711,26 +711,37 @@ func Test_authenticationDegradedExceptionDuringUpgrade(t *testing.T) {
 	tests := []struct {
 		name      string
 		reason    string
+		topology  configv1.TopologyMode
 		wantFatal bool
 	}{
 		{
-			name:      "compound reason containing OAuthServerDeployment_UnavailablePod should be excepted",
+			name:      "DualReplica: compound reason containing OAuthServerDeployment_UnavailablePod should be excepted",
 			reason:    "APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod",
+			topology:  configv1.DualReplicaTopologyMode,
 			wantFatal: false,
 		},
 		{
-			name:      "OAuthServerDeployment_UnavailablePod alone should be excepted",
+			name:      "DualReplica: OAuthServerDeployment_UnavailablePod alone should be excepted",
 			reason:    "OAuthServerDeployment_UnavailablePod",
+			topology:  configv1.DualReplicaTopologyMode,
 			wantFatal: false,
 		},
 		{
-			name:      "APIServerDeployment_UnavailablePod alone should NOT be excepted",
+			name:      "DualReplica: APIServerDeployment_UnavailablePod alone should NOT be excepted",
 			reason:    "APIServerDeployment_UnavailablePod",
+			topology:  configv1.DualReplicaTopologyMode,
+			wantFatal: true,
+		},
+		{
+			name:      "HA non-OKD: OAuthServerDeployment_UnavailablePod should NOT be excepted",
+			reason:    "OAuthServerDeployment_UnavailablePod",
+			topology:  configv1.HighlyAvailableTopologyMode,
 			wantFatal: true,
 		},
 		{
 			name:      "unrelated Degraded reason should NOT be excepted",
 			reason:    "SomeOtherDegradedReason",
+			topology:  configv1.HighlyAvailableTopologyMode,
 			wantFatal: true,
 		},
 	}
@@ -749,7 +760,8 @@ func Test_authenticationDegradedExceptionDuringUpgrade(t *testing.T) {
 			events = append(events, upgradeEvents...)
 			events = append(events, conditionEvent)
 
-			results := testUpgradeOperatorStateTransitions(events, nil, configv1.HighlyAvailableTopologyMode)
+			// nil clientConfig means isOKD=false; OKD path requires a live cluster
+			results := testUpgradeOperatorStateTransitions(events, nil, tt.topology)
 
 			testName := "[bz-apiserver-auth] clusteroperator/authentication should not change condition/Degraded"
 			var hasFailure, hasSuccess bool

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -674,3 +674,103 @@ func TestOverlapsNoExecuteTaintManagerTest(t *testing.T) {
 		})
 	}
 }
+
+func buildOperatorConditionInterval(operator, conditionType, status, reason string, from, to time.Time) monitorapi.Interval {
+	return monitorapi.Interval{
+		Source: monitorapi.SourceClusterOperatorMonitor,
+		Condition: monitorapi.Condition{
+			Locator: monitorapi.Locator{
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorClusterOperatorKey: operator,
+				},
+			},
+			Message: monitorapi.Message{
+				Reason:       monitorapi.IntervalReason(reason),
+				HumanMessage: "test condition",
+				Annotations: map[monitorapi.AnnotationKey]string{
+					monitorapi.AnnotationCondition: conditionType,
+					monitorapi.AnnotationStatus:    status,
+					monitorapi.AnnotationReason:    reason,
+				},
+			},
+		},
+		From: from,
+		To:   to,
+	}
+}
+
+func Test_authenticationDegradedExceptionDuringUpgrade(t *testing.T) {
+	upgradeStart := time.Date(2026, 8, 17, 16, 0, 0, 0, time.UTC)
+	upgradeEnd := time.Date(2026, 8, 17, 17, 30, 0, 0, time.UTC)
+
+	upgradeEvents := makeUpgradeEventList([]upgradeEvent{
+		{eventTime: upgradeStart, reason: monitorapi.UpgradeStartedReason},
+		{eventTime: upgradeEnd, reason: monitorapi.UpgradeCompleteReason},
+	})
+
+	tests := []struct {
+		name      string
+		reason    string
+		wantFatal bool
+	}{
+		{
+			name:      "compound UnavailablePod reason should be excepted",
+			reason:    "APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod",
+			wantFatal: false,
+		},
+		{
+			name:      "APIServerDeployment_UnavailablePod alone should be excepted",
+			reason:    "APIServerDeployment_UnavailablePod",
+			wantFatal: false,
+		},
+		{
+			name:      "OAuthServerDeployment_UnavailablePod alone should be excepted",
+			reason:    "OAuthServerDeployment_UnavailablePod",
+			wantFatal: false,
+		},
+		{
+			name:      "unrelated Degraded reason should NOT be excepted",
+			reason:    "SomeOtherDegradedReason",
+			wantFatal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			condFrom := upgradeStart.Add(50 * time.Minute)
+			condTo := condFrom.Add(10 * time.Second)
+
+			conditionEvent := buildOperatorConditionInterval(
+				"authentication", "Degraded", "True", tt.reason,
+				condFrom, condTo,
+			)
+
+			var events monitorapi.Intervals
+			events = append(events, upgradeEvents...)
+			events = append(events, conditionEvent)
+
+			results := testUpgradeOperatorStateTransitions(events, nil, configv1.HighlyAvailableTopologyMode)
+
+			testName := "[bz-apiserver-auth] clusteroperator/authentication should not change condition/Degraded"
+			var hasFailure, hasSuccess bool
+			for _, tc := range results {
+				if tc.Name == testName {
+					if tc.FailureOutput != nil {
+						hasFailure = true
+					} else {
+						hasSuccess = true
+					}
+				}
+			}
+
+			if tt.wantFatal {
+				assert.True(t, hasFailure, "expected a failure JUnit for reason %s", tt.reason)
+				assert.False(t, hasSuccess, "expected no success JUnit for reason %s (should be hard failure)", tt.reason)
+			} else {
+				if hasFailure {
+					assert.True(t, hasSuccess, "expected both failure and success JUnit (flake) for reason %s", tt.reason)
+				}
+			}
+		})
+	}
+}

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators_test.go
@@ -714,19 +714,19 @@ func Test_authenticationDegradedExceptionDuringUpgrade(t *testing.T) {
 		wantFatal bool
 	}{
 		{
-			name:      "compound UnavailablePod reason should be excepted",
+			name:      "compound reason containing OAuthServerDeployment_UnavailablePod should be excepted",
 			reason:    "APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod",
-			wantFatal: false,
-		},
-		{
-			name:      "APIServerDeployment_UnavailablePod alone should be excepted",
-			reason:    "APIServerDeployment_UnavailablePod",
 			wantFatal: false,
 		},
 		{
 			name:      "OAuthServerDeployment_UnavailablePod alone should be excepted",
 			reason:    "OAuthServerDeployment_UnavailablePod",
 			wantFatal: false,
+		},
+		{
+			name:      "APIServerDeployment_UnavailablePod alone should NOT be excepted",
+			reason:    "APIServerDeployment_UnavailablePod",
+			wantFatal: true,
 		},
 		{
 			name:      "unrelated Degraded reason should NOT be excepted",


### PR DESCRIPTION
## Summary

- Add a narrow `Degraded=True` exception for the `authentication` operator during upgrade, scoped to `UnavailablePod` reasons only
- Follows the existing pattern for `kube-apiserver` (OCPBUGS-38661), `kube-controller-manager` (OCPBUGS-38662), and `kube-scheduler` (OCPBUGS-38663)
- Unblocks the OKD SCOS 5.0 promoted upgrade job which has been failing consistently since ec.4 ([OKD-424](https://redhat.atlassian.net/browse/OKD-424))

## Details

During upgrade rollout, the authentication operator transiently goes `Degraded=True` for ~8.5 seconds when oauth-apiserver and oauth-server pods are briefly unavailable. The condition reason is `APIServerDeployment_UnavailablePod::OAuthServerDeployment_UnavailablePod`.

The `except()` function in `operators.go` already has Degraded exceptions for other control plane operators but was missing one for `authentication`. Without this exception, the transient state is recorded as a hard failure rather than a flake, blocking the upgrade job.

The exception is narrowly scoped to three `UnavailablePod` reason combinations observed in upgrade logs — it will not mask real authentication degradations from other causes.

## Test plan

- [x] Existing tests pass (`go test ./pkg/monitortests/clusterversionoperator/legacycvomonitortests/`)
- [x] `go vet` passes
- [ ] Verify the OKD SCOS 5.0 upgrade job passes with a payload containing this change

## References

- OCPBUGS-111997
- [OKD-424](https://redhat.atlassian.net/browse/OKD-424) — full investigation of the upgrade failure
- OCPBUGS-38661 — kube-apiserver Degraded exception (same pattern)
- OCPBUGS-38662 — kube-controller-manager Degraded exception (same pattern)
- OCPBUGS-38663 — kube-scheduler Degraded exception (same pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication monitoring during cluster upgrades.
  * Better recognizes expected temporary degradation while OAuth server components are rolling out, including combined rollout conditions.
  * Prevents known OAuth-related rollout states from being incorrectly reported as upgrade failures while continuing to flag unrelated degraded conditions for investigation.
  * Added coverage to verify both accepted and unexpected degradation scenarios are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->