### PR TITLE
OCPBUGS-86257: Fix pathological events

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1030,6 +1030,9 @@ type OverlapOtherIntervalsPathologicalEventMatcher struct {
 	// allowIfWithinIntervals is the list of intervals that the incoming pathological event will
 	// match if it contained within one of these.
 	allowIfWithinIntervals monitorapi.Intervals
+	// useLastTimestamp attributes a repeated event to its most recent occurrence instead of
+	// requiring the full lifetime of the Kubernetes Event object to fit within the interval.
+	useLastTimestamp bool
 }
 
 func (ade *OverlapOtherIntervalsPathologicalEventMatcher) Name() string {
@@ -1051,9 +1054,11 @@ func (ade *OverlapOtherIntervalsPathologicalEventMatcher) Allows(i monitorapi.In
 	// but the event may have first fired much earlier. Use firstTimestamp from the
 	// annotations when available so the overlap check covers the full span of the event.
 	eventFrom := i.From
-	if ft, ok := i.Message.Annotations["firstTimestamp"]; ok {
-		if parsed, err := time.Parse(time.RFC3339, ft); err == nil {
-			eventFrom = parsed
+	if !ade.useLastTimestamp {
+		if ft, ok := i.Message.Annotations["firstTimestamp"]; ok {
+			if parsed, err := time.Parse(time.RFC3339, ft); err == nil {
+				eventFrom = parsed
+			}
 		}
 	}
 
@@ -1127,11 +1132,12 @@ func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals moni
 			locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
 				monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
 			},
-			messageReasonRegex: regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
-			messageHumanRegex:  regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
+			messageReasonRegex: regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*|^ScalingReplicaSet$)`),
+			messageHumanRegex:  regexp.MustCompile(`vmware-vsphere-csi-driver`),
+			jira:               "https://redhat.atlassian.net/browse/OCPBUGS-94112",
 		},
 		allowIfWithinIntervals: configurationTestIntervals,
+		useLastTimestamp:       true,
 	}
 }
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
@@ -85,6 +85,89 @@ func Test_OverlapMatcherUsesFirstTimestamp(t *testing.T) {
 		"event without firstTimestamp should fall back to From for overlap check")
 }
 
+func TestVsphereConfigurationMatcherUsesLastOccurrence(t *testing.T) {
+	testStart := time.Date(2026, 6, 28, 22, 30, 0, 0, time.UTC)
+	testEnd := testStart.Add(30 * time.Minute)
+	firstTimestamp := testStart.Add(-4 * time.Hour)
+	lastTimestamp := testStart.Add(15 * time.Minute)
+
+	testInterval := monitorapi.NewInterval(monitorapi.SourceE2ETest, monitorapi.Info).
+		Locator(monitorapi.NewLocator().E2ETest("[sig-storage] snapshot options in clusterCSIDriver should restore configuration")).
+		Message(monitorapi.NewMessage().HumanMessage("test interval")).
+		Build(testStart, testEnd)
+
+	tests := []struct {
+		name    string
+		locator monitorapi.Locator
+		reason  monitorapi.IntervalReason
+		message string
+	}{
+		{
+			name:    "daemonset update",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-operator"),
+			reason:  "DaemonSetUpdated",
+			message: "Updated DaemonSet.apps/vmware-vsphere-csi-driver-node because it changed",
+		},
+		{
+			name:    "daemonset pod creation",
+			locator: monitorapi.NewLocator().DaemonSetFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-node"),
+			reason:  "SuccessfulCreate",
+			message: "Created pod: vmware-vsphere-csi-driver-node-abcde",
+		},
+		{
+			name:    "configuration secret update",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-operator"),
+			reason:  "SecretUpdated",
+			message: "Updated Secret/vmware-vsphere-csi-driver-config",
+		},
+		{
+			name:    "deployment scaling",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-controller"),
+			reason:  "ScalingReplicaSet",
+			message: "Scaled down replica set vmware-vsphere-csi-driver-controller-abcde from 2 to 1",
+		},
+	}
+
+	matcher := newVsphereConfigurationTestsRollOutTooOftenEventMatcher(monitorapi.Intervals{testInterval})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+				Locator(test.locator).
+				Message(monitorapi.NewMessage().
+					Reason(test.reason).
+					HumanMessage(test.message).
+					WithAnnotation(monitorapi.AnnotationCount, "25").
+					WithAnnotation("firstTimestamp", firstTimestamp.Format(time.RFC3339)).
+					WithAnnotation("lastTimestamp", lastTimestamp.Format(time.RFC3339))).
+				Build(lastTimestamp, lastTimestamp.Add(time.Second))
+
+			assert.True(t, matcher.Allows(event, v1.HighlyAvailableTopologyMode),
+				"expected the rollout event's last occurrence to be attributed to the configuration test")
+		})
+	}
+
+	outsideTestWindow := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+		Locator(monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-controller")).
+		Message(monitorapi.NewMessage().
+			Reason("ScalingReplicaSet").
+			HumanMessage("Scaled down replica set vmware-vsphere-csi-driver-controller-abcde from 2 to 1").
+			WithAnnotation(monitorapi.AnnotationCount, "25").
+			WithAnnotation("firstTimestamp", firstTimestamp.Format(time.RFC3339))).
+		Build(testEnd.Add(20*time.Minute), testEnd.Add(20*time.Minute+time.Second))
+	assert.False(t, matcher.Allows(outsideTestWindow, v1.HighlyAvailableTopologyMode),
+		"expected an event outside the buffered test interval to remain pathological")
+
+	unrelatedScalingEvent := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+		Locator(monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "unrelated-controller")).
+		Message(monitorapi.NewMessage().
+			Reason("ScalingReplicaSet").
+			HumanMessage("some unrelated scaling operation").
+			WithAnnotation(monitorapi.AnnotationCount, "25")).
+		Build(lastTimestamp, lastTimestamp.Add(time.Second))
+	assert.False(t, matcher.Allows(unrelatedScalingEvent, v1.HighlyAvailableTopologyMode),
+		"expected an unrelated scaling event not to match the rollout allowance")
+}
+
 func Test_singleEventThresholdCheck_getNamespacedFailuresAndFlakes(t *testing.T) {
 	namespace := "openshift-etcd-operator"
 	samplePod := "etcd-operator-6f9b4d9d4f-4q9q8"


### PR DESCRIPTION
Fixes https://redhat.atlassian.net/browse/OCPBUGS-86257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VMware vSphere event matching by using the latest occurrence when evaluating overlapping events.
  * Added support for matching scaling-related rollout events.
  * Refined event message matching for greater accuracy.
* **Tests**
  * Added coverage for valid rollout events, out-of-window events, unrelated scaling events, and events with differing first and last occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->