### PR TITLE
[release-5.0] OCPBUGS-112042: allow baremetal to progress while MCO does

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -695,8 +695,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, summary)
 		}
 		switch co {
-		case "baremetal":
-			return "https://issues.redhat.com/browse/OCPBUGS-66101"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "operator-lifecycle-manager":
@@ -755,6 +753,13 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 
 	except = func(co string, reason string) string {
 		switch co {
+		case "baremetal":
+			// Since OCPBUGS-66101 was fixed, the baremetal operator intentionally reports Progressing=True
+			// during upgrades (reason SyncingResources, "Applying metal3 resources") while it syncs its
+			// metal3 resources, which legitimately overlaps with the machine-config progressing window.
+			if reason == "SyncingResources" {
+				return "baremetal is allowed to be Progressing=True while machine-config is progressing, as it applies metal3 resources during upgrades"
+			}
 		case "authentication":
 			if isTwoNode && (reason == "APIServerDeployment_NewGeneration" || reason == "APIServerDeployment_PodsUpdating") {
 				return "authentication operator may roll oauth-apiserver (APIServerDeployment_NewGeneration or APIServerDeployment_PodsUpdating) during DualReplica upgrades while machine-config is progressing"


### PR DESCRIPTION
manual cherry-pick from https://github.com/openshift/origin/pull/31511