### PR TITLE
OCPBUGS-105460: Use tagged version for openshift/kubernetes dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -313,7 +313,7 @@ replace (
 	k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20260209193319-41c4e9ba94f4
 	k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20260209193319-41c4e9ba94f4
 	k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20260209193319-41c4e9ba94f4
-	k8s.io/kubernetes => github.com/openshift/kubernetes v1.29.0-rc.1.0.20260209193319-41c4e9ba94f4
+	k8s.io/kubernetes => github.com/openshift/kubernetes v1.29.14-openshift.1
 	k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20260209193319-41c4e9ba94f4
 	k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20260209193319-41c4e9ba94f4
 	k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20260209193319-41c4e9ba94f4

--- a/go.sum
+++ b/go.sum
@@ -644,8 +644,8 @@ github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250 h1:WQ0e89xebsN
 github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250/go.mod h1:tjGjTE59N1+5W0YE4Wqf0zJpFLIY4d+EpMihDKOn1oA=
 github.com/openshift/cluster-network-operator v0.0.0-20240111190956-90754aa19843 h1:gnesIcAzYdKHsUuKlHT9U36bWJ/8xBDkyjY/mRkdCBU=
 github.com/openshift/cluster-network-operator v0.0.0-20240111190956-90754aa19843/go.mod h1:chX1Hl5mlarhOVgqSrG8lbYoxUjO8x9+eALxBhGOLxM=
-github.com/openshift/kubernetes v1.29.0-rc.1.0.20260209193319-41c4e9ba94f4 h1:qOVRuW6bjf7Jxlv14fveQr9K5rDB1DAMOXQ8d0BcZdY=
-github.com/openshift/kubernetes v1.29.0-rc.1.0.20260209193319-41c4e9ba94f4/go.mod h1:o/2Y2qmbcgLLzlwoN3iMFiR03X9Mjj+cBgA8oc2rklQ=
+github.com/openshift/kubernetes v1.29.14-openshift.1 h1:ejpAaFamD1Vddll84urMtM/XbFdp90LdVBbk4MQ4o+4=
+github.com/openshift/kubernetes v1.29.14-openshift.1/go.mod h1:o/2Y2qmbcgLLzlwoN3iMFiR03X9Mjj+cBgA8oc2rklQ=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20260209193319-41c4e9ba94f4 h1:HU6RPZpIUc42q1OzXrIxHamM/ukSL+WvW/tM+QXdPB4=
 github.com/openshift/kubernetes/staging/src/k8s.io/api v0.0.0-20260209193319-41c4e9ba94f4/go.mod h1:qMfTVH/yQM4Gc2f5VQJbV1AMWQi8YFwu6fKRuT1Csx4=
 github.com/openshift/kubernetes/staging/src/k8s.io/apiextensions-apiserver v0.0.0-20260209193319-41c4e9ba94f4 h1:U+Gi8v/CsVHhzrB7UZoZeqEHHQDaQVtmCnYCtQQI7+c=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2695,7 +2695,7 @@ k8s.io/kubelet/pkg/cri/streaming
 k8s.io/kubelet/pkg/cri/streaming/portforward
 k8s.io/kubelet/pkg/cri/streaming/remotecommand
 k8s.io/kubelet/pkg/types
-# k8s.io/kubernetes v1.29.0 => github.com/openshift/kubernetes v1.29.0-rc.1.0.20260209193319-41c4e9ba94f4
+# k8s.io/kubernetes v1.29.0 => github.com/openshift/kubernetes v1.29.14-openshift.1
 ## explicit; go 1.21
 k8s.io/kubernetes/cmd/kube-apiserver/app
 k8s.io/kubernetes/cmd/kube-apiserver/app/options
@@ -3713,7 +3713,7 @@ sigs.k8s.io/yaml
 # k8s.io/kube-scheduler => github.com/openshift/kubernetes/staging/src/k8s.io/kube-scheduler v0.0.0-20260209193319-41c4e9ba94f4
 # k8s.io/kubectl => github.com/openshift/kubernetes/staging/src/k8s.io/kubectl v0.0.0-20260209193319-41c4e9ba94f4
 # k8s.io/kubelet => github.com/openshift/kubernetes/staging/src/k8s.io/kubelet v0.0.0-20260209193319-41c4e9ba94f4
-# k8s.io/kubernetes => github.com/openshift/kubernetes v1.29.0-rc.1.0.20260209193319-41c4e9ba94f4
+# k8s.io/kubernetes => github.com/openshift/kubernetes v1.29.14-openshift.1
 # k8s.io/legacy-cloud-providers => github.com/openshift/kubernetes/staging/src/k8s.io/legacy-cloud-providers v0.0.0-20260209193319-41c4e9ba94f4
 # k8s.io/metrics => github.com/openshift/kubernetes/staging/src/k8s.io/metrics v0.0.0-20260209193319-41c4e9ba94f4
 # k8s.io/mount-utils => github.com/openshift/kubernetes/staging/src/k8s.io/mount-utils v0.0.0-20260209193319-41c4e9ba94f4


### PR DESCRIPTION
## Summary
- Replace pseudo-version pin for `k8s.io/kubernetes` with the `v1.29.14-openshift.1` tag, which now resolves on proxy.golang.org.
- Same underlying commit (`41c4e9ba94f4`), just using the proper tag instead of a pseudo-version.

## Test plan
- [ ] Verify `go mod tidy` succeeds
- [ ] Verify `go mod vendor` produces no additional changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)