### PR TITLE
OCPEDGE-2448: Add/update TNF recovery tests to verify PacemakerHealthCheck

### DIFF
--- a/test/extended/edge_topologies/tnf_etcd_disruption.go
+++ b/test/extended/edge_topologies/tnf_etcd_disruption.go
@@ -12,6 +12,7 @@ import (
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/core"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/services"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
@@ -582,6 +583,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By(fmt.Sprintf("Killing etcd container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd container kill")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd container kill")
+
 		// Wait for the cluster to self-heal.
 		g.By("Waiting for etcd cluster to self-heal after container kill")
 		o.Eventually(func() error {
@@ -611,6 +616,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(failedSection).To(o.ContainSubstring("etcd"),
 			"Expected Failed Resource Actions to reference etcd")
 		framework.Logf("Failed Resource Actions section:\n%s", failedSection)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after coordinated recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, longRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after coordinated recovery")
 	})
 
 	// This test verifies that Pacemaker detects an etcd process crash and automatically
@@ -627,11 +636,19 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By(fmt.Sprintf("Killing etcd process/container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd process kill")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd process kill")
+
 		g.By("Waiting for cluster to recover - both nodes become started voting members")
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&execNode,
 			&targetNode, true, false,
 			6*time.Minute, 45*time.Second)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after etcd process crash recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, 6*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd process crash recovery")
 	})
 
 	// This test verifies that the podman-etcd resource agent retries setting
@@ -661,6 +678,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(),
 			fmt.Sprintf("Expected pcs node standby to succeed, output: %s", output))
 		framework.Logf("PCS node standby output: %s", output)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after node standby")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after node standby")
 
 		// Wait for force-new-cluster recovery to complete.
 		g.By(fmt.Sprintf("Waiting for %s to appear as learner in etcd member list", standbyNode.Name))
@@ -760,5 +781,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			return verifyEtcdCloneStartedOnAllNodes(oc, execNode.Name, nodes)
 		}, longRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "etcd-clone should be Started on both nodes after recovery")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after attribute retry recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, longRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after attribute retry recovery")
 	})
 })

--- a/test/extended/edge_topologies/tnf_etcd_disruption.go
+++ b/test/extended/edge_topologies/tnf_etcd_disruption.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -330,6 +331,62 @@ func killEtcdViaSSH(node *corev1.Node) {
 	framework.Logf("Killed etcd on %s via SSH (stdout: %s)", node.Name, strings.TrimSpace(stdout))
 }
 
+// pacemakerDegradedObserver polls PacemakerHealthCheckDegraded in a background
+// goroutine so a test can detect a transient degraded state that Pacemaker
+// recovers from before it becomes observable. The PacemakerCluster CR (and thus
+// a blocking WaitForPacemakerHealthCheckDegraded call) is only refreshed by a
+// once-per-minute status-collector CronJob snapshot; when the resource agent's
+// own out-of-band detection and restart of a killed etcd container complete
+// faster than that, the fault can be fully recovered within a single snapshot
+// gap and never be caught by a snapshot-driven wait (see the equivalent race
+// documented in tnf_kubelet_disruption.go).
+type pacemakerDegradedObserver struct {
+	oc       *exutil.CLI
+	interval time.Duration
+
+	mu       sync.Mutex
+	observed bool
+	message  string
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+func newPacemakerDegradedObserver(oc *exutil.CLI, interval time.Duration) *pacemakerDegradedObserver {
+	return &pacemakerDegradedObserver{oc: oc, interval: interval, stopCh: make(chan struct{})}
+}
+
+func (p *pacemakerDegradedObserver) Start() {
+	go func() {
+		for {
+			select {
+			case <-p.stopCh:
+				return
+			default:
+				if degraded, msg, err := apis.IsPacemakerHealthCheckDegraded(p.oc); err == nil && degraded {
+					p.mu.Lock()
+					if !p.observed {
+						framework.Logf("pacemakerDegradedObserver: detected PacemakerHealthCheckDegraded=True (message: %q)", msg)
+					}
+					p.observed = true
+					p.message = msg
+					p.mu.Unlock()
+				}
+				time.Sleep(p.interval)
+			}
+		}
+	}()
+}
+
+func (p *pacemakerDegradedObserver) Stop() {
+	p.stopOnce.Do(func() { close(p.stopCh) })
+}
+
+func (p *pacemakerDegradedObserver) WasObserved() (message string, observed bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.message, p.observed
+}
+
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] Two Node with Fencing etcd disruption", func() {
 	defer g.GinkgoRecover()
 
@@ -580,12 +637,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
+		g.By("Starting background PacemakerHealthCheckDegraded observer")
+		degradedObserver := newPacemakerDegradedObserver(oc, 5*time.Second)
+		degradedObserver.Start()
+		defer degradedObserver.Stop()
+
 		g.By(fmt.Sprintf("Killing etcd container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
-
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd container kill")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd container kill")
 
 		// Wait for the cluster to self-heal.
 		g.By("Waiting for etcd cluster to self-heal after container kill")
@@ -593,6 +651,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			return utils.LogEtcdClusterStatus(oc, "after container kill", etcdClientFactory)
 		}, longRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "etcd cluster should self-heal after container kill")
+
+		g.By("Verifying PacemakerHealthCheckDegraded was observed during container kill/recovery")
+		degradedMsg, wasDegraded := degradedObserver.WasObserved()
+		o.Expect(wasDegraded).To(o.BeTrue(),
+			"expected PacemakerHealthCheckDegraded=True to be observed at some point during etcd container kill recovery")
+		framework.Logf("PacemakerHealthCheckDegraded observed message: %q", degradedMsg)
 
 		g.By("Verifying pcs status shows etcd-clone Started on both nodes")
 		o.Eventually(func() error {
@@ -633,18 +697,25 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
+		g.By("Starting background PacemakerHealthCheckDegraded observer")
+		degradedObserver := newPacemakerDegradedObserver(oc, 5*time.Second)
+		degradedObserver.Start()
+		defer degradedObserver.Stop()
+
 		g.By(fmt.Sprintf("Killing etcd process/container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
-
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd process kill")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd process kill")
 
 		g.By("Waiting for cluster to recover - both nodes become started voting members")
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&execNode,
 			&targetNode, true, false,
 			6*time.Minute, 45*time.Second)
+
+		g.By("Verifying PacemakerHealthCheckDegraded was observed during process crash/recovery")
+		degradedMsg, wasDegraded := degradedObserver.WasObserved()
+		o.Expect(wasDegraded).To(o.BeTrue(),
+			"expected PacemakerHealthCheckDegraded=True to be observed at some point during etcd process crash recovery")
+		framework.Logf("PacemakerHealthCheckDegraded observed message: %q", degradedMsg)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after etcd process crash recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, 6*time.Minute)).
@@ -680,7 +751,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		framework.Logf("PCS node standby output: %s", output)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after node standby")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", apis.PacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after node standby")
 
 		// Wait for force-new-cluster recovery to complete.

--- a/test/extended/edge_topologies/tnf_etcd_disruption.go
+++ b/test/extended/edge_topologies/tnf_etcd_disruption.go
@@ -584,7 +584,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		killEtcdViaSSH(&targetNode)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd container kill")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd container kill")
 
 		// Wait for the cluster to self-heal.
@@ -637,7 +637,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		killEtcdViaSSH(&targetNode)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after etcd process kill")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after etcd process kill")
 
 		g.By("Waiting for cluster to recover - both nodes become started voting members")
@@ -680,7 +680,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		framework.Logf("PCS node standby output: %s", output)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after node standby")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after node standby")
 
 		// Wait for force-new-cluster recovery to complete.

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -293,13 +293,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		framework.Logf("Selected fencing agent to unmanage: %s", stonithResourceName)
 
 		g.By(fmt.Sprintf("Unmanaging fencing agent %s to create FencingHealthy=False, FencingAvailable=True state", stonithResourceName))
-		unmanageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=false", stonithResourceName)
+		unmanageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=false", stonithResourceName)
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", unmanageCmd)
 		o.Expect(err).ToNot(o.HaveOccurred(), "expected to unmanage fencing agent")
 
 		g.DeferCleanup(func() {
 			framework.Logf("Restoring management of fencing agent %s", stonithResourceName)
-			manageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=true 2>/dev/null; true", stonithResourceName)
+			manageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=true 2>/dev/null; true", stonithResourceName)
 			if _, restoreErr := exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd); restoreErr != nil {
 				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to re-manage fencing agent: %v\n", restoreErr)
 			}
@@ -331,7 +331,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			"PacemakerHealthCheckDegraded should stay False when fencing is at risk but still available")
 
 		g.By(fmt.Sprintf("Re-managing fencing agent %s", stonithResourceName))
-		manageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=true", stonithResourceName)
+		manageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=true", stonithResourceName)
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd)
 		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-manage fencing agent")
 

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -106,7 +106,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				creds.Username, currentPw, newPw)
 		}
 
-		hasPacemakerCR := apis.IsPacemakerClusterAvailable(oc)
+		hasPacemakerCR, availErr := apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
 		if hasPacemakerCR {
 			g.By("Verifying PacemakerCluster CR is healthy before credential change")
 			pc, pcErr := apis.GetPacemakerCluster(oc)
@@ -304,7 +305,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			}
 		})
 
-		if apis.IsPacemakerClusterAvailable(oc) {
+		pcAvailable, availErr := apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if pcAvailable {
 			g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
 			o.Eventually(func() error {
 				pc, pcErr := apis.GetPacemakerCluster(oc)
@@ -333,7 +336,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-manage fencing agent")
 
 		g.By("Verifying cluster returns to fully healthy state")
-		if apis.IsPacemakerClusterAvailable(oc) {
+		pcAvailable, availErr = apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if pcAvailable {
 			o.Eventually(func() error {
 				pc, pcErr := apis.GetPacemakerCluster(oc)
 				if pcErr != nil {
@@ -398,7 +403,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "fencing unavailable", healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when fencing is completely unavailable")
 
-		if apis.IsPacemakerClusterAvailable(oc) {
+		pcAvailable, availErr := apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if pcAvailable {
 			g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
 			o.Eventually(func() error {
 				pc, pcErr := apis.GetPacemakerCluster(oc)
@@ -421,7 +428,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after fencing is re-enabled")
 
-		if apis.IsPacemakerClusterAvailable(oc) {
+		pcAvailable, availErr = apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if pcAvailable {
 			g.By("Verifying cluster returns to fully healthy state")
 			o.Eventually(func() error {
 				pc, pcErr := apis.GetPacemakerCluster(oc)
@@ -431,9 +440,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				if err := apis.ExpectClusterHealthy(pc); err != nil {
 					return err
 				}
+				if err := apis.ExpectNodeFencingHealthy(pc, targetNode.Name); err != nil {
+					return err
+				}
 				return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
 			}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-				"expected PacemakerCluster to be healthy with FencingAvailable=True after re-enabling agent")
+				"expected PacemakerCluster to be healthy with FencingHealthy=True and FencingAvailable=True after re-enabling agent")
 		} else {
 			framework.Logf("PacemakerCluster CRD not available, skipping final CR health check")
 		}

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -50,6 +50,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
 
+		hasPacemakerCR, availErr := apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if !hasPacemakerCR {
+			g.Skip("PacemakerCluster CRD not available")
+		}
+
 		nodes, err := utils.GetNodes(oc, utils.AllNodes)
 		o.Expect(err).ShouldNot(o.HaveOccurred(), "Expected to retrieve nodes without error")
 		o.Expect(nodes.Items).To(o.HaveLen(2), "Expected exactly two nodes for dual-replica fencing test")
@@ -106,18 +112,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				creds.Username, currentPw, newPw)
 		}
 
-		hasPacemakerCR, availErr := apis.IsPacemakerClusterAvailable(oc)
-		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
-		if hasPacemakerCR {
-			g.By("Verifying PacemakerCluster CR is healthy before credential change")
-			pc, pcErr := apis.GetPacemakerCluster(oc)
-			o.Expect(pcErr).ToNot(o.HaveOccurred(), "expected to get PacemakerCluster CR")
-			o.Expect(apis.ExpectClusterHealthy(pc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be healthy before credential change")
-			o.Expect(apis.ExpectNodeFencingHealthy(pc, bmcNode.Name)).ToNot(o.HaveOccurred(),
-				"expected fencing to be healthy for %s before credential change", bmcNode.Name)
-		} else {
-			framework.Logf("PacemakerCluster CRD not available, skipping CR health checks")
-		}
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy before credential change")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be fully healthy before credential change")
 
 		sslInsecure := creds.CertificateVerification == "Disabled"
 		originalPassword := creds.Password
@@ -156,7 +152,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			if bmcPasswordChanged {
 				framework.Logf("Restoring original BMC password")
 				if restoreErr := changeBMCPassword(newPassword, originalPassword); restoreErr != nil {
-					fmt.Fprintf(g.GinkgoWriter, "Warning: failed to restore BMC password: %v\n", restoreErr)
+					framework.Logf("Warning: failed to restore BMC password: %v", restoreErr)
 					cleanupFailed = true
 				}
 			} else {
@@ -173,7 +169,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				"bash", "-c", bashCmd, "update-fencing-credentials",
 				nodeIdentifier, creds.Username, scriptPassword, creds.Address)
 			if restoreErr != nil {
-				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to restore fencing credentials via script: %v\noutput: %s\n",
+				framework.Logf("Warning: failed to restore fencing credentials via script: %v\noutput: %s",
 					restoreErr, output)
 			}
 
@@ -183,7 +179,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 					"bash", "-c", survivedBashCmd, "update-fencing-credentials",
 					survivedNodeIdentifier, survivedNodeCreds.Username, scriptPassword, survivedNodeCreds.Address)
 				if survivedErr != nil {
-					fmt.Fprintf(g.GinkgoWriter, "Warning: failed to restore survived node fencing credentials: %v\noutput: %s\n",
+					framework.Logf("Warning: failed to restore survived node fencing credentials: %v\noutput: %s",
 						survivedErr, survivedOutput)
 				}
 			}
@@ -236,218 +232,14 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
 			"etcd members should be healthy after fencing credentials update")
 
-		if hasPacemakerCR {
-			g.By("Verifying PacemakerCluster CR remains healthy after credential update")
-			o.Eventually(func() error {
-				pc, pcErr := apis.GetPacemakerCluster(oc)
-				if pcErr != nil {
-					return pcErr
-				}
-				if pcErr = apis.ExpectClusterHealthy(pc); pcErr != nil {
-					return pcErr
-				}
-				if pcErr = apis.ExpectNodeFencingHealthy(pc, bmcNode.Name); pcErr != nil {
-					return pcErr
-				}
-				return apis.ExpectNodeFencingHealthy(pc, survivedNode.Name)
-			}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-				"expected PacemakerCluster to remain healthy after credential update")
-		}
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy after credential update")
+		o.Eventually(func() error {
+			return apis.ExpectPacemakerBaseline(oc)
+		}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected PacemakerCluster to be fully healthy after credential update")
+
 		g.By("Verifying PacemakerHealthCheckDegraded is not set after credential update")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, fencingHealthTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should not be set after credential update")
-	})
-
-	g.It("should not degrade when fencing is at risk but still available", func() {
-		g.By("Finding a fencing agent to unmanage on the target node")
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		pcsOutput, err := services.PcsStatusViaDebug(ctx, oc, peerNode.Name)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected pcs status to succeed")
-
-		var stonithResourceName string
-		for _, line := range strings.Split(pcsOutput, "\n") {
-			trimmed := strings.TrimSpace(line)
-			if !strings.Contains(trimmed, "fence_") || !strings.Contains(trimmed, "Started") {
-				continue
-			}
-			// Resource lines are bullet-prefixed (e.g. "* master-1_redfish\t(stonith:fence_redfish):\t Started master-1"),
-			// so fields[0] is the "*" bullet and the resource name is fields[1]. Stonith resources are
-			// named "<targetedNodeName>_redfish" — the node they fence, NOT the node they currently run
-			// on (pcs may run either node's fencing agent on either surviving node). Matching on the
-			// resource name itself avoids picking the wrong agent when both agents happen to be Started
-			// on the same node (a valid pacemaker placement, not tied to which node they fence).
-			fields := strings.Fields(trimmed)
-			if len(fields) < 2 {
-				continue
-			}
-			resourceName := strings.TrimSuffix(fields[1], ":")
-			if strings.HasPrefix(resourceName, targetNode.Name) {
-				stonithResourceName = resourceName
-				break
-			}
-		}
-		if stonithResourceName == "" {
-			g.Skip("Could not identify a started fencing agent for the target node — skipping negative test")
-		}
-		framework.Logf("Selected fencing agent to unmanage: %s", stonithResourceName)
-
-		g.By(fmt.Sprintf("Unmanaging fencing agent %s to create FencingHealthy=False, FencingAvailable=True state", stonithResourceName))
-		unmanageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=false", stonithResourceName)
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", unmanageCmd)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected to unmanage fencing agent")
-
-		g.DeferCleanup(func() {
-			framework.Logf("Restoring management of fencing agent %s", stonithResourceName)
-			manageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=true 2>/dev/null; true", stonithResourceName)
-			if _, restoreErr := exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd); restoreErr != nil {
-				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to re-manage fencing agent: %v\n", restoreErr)
-			}
-		})
-
-		pcAvailable, availErr := apis.IsPacemakerClusterAvailable(oc)
-		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
-		if pcAvailable {
-			g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
-			o.Eventually(func() error {
-				pc, pcErr := apis.GetPacemakerCluster(oc)
-				if pcErr != nil {
-					return pcErr
-				}
-				if err := apis.ExpectNodeFencingUnhealthy(pc, targetNode.Name); err != nil {
-					return err
-				}
-				return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
-			}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-				"expected fencing to be at-risk (FencingHealthy=False) but still available (FencingAvailable=True) for target node")
-		} else {
-			framework.Logf("PacemakerCluster CRD not available, skipping CR fencing-state checks")
-		}
-
-		g.By("Verifying PacemakerHealthCheckDegraded stays False during fencing warning state")
-		o.Consistently(func() error {
-			return apis.ExpectPacemakerHealthCheckNotDegraded(oc)
-		}, 3*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-			"PacemakerHealthCheckDegraded should stay False when fencing is at risk but still available")
-
-		g.By(fmt.Sprintf("Re-managing fencing agent %s", stonithResourceName))
-		manageCmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=true", stonithResourceName)
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-manage fencing agent")
-
-		g.By("Verifying cluster returns to fully healthy state")
-		pcAvailable, availErr = apis.IsPacemakerClusterAvailable(oc)
-		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
-		if pcAvailable {
-			o.Eventually(func() error {
-				pc, pcErr := apis.GetPacemakerCluster(oc)
-				if pcErr != nil {
-					return pcErr
-				}
-				return apis.ExpectClusterHealthy(pc)
-			}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-				"expected PacemakerCluster to be healthy after re-managing fencing agent")
-		}
-	})
-
-	g.It("should degrade when a node's fencing agent is completely unavailable", func() {
-		g.By("Finding a fencing agent to disable on the target node")
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		pcsOutput, err := services.PcsStatusViaDebug(ctx, oc, peerNode.Name)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected pcs status to succeed")
-
-		var stonithResourceName string
-		for _, line := range strings.Split(pcsOutput, "\n") {
-			trimmed := strings.TrimSpace(line)
-			if !strings.Contains(trimmed, "fence_") || !strings.Contains(trimmed, "Started") {
-				continue
-			}
-			// Resource lines are bullet-prefixed (e.g. "* master-1_redfish\t(stonith:fence_redfish):\t Started master-1"),
-			// so fields[0] is the "*" bullet and the resource name is fields[1]. Stonith resources are
-			// named "<targetedNodeName>_redfish" — the node they fence, NOT the node they currently run
-			// on (pcs may run either node's fencing agent on either surviving node). Matching on the
-			// resource name itself avoids picking the wrong agent when both agents happen to be Started
-			// on the same node (a valid pacemaker placement, not tied to which node they fence).
-			fields := strings.Fields(trimmed)
-			if len(fields) < 2 {
-				continue
-			}
-			resourceName := strings.TrimSuffix(fields[1], ":")
-			if strings.HasPrefix(resourceName, targetNode.Name) {
-				stonithResourceName = resourceName
-				break
-			}
-		}
-		if stonithResourceName == "" {
-			g.Skip("Could not identify a started fencing agent for the target node — skipping fencing disable test")
-		}
-		framework.Logf("Selected fencing agent to disable: %s", stonithResourceName)
-
-		g.By(fmt.Sprintf("Disabling fencing agent %s to make fencing completely unavailable for %s", stonithResourceName, targetNode.Name))
-		// pcs rejects `pcs resource disable/enable` for stonith resources ("This command
-		// does not accept stonith resources") — must use `pcs stonith disable/enable` instead.
-		disableCmd := fmt.Sprintf("sudo pcs stonith disable %s", stonithResourceName)
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", disableCmd)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected to disable fencing agent")
-
-		g.DeferCleanup(func() {
-			framework.Logf("Re-enabling fencing agent %s", stonithResourceName)
-			enableCmd := fmt.Sprintf("sudo pcs stonith enable %s 2>/dev/null; true", stonithResourceName)
-			if _, enableErr := exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", enableCmd); enableErr != nil {
-				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to re-enable fencing agent: %v\n", enableErr)
-			}
-		})
-
-		g.By("Waiting for PacemakerHealthCheckDegraded=True due to fencing unavailable")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "fencing unavailable", healthCheckRecoveryTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when fencing is completely unavailable")
-
-		pcAvailable, availErr := apis.IsPacemakerClusterAvailable(oc)
-		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
-		if pcAvailable {
-			g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
-			o.Eventually(func() error {
-				pc, pcErr := apis.GetPacemakerCluster(oc)
-				if pcErr != nil {
-					return pcErr
-				}
-				return apis.ExpectNodeFencingUnavailable(pc, targetNode.Name)
-			}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
-				"expected FencingAvailable=False on PacemakerCluster CR for target node")
-		} else {
-			framework.Logf("PacemakerCluster CRD not available, skipping CR FencingAvailable=False check")
-		}
-
-		g.By(fmt.Sprintf("Re-enabling fencing agent %s", stonithResourceName))
-		enableCmd := fmt.Sprintf("sudo pcs stonith enable %s", stonithResourceName)
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", enableCmd)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-enable fencing agent")
-
-		g.By("Waiting for PacemakerHealthCheckDegraded to clear after re-enabling fencing")
-		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after fencing is re-enabled")
-
-		pcAvailable, availErr = apis.IsPacemakerClusterAvailable(oc)
-		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
-		if pcAvailable {
-			g.By("Verifying cluster returns to fully healthy state")
-			o.Eventually(func() error {
-				pc, pcErr := apis.GetPacemakerCluster(oc)
-				if pcErr != nil {
-					return pcErr
-				}
-				if err := apis.ExpectClusterHealthy(pc); err != nil {
-					return err
-				}
-				if err := apis.ExpectNodeFencingHealthy(pc, targetNode.Name); err != nil {
-					return err
-				}
-				return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
-			}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-				"expected PacemakerCluster to be healthy with FencingHealthy=True and FencingAvailable=True after re-enabling agent")
-		} else {
-			framework.Logf("PacemakerCluster CRD not available, skipping final CR health check")
-		}
 	})
 })

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -252,5 +252,168 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
 				"expected PacemakerCluster to remain healthy after credential update")
 		}
+		g.By("Verifying PacemakerHealthCheckDegraded is not set after credential update")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, fencingHealthTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should not be set after credential update")
+	})
+
+	g.It("should not degrade when fencing is at risk but still available", func() {
+		g.By("Finding a fencing agent to unmanage on the target node")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		pcsOutput, err := services.PcsStatusViaDebug(ctx, oc, peerNode.Name)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected pcs status to succeed")
+
+		var stonithResourceName string
+		for _, line := range strings.Split(pcsOutput, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if !strings.Contains(trimmed, "fence_") || !strings.Contains(trimmed, "Started") {
+				continue
+			}
+			// Resource lines are bullet-prefixed (e.g. "* master-1_redfish\t(stonith:fence_redfish):\t Started master-1"),
+			// so fields[0] is the "*" bullet and the resource name is fields[1]. Stonith resources are
+			// named "<targetedNodeName>_redfish" — the node they fence, NOT the node they currently run
+			// on (pcs may run either node's fencing agent on either surviving node). Matching on the
+			// resource name itself avoids picking the wrong agent when both agents happen to be Started
+			// on the same node (a valid pacemaker placement, not tied to which node they fence).
+			fields := strings.Fields(trimmed)
+			if len(fields) < 2 {
+				continue
+			}
+			resourceName := strings.TrimSuffix(fields[1], ":")
+			if strings.HasPrefix(resourceName, targetNode.Name) {
+				stonithResourceName = resourceName
+				break
+			}
+		}
+		if stonithResourceName == "" {
+			g.Skip("Could not identify a started fencing agent for the target node — skipping negative test")
+		}
+		framework.Logf("Selected fencing agent to unmanage: %s", stonithResourceName)
+
+		g.By(fmt.Sprintf("Unmanaging fencing agent %s to create FencingHealthy=False, FencingAvailable=True state", stonithResourceName))
+		unmanageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=false", stonithResourceName)
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", unmanageCmd)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to unmanage fencing agent")
+
+		g.DeferCleanup(func() {
+			framework.Logf("Restoring management of fencing agent %s", stonithResourceName)
+			manageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=true 2>/dev/null; true", stonithResourceName)
+			if _, restoreErr := exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd); restoreErr != nil {
+				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to re-manage fencing agent: %v\n", restoreErr)
+			}
+		})
+
+		g.By("Verifying PacemakerHealthCheckDegraded stays False during fencing warning state")
+		o.Consistently(func() error {
+			return apis.ExpectPacemakerHealthCheckNotDegraded(oc)
+		}, 3*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"PacemakerHealthCheckDegraded should stay False when fencing is at risk but still available")
+
+		g.By(fmt.Sprintf("Re-managing fencing agent %s", stonithResourceName))
+		manageCmd := fmt.Sprintf("sudo pcs resource meta %s is-managed=true", stonithResourceName)
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", manageCmd)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-manage fencing agent")
+
+		g.By("Verifying cluster returns to fully healthy state")
+		if apis.IsPacemakerClusterAvailable(oc) {
+			o.Eventually(func() error {
+				pc, pcErr := apis.GetPacemakerCluster(oc)
+				if pcErr != nil {
+					return pcErr
+				}
+				return apis.ExpectClusterHealthy(pc)
+			}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+				"expected PacemakerCluster to be healthy after re-managing fencing agent")
+		}
+	})
+
+	g.It("should degrade when a node's fencing agent is completely unavailable", func() {
+		g.By("Finding a fencing agent to disable on the target node")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		pcsOutput, err := services.PcsStatusViaDebug(ctx, oc, peerNode.Name)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected pcs status to succeed")
+
+		var stonithResourceName string
+		for _, line := range strings.Split(pcsOutput, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if !strings.Contains(trimmed, "fence_") || !strings.Contains(trimmed, "Started") {
+				continue
+			}
+			// Resource lines are bullet-prefixed (e.g. "* master-1_redfish\t(stonith:fence_redfish):\t Started master-1"),
+			// so fields[0] is the "*" bullet and the resource name is fields[1]. Stonith resources are
+			// named "<targetedNodeName>_redfish" — the node they fence, NOT the node they currently run
+			// on (pcs may run either node's fencing agent on either surviving node). Matching on the
+			// resource name itself avoids picking the wrong agent when both agents happen to be Started
+			// on the same node (a valid pacemaker placement, not tied to which node they fence).
+			fields := strings.Fields(trimmed)
+			if len(fields) < 2 {
+				continue
+			}
+			resourceName := strings.TrimSuffix(fields[1], ":")
+			if strings.HasPrefix(resourceName, targetNode.Name) {
+				stonithResourceName = resourceName
+				break
+			}
+		}
+		if stonithResourceName == "" {
+			g.Skip("Could not identify a started fencing agent for the target node — skipping fencing disable test")
+		}
+		framework.Logf("Selected fencing agent to disable: %s", stonithResourceName)
+
+		g.By(fmt.Sprintf("Disabling fencing agent %s to make fencing completely unavailable for %s", stonithResourceName, targetNode.Name))
+		// pcs rejects `pcs resource disable/enable` for stonith resources ("This command
+		// does not accept stonith resources") — must use `pcs stonith disable/enable` instead.
+		disableCmd := fmt.Sprintf("sudo pcs stonith disable %s", stonithResourceName)
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", disableCmd)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to disable fencing agent")
+
+		g.DeferCleanup(func() {
+			framework.Logf("Re-enabling fencing agent %s", stonithResourceName)
+			enableCmd := fmt.Sprintf("sudo pcs stonith enable %s 2>/dev/null; true", stonithResourceName)
+			if _, enableErr := exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", enableCmd); enableErr != nil {
+				fmt.Fprintf(g.GinkgoWriter, "Warning: failed to re-enable fencing agent: %v\n", enableErr)
+			}
+		})
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True due to fencing unavailable")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "fencing unavailable", healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when fencing is completely unavailable")
+
+		g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			if fencingErr := apis.ExpectNodeFencingAvailable(pc, targetNode.Name); fencingErr != nil {
+				return nil
+			}
+			return fmt.Errorf("FencingAvailable is still True for %s — expected False", targetNode.Name)
+		}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
+			"expected FencingAvailable=False on PacemakerCluster CR for target node")
+
+		g.By(fmt.Sprintf("Re-enabling fencing agent %s", stonithResourceName))
+		enableCmd := fmt.Sprintf("sudo pcs stonith enable %s", stonithResourceName)
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(oc, peerNode.Name, "default", "bash", "-c", enableCmd)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-enable fencing agent")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after re-enabling fencing")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after fencing is re-enabled")
+
+		g.By("Verifying cluster returns to fully healthy state")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			if err := apis.ExpectClusterHealthy(pc); err != nil {
+				return err
+			}
+			return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected PacemakerCluster to be healthy with FencingAvailable=True after re-enabling agent")
 	})
 })

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -304,6 +304,19 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			}
 		})
 
+		g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			if err := apis.ExpectNodeFencingUnhealthy(pc, targetNode.Name); err != nil {
+				return err
+			}
+			return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
+		}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected fencing to be at-risk (FencingHealthy=False) but still available (FencingAvailable=True) for target node")
+
 		g.By("Verifying PacemakerHealthCheckDegraded stays False during fencing warning state")
 		o.Consistently(func() error {
 			return apis.ExpectPacemakerHealthCheckNotDegraded(oc)
@@ -387,10 +400,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			if pcErr != nil {
 				return pcErr
 			}
-			if fencingErr := apis.ExpectNodeFencingAvailable(pc, targetNode.Name); fencingErr != nil {
-				return nil
-			}
-			return fmt.Errorf("FencingAvailable is still True for %s — expected False", targetNode.Name)
+			return apis.ExpectNodeFencingUnavailable(pc, targetNode.Name)
 		}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
 			"expected FencingAvailable=False on PacemakerCluster CR for target node")
 

--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -304,18 +304,22 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			}
 		})
 
-		g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
-		o.Eventually(func() error {
-			pc, pcErr := apis.GetPacemakerCluster(oc)
-			if pcErr != nil {
-				return pcErr
-			}
-			if err := apis.ExpectNodeFencingUnhealthy(pc, targetNode.Name); err != nil {
-				return err
-			}
-			return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
-		}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-			"expected fencing to be at-risk (FencingHealthy=False) but still available (FencingAvailable=True) for target node")
+		if apis.IsPacemakerClusterAvailable(oc) {
+			g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
+			o.Eventually(func() error {
+				pc, pcErr := apis.GetPacemakerCluster(oc)
+				if pcErr != nil {
+					return pcErr
+				}
+				if err := apis.ExpectNodeFencingUnhealthy(pc, targetNode.Name); err != nil {
+					return err
+				}
+				return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
+			}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+				"expected fencing to be at-risk (FencingHealthy=False) but still available (FencingAvailable=True) for target node")
+		} else {
+			framework.Logf("PacemakerCluster CRD not available, skipping CR fencing-state checks")
+		}
 
 		g.By("Verifying PacemakerHealthCheckDegraded stays False during fencing warning state")
 		o.Consistently(func() error {
@@ -394,15 +398,19 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "fencing unavailable", healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when fencing is completely unavailable")
 
-		g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
-		o.Eventually(func() error {
-			pc, pcErr := apis.GetPacemakerCluster(oc)
-			if pcErr != nil {
-				return pcErr
-			}
-			return apis.ExpectNodeFencingUnavailable(pc, targetNode.Name)
-		}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
-			"expected FencingAvailable=False on PacemakerCluster CR for target node")
+		if apis.IsPacemakerClusterAvailable(oc) {
+			g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
+			o.Eventually(func() error {
+				pc, pcErr := apis.GetPacemakerCluster(oc)
+				if pcErr != nil {
+					return pcErr
+				}
+				return apis.ExpectNodeFencingUnavailable(pc, targetNode.Name)
+			}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
+				"expected FencingAvailable=False on PacemakerCluster CR for target node")
+		} else {
+			framework.Logf("PacemakerCluster CRD not available, skipping CR FencingAvailable=False check")
+		}
 
 		g.By(fmt.Sprintf("Re-enabling fencing agent %s", stonithResourceName))
 		enableCmd := fmt.Sprintf("sudo pcs stonith enable %s", stonithResourceName)
@@ -413,17 +421,21 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after fencing is re-enabled")
 
-		g.By("Verifying cluster returns to fully healthy state")
-		o.Eventually(func() error {
-			pc, pcErr := apis.GetPacemakerCluster(oc)
-			if pcErr != nil {
-				return pcErr
-			}
-			if err := apis.ExpectClusterHealthy(pc); err != nil {
-				return err
-			}
-			return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
-		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
-			"expected PacemakerCluster to be healthy with FencingAvailable=True after re-enabling agent")
+		if apis.IsPacemakerClusterAvailable(oc) {
+			g.By("Verifying cluster returns to fully healthy state")
+			o.Eventually(func() error {
+				pc, pcErr := apis.GetPacemakerCluster(oc)
+				if pcErr != nil {
+					return pcErr
+				}
+				if err := apis.ExpectClusterHealthy(pc); err != nil {
+					return err
+				}
+				return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
+			}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+				"expected PacemakerCluster to be healthy with FencingAvailable=True after re-enabling agent")
+		} else {
+			framework.Logf("PacemakerCluster CRD not available, skipping final CR health check")
+		}
 	})
 })

--- a/test/extended/edge_topologies/tnf_kubelet_disruption.go
+++ b/test/extended/edge_topologies/tnf_kubelet_disruption.go
@@ -9,6 +9,7 @@ import (
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,6 +137,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			return !nodeutil.IsNodeReady(nodeObj)
 		}, kubeletDisruptionTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(), fmt.Sprintf("Node %s is not in state Ready after kubelet resource ban is applied", targetNode.Name))
 
+		g.By("Waiting for PacemakerHealthCheckDegraded to become True")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "node is unhealthy", kubeletDisruptionTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after kubelet disruption")
+
 		g.By("Validating etcd cluster remains healthy with surviving node")
 		o.Consistently(func() error {
 			return helpers.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, survivingNode.Name)
@@ -165,6 +170,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Eventually(func() error {
 			return utils.ValidateEssentialOperatorsAvailable(oc)
 		}, kubeletRestoreTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(), "Essential operators should be available")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, kubeletRestoreTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after kubelet recovery")
 	})
 
 	g.It("should properly stop kubelet service and verify automatic restart on target node", func() {
@@ -217,6 +226,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(hasFailure).To(o.BeTrue(), "Pacemaker should have recorded kubelet failure in operation history")
 		framework.Logf("Pacemaker recorded %d failure(s) for kubelet-clone: %+v", len(failures), failures)
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after kubelet stop")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after kubelet stop")
+
 		g.By("Validating both nodes are Ready after Pacemaker restart")
 		for _, node := range nodes {
 			o.Eventually(func() bool {
@@ -237,6 +250,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Eventually(func() error {
 			return utils.ValidateEssentialOperatorsAvailable(oc)
 		}, kubeletRestoreTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(), "Essential operators should be available")
-	})
 
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, kubeletRestoreTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after kubelet recovery")
+	})
 })

--- a/test/extended/edge_topologies/tnf_kubelet_disruption.go
+++ b/test/extended/edge_topologies/tnf_kubelet_disruption.go
@@ -211,12 +211,40 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = utils.StopKubeletService(oc, targetNode.Name)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected to stop kubelet service on node %s without errors", targetNode.Name))
 
-		// Assert degradation before waiting on recovery: Pacemaker auto-restarts
-		// kubelet, which clears the degraded condition, so the window is transient
-		// and must be observed while kubelet is still down.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after kubelet stop")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after kubelet stop")
+		// Assert degradation before waiting on recovery. This is racy by nature:
+		// Pacemaker auto-restarts kubelet, which clears the degraded condition once
+		// healthy again. The PacemakerCluster CR backing this condition is only
+		// refreshed by a once-per-minute CronJob, and Pacemaker's own out-of-band
+		// failure detection plus recovery for the kubelet resource can complete in
+		// less than one CronJob interval — so a single stop can be fully recovered
+		// within a gap between snapshots and never be observed as degraded.
+		//
+		// To observe the condition reliably, poll it directly and, whenever we find
+		// that Pacemaker has already restarted kubelet before degradation was seen,
+		// stop kubelet again. This keeps the resource failing across at least one
+		// status snapshot without suppressing Pacemaker's real recovery behavior.
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after kubelet stop (re-stopping kubelet as needed)")
+		o.Eventually(func() (bool, error) {
+			degraded, msg, err := apis.IsPacemakerHealthCheckDegraded(oc)
+			if err != nil {
+				framework.Logf("Error checking PacemakerHealthCheckDegraded: %v", err)
+				return false, nil
+			}
+			if degraded {
+				framework.Logf("PacemakerHealthCheckDegraded=True observed (message: %q)", msg)
+				return true, nil
+			}
+
+			// Not degraded yet. If Pacemaker has already restarted kubelet, re-stop
+			// it so the failure persists until the next status snapshot catches it.
+			if utils.IsServiceRunning(oc, survivingNode.Name, targetNode.Name, "kubelet") {
+				framework.Logf("Kubelet was restarted by Pacemaker before degradation was observed; stopping it again on %s", targetNode.Name)
+				if stopErr := utils.StopKubeletService(oc, targetNode.Name); stopErr != nil {
+					framework.Logf("Warning: failed to re-stop kubelet on %s: %v", targetNode.Name, stopErr)
+				}
+			}
+			return false, nil
+		}, kubeletDisruptionTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(), "PacemakerHealthCheckDegraded should become True after kubelet stop")
 
 		g.By("Waiting for Pacemaker to auto-recover and restart kubelet-clone service")
 		o.Eventually(func() bool {

--- a/test/extended/edge_topologies/tnf_kubelet_disruption.go
+++ b/test/extended/edge_topologies/tnf_kubelet_disruption.go
@@ -211,6 +211,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = utils.StopKubeletService(oc, targetNode.Name)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected to stop kubelet service on node %s without errors", targetNode.Name))
 
+		// Assert degradation before waiting on recovery: Pacemaker auto-restarts
+		// kubelet, which clears the degraded condition, so the window is transient
+		// and must be observed while kubelet is still down.
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after kubelet stop")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after kubelet stop")
+
 		g.By("Waiting for Pacemaker to auto-recover and restart kubelet-clone service")
 		o.Eventually(func() bool {
 			isRunning := utils.IsServiceRunning(oc, survivingNode.Name, targetNode.Name, "kubelet")
@@ -225,10 +232,6 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to check resource failure history without errors")
 		o.Expect(hasFailure).To(o.BeTrue(), "Pacemaker should have recorded kubelet failure in operation history")
 		framework.Logf("Pacemaker recorded %d failure(s) for kubelet-clone: %+v", len(failures), failures)
-
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after kubelet stop")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after kubelet stop")
 
 		g.By("Validating both nodes are Ready after Pacemaker restart")
 		for _, node := range nodes {

--- a/test/extended/edge_topologies/tnf_node_replacement.go
+++ b/test/extended/edge_topologies/tnf_node_replacement.go
@@ -141,6 +141,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		e2e.Logf("[stage timing] Restoring etcd quorum: %v (phase1 etcd start cap: %v, phase2 %d×%v)", time.Since(stageStart), etcdPhase1StartAfterStonithTimeout, stonithCleanupMaxAttempts, stonithCleanupRoundTimeout)
 		stageStart = time.Now()
 
+		g.By("Verifying PacemakerHealthCheckDegraded=True after node destruction")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should be True after node destruction and quorum restore")
+
 		g.By("Deleting OpenShift node references")
 		deleteNodeReferences(&testConfig, oc)
 		e2e.Logf("[stage timing] Deleting node references (BMH/Machine/Node + OVN SB chassis-del + etcd/KAS nodeStatus + installer pods): %v (BMH/Machine delete wait: %v, poll: %v)", time.Since(stageStart), bmhMachineDeleteWaitTimeout, bmhMachineDeletePollInterval)
@@ -214,6 +218,23 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		restorePacemakerCluster(&testConfig, oc, readyTime)
 		e2e.Logf("[stage timing] Restoring pacemaker cluster (total): %v (see sub-lines from restorePacemakerCluster for CEO job vs pcs online caps)", time.Since(stageStart))
 		stageStart = time.Now()
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after full node replacement")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, 5*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after pacemaker cluster is restored")
+
+		g.By("Verifying PacemakerCluster CR shows replacement node as member with fencing available")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			if err := apis.ExpectNodeMember(pc, testConfig.TargetNode.Name); err != nil {
+				return err
+			}
+			return apis.ExpectNodeFencingAvailable(pc, testConfig.TargetNode.Name)
+		}, 5*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
+			"Replacement node should be a member with fencing available in PacemakerCluster CR")
 
 		g.By("Verifying the cluster is fully restored")
 		verifyRestoredCluster(&testConfig, oc)

--- a/test/extended/edge_topologies/tnf_node_replacement.go
+++ b/test/extended/edge_topologies/tnf_node_replacement.go
@@ -142,8 +142,18 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		stageStart = time.Now()
 
 		g.By("Verifying PacemakerHealthCheckDegraded=True after node destruction")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should be True after node destruction and quorum restore")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "is offline", apis.PacemakerDegradedDetectionTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should be True with an offline-node reason after node destruction and quorum restore")
+
+		g.By("Verifying PacemakerCluster CR shows target node Online=False")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			return apis.ExpectNodeOnlineFalse(pc, testConfig.TargetNode.Name)
+		}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"Target node should show Online=False in PacemakerCluster CR after destruction")
 
 		g.By("Deleting OpenShift node references")
 		deleteNodeReferences(&testConfig, oc)

--- a/test/extended/edge_topologies/tnf_node_replacement.go
+++ b/test/extended/edge_topologies/tnf_node_replacement.go
@@ -142,7 +142,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][Suite:openshift/two
 		stageStart = time.Now()
 
 		g.By("Verifying PacemakerHealthCheckDegraded=True after node destruction")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should be True after node destruction and quorum restore")
 
 		g.By("Deleting OpenShift node references")

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -1,0 +1,152 @@
+package edge_topologies
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
+	"github.com/openshift/origin/test/extended/etcd/helpers"
+	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	healthCheckRecoveryTimeout = 10 * time.Minute
+)
+
+var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] PacemakerHealthCheck degraded condition", func() {
+	defer g.GinkgoRecover()
+
+	var (
+		oc                = exutil.NewCLIWithoutNamespace("").AsAdmin()
+		etcdClientFactory *helpers.EtcdClientFactoryImpl
+		execNode          corev1.Node
+		targetNode        corev1.Node
+		nodes             []corev1.Node
+	)
+
+	g.BeforeEach(func() {
+		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
+
+		etcdClientFactory = helpers.NewEtcdClientFactory(oc.KubeClient())
+
+		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
+
+		nodeList, err := utils.GetNodes(oc, utils.AllNodes)
+		o.Expect(err).To(o.BeNil(), "Expected to retrieve nodes without error")
+		o.Expect(len(nodeList.Items)).To(o.Equal(2), "Expected exactly 2 nodes for two-node cluster")
+
+		randomIndex := rand.Intn(len(nodeList.Items))
+		execNode = nodeList.Items[randomIndex]
+		targetNode = nodeList.Items[(randomIndex+1)%len(nodeList.Items)]
+		nodes = nodeList.Items
+
+		g.DeferCleanup(func() {
+			logFinalClusterStatus(nodes)
+		})
+	})
+
+	g.It("should detect and recover from cluster maintenance mode", func() {
+		g.By("Enabling cluster maintenance mode")
+		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNode.Name, "default", "bash", "-c",
+			"sudo pcs property set maintenance-mode=true")
+		o.Expect(err).To(o.BeNil(), "Expected to enable maintenance mode")
+
+		g.DeferCleanup(func() {
+			framework.Logf("DeferCleanup: Ensuring maintenance mode is disabled")
+			if _, cleanupErr := exutil.DebugNodeRetryWithOptionsAndChroot(
+				oc, execNode.Name, "default", "bash", "-c",
+				"sudo pcs property set maintenance-mode=false 2>/dev/null; true"); cleanupErr != nil {
+				framework.Logf("Warning: Failed to disable maintenance mode: %v", cleanupErr)
+			}
+		})
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True due to maintenance mode")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "maintenance mode", healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when cluster is in maintenance mode")
+
+		g.By("Verifying PacemakerClusterInMaintenance event was emitted")
+		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerClusterInMaintenance", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "Expected PacemakerClusterInMaintenance event in openshift-etcd namespace")
+
+		g.By("Disabling cluster maintenance mode")
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNode.Name, "default", "bash", "-c",
+			"sudo pcs property set maintenance-mode=false")
+		o.Expect(err).To(o.BeNil(), "Expected to disable maintenance mode")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after maintenance mode is disabled")
+
+		g.By("Verifying PacemakerHealthy event was emitted after recovery")
+		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerHealthy", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "Expected PacemakerHealthy event in openshift-etcd namespace after recovery")
+
+		g.By("Validating cluster health after maintenance mode recovery")
+		o.Eventually(func() error {
+			return utils.ValidateEssentialOperatorsAvailable(oc)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
+			o.HaveOccurred(), "Essential operators should be available after maintenance mode recovery")
+	})
+
+	g.It("should detect and recover from a node going offline via pcs cluster stop", func() {
+		g.By(fmt.Sprintf("Stopping pacemaker cluster on %s from peer node %s", targetNode.Name, execNode.Name))
+		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNode.Name, "default", "bash", "-c",
+			fmt.Sprintf("sudo pcs cluster stop %s", targetNode.Name))
+		o.Expect(err).To(o.BeNil(), "Expected pcs cluster stop to succeed")
+
+		g.DeferCleanup(func() {
+			framework.Logf("DeferCleanup: Ensuring pacemaker cluster is started on %s", targetNode.Name)
+			if _, cleanupErr := exutil.DebugNodeRetryWithOptionsAndChroot(
+				oc, execNode.Name, "default", "bash", "-c",
+				fmt.Sprintf("sudo pcs cluster start %s 2>/dev/null; true", targetNode.Name)); cleanupErr != nil {
+				framework.Logf("Warning: Failed to restart pacemaker on %s: %v", targetNode.Name, cleanupErr)
+			}
+		})
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True due to node offline")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "is offline", healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when a node is offline")
+
+		g.By("Checking PacemakerCluster CR NodeCountAsExpected condition while node is offline")
+		pc, pcErr := apis.GetPacemakerCluster(oc)
+		if pcErr != nil {
+			framework.Logf("Warning: could not read PacemakerCluster CR: %v", pcErr)
+		} else if ncErr := apis.ExpectClusterNodeCountAsExpected(pc); ncErr != nil {
+			framework.Logf("NodeCountAsExpected is False while node is offline (expected): %v", ncErr)
+		} else {
+			framework.Logf("NodeCountAsExpected remains True while node is offline (pcs cluster stop does not affect corosync node count)")
+		}
+
+		g.By(fmt.Sprintf("Starting pacemaker cluster on %s", targetNode.Name))
+		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNode.Name, "default", "bash", "-c",
+			fmt.Sprintf("sudo pcs cluster start %s", targetNode.Name))
+		o.Expect(err).To(o.BeNil(), "Expected pcs cluster start to succeed")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after node comes back online")
+
+		g.By("Validating cluster health after node restart")
+		o.Eventually(func() error {
+			return utils.ValidateEssentialOperatorsAvailable(oc)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
+			o.HaveOccurred(), "Essential operators should be available after node restart")
+
+		g.By("Validating etcd cluster recovered")
+		o.Eventually(func() error {
+			return utils.LogEtcdClusterStatus(oc, "after pcs cluster start", etcdClientFactory)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
+			o.HaveOccurred(), "Etcd cluster should be healthy after node restart")
+	})
+})

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -53,6 +53,11 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	})
 
 	g.It("should detect and recover from cluster maintenance mode", func() {
+		// Capture an event baseline before the disruptive action so the event
+		// assertions below only accept freshly-emitted events, not stale ones
+		// left over from a prior reconcile or test run.
+		maintenanceBaseline := time.Now()
+
 		g.By("Enabling cluster maintenance mode")
 		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(
 			oc, execNode.Name, "default", "bash", "-c",
@@ -73,8 +78,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when cluster is in maintenance mode")
 
 		g.By("Verifying PacemakerClusterInMaintenance event was emitted")
-		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerClusterInMaintenance", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerClusterInMaintenance", maintenanceBaseline, 2*time.Minute)).
 			ShouldNot(o.HaveOccurred(), "Expected PacemakerClusterInMaintenance event in openshift-etcd namespace")
+
+		// Baseline for the post-recovery PacemakerHealthy event: the cluster was
+		// healthy before this test, so an earlier PacemakerHealthy event may
+		// exist. Require one emitted after recovery begins.
+		recoveryBaseline := time.Now()
 
 		g.By("Disabling cluster maintenance mode")
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(
@@ -87,7 +97,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after maintenance mode is disabled")
 
 		g.By("Verifying PacemakerHealthy event was emitted after recovery")
-		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerHealthy", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerHealthy", recoveryBaseline, 2*time.Minute)).
 			ShouldNot(o.HaveOccurred(), "Expected PacemakerHealthy event in openshift-etcd namespace after recovery")
 
 		g.By("Validating cluster health after maintenance mode recovery")
@@ -117,15 +127,19 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "is offline", healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when a node is offline")
 
-		g.By("Checking PacemakerCluster CR NodeCountAsExpected condition while node is offline")
-		pc, pcErr := apis.GetPacemakerCluster(oc)
-		if pcErr != nil {
-			framework.Logf("Warning: could not read PacemakerCluster CR: %v", pcErr)
-		} else if ncErr := apis.ExpectClusterNodeCountAsExpected(pc); ncErr != nil {
-			framework.Logf("NodeCountAsExpected is False while node is offline (expected): %v", ncErr)
-		} else {
-			framework.Logf("NodeCountAsExpected remains True while node is offline (pcs cluster stop does not affect corosync node count)")
-		}
+		// NodeCountAsExpected is derived from the CIB (`pcs cluster config`), which
+		// still lists both nodes after `pcs cluster stop` — stopping corosync on a
+		// node does not remove it from the configured node count. The condition must
+		// therefore remain True while the node is offline.
+		g.By("Verifying PacemakerCluster CR keeps NodeCountAsExpected=True while node is offline")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			return apis.ExpectClusterNodeCountAsExpected(pc)
+		}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"NodeCountAsExpected should remain True while node is offline (pcs cluster stop does not change the CIB node count)")
 
 		g.By(fmt.Sprintf("Starting pacemaker cluster on %s", targetNode.Name))
 		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -139,7 +139,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		// scheduled onto the corosync-stopped node before the surviving node's
 		// collector writes NodeOnline=False. Both paths correctly signal degradation.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True due to node offline")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", healthCheckRecoveryTimeout)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when a node is offline")
 
 		// NodeCountAsExpected is derived from the CIB (`pcs cluster config`), which

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -18,6 +18,8 @@ import (
 
 const (
 	healthCheckRecoveryTimeout = 10 * time.Minute
+
+	pacemakerDegradedDetectionTimeout = 5 * time.Minute
 )
 
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] PacemakerHealthCheck degraded condition", func() {

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -10,25 +10,54 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/services"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-const (
-	healthCheckRecoveryTimeout = 10 * time.Minute
+const healthCheckRecoveryTimeout = 10 * time.Minute
 
-	// pacemakerDegradedDetectionTimeout must exceed the operator's worst-case
-	// detection latency. When a node drops, the etcd/API/CronJob pipeline is
-	// disrupted, so degraded is often reached via the staleness path:
-	// StatusStalenessThreshold (5m) -> status Unknown, then
-	// StatusUnknownDegradedThreshold (5m) -> PacemakerHealthCheckDegraded=True
-	// (see cluster-etcd-operator pkg/tnf/pkg/pacemaker/constants.go). That is a
-	// 10m minimum even with a healthy controller; the extra margin covers
-	// status-collector CronJob scheduling jitter.
-	pacemakerDegradedDetectionTimeout = 15 * time.Minute
-)
+// findStonithResourceName determines the pcs stonith resource name that fences
+// targetNode (e.g. "master-0_redfish") via the PacemakerCluster CR — the object
+// under test, giving a deterministic Name/Method lookup. The BeforeEach in this
+// suite skips the test entirely when the CR is unavailable, so callers can rely
+// on it being present here.
+func findStonithResourceName(oc *exutil.CLI, targetNode *corev1.Node) (string, error) {
+	pc, err := apis.GetPacemakerCluster(oc)
+	if err != nil {
+		return "", err
+	}
+	return apis.FindStartedFencingAgent(pc, targetNode.Name)
+}
+
+// waitForHealthCheckClearedBestEffort blocks (bounded) until PacemakerHealthCheckDegraded
+// clears before a DeferCleanup returns. Without this, a spec that fails before reaching its
+// own WaitForPacemakerHealthCheckCleared call restores pcs state via a best-effort helper that
+// returns immediately, leaving Degraded=True; the next spec's BeforeEach then observes the
+// still-True condition via SkipIfClusterIsNotHealthy's one-shot check and skips instead of
+// running against a genuinely broken pipeline. Logs rather than fails on timeout, consistent
+// with the best-effort restores it follows.
+func waitForHealthCheckClearedBestEffort(oc *exutil.CLI) {
+	if err := apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout); err != nil {
+		framework.Logf("DeferCleanup: PacemakerHealthCheckDegraded did not clear: %v", err)
+	}
+}
+
+// deferHealthCheckDiagnosticsOnFailure registers a DeferCleanup that dumps
+// PacemakerHealthCheck diagnostics when the current spec fails. WaitForPacemakerHealthCheckDegraded
+// and WaitForPacemakerHealthCheckCleared already dump diagnostics on their own timeout, but any
+// other failing assertion in this suite (e.g. an Eventually/Consistently on the PacemakerCluster
+// CR, or a WaitForPacemakerEvent timeout) would otherwise leave a failure with no diagnostics at
+// all. Mirrors deferDiagnosticsOnFailure in tnf_recovery.go.
+func deferHealthCheckDiagnosticsOnFailure(oc *exutil.CLI) {
+	g.DeferCleanup(func() {
+		if g.CurrentSpecReport().Failed() {
+			apis.DumpHealthCheckDiagnostics(oc, "spec failed")
+		}
+	})
+}
 
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] PacemakerHealthCheck degraded condition", func() {
 	defer g.GinkgoRecover()
@@ -48,6 +77,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		utils.SkipIfClusterIsNotHealthy(oc, etcdClientFactory)
 
+		hasPacemakerCR, availErr := apis.IsPacemakerClusterAvailable(oc)
+		o.Expect(availErr).ToNot(o.HaveOccurred(), "expected to check PacemakerCluster availability without error")
+		if !hasPacemakerCR {
+			g.Skip("PacemakerCluster CRD not available")
+		}
+
 		nodeList, err := utils.GetNodes(oc, utils.AllNodes)
 		o.Expect(err).To(o.BeNil(), "Expected to retrieve nodes without error")
 		o.Expect(len(nodeList.Items)).To(o.Equal(2), "Expected exactly 2 nodes for two-node cluster")
@@ -57,30 +92,30 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		targetNode = nodeList.Items[(randomIndex+1)%len(nodeList.Items)]
 		nodes = nodeList.Items
 
+		deferHealthCheckDiagnosticsOnFailure(oc)
+
 		g.DeferCleanup(func() {
 			logFinalClusterStatus(nodes)
 		})
 	})
 
 	g.It("should detect and recover from cluster maintenance mode", func() {
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy before the test")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be fully healthy before test")
+
 		// Capture an event baseline before the disruptive action so the event
 		// assertions below only accept freshly-emitted events, not stale ones
 		// left over from a prior reconcile or test run.
 		maintenanceBaseline := time.Now()
 
 		g.By("Enabling cluster maintenance mode")
-		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(
-			oc, execNode.Name, "default", "bash", "-c",
-			"sudo pcs property set maintenance-mode=true")
+		err := services.PcsPropertySetViaDebug(oc, execNode.Name, "maintenance-mode", "true")
 		o.Expect(err).To(o.BeNil(), "Expected to enable maintenance mode")
 
 		g.DeferCleanup(func() {
 			framework.Logf("DeferCleanup: Ensuring maintenance mode is disabled")
-			if _, cleanupErr := exutil.DebugNodeRetryWithOptionsAndChroot(
-				oc, execNode.Name, "default", "bash", "-c",
-				"sudo pcs property set maintenance-mode=false 2>/dev/null; true"); cleanupErr != nil {
-				framework.Logf("Warning: Failed to disable maintenance mode: %v", cleanupErr)
-			}
+			services.PcsPropertySetBestEffortViaDebug(oc, execNode.Name, "maintenance-mode", "false")
+			waitForHealthCheckClearedBestEffort(oc)
 		})
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True due to maintenance mode")
@@ -88,8 +123,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when cluster is in maintenance mode")
 
 		g.By("Verifying PacemakerClusterInMaintenance event was emitted")
-		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerClusterInMaintenance", maintenanceBaseline, 2*time.Minute)).
-			ShouldNot(o.HaveOccurred(), "Expected PacemakerClusterInMaintenance event in openshift-etcd namespace")
+		o.Expect(apis.WaitForPacemakerEvent(oc, apis.PacemakerHealthCheckEventNamespace, "PacemakerClusterInMaintenance", maintenanceBaseline, 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "Expected PacemakerClusterInMaintenance event in openshift-etcd-operator namespace")
 
 		// Baseline for the post-recovery PacemakerHealthy event: the cluster was
 		// healthy before this test, so an earlier PacemakerHealthy event may
@@ -97,9 +132,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		recoveryBaseline := time.Now()
 
 		g.By("Disabling cluster maintenance mode")
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(
-			oc, execNode.Name, "default", "bash", "-c",
-			"sudo pcs property set maintenance-mode=false")
+		err = services.PcsPropertySetViaDebug(oc, execNode.Name, "maintenance-mode", "false")
 		o.Expect(err).To(o.BeNil(), "Expected to disable maintenance mode")
 
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
@@ -107,30 +140,34 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after maintenance mode is disabled")
 
 		g.By("Verifying PacemakerHealthy event was emitted after recovery")
-		o.Expect(apis.WaitForPacemakerEvent(oc, "PacemakerHealthy", recoveryBaseline, 2*time.Minute)).
-			ShouldNot(o.HaveOccurred(), "Expected PacemakerHealthy event in openshift-etcd namespace after recovery")
+		o.Expect(apis.WaitForPacemakerEvent(oc, apis.PacemakerHealthCheckEventNamespace, "PacemakerHealthy", recoveryBaseline, 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "Expected PacemakerHealthy event in openshift-etcd-operator namespace after recovery")
 
 		g.By("Validating cluster health after maintenance mode recovery")
 		o.Eventually(func() error {
 			return utils.ValidateEssentialOperatorsAvailable(oc)
 		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "Essential operators should be available after maintenance mode recovery")
+
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy after the test")
+		o.Eventually(func() error {
+			return apis.ExpectPacemakerBaseline(oc)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
+			o.HaveOccurred(), "expected PacemakerCluster to be fully healthy after test")
 	})
 
 	g.It("should detect and recover from a node going offline via pcs cluster stop", func() {
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy before the test")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be fully healthy before test")
+
 		g.By(fmt.Sprintf("Stopping pacemaker cluster on %s from peer node %s", targetNode.Name, execNode.Name))
-		_, err := exutil.DebugNodeRetryWithOptionsAndChroot(
-			oc, execNode.Name, "default", "bash", "-c",
-			fmt.Sprintf("sudo pcs cluster stop %s", targetNode.Name))
+		err := services.PcsClusterStopViaDebug(oc, execNode.Name, targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected pcs cluster stop to succeed")
 
 		g.DeferCleanup(func() {
 			framework.Logf("DeferCleanup: Ensuring pacemaker cluster is started on %s", targetNode.Name)
-			if _, cleanupErr := exutil.DebugNodeRetryWithOptionsAndChroot(
-				oc, execNode.Name, "default", "bash", "-c",
-				fmt.Sprintf("sudo pcs cluster start %s 2>/dev/null; true", targetNode.Name)); cleanupErr != nil {
-				framework.Logf("Warning: Failed to restart pacemaker on %s: %v", targetNode.Name, cleanupErr)
-			}
+			services.PcsClusterStartBestEffortViaDebug(oc, execNode.Name, targetNode.Name)
+			waitForHealthCheckClearedBestEffort(oc)
 		})
 
 		// Accept any degraded message rather than requiring "is offline". Even in
@@ -139,7 +176,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		// scheduled onto the corosync-stopped node before the surviving node's
 		// collector writes NodeOnline=False. Both paths correctly signal degradation.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True due to node offline")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", apis.PacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when a node is offline")
 
 		// NodeCountAsExpected is derived from the CIB (`pcs cluster config`), which
@@ -157,9 +194,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			"NodeCountAsExpected should remain True while node is offline (pcs cluster stop does not change the CIB node count)")
 
 		g.By(fmt.Sprintf("Starting pacemaker cluster on %s", targetNode.Name))
-		_, err = exutil.DebugNodeRetryWithOptionsAndChroot(
-			oc, execNode.Name, "default", "bash", "-c",
-			fmt.Sprintf("sudo pcs cluster start %s", targetNode.Name))
+		err = services.PcsClusterStartViaDebug(oc, execNode.Name, targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected pcs cluster start to succeed")
 
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear")
@@ -177,5 +212,114 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			return utils.LogEtcdClusterStatus(oc, "after pcs cluster start", etcdClientFactory)
 		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "Etcd cluster should be healthy after node restart")
+
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy after the test")
+		o.Eventually(func() error {
+			return apis.ExpectPacemakerBaseline(oc)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
+			o.HaveOccurred(), "expected PacemakerCluster to be fully healthy after test")
+	})
+
+	g.It("should not degrade when fencing is at risk but still available", func() {
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy before the test")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be fully healthy before test")
+
+		g.By("Finding a fencing agent to unmanage on the target node")
+		stonithResourceName, err := findStonithResourceName(oc, &targetNode)
+		if err != nil {
+			framework.Logf("Could not identify a started fencing agent for the target node: %v", err)
+			g.Skip("Could not identify a started fencing agent for the target node — skipping negative test")
+		}
+		framework.Logf("Selected fencing agent to unmanage: %s", stonithResourceName)
+
+		g.By(fmt.Sprintf("Unmanaging fencing agent %s to create FencingHealthy=False, FencingAvailable=True state", stonithResourceName))
+		err = services.PcsStonithSetManagedViaDebug(oc, execNode.Name, stonithResourceName, false)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to unmanage fencing agent")
+
+		g.DeferCleanup(func() {
+			framework.Logf("Restoring management of fencing agent %s", stonithResourceName)
+			services.PcsStonithSetManagedBestEffortViaDebug(oc, execNode.Name, stonithResourceName, true)
+			waitForHealthCheckClearedBestEffort(oc)
+		})
+
+		g.By("Waiting for PacemakerCluster to report FencingHealthy=False, FencingAvailable=True for target node")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			if err := apis.ExpectNodeFencingUnhealthy(pc, targetNode.Name); err != nil {
+				return err
+			}
+			return apis.ExpectNodeFencingAvailable(pc, targetNode.Name)
+		}, 2*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected fencing to be at-risk (FencingHealthy=False) but still available (FencingAvailable=True) for target node")
+
+		g.By("Verifying PacemakerHealthCheckDegraded stays False during fencing warning state")
+		o.Consistently(func() error {
+			return apis.ExpectPacemakerHealthCheckNotDegraded(oc)
+		}, 3*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"PacemakerHealthCheckDegraded should stay False when fencing is at risk but still available")
+
+		g.By(fmt.Sprintf("Re-managing fencing agent %s", stonithResourceName))
+		err = services.PcsStonithSetManagedViaDebug(oc, execNode.Name, stonithResourceName, true)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-manage fencing agent")
+
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy after re-managing fencing agent")
+		o.Eventually(func() error {
+			return apis.ExpectPacemakerBaseline(oc)
+		}, fencingHealthTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected PacemakerCluster to be fully healthy after re-managing fencing agent")
+	})
+
+	g.It("should degrade when a node's fencing agent is completely unavailable", func() {
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy before the test")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(), "expected PacemakerCluster to be fully healthy before test")
+
+		g.By("Finding a fencing agent to disable on the target node")
+		stonithResourceName, err := findStonithResourceName(oc, &targetNode)
+		if err != nil {
+			framework.Logf("Could not identify a started fencing agent for the target node: %v", err)
+			g.Skip("Could not identify a started fencing agent for the target node — skipping fencing disable test")
+		}
+		framework.Logf("Selected fencing agent to disable: %s", stonithResourceName)
+
+		g.By(fmt.Sprintf("Disabling fencing agent %s to make fencing completely unavailable for %s", stonithResourceName, targetNode.Name))
+		err = services.PcsStonithResourceDisableViaDebug(oc, execNode.Name, stonithResourceName)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to disable fencing agent")
+
+		g.DeferCleanup(func() {
+			framework.Logf("Re-enabling fencing agent %s", stonithResourceName)
+			services.PcsStonithResourceEnableBestEffortViaDebug(oc, execNode.Name, stonithResourceName)
+			waitForHealthCheckClearedBestEffort(oc)
+		})
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True due to fencing unavailable")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "fencing unavailable", healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when fencing is completely unavailable")
+
+		g.By("Verifying PacemakerCluster CR shows FencingAvailable=False for target node")
+		o.Eventually(func() error {
+			pc, pcErr := apis.GetPacemakerCluster(oc)
+			if pcErr != nil {
+				return pcErr
+			}
+			return apis.ExpectNodeFencingUnavailable(pc, targetNode.Name)
+		}, 2*time.Minute, 10*time.Second).ShouldNot(o.HaveOccurred(),
+			"expected FencingAvailable=False on PacemakerCluster CR for target node")
+
+		g.By(fmt.Sprintf("Re-enabling fencing agent %s", stonithResourceName))
+		err = services.PcsStonithResourceEnableViaDebug(oc, execNode.Name, stonithResourceName)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to re-enable fencing agent")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after re-enabling fencing")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, healthCheckRecoveryTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after fencing is re-enabled")
+
+		g.By("Verifying PacemakerCluster CR baseline is fully healthy after re-enabling fencing agent")
+		o.Eventually(func() error {
+			return apis.ExpectPacemakerBaseline(oc)
+		}, healthCheckRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"expected PacemakerCluster to be fully healthy after re-enabling fencing agent")
 	})
 })

--- a/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
+++ b/test/extended/edge_topologies/tnf_pacemaker_healthcheck.go
@@ -19,7 +19,15 @@ import (
 const (
 	healthCheckRecoveryTimeout = 10 * time.Minute
 
-	pacemakerDegradedDetectionTimeout = 5 * time.Minute
+	// pacemakerDegradedDetectionTimeout must exceed the operator's worst-case
+	// detection latency. When a node drops, the etcd/API/CronJob pipeline is
+	// disrupted, so degraded is often reached via the staleness path:
+	// StatusStalenessThreshold (5m) -> status Unknown, then
+	// StatusUnknownDegradedThreshold (5m) -> PacemakerHealthCheckDegraded=True
+	// (see cluster-etcd-operator pkg/tnf/pkg/pacemaker/constants.go). That is a
+	// 10m minimum even with a healthy controller; the extra margin covers
+	// status-collector CronJob scheduling jitter.
+	pacemakerDegradedDetectionTimeout = 15 * time.Minute
 )
 
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] PacemakerHealthCheck degraded condition", func() {
@@ -125,8 +133,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			}
 		})
 
+		// Accept any degraded message rather than requiring "is offline". Even in
+		// this single-node-down scenario the controller can reach degraded via the
+		// staleness path (message "is stale") if the status-collector CronJob pod is
+		// scheduled onto the corosync-stopped node before the surviving node's
+		// collector writes NodeOnline=False. Both paths correctly signal degradation.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True due to node offline")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "is offline", healthCheckRecoveryTimeout)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", healthCheckRecoveryTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True when a node is offline")
 
 		// NodeCountAsExpected is derived from the CIB (`pcs cluster config`), which

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -138,6 +138,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		g.By(fmt.Sprintf("Checking recovery path for %s from %s journal", targetNode.Name, survivedNode.Name))
 		logRecoveryPath(oc, &survivedNode, &targetNode)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after graceful recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
 	})
 
 	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {
@@ -168,6 +172,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&survivedNode,
 			&targetNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after ungraceful recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
 	})
 
 	g.It("should recover from network disruption with etcd member re-addition", func() {
@@ -202,6 +210,13 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			leaderNode,
 			learnerNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
+
+		g.By("Checking PacemakerHealthCheckDegraded after short network disruption (informational)")
+		if checkErr := apis.ExpectPacemakerHealthCheckNotDegraded(oc); checkErr != nil {
+			framework.Logf("PacemakerHealthCheckDegraded was True after network disruption (may be expected): %v", checkErr)
+		} else {
+			framework.Logf("PacemakerHealthCheckDegraded remained False after short network disruption (fault window shorter than healthcheck resync)")
+		}
 	})
 
 	g.It("should recover from a double node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -241,6 +256,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&nodeA,
 			&nodeB, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after double node failure recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after double node failure recovery")
 	})
 
 	g.It("should recover from double graceful node shutdown (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -280,6 +299,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&nodeA,
 			&nodeB, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after double graceful shutdown recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after double graceful shutdown recovery")
 	})
 
 	g.It("should recover from sequential graceful node shutdowns (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -305,6 +328,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
+
 		g.By(fmt.Sprintf("Gracefully shutting down second node: %s", secondToShutdown.Name))
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmSecondToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmSecondToShutdown))
@@ -318,6 +345,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&firstToShutdown,
 			&secondToShutdown, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after sequential shutdown recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after sequential shutdown recovery")
 	})
 
 	g.It("should recover from graceful shutdown followed by ungraceful node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -342,6 +373,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
+
 		g.By(fmt.Sprintf("Waiting for %s to recover the etcd cluster standalone (timeout: %v)", secondToShutdown.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&secondToShutdown,
@@ -361,6 +396,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			&firstToShutdown,
 			&secondToShutdown, true, false,
 			membersHealthyAfterDoubleReboot, utils.FiveSecondPollInterval)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after mixed cold-boot recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after mixed cold-boot recovery")
 	})
 
 	g.It("should recover from BMC credential rotation with fencing", func() {
@@ -548,6 +587,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		}, 5*time.Minute, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
 			fmt.Sprintf("expected etcd-previous container to exist on %s", targetNode.Name))
 
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after kernel panic recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after kernel panic recovery")
 	})
 
 	g.It("should recover after simultaneous graceful shutdown of both nodes", func() {
@@ -578,6 +620,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected no error checking etcd on %s", node.Name))
 			o.Expect(got).To(o.Equal("'true'"), fmt.Sprintf("Expected etcd container running on %s", node.Name))
 		}
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after simultaneous graceful shutdown recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after simultaneous graceful shutdown recovery")
 	})
 })
 

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -119,7 +119,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		time.Sleep(time.Minute)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
 
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
@@ -160,7 +160,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		time.Sleep(1 * time.Minute)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
@@ -337,7 +337,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
 
 		g.By(fmt.Sprintf("Gracefully shutting down second node: %s", secondToShutdown.Name))
@@ -382,7 +382,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
 
 		g.By(fmt.Sprintf("Waiting for %s to recover the etcd cluster standalone (timeout: %v)", secondToShutdown.Name, memberIsLeaderTimeout))
@@ -496,7 +496,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to trigger kernel panic without error")
 
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down after kernel panic")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down after kernel panic")
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", survivedNode.Name, targetNode.Name, memberIsLeaderTimeout))

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -118,6 +118,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to gracefully shutdown the node without errors")
 		time.Sleep(time.Minute)
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
+
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&survivedNode,
@@ -154,6 +158,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err := exutil.TriggerNodeRebootUngraceful(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to ungracefully shutdown the node without errors", targetNode.Name, err)
 		time.Sleep(1 * time.Minute)
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -486,6 +494,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		disruptPodName := fmt.Sprintf("disrupt-%s-0", targetNode.Name)
 		err = exutil.TriggerKernelPanic(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to trigger kernel panic without error")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down after kernel panic")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down after kernel panic")
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", survivedNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -36,7 +36,29 @@ const (
 	vmGracefulShutdownTimeout       = 10 * time.Minute // Graceful VM shutdown is typically slow
 	membersHealthyAfterDoubleReboot = 30 * time.Minute // Includes full VM reboot and etcd member healthy
 	progressLogInterval             = time.Minute      // Target interval for progress logging
+
+	// phcNodeOfflineEventCheckTimeout bounds the post-recovery, informational check for a
+	// PacemakerNodeOffline event. It is checked only after the node has already recovered,
+	// so this only needs to cover event-listing/propagation lag, not detection latency.
+	phcNodeOfflineEventCheckTimeout = 2 * time.Minute
 )
+
+// checkPacemakerNodeOfflineObserved performs a bounded, non-blocking, informational check
+// for a PacemakerNodeOffline event emitted at or after since. It is called AFTER the node
+// has already recovered, so — unlike WaitForPacemakerHealthCheckDegraded — it never delays
+// the recovery validation that follows a node going down, and it can't shift the timing of
+// a subsequent, deliberately-overlapping failure in multi-node scenarios. A missed event
+// signals a monitoring gap (directly covered by the dedicated tnf_pacemaker_healthcheck.go
+// tests), so this only logs, it never fails the recovery test.
+func checkPacemakerNodeOfflineObserved(oc *exutil.CLI, nodeName string, since time.Time) {
+	if err := apis.WaitForPacemakerEvent(oc, apis.PacemakerHealthCheckEventNamespace, "PacemakerNodeOffline", since, phcNodeOfflineEventCheckTimeout); err != nil {
+		framework.Logf("[sig-etcd][PHCMiss] node=%s: PacemakerNodeOffline event not observed for outage starting %s "+
+			"(health monitoring gap): %v", nodeName, since.Format(time.RFC3339), err)
+	} else {
+		framework.Logf("[sig-etcd][PHCCheck] node=%s: PacemakerNodeOffline event observed for outage starting %s",
+			nodeName, since.Format(time.RFC3339))
+	}
+}
 
 // computeLogInterval calculates poll attempts between progress logs based on poll interval.
 func computeLogInterval(pollInterval time.Duration) int {
@@ -114,19 +136,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.GinkgoT().Printf("Randomly selected %s (%s) to be shut down and %s (%s) to take the lead\n",
 			targetNode.Name, targetNode.Status.Addresses[0].Address, peerNode.Name, peerNode.Status.Addresses[0].Address)
 		g.By(fmt.Sprintf("Shutting down %s gracefully in 1 minute", targetNode.Name))
+		outageStart := time.Now()
 		err := exutil.TriggerNodeRebootGraceful(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to gracefully shutdown the node without errors")
 		time.Sleep(time.Minute)
-
-		// Informational: these recovery tests validate etcd recovery, not the health
-		// monitoring pipeline. A missed degraded transition signals a monitoring gap
-		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
-		// log and continue rather than block the recovery validation that follows.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
-			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while target node was down "+
-				"(health monitoring gap — recovery validation continues): %v", err)
-		}
 
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -152,6 +165,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after graceful recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during target node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, targetNode.Name, outageStart)
 	})
 
 	g.It("should recover from ungraceful node shutdown with etcd member re-addition", func() {
@@ -161,19 +177,10 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.GinkgoT().Printf("Randomly selected %s (%s) to be shut down and %s (%s) to take the lead\n",
 			targetNode.Name, targetNode.Status.Addresses[0].Address, peerNode.Name, peerNode.Status.Addresses[0].Address)
 		g.By(fmt.Sprintf("Shutting down %s ungracefully in 1 minute", targetNode.Name))
+		outageStart := time.Now()
 		err := exutil.TriggerNodeRebootUngraceful(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to ungracefully shutdown the node without errors", targetNode.Name, err)
 		time.Sleep(1 * time.Minute)
-
-		// Informational: these recovery tests validate etcd recovery, not the health
-		// monitoring pipeline. A missed degraded transition signals a monitoring gap
-		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
-		// log and continue rather than block the recovery validation that follows.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
-			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while target node was down "+
-				"(health monitoring gap — recovery validation continues): %v", err)
-		}
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -196,6 +203,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after ungraceful recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during target node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, targetNode.Name, outageStart)
 	})
 
 	g.It("should recover from network disruption with etcd member re-addition", func() {
@@ -233,9 +243,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		g.By("Checking PacemakerHealthCheckDegraded after short network disruption (informational)")
 		if checkErr := apis.ExpectPacemakerHealthCheckNotDegraded(oc); checkErr != nil {
-			framework.Logf("PacemakerHealthCheckDegraded was True after network disruption (may be expected): %v", checkErr)
+			framework.Logf("[sig-etcd][PHCMiss] PacemakerHealthCheckDegraded was True after network disruption (may be expected): %v", checkErr)
 		} else {
-			framework.Logf("PacemakerHealthCheckDegraded remained False after short network disruption (fault window shorter than healthcheck resync)")
+			framework.Logf("[sig-etcd][PHCCheck] PacemakerHealthCheckDegraded remained False after short network disruption (fault window shorter than healthcheck resync)")
 		}
 	})
 
@@ -345,19 +355,14 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		g.By(fmt.Sprintf("Gracefully shutting down first node: %s", firstToShutdown.Name))
 
+		firstOutageStart := time.Now()
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
-		// Informational: these recovery tests validate etcd recovery, not the health
-		// monitoring pipeline. A missed degraded transition signals a monitoring gap
-		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
-		// log and continue rather than block the recovery validation that follows.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
-			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while first node was down "+
-				"(health monitoring gap — recovery validation continues): %v", err)
-		}
-
+		// Deliberately do not wait for PacemakerHealthCheckDegraded here: this test's premise
+		// is shutting down the second node while the first is still down/recovering, so
+		// blocking here would change how close together the two failures land. The
+		// PacemakerNodeOffline check below runs after the fact instead.
 		g.By(fmt.Sprintf("Gracefully shutting down second node: %s", secondToShutdown.Name))
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmSecondToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmSecondToShutdown))
@@ -375,6 +380,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after sequential shutdown recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after sequential shutdown recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during first node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, firstToShutdown.Name, firstOutageStart)
 	})
 
 	g.It("should recover from graceful shutdown followed by ungraceful node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {
@@ -396,19 +404,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		defer restartVms(dataPair, c)
 
 		g.By(fmt.Sprintf("Gracefully shutting down VM %s (node: %s)", vmFirstToShutdown, firstToShutdown.Name))
+		firstOutageStart := time.Now()
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
-		// Informational: these recovery tests validate etcd recovery, not the health
-		// monitoring pipeline. A missed degraded transition signals a monitoring gap
-		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
-		// log and continue rather than block the recovery validation that follows.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
-			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while first node was down "+
-				"(health monitoring gap — recovery validation continues): %v", err)
-		}
-
+		// Deliberately do not wait for PacemakerHealthCheckDegraded here: this test's premise
+		// is failing the second node while the first is still a learner (not yet promoted),
+		// so blocking here risks the first node fully recovering before the second failure is
+		// induced, changing the scenario under test. The PacemakerNodeOffline check below runs
+		// after the fact instead.
 		g.By(fmt.Sprintf("Waiting for %s to recover the etcd cluster standalone (timeout: %v)", secondToShutdown.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&secondToShutdown,
@@ -432,6 +436,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after mixed cold-boot recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, membersHealthyAfterDoubleReboot)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after mixed cold-boot recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during first node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, firstToShutdown.Name, firstOutageStart)
 	})
 
 	g.It("should recover from BMC credential rotation with fencing", func() {
@@ -516,18 +523,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 		g.By(fmt.Sprintf("Triggering kernel panic on %s via sysrq trigger", targetNode.Name))
 		disruptPodName := fmt.Sprintf("disrupt-%s-0", targetNode.Name)
+		outageStart := time.Now()
 		err = exutil.TriggerKernelPanic(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to trigger kernel panic without error")
-
-		// Informational: this test validates etcd recovery and the revision bump, not
-		// the health monitoring pipeline. A missed degraded transition signals a
-		// monitoring gap (directly covered by the dedicated
-		// tnf_pacemaker_healthcheck.go tests), so log and continue.
-		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down after kernel panic")
-		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
-			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire after kernel panic "+
-				"(health monitoring gap — recovery validation continues): %v", err)
-		}
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", survivedNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -632,6 +630,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after kernel panic recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after kernel panic recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during target node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, targetNode.Name, outageStart)
 	})
 
 	g.It("should recover after simultaneous graceful shutdown of both nodes", func() {

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -118,9 +118,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to gracefully shutdown the node without errors")
 		time.Sleep(time.Minute)
 
+		// Informational: these recovery tests validate etcd recovery, not the health
+		// monitoring pipeline. A missed degraded transition signals a monitoring gap
+		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
+		// log and continue rather than block the recovery validation that follows.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
+		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
+			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while target node was down "+
+				"(health monitoring gap — recovery validation continues): %v", err)
+		}
 
 		g.By(fmt.Sprintf("Ensuring that %s is a healthy voting member and adds %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -159,9 +165,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(err).To(o.BeNil(), "Expected to ungracefully shutdown the node without errors", targetNode.Name, err)
 		time.Sleep(1 * time.Minute)
 
+		// Informational: these recovery tests validate etcd recovery, not the health
+		// monitoring pipeline. A missed degraded transition signals a monitoring gap
+		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
+		// log and continue rather than block the recovery validation that follows.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down")
+		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
+			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while target node was down "+
+				"(health monitoring gap — recovery validation continues): %v", err)
+		}
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", peerNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -336,9 +348,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
+		// Informational: these recovery tests validate etcd recovery, not the health
+		// monitoring pipeline. A missed degraded transition signals a monitoring gap
+		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
+		// log and continue rather than block the recovery validation that follows.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
+		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
+			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while first node was down "+
+				"(health monitoring gap — recovery validation continues): %v", err)
+		}
 
 		g.By(fmt.Sprintf("Gracefully shutting down second node: %s", secondToShutdown.Name))
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmSecondToShutdown, c)
@@ -381,9 +399,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = vmShutdownAndWait(VMShutdownModeGraceful, vmFirstToShutdown, c)
 		o.Expect(err).To(o.BeNil(), fmt.Sprintf("Expected VM %s to reach shut off state", vmFirstToShutdown))
 
+		// Informational: these recovery tests validate etcd recovery, not the health
+		// monitoring pipeline. A missed degraded transition signals a monitoring gap
+		// (directly covered by the dedicated tnf_pacemaker_healthcheck.go tests), so
+		// log and continue rather than block the recovery validation that follows.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True after first node shutdown")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while first node is down")
+		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
+			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire while first node was down "+
+				"(health monitoring gap — recovery validation continues): %v", err)
+		}
 
 		g.By(fmt.Sprintf("Waiting for %s to recover the etcd cluster standalone (timeout: %v)", secondToShutdown.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,
@@ -495,9 +519,15 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		err = exutil.TriggerKernelPanic(oc.KubeClient(), targetNode.Name)
 		o.Expect(err).To(o.BeNil(), "Expected to trigger kernel panic without error")
 
+		// Informational: this test validates etcd recovery and the revision bump, not
+		// the health monitoring pipeline. A missed degraded transition signals a
+		// monitoring gap (directly covered by the dedicated
+		// tnf_pacemaker_healthcheck.go tests), so log and continue.
 		g.By("Waiting for PacemakerHealthCheckDegraded=True while target node is down after kernel panic")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True while the target node is down after kernel panic")
+		if err := apis.WaitForPacemakerHealthCheckDegraded(oc, "", pacemakerDegradedDetectionTimeout); err != nil {
+			framework.Logf("WARNING: PacemakerHealthCheckDegraded did not fire after kernel panic "+
+				"(health monitoring gap — recovery validation continues): %v", err)
+		}
 
 		g.By(fmt.Sprintf("Ensuring that %s added %s back as learner (timeout: %v)", survivedNode.Name, targetNode.Name, memberIsLeaderTimeout))
 		validateEtcdRecoveryState(oc, etcdClientFactory,

--- a/test/extended/edge_topologies/tnf_taint.go
+++ b/test/extended/edge_topologies/tnf_taint.go
@@ -11,7 +11,6 @@ import (
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils"
-	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/services"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -127,8 +126,8 @@ var _ = g.Describe("[sig-node][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	g.BeforeEach(func() {
 		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
 
-		// Skip the test if cluster version is below 5.0, as fencing taint was introduced in that version
-		utils.SkipIfVersionBelow(oc, 5, 0)
+		// Skip the test if cluster version is below 4.22, as fencing taint was introduced in that version
+		utils.SkipIfVersionBelow(oc, 4, 22)
 	})
 
 	g.It("should have pacemaker taint and untaint alerts registered", func() {
@@ -172,8 +171,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	g.BeforeEach(func() {
 		utils.SkipIfNotTopology(oc, v1.DualReplicaTopologyMode)
 
-		// Skip the test if cluster version is below 5.0, as fencing taint was introduced in that version
-		utils.SkipIfVersionBelow(oc, 5, 0)
+		// Skip the test if cluster version is below 4.22, as fencing taint was introduced in that version
+		utils.SkipIfVersionBelow(oc, 4, 22)
 
 		etcdClientFactory = helpers.NewEtcdClientFactory(oc.KubeClient())
 
@@ -332,10 +331,6 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		}, journalCheckTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(),
 			"taint-fenced-node should log successful taint and annotation application")
 
-		g.By("Waiting for PacemakerHealthCheckDegraded=True after fencing")
-		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after fencing")
-
 		// --- Recovery Wait ---
 		if !learnerStarted {
 			g.By(fmt.Sprintf("Ensuring %s rejoins as learner (timeout: %v)",
@@ -387,9 +382,5 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				services.UntaintScriptLogTag, services.UntaintSuccessLog, baseTimestamp)
 		}, taintRemovedTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(),
 			"untaint-fenced-node should log successful untaint on at least one node")
-
-		g.By("Waiting for PacemakerHealthCheckDegraded to clear after network disruption recovery")
-		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, taintRemovedTimeout)).
-			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after network disruption recovery")
 	})
 })

--- a/test/extended/edge_topologies/tnf_taint.go
+++ b/test/extended/edge_topologies/tnf_taint.go
@@ -11,6 +11,7 @@ import (
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/services"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -330,8 +331,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				services.TaintScriptLogTag, services.TaintSuccessLog, baseTimestamp)
 		}, journalCheckTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(),
 			"taint-fenced-node should log successful taint and annotation application")
-		// --- Recovery Wait ---
 
+		g.By("Waiting for PacemakerHealthCheckDegraded=True after fencing")
+		o.Expect(apis.WaitForPacemakerHealthCheckDegraded(oc, "", 2*time.Minute)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should become True after fencing")
+
+		// --- Recovery Wait ---
 		if !learnerStarted {
 			g.By(fmt.Sprintf("Ensuring %s rejoins as learner (timeout: %v)",
 				learnerNode.Name, memberRejoinedLearnerTimeout))
@@ -382,5 +387,9 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 				services.UntaintScriptLogTag, services.UntaintSuccessLog, baseTimestamp)
 		}, taintRemovedTimeout, utils.FiveSecondPollInterval).Should(o.BeTrue(),
 			"untaint-fenced-node should log successful untaint on at least one node")
+
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after network disruption recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, taintRemovedTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after network disruption recovery")
 	})
 })

--- a/test/extended/edge_topologies/utils/apis/baremetalhost.go
+++ b/test/extended/edge_topologies/utils/apis/baremetalhost.go
@@ -20,10 +20,12 @@ import (
 )
 
 const (
-	BMCSecretNamespace          = "openshift-machine-api"
-	FencingCredentialsNamespace = "openshift-etcd"
-	fencingCredentialsPrefix    = "fencing-credentials-"
-	secretsDataPasswordKey      = "password"
+	BMCSecretNamespace = "openshift-machine-api"
+	// EtcdNamespace is the OpenShift namespace for etcd static pods and related
+	// Secrets/CronJobs, including fencing-credentials secrets.
+	EtcdNamespace            = "openshift-etcd"
+	fencingCredentialsPrefix = "fencing-credentials-"
+	secretsDataPasswordKey   = "password"
 )
 
 // FencingCredentials holds the fields from a fencing-credentials secret in openshift-etcd.
@@ -41,9 +43,9 @@ func FindFencingCredentialsByNodeName(oc *exutil.CLI, nodeName string) (*Fencing
 	shortName := strings.Split(nodeName, ".")[0]
 
 	ctx := context.Background()
-	list, err := oc.AdminKubeClient().CoreV1().Secrets(FencingCredentialsNamespace).List(ctx, metav1.ListOptions{})
+	list, err := oc.AdminKubeClient().CoreV1().Secrets(EtcdNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("list secrets in %s: %w", FencingCredentialsNamespace, err)
+		return nil, fmt.Errorf("list secrets in %s: %w", EtcdNamespace, err)
 	}
 
 	expected := map[string]struct{}{
@@ -83,7 +85,7 @@ func FindFencingCredentialsByNodeName(oc *exutil.CLI, nodeName string) (*Fencing
 	}
 
 	return nil, fmt.Errorf("no fencing-credentials secret found matching node %q (prefix: %s, contains: %s) in %s",
-		nodeName, fencingCredentialsPrefix, shortName, FencingCredentialsNamespace)
+		nodeName, fencingCredentialsPrefix, shortName, EtcdNamespace)
 }
 
 // BMHGVR is the GroupVersionResource for BareMetalHost (metal3.io/v1alpha1). Use for API-based get/delete/patch.

--- a/test/extended/edge_topologies/utils/apis/pacemakercluster.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakercluster.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	etcdv1alpha1 "github.com/openshift/api/etcd/v1alpha1"
+	etcdv1 "github.com/openshift/api/etcd/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,7 +13,7 @@ import (
 )
 
 var PacemakerClusterGVR = schema.GroupVersionResource{
-	Group: etcdv1alpha1.GroupName, Version: "v1alpha1", Resource: "pacemakerclusters",
+	Group: etcdv1.GroupName, Version: "v1", Resource: "pacemakerclusters",
 }
 
 func IsPacemakerClusterAvailable(oc *exutil.CLI) bool {
@@ -22,14 +22,14 @@ func IsPacemakerClusterAvailable(oc *exutil.CLI) bool {
 	return err == nil
 }
 
-func GetPacemakerCluster(oc *exutil.CLI) (*etcdv1alpha1.PacemakerCluster, error) {
+func GetPacemakerCluster(oc *exutil.CLI) (*etcdv1.PacemakerCluster, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	u, err := oc.AdminDynamicClient().Resource(PacemakerClusterGVR).Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("get PacemakerCluster: %w", err)
 	}
-	var pc etcdv1alpha1.PacemakerCluster
+	var pc etcdv1.PacemakerCluster
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &pc); err != nil {
 		return nil, fmt.Errorf("convert PacemakerCluster: %w", err)
 	}
@@ -45,19 +45,19 @@ func findCondition(conditions []metav1.Condition, condType string) *metav1.Condi
 	return nil
 }
 
-func ExpectClusterHealthy(pc *etcdv1alpha1.PacemakerCluster) error {
-	c := findCondition(pc.Status.Conditions, etcdv1alpha1.ClusterHealthyConditionType)
+func ExpectClusterHealthy(pc *etcdv1.PacemakerCluster) error {
+	c := findCondition(pc.Status.Conditions, etcdv1.ClusterHealthyConditionType)
 	if c == nil {
-		return fmt.Errorf("PacemakerCluster missing %s condition", etcdv1alpha1.ClusterHealthyConditionType)
+		return fmt.Errorf("PacemakerCluster missing %s condition", etcdv1.ClusterHealthyConditionType)
 	}
 	if c.Status != metav1.ConditionTrue {
 		return fmt.Errorf("PacemakerCluster %s=%s (reason: %s, message: %s)",
-			etcdv1alpha1.ClusterHealthyConditionType, c.Status, c.Reason, c.Message)
+			etcdv1.ClusterHealthyConditionType, c.Status, c.Reason, c.Message)
 	}
 	return nil
 }
 
-func ExpectNodeFencingHealthy(pc *etcdv1alpha1.PacemakerCluster, nodeName string) error {
+func ExpectNodeFencingAvailable(pc *etcdv1.PacemakerCluster, nodeName string) error {
 	if pc.Status.Nodes == nil {
 		return fmt.Errorf("PacemakerCluster has no nodes in status")
 	}
@@ -65,13 +65,67 @@ func ExpectNodeFencingHealthy(pc *etcdv1alpha1.PacemakerCluster, nodeName string
 		if node.NodeName != nodeName {
 			continue
 		}
-		c := findCondition(node.Conditions, etcdv1alpha1.NodeFencingHealthyConditionType)
+		c := findCondition(node.Conditions, etcdv1.NodeFencingAvailableConditionType)
 		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1alpha1.NodeFencingHealthyConditionType)
+			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingAvailableConditionType)
 		}
 		if c.Status != metav1.ConditionTrue {
 			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
-				nodeName, etcdv1alpha1.NodeFencingHealthyConditionType, c.Status, c.Reason, c.Message)
+				nodeName, etcdv1.NodeFencingAvailableConditionType, c.Status, c.Reason, c.Message)
+		}
+		return nil
+	}
+	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+}
+
+func ExpectNodeMember(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	if pc.Status.Nodes == nil {
+		return fmt.Errorf("PacemakerCluster has no nodes in status")
+	}
+	for _, node := range *pc.Status.Nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		c := findCondition(node.Conditions, etcdv1.NodeMemberConditionType)
+		if c == nil {
+			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeMemberConditionType)
+		}
+		if c.Status != metav1.ConditionTrue {
+			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
+				nodeName, etcdv1.NodeMemberConditionType, c.Status, c.Reason, c.Message)
+		}
+		return nil
+	}
+	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+}
+
+func ExpectClusterNodeCountAsExpected(pc *etcdv1.PacemakerCluster) error {
+	c := findCondition(pc.Status.Conditions, etcdv1.ClusterNodeCountAsExpectedConditionType)
+	if c == nil {
+		return fmt.Errorf("PacemakerCluster missing %s condition", etcdv1.ClusterNodeCountAsExpectedConditionType)
+	}
+	if c.Status != metav1.ConditionTrue {
+		return fmt.Errorf("PacemakerCluster %s=%s (reason: %s, message: %s)",
+			etcdv1.ClusterNodeCountAsExpectedConditionType, c.Status, c.Reason, c.Message)
+	}
+	return nil
+}
+
+func ExpectNodeFencingHealthy(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	if pc.Status.Nodes == nil {
+		return fmt.Errorf("PacemakerCluster has no nodes in status")
+	}
+	for _, node := range *pc.Status.Nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		c := findCondition(node.Conditions, etcdv1.NodeFencingHealthyConditionType)
+		if c == nil {
+			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingHealthyConditionType)
+		}
+		if c.Status != metav1.ConditionTrue {
+			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
+				nodeName, etcdv1.NodeFencingHealthyConditionType, c.Status, c.Reason, c.Message)
 		}
 		return nil
 	}

--- a/test/extended/edge_topologies/utils/apis/pacemakercluster.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakercluster.go
@@ -7,6 +7,7 @@ import (
 
 	etcdv1 "github.com/openshift/api/etcd/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,10 +17,20 @@ var PacemakerClusterGVR = schema.GroupVersionResource{
 	Group: etcdv1.GroupName, Version: "v1", Resource: "pacemakerclusters",
 }
 
-func IsPacemakerClusterAvailable(oc *exutil.CLI) bool {
+// IsPacemakerClusterAvailable reports whether the PacemakerCluster CRD is served
+// by the API. Only a NotFound error means the CRD is genuinely absent; any other
+// error (authorization, transient API failures) is returned so callers fail
+// rather than silently skip checks by mistaking a real error for CRD absence.
+func IsPacemakerClusterAvailable(oc *exutil.CLI) (bool, error) {
 	_, err := oc.AdminDynamicClient().Resource(PacemakerClusterGVR).List(
 		context.Background(), metav1.ListOptions{Limit: 1})
-	return err == nil
+	if err == nil {
+		return true, nil
+	}
+	if apierrors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("check PacemakerCluster availability: %w", err)
 }
 
 func GetPacemakerCluster(oc *exutil.CLI) (*etcdv1.PacemakerCluster, error) {

--- a/test/extended/edge_topologies/utils/apis/pacemakercluster.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakercluster.go
@@ -78,6 +78,57 @@ func ExpectNodeFencingAvailable(pc *etcdv1.PacemakerCluster, nodeName string) er
 	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
 }
 
+// ExpectNodeFencingUnavailable returns nil only when the node's
+// NodeFencingAvailable condition is explicitly False. Missing nodes, missing
+// conditions, and other schema errors are propagated so a definitively-False
+// state is the only success — a lookup failure must never be mistaken for
+// "fencing is unavailable".
+func ExpectNodeFencingUnavailable(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	if pc.Status.Nodes == nil {
+		return fmt.Errorf("PacemakerCluster has no nodes in status")
+	}
+	for _, node := range *pc.Status.Nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		c := findCondition(node.Conditions, etcdv1.NodeFencingAvailableConditionType)
+		if c == nil {
+			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingAvailableConditionType)
+		}
+		if c.Status != metav1.ConditionFalse {
+			return fmt.Errorf("node %s %s=%s, expected False (reason: %s, message: %s)",
+				nodeName, etcdv1.NodeFencingAvailableConditionType, c.Status, c.Reason, c.Message)
+		}
+		return nil
+	}
+	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+}
+
+// ExpectNodeFencingUnhealthy returns nil only when the node's
+// NodeFencingHealthy condition is explicitly False (e.g. a fencing agent is
+// unmanaged but still running). Missing nodes, missing conditions, and other
+// schema errors are propagated so they cannot be mistaken for the desired state.
+func ExpectNodeFencingUnhealthy(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	if pc.Status.Nodes == nil {
+		return fmt.Errorf("PacemakerCluster has no nodes in status")
+	}
+	for _, node := range *pc.Status.Nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		c := findCondition(node.Conditions, etcdv1.NodeFencingHealthyConditionType)
+		if c == nil {
+			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingHealthyConditionType)
+		}
+		if c.Status != metav1.ConditionFalse {
+			return fmt.Errorf("node %s %s=%s, expected False (reason: %s, message: %s)",
+				nodeName, etcdv1.NodeFencingHealthyConditionType, c.Status, c.Reason, c.Message)
+		}
+		return nil
+	}
+	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+}
+
 func ExpectNodeMember(pc *etcdv1.PacemakerCluster, nodeName string) error {
 	if pc.Status.Nodes == nil {
 		return fmt.Errorf("PacemakerCluster has no nodes in status")

--- a/test/extended/edge_topologies/utils/apis/pacemakercluster.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakercluster.go
@@ -8,6 +8,7 @@ import (
 	etcdv1 "github.com/openshift/api/etcd/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -47,149 +48,160 @@ func GetPacemakerCluster(oc *exutil.CLI) (*etcdv1.PacemakerCluster, error) {
 	return &pc, nil
 }
 
-func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
-	for i := range conditions {
-		if conditions[i].Type == condType {
-			return &conditions[i]
-		}
+// ExpectClusterCondition returns nil only when the PacemakerCluster's cluster-level
+// condition condType is explicitly set to expected. A missing condition is
+// propagated as an error so a lookup failure can never be mistaken for the
+// desired state.
+func ExpectClusterCondition(pc *etcdv1.PacemakerCluster, condType string, expected metav1.ConditionStatus) error {
+	c := meta.FindStatusCondition(pc.Status.Conditions, condType)
+	if c == nil {
+		return fmt.Errorf("PacemakerCluster missing %s condition", condType)
+	}
+	if c.Status != expected {
+		return fmt.Errorf("PacemakerCluster %s=%s, expected %s (reason: %s, message: %s)",
+			condType, c.Status, expected, c.Reason, c.Message)
 	}
 	return nil
+}
+
+// ExpectNodeCondition returns nil only when nodeName's condition condType is
+// explicitly set to expected. Missing nodes, missing conditions, and other
+// schema errors are propagated so a lookup failure can never be mistaken for
+// the desired state.
+func ExpectNodeCondition(pc *etcdv1.PacemakerCluster, nodeName, condType string, expected metav1.ConditionStatus) error {
+	if pc.Status.Nodes == nil {
+		return fmt.Errorf("PacemakerCluster has no nodes in status")
+	}
+	for _, node := range *pc.Status.Nodes {
+		if node.NodeName != nodeName {
+			continue
+		}
+		c := meta.FindStatusCondition(node.Conditions, condType)
+		if c == nil {
+			return fmt.Errorf("node %s missing %s condition", nodeName, condType)
+		}
+		if c.Status != expected {
+			return fmt.Errorf("node %s %s=%s, expected %s (reason: %s, message: %s)",
+				nodeName, condType, c.Status, expected, c.Reason, c.Message)
+		}
+		return nil
+	}
+	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
 }
 
 func ExpectClusterHealthy(pc *etcdv1.PacemakerCluster) error {
-	c := findCondition(pc.Status.Conditions, etcdv1.ClusterHealthyConditionType)
-	if c == nil {
-		return fmt.Errorf("PacemakerCluster missing %s condition", etcdv1.ClusterHealthyConditionType)
-	}
-	if c.Status != metav1.ConditionTrue {
-		return fmt.Errorf("PacemakerCluster %s=%s (reason: %s, message: %s)",
-			etcdv1.ClusterHealthyConditionType, c.Status, c.Reason, c.Message)
-	}
-	return nil
+	return ExpectClusterCondition(pc, etcdv1.ClusterHealthyConditionType, metav1.ConditionTrue)
 }
 
 func ExpectNodeFencingAvailable(pc *etcdv1.PacemakerCluster, nodeName string) error {
-	if pc.Status.Nodes == nil {
-		return fmt.Errorf("PacemakerCluster has no nodes in status")
-	}
-	for _, node := range *pc.Status.Nodes {
-		if node.NodeName != nodeName {
-			continue
-		}
-		c := findCondition(node.Conditions, etcdv1.NodeFencingAvailableConditionType)
-		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingAvailableConditionType)
-		}
-		if c.Status != metav1.ConditionTrue {
-			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
-				nodeName, etcdv1.NodeFencingAvailableConditionType, c.Status, c.Reason, c.Message)
-		}
-		return nil
-	}
-	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeFencingAvailableConditionType, metav1.ConditionTrue)
 }
 
 // ExpectNodeFencingUnavailable returns nil only when the node's
-// NodeFencingAvailable condition is explicitly False. Missing nodes, missing
-// conditions, and other schema errors are propagated so a definitively-False
-// state is the only success — a lookup failure must never be mistaken for
-// "fencing is unavailable".
+// NodeFencingAvailable condition is explicitly False.
 func ExpectNodeFencingUnavailable(pc *etcdv1.PacemakerCluster, nodeName string) error {
-	if pc.Status.Nodes == nil {
-		return fmt.Errorf("PacemakerCluster has no nodes in status")
-	}
-	for _, node := range *pc.Status.Nodes {
-		if node.NodeName != nodeName {
-			continue
-		}
-		c := findCondition(node.Conditions, etcdv1.NodeFencingAvailableConditionType)
-		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingAvailableConditionType)
-		}
-		if c.Status != metav1.ConditionFalse {
-			return fmt.Errorf("node %s %s=%s, expected False (reason: %s, message: %s)",
-				nodeName, etcdv1.NodeFencingAvailableConditionType, c.Status, c.Reason, c.Message)
-		}
-		return nil
-	}
-	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeFencingAvailableConditionType, metav1.ConditionFalse)
 }
 
 // ExpectNodeFencingUnhealthy returns nil only when the node's
 // NodeFencingHealthy condition is explicitly False (e.g. a fencing agent is
-// unmanaged but still running). Missing nodes, missing conditions, and other
-// schema errors are propagated so they cannot be mistaken for the desired state.
+// unmanaged but still running).
 func ExpectNodeFencingUnhealthy(pc *etcdv1.PacemakerCluster, nodeName string) error {
-	if pc.Status.Nodes == nil {
-		return fmt.Errorf("PacemakerCluster has no nodes in status")
-	}
-	for _, node := range *pc.Status.Nodes {
-		if node.NodeName != nodeName {
-			continue
-		}
-		c := findCondition(node.Conditions, etcdv1.NodeFencingHealthyConditionType)
-		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingHealthyConditionType)
-		}
-		if c.Status != metav1.ConditionFalse {
-			return fmt.Errorf("node %s %s=%s, expected False (reason: %s, message: %s)",
-				nodeName, etcdv1.NodeFencingHealthyConditionType, c.Status, c.Reason, c.Message)
-		}
-		return nil
-	}
-	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeFencingHealthyConditionType, metav1.ConditionFalse)
+}
+
+// ExpectNodeOnlineFalse returns nil only when the node's Online condition is
+// explicitly False.
+func ExpectNodeOnlineFalse(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeOnlineConditionType, metav1.ConditionFalse)
 }
 
 func ExpectNodeMember(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeMemberConditionType, metav1.ConditionTrue)
+}
+
+func ExpectClusterNodeCountAsExpected(pc *etcdv1.PacemakerCluster) error {
+	return ExpectClusterCondition(pc, etcdv1.ClusterNodeCountAsExpectedConditionType, metav1.ConditionTrue)
+}
+
+// ExpectPacemakerCRFresh returns nil only when the PacemakerCluster CR's
+// Status.LastUpdated is set and within maxAge of now. A zero/missing
+// LastUpdated or one older than maxAge means the status-collector pipeline
+// has stalled, so the CR can no longer be trusted to reflect live state.
+func ExpectPacemakerCRFresh(pc *etcdv1.PacemakerCluster, maxAge time.Duration) error {
+	lastUpdated := pc.Status.LastUpdated.Time
+	if lastUpdated.IsZero() {
+		return fmt.Errorf("PacemakerCluster CR lastUpdated is zero (status never populated)")
+	}
+	if age := time.Since(lastUpdated); age > maxAge {
+		return fmt.Errorf("PacemakerCluster CR is stale: lastUpdated %s ago, expected < %s", age.Round(time.Second), maxAge)
+	}
+	return nil
+}
+
+// ExpectPacemakerBaseline asserts the PacemakerCluster CR reflects a fully
+// healthy cluster: cluster-level Healthy, InService, and NodeCountAsExpected
+// conditions, plus per-node FencingAvailable, FencingHealthy, and Member
+// conditions for every node currently reported in status. It is the test
+// payload for the dedicated PacemakerHealthCheck/fencing-credentials tests,
+// not a skip gate — it is built on etcdv1 condition type constants, so it
+// only breaks on an actual API break to the GA'd v1 type, not when
+// cluster-etcd-operator adds new conditions.
+func ExpectPacemakerBaseline(oc *exutil.CLI) error {
+	pc, err := GetPacemakerCluster(oc)
+	if err != nil {
+		return err
+	}
+
+	if err := ExpectClusterHealthy(pc); err != nil {
+		return err
+	}
+	if err := ExpectClusterCondition(pc, etcdv1.ClusterInServiceConditionType, metav1.ConditionTrue); err != nil {
+		return err
+	}
+	if err := ExpectClusterNodeCountAsExpected(pc); err != nil {
+		return err
+	}
+
 	if pc.Status.Nodes == nil {
 		return fmt.Errorf("PacemakerCluster has no nodes in status")
 	}
 	for _, node := range *pc.Status.Nodes {
-		if node.NodeName != nodeName {
-			continue
+		if err := ExpectNodeFencingAvailable(pc, node.NodeName); err != nil {
+			return err
 		}
-		c := findCondition(node.Conditions, etcdv1.NodeMemberConditionType)
-		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeMemberConditionType)
+		if err := ExpectNodeFencingHealthy(pc, node.NodeName); err != nil {
+			return err
 		}
-		if c.Status != metav1.ConditionTrue {
-			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
-				nodeName, etcdv1.NodeMemberConditionType, c.Status, c.Reason, c.Message)
+		if err := ExpectNodeMember(pc, node.NodeName); err != nil {
+			return err
 		}
-		return nil
-	}
-	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
-}
-
-func ExpectClusterNodeCountAsExpected(pc *etcdv1.PacemakerCluster) error {
-	c := findCondition(pc.Status.Conditions, etcdv1.ClusterNodeCountAsExpectedConditionType)
-	if c == nil {
-		return fmt.Errorf("PacemakerCluster missing %s condition", etcdv1.ClusterNodeCountAsExpectedConditionType)
-	}
-	if c.Status != metav1.ConditionTrue {
-		return fmt.Errorf("PacemakerCluster %s=%s (reason: %s, message: %s)",
-			etcdv1.ClusterNodeCountAsExpectedConditionType, c.Status, c.Reason, c.Message)
 	}
 	return nil
 }
 
 func ExpectNodeFencingHealthy(pc *etcdv1.PacemakerCluster, nodeName string) error {
+	return ExpectNodeCondition(pc, nodeName, etcdv1.NodeFencingHealthyConditionType, metav1.ConditionTrue)
+}
+
+// FindStartedFencingAgent returns the name of a fencing agent that targets nodeName
+// (e.g. "master-0_redfish") and is currently reporting Started=True. This reads the
+// PacemakerCluster CR's Status.Nodes[].FencingAgents — the structured source of truth
+// for fencing agent identity — so callers don't need to parse pcs status text.
+func FindStartedFencingAgent(pc *etcdv1.PacemakerCluster, nodeName string) (string, error) {
 	if pc.Status.Nodes == nil {
-		return fmt.Errorf("PacemakerCluster has no nodes in status")
+		return "", fmt.Errorf("PacemakerCluster has no nodes in status")
 	}
 	for _, node := range *pc.Status.Nodes {
 		if node.NodeName != nodeName {
 			continue
 		}
-		c := findCondition(node.Conditions, etcdv1.NodeFencingHealthyConditionType)
-		if c == nil {
-			return fmt.Errorf("node %s missing %s condition", nodeName, etcdv1.NodeFencingHealthyConditionType)
+		for _, agent := range node.FencingAgents {
+			if c := meta.FindStatusCondition(agent.Conditions, etcdv1.ResourceStartedConditionType); c != nil && c.Status == metav1.ConditionTrue {
+				return agent.Name, nil
+			}
 		}
-		if c.Status != metav1.ConditionTrue {
-			return fmt.Errorf("node %s %s=%s (reason: %s, message: %s)",
-				nodeName, etcdv1.NodeFencingHealthyConditionType, c.Status, c.Reason, c.Message)
-		}
-		return nil
+		return "", fmt.Errorf("no started fencing agent found for node %s", nodeName)
 	}
-	return fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
+	return "", fmt.Errorf("node %s not found in PacemakerCluster status", nodeName)
 }

--- a/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
@@ -1,0 +1,185 @@
+package apis
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	exutil "github.com/openshift/origin/test/extended/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	PacemakerHealthCheckDegradedCondition = "PacemakerHealthCheckDegraded"
+
+	healthCheckPollInterval = 10 * time.Second
+)
+
+func getEtcdOperator(oc *exutil.CLI) (*operatorv1.Etcd, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	return oc.AdminOperatorClient().OperatorV1().Etcds().Get(ctx, "cluster", metav1.GetOptions{})
+}
+
+func findOperatorCondition(etcd *operatorv1.Etcd, condType string) *operatorv1.OperatorCondition {
+	for i := range etcd.Status.Conditions {
+		if etcd.Status.Conditions[i].Type == condType {
+			return &etcd.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// describeNotDegradedCondition formats a not-yet-True PacemakerHealthCheckDegraded
+// condition for logging. The operator's clearPacemakerDegradedCondition intentionally
+// leaves Reason/Message empty when setting Status=False (see healthcheck.go), so an
+// empty reason/message here reflects the healthy baseline, not a missing field bug.
+func describeNotDegradedCondition(cond *operatorv1.OperatorCondition) string {
+	if cond.Reason == "" && cond.Message == "" {
+		return fmt.Sprintf("Status=%s (healthy)", cond.Status)
+	}
+	return fmt.Sprintf("Status=%s reason=%s message=%q", cond.Status, cond.Reason, cond.Message)
+}
+
+// WaitForPacemakerHealthCheckDegraded polls the etcd operator resource until
+// PacemakerHealthCheckDegraded=True with a message containing expectedSubstring.
+// Pass an empty expectedSubstring to accept any message.
+func WaitForPacemakerHealthCheckDegraded(oc *exutil.CLI, expectedSubstring string, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(healthCheckPollInterval)
+	defer ticker.Stop()
+
+	var lastErr string
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded=True (last: %s)", timeout, lastErr)
+		case <-ticker.C:
+			etcd, err := getEtcdOperator(oc)
+			if err != nil {
+				lastErr = fmt.Sprintf("get etcd operator: %v", err)
+				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+				continue
+			}
+
+			cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+			if cond == nil {
+				lastErr = "condition not found"
+				framework.Logf("WaitForPacemakerHealthCheckDegraded: condition not yet present on etcd operator")
+				continue
+			}
+
+			if cond.Status != operatorv1.ConditionTrue {
+				lastErr = describeNotDegradedCondition(cond)
+				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+				continue
+			}
+
+			if expectedSubstring != "" && !strings.Contains(cond.Message, expectedSubstring) {
+				lastErr = fmt.Sprintf("True but message %q does not contain %q", cond.Message, expectedSubstring)
+				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+				continue
+			}
+
+			framework.Logf("PacemakerHealthCheckDegraded=True confirmed (reason=%s, message=%q)", cond.Reason, cond.Message)
+			return nil
+		}
+	}
+}
+
+// WaitForPacemakerHealthCheckCleared polls the etcd operator resource until
+// PacemakerHealthCheckDegraded=False or the condition is absent.
+func WaitForPacemakerHealthCheckCleared(oc *exutil.CLI, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(healthCheckPollInterval)
+	defer ticker.Stop()
+
+	var lastErr string
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded to clear (last: %s)", timeout, lastErr)
+		case <-ticker.C:
+			etcd, err := getEtcdOperator(oc)
+			if err != nil {
+				lastErr = fmt.Sprintf("get etcd operator: %v", err)
+				framework.Logf("WaitForPacemakerHealthCheckCleared: %s", lastErr)
+				continue
+			}
+
+			cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+			if cond == nil {
+				framework.Logf("PacemakerHealthCheckDegraded condition absent — treating as cleared")
+				return nil
+			}
+
+			if cond.Status == operatorv1.ConditionFalse {
+				framework.Logf("PacemakerHealthCheckDegraded=False confirmed")
+				return nil
+			}
+
+			lastErr = fmt.Sprintf("Status=%s reason=%s message=%q", cond.Status, cond.Reason, cond.Message)
+			framework.Logf("WaitForPacemakerHealthCheckCleared: still degraded — %s", lastErr)
+		}
+	}
+}
+
+// pacemakerHealthCheckEventNamespace is where the healthcheck controller's
+// library-go event recorder writes events — the operator's own pod namespace
+// (openshift-etcd-operator), not the target namespace (openshift-etcd) that
+// the status collector uses for its own PacemakerFailedResourceAction /
+// PacemakerStatusCollectionError events.
+const pacemakerHealthCheckEventNamespace = "openshift-etcd-operator"
+
+// WaitForPacemakerEvent polls events in the openshift-etcd-operator namespace
+// until one with the given Reason appears. This applies to healthcheck-controller
+// reasons (e.g. PacemakerHealthy, PacemakerClusterInMaintenance, PacemakerNodeOffline).
+func WaitForPacemakerEvent(oc *exutil.CLI, reason string, timeout time.Duration) error {
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(healthCheckPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return fmt.Errorf("timed out after %v waiting for event with reason %q in %s", timeout, reason, pacemakerHealthCheckEventNamespace)
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			events, err := oc.AdminKubeClient().CoreV1().Events(pacemakerHealthCheckEventNamespace).List(ctx, metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("reason=%s", reason),
+			})
+			cancel()
+			if err != nil {
+				framework.Logf("WaitForPacemakerEvent: list events: %v", err)
+				continue
+			}
+			if len(events.Items) > 0 {
+				latest := events.Items[len(events.Items)-1]
+				framework.Logf("Found event reason=%s message=%q", latest.Reason, latest.Message)
+				return nil
+			}
+		}
+	}
+}
+
+// ExpectPacemakerHealthCheckNotDegraded checks the etcd operator resource
+// and returns an error if PacemakerHealthCheckDegraded is True.
+func ExpectPacemakerHealthCheckNotDegraded(oc *exutil.CLI) error {
+	etcd, err := getEtcdOperator(oc)
+	if err != nil {
+		return fmt.Errorf("get etcd operator: %w", err)
+	}
+
+	cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+	if cond == nil {
+		return nil
+	}
+
+	if cond.Status == operatorv1.ConditionTrue {
+		return fmt.Errorf("PacemakerHealthCheckDegraded=True (reason=%s, message=%q)", cond.Reason, cond.Message)
+	}
+	return nil
+}

--- a/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/core"
 	exutil "github.com/openshift/origin/test/extended/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,13 +20,22 @@ const (
 
 	healthCheckPollInterval = 10 * time.Second
 
-	// pacemakerTargetNamespace is where the status-collector CronJob and the
-	// PacemakerCluster data pipeline run.
-	pacemakerTargetNamespace = "openshift-etcd"
-
 	// statusCollectorCronJobName is the CronJob that snapshots pacemaker status
 	// into the PacemakerCluster CR (see cluster-etcd-operator).
 	statusCollectorCronJobName = "pacemaker-status-collector"
+
+	// PacemakerDegradedDetectionTimeout must exceed the operator's worst-case
+	// detection latency. When a node drops, the etcd/API/CronJob pipeline is
+	// disrupted, so degraded is often reached via the staleness path:
+	// StatusStalenessThreshold (5m) -> status Unknown, then
+	// StatusUnknownDegradedThreshold (5m) -> PacemakerHealthCheckDegraded=True
+	// (see cluster-etcd-operator pkg/tnf/pkg/pacemaker/constants.go). Both
+	// thresholds are measured from the same frozen previous.CRLastUpdated
+	// timestamp (only advanced on non-Unknown syncs), not chained, so degraded
+	// follows within roughly the same ~5m window staleness first fires in, not
+	// 5m+5m. That is a 5m minimum even with a healthy controller; the extra
+	// margin covers status-collector CronJob scheduling jitter.
+	PacemakerDegradedDetectionTimeout = 15 * time.Minute
 )
 
 func getEtcdOperator(oc *exutil.CLI) (*operatorv1.Etcd, error) {
@@ -33,29 +44,22 @@ func getEtcdOperator(oc *exutil.CLI) (*operatorv1.Etcd, error) {
 	return oc.AdminOperatorClient().OperatorV1().Etcds().Get(ctx, "cluster", metav1.GetOptions{})
 }
 
-func findOperatorCondition(etcd *operatorv1.Etcd, condType string) *operatorv1.OperatorCondition {
-	for i := range etcd.Status.Conditions {
-		if etcd.Status.Conditions[i].Type == condType {
-			return &etcd.Status.Conditions[i]
-		}
-	}
-	return nil
-}
-
-// dumpHealthCheckDiagnostics logs the state most useful for triaging why a
-// PacemakerHealthCheckDegraded transition did not happen within the timeout: the
-// etcd operator condition, the PacemakerCluster CR staleness and conditions, the
-// status-collector CronJob's last run, and node readiness. Together these show
-// whether the data pipeline was flowing (CR fresh, CronJob running, nodes Ready)
-// or broken. Every step is best-effort — this runs on an already-failing path and
-// must never itself fail or panic.
-func dumpHealthCheckDiagnostics(oc *exutil.CLI, reason string) {
+// DumpHealthCheckDiagnostics logs the state most useful for triaging a
+// PacemakerHealthCheck test failure: the etcd operator condition, the
+// PacemakerCluster CR staleness and conditions, the status-collector CronJob's
+// last run, and node readiness. Together these show whether the data pipeline
+// was flowing (CR fresh, CronJob running, nodes Ready) or broken. Every step is
+// best-effort — this runs on an already-failing path and must never itself fail
+// or panic. Called both internally on wait timeouts and by callers wiring it up
+// as a failure-time DeferCleanup so any failing assertion gets the dump, not
+// just polling timeouts.
+func DumpHealthCheckDiagnostics(oc *exutil.CLI, reason string) {
 	framework.Logf("========== PACEMAKER HEALTHCHECK DIAGNOSTICS (%s) ==========", reason)
 
 	// 1. etcd operator PacemakerHealthCheckDegraded condition
 	if etcd, err := getEtcdOperator(oc); err != nil {
 		framework.Logf("diagnostics: get etcd operator: %v", err)
-	} else if cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition); cond == nil {
+	} else if cond := v1helpers.FindOperatorCondition(etcd.Status.Conditions, PacemakerHealthCheckDegradedCondition); cond == nil {
 		framework.Logf("diagnostics: etcd operator %s condition absent", PacemakerHealthCheckDegradedCondition)
 	} else {
 		framework.Logf("diagnostics: etcd operator %s: Status=%s reason=%s message=%q lastTransition=%s",
@@ -83,10 +87,10 @@ func dumpHealthCheckDiagnostics(oc *exutil.CLI, reason string) {
 
 	// 3. status-collector CronJob last run
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	cronJob, err := oc.AdminKubeClient().BatchV1().CronJobs(pacemakerTargetNamespace).Get(ctx, statusCollectorCronJobName, metav1.GetOptions{})
+	cronJob, err := oc.AdminKubeClient().BatchV1().CronJobs(EtcdNamespace).Get(ctx, statusCollectorCronJobName, metav1.GetOptions{})
 	cancel()
 	if err != nil {
-		framework.Logf("diagnostics: get CronJob %s/%s: %v", pacemakerTargetNamespace, statusCollectorCronJobName, err)
+		framework.Logf("diagnostics: get CronJob %s/%s: %v", EtcdNamespace, statusCollectorCronJobName, err)
 	} else {
 		lastSchedule := "never"
 		if cronJob.Status.LastScheduleTime != nil {
@@ -138,93 +142,90 @@ func describeNotDegradedCondition(cond *operatorv1.OperatorCondition) string {
 // PacemakerHealthCheckDegraded=True with a message containing expectedSubstring.
 // Pass an empty expectedSubstring to accept any message.
 func WaitForPacemakerHealthCheckDegraded(oc *exutil.CLI, expectedSubstring string, timeout time.Duration) error {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(healthCheckPollInterval)
-	defer ticker.Stop()
-
 	var lastErr string
-	for {
-		select {
-		case <-deadline:
-			dumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckDegraded timeout")
-			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded=True (last: %s)", timeout, lastErr)
-		case <-ticker.C:
-			etcd, err := getEtcdOperator(oc)
-			if err != nil {
-				lastErr = fmt.Sprintf("get etcd operator: %v", err)
-				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
-				continue
-			}
-
-			cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
-			if cond == nil {
-				lastErr = "condition not found"
-				framework.Logf("WaitForPacemakerHealthCheckDegraded: condition not yet present on etcd operator")
-				continue
-			}
-
-			if cond.Status != operatorv1.ConditionTrue {
-				lastErr = describeNotDegradedCondition(cond)
-				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
-				continue
-			}
-
-			if expectedSubstring != "" && !strings.Contains(cond.Message, expectedSubstring) {
-				lastErr = fmt.Sprintf("True but message %q does not contain %q", cond.Message, expectedSubstring)
-				framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
-				continue
-			}
-
-			framework.Logf("PacemakerHealthCheckDegraded=True confirmed (reason=%s, message=%q)", cond.Reason, cond.Message)
-			return nil
+	checker := func() (bool, error) {
+		etcd, err := getEtcdOperator(oc)
+		if err != nil {
+			lastErr = fmt.Sprintf("get etcd operator: %v", err)
+			framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+			return false, nil
 		}
+
+		cond := v1helpers.FindOperatorCondition(etcd.Status.Conditions, PacemakerHealthCheckDegradedCondition)
+		if cond == nil {
+			lastErr = "condition not found"
+			framework.Logf("WaitForPacemakerHealthCheckDegraded: condition not yet present on etcd operator")
+			return false, nil
+		}
+
+		if cond.Status != operatorv1.ConditionTrue {
+			lastErr = describeNotDegradedCondition(cond)
+			framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+			return false, nil
+		}
+
+		if expectedSubstring != "" && !strings.Contains(cond.Message, expectedSubstring) {
+			lastErr = fmt.Sprintf("True but message %q does not contain %q", cond.Message, expectedSubstring)
+			framework.Logf("WaitForPacemakerHealthCheckDegraded: %s", lastErr)
+			return false, nil
+		}
+
+		framework.Logf("PacemakerHealthCheckDegraded=True confirmed (reason=%s, message=%q)", cond.Reason, cond.Message)
+		return true, nil
 	}
+
+	if err := core.PollUntil(checker, timeout, healthCheckPollInterval, "PacemakerHealthCheckDegraded=True"); err != nil {
+		DumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckDegraded timeout")
+		return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded=True (last: %s)", timeout, lastErr)
+	}
+	return nil
 }
 
 // WaitForPacemakerHealthCheckCleared polls the etcd operator resource until
-// PacemakerHealthCheckDegraded=False or the condition is absent.
+// PacemakerHealthCheckDegraded=False. An absent condition is not treated as
+// cleared: clearPacemakerDegradedCondition in cluster-etcd-operator always
+// writes an explicit False on the controller's first healthy sync, so an
+// absent condition means the health check controller never ran at all.
 func WaitForPacemakerHealthCheckCleared(oc *exutil.CLI, timeout time.Duration) error {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(healthCheckPollInterval)
-	defer ticker.Stop()
-
 	var lastErr string
-	for {
-		select {
-		case <-deadline:
-			dumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckCleared timeout")
-			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded to clear (last: %s)", timeout, lastErr)
-		case <-ticker.C:
-			etcd, err := getEtcdOperator(oc)
-			if err != nil {
-				lastErr = fmt.Sprintf("get etcd operator: %v", err)
-				framework.Logf("WaitForPacemakerHealthCheckCleared: %s", lastErr)
-				continue
-			}
-
-			cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
-			if cond == nil {
-				framework.Logf("PacemakerHealthCheckDegraded condition absent — treating as cleared")
-				return nil
-			}
-
-			if cond.Status == operatorv1.ConditionFalse {
-				framework.Logf("PacemakerHealthCheckDegraded=False confirmed")
-				return nil
-			}
-
-			lastErr = fmt.Sprintf("Status=%s reason=%s message=%q", cond.Status, cond.Reason, cond.Message)
-			framework.Logf("WaitForPacemakerHealthCheckCleared: still degraded — %s", lastErr)
+	checker := func() (bool, error) {
+		etcd, err := getEtcdOperator(oc)
+		if err != nil {
+			lastErr = fmt.Sprintf("get etcd operator: %v", err)
+			framework.Logf("WaitForPacemakerHealthCheckCleared: %s", lastErr)
+			return false, nil
 		}
+
+		cond := v1helpers.FindOperatorCondition(etcd.Status.Conditions, PacemakerHealthCheckDegradedCondition)
+		if cond == nil {
+			lastErr = "condition not yet present on etcd operator"
+			framework.Logf("WaitForPacemakerHealthCheckCleared: %s", lastErr)
+			return false, nil
+		}
+
+		if cond.Status == operatorv1.ConditionFalse {
+			framework.Logf("PacemakerHealthCheckDegraded=False confirmed")
+			return true, nil
+		}
+
+		lastErr = fmt.Sprintf("Status=%s reason=%s message=%q", cond.Status, cond.Reason, cond.Message)
+		framework.Logf("WaitForPacemakerHealthCheckCleared: still degraded — %s", lastErr)
+		return false, nil
 	}
+
+	if err := core.PollUntil(checker, timeout, healthCheckPollInterval, "PacemakerHealthCheckDegraded=False"); err != nil {
+		DumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckCleared timeout")
+		return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded to clear (last: %s)", timeout, lastErr)
+	}
+	return nil
 }
 
-// pacemakerHealthCheckEventNamespace is where the healthcheck controller's
+// PacemakerHealthCheckEventNamespace is where the healthcheck controller's
 // library-go event recorder writes events — the operator's own pod namespace
 // (openshift-etcd-operator), not the target namespace (openshift-etcd) that
-// the status collector uses for its own PacemakerFailedResourceAction /
-// PacemakerStatusCollectionError events.
-const pacemakerHealthCheckEventNamespace = "openshift-etcd-operator"
+// the status collector uses for its own events (e.g. PacemakerFencingEvent,
+// PacemakerFailedResourceAction, PacemakerStatusCollectionError).
+const PacemakerHealthCheckEventNamespace = "openshift-etcd-operator"
 
 // eventTime returns the most recent activity timestamp for an event, preferring
 // EventTime, then LastTimestamp, then the object's creation timestamp. This is
@@ -240,43 +241,42 @@ func eventTime(ev *corev1.Event) time.Time {
 	return ev.CreationTimestamp.Time
 }
 
-// WaitForPacemakerEvent polls events in the openshift-etcd-operator namespace
-// until one with the given Reason emitted at or after the provided lower bound
-// (since) appears. This applies to healthcheck-controller reasons (e.g.
-// PacemakerHealthy, PacemakerClusterInMaintenance, PacemakerNodeOffline). The
+// WaitForPacemakerEvent polls events in the given namespace until one with
+// the given Reason emitted at or after the provided lower bound (since)
+// appears. Use PacemakerHealthCheckEventNamespace for healthcheck-controller
+// reasons (e.g. PacemakerHealthy, PacemakerClusterInMaintenance,
+// PacemakerNodeOffline); use the status collector's target namespace
+// (openshift-etcd) for reasons it emits (e.g. PacemakerFencingEvent). The
 // since bound prevents a stale event from a prior reconcile or test from
 // satisfying the wait.
-func WaitForPacemakerEvent(oc *exutil.CLI, reason string, since time.Time, timeout time.Duration) error {
-	deadline := time.After(timeout)
-	ticker := time.NewTicker(healthCheckPollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-deadline:
-			return fmt.Errorf("timed out after %v waiting for event with reason %q emitted at or after %s in %s",
-				timeout, reason, since.Format(time.RFC3339), pacemakerHealthCheckEventNamespace)
-		case <-ticker.C:
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			events, err := oc.AdminKubeClient().CoreV1().Events(pacemakerHealthCheckEventNamespace).List(ctx, metav1.ListOptions{
-				FieldSelector: fmt.Sprintf("reason=%s", reason),
-			})
-			cancel()
-			if err != nil {
-				framework.Logf("WaitForPacemakerEvent: list events: %v", err)
+func WaitForPacemakerEvent(oc *exutil.CLI, namespace, reason string, since time.Time, timeout time.Duration) error {
+	checker := func() (bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		events, err := oc.AdminKubeClient().CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("reason=%s", reason),
+		})
+		cancel()
+		if err != nil {
+			framework.Logf("WaitForPacemakerEvent: list events: %v", err)
+			return false, nil
+		}
+		for i := range events.Items {
+			ev := &events.Items[i]
+			if eventTime(ev).Before(since) {
 				continue
 			}
-			for i := range events.Items {
-				ev := &events.Items[i]
-				if eventTime(ev).Before(since) {
-					continue
-				}
-				framework.Logf("Found event reason=%s message=%q at %s (baseline %s)",
-					ev.Reason, ev.Message, eventTime(ev).Format(time.RFC3339), since.Format(time.RFC3339))
-				return nil
-			}
+			framework.Logf("Found event reason=%s message=%q at %s (baseline %s)",
+				ev.Reason, ev.Message, eventTime(ev).Format(time.RFC3339), since.Format(time.RFC3339))
+			return true, nil
 		}
+		return false, nil
 	}
+
+	if err := core.PollUntil(checker, timeout, healthCheckPollInterval, fmt.Sprintf("event with reason %q in %s", reason, namespace)); err != nil {
+		return fmt.Errorf("timed out after %v waiting for event with reason %q emitted at or after %s in %s",
+			timeout, reason, since.Format(time.RFC3339), namespace)
+	}
+	return nil
 }
 
 // IsPacemakerHealthCheckDegraded performs a single check of the etcd operator
@@ -291,7 +291,7 @@ func IsPacemakerHealthCheckDegraded(oc *exutil.CLI) (bool, string, error) {
 		return false, "", fmt.Errorf("get etcd operator: %w", err)
 	}
 
-	cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+	cond := v1helpers.FindOperatorCondition(etcd.Status.Conditions, PacemakerHealthCheckDegradedCondition)
 	if cond == nil {
 		return false, "", nil
 	}
@@ -307,7 +307,7 @@ func ExpectPacemakerHealthCheckNotDegraded(oc *exutil.CLI) error {
 		return fmt.Errorf("get etcd operator: %w", err)
 	}
 
-	cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+	cond := v1helpers.FindOperatorCondition(etcd.Status.Conditions, PacemakerHealthCheckDegradedCondition)
 	if cond == nil {
 		return nil
 	}

--- a/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
@@ -188,6 +188,26 @@ func WaitForPacemakerEvent(oc *exutil.CLI, reason string, since time.Time, timeo
 	}
 }
 
+// IsPacemakerHealthCheckDegraded performs a single check of the etcd operator
+// resource and reports whether PacemakerHealthCheckDegraded is currently True,
+// along with the condition message. A missing condition is reported as not
+// degraded. Unlike WaitForPacemakerHealthCheckDegraded, this does not poll, so
+// callers can interleave it with other actions (e.g. re-inducing a failure that
+// Pacemaker would otherwise auto-recover before the next status snapshot).
+func IsPacemakerHealthCheckDegraded(oc *exutil.CLI) (bool, string, error) {
+	etcd, err := getEtcdOperator(oc)
+	if err != nil {
+		return false, "", fmt.Errorf("get etcd operator: %w", err)
+	}
+
+	cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition)
+	if cond == nil {
+		return false, "", nil
+	}
+
+	return cond.Status == operatorv1.ConditionTrue, cond.Message, nil
+}
+
 // ExpectPacemakerHealthCheckNotDegraded checks the etcd operator resource
 // and returns an error if PacemakerHealthCheckDegraded is True.
 func ExpectPacemakerHealthCheckNotDegraded(oc *exutil.CLI) error {

--- a/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
@@ -17,6 +17,14 @@ const (
 	PacemakerHealthCheckDegradedCondition = "PacemakerHealthCheckDegraded"
 
 	healthCheckPollInterval = 10 * time.Second
+
+	// pacemakerTargetNamespace is where the status-collector CronJob and the
+	// PacemakerCluster data pipeline run.
+	pacemakerTargetNamespace = "openshift-etcd"
+
+	// statusCollectorCronJobName is the CronJob that snapshots pacemaker status
+	// into the PacemakerCluster CR (see cluster-etcd-operator).
+	statusCollectorCronJobName = "pacemaker-status-collector"
 )
 
 func getEtcdOperator(oc *exutil.CLI) (*operatorv1.Etcd, error) {
@@ -32,6 +40,87 @@ func findOperatorCondition(etcd *operatorv1.Etcd, condType string) *operatorv1.O
 		}
 	}
 	return nil
+}
+
+// dumpHealthCheckDiagnostics logs the state most useful for triaging why a
+// PacemakerHealthCheckDegraded transition did not happen within the timeout: the
+// etcd operator condition, the PacemakerCluster CR staleness and conditions, the
+// status-collector CronJob's last run, and node readiness. Together these show
+// whether the data pipeline was flowing (CR fresh, CronJob running, nodes Ready)
+// or broken. Every step is best-effort — this runs on an already-failing path and
+// must never itself fail or panic.
+func dumpHealthCheckDiagnostics(oc *exutil.CLI, reason string) {
+	framework.Logf("========== PACEMAKER HEALTHCHECK DIAGNOSTICS (%s) ==========", reason)
+
+	// 1. etcd operator PacemakerHealthCheckDegraded condition
+	if etcd, err := getEtcdOperator(oc); err != nil {
+		framework.Logf("diagnostics: get etcd operator: %v", err)
+	} else if cond := findOperatorCondition(etcd, PacemakerHealthCheckDegradedCondition); cond == nil {
+		framework.Logf("diagnostics: etcd operator %s condition absent", PacemakerHealthCheckDegradedCondition)
+	} else {
+		framework.Logf("diagnostics: etcd operator %s: Status=%s reason=%s message=%q lastTransition=%s",
+			PacemakerHealthCheckDegradedCondition, cond.Status, cond.Reason, cond.Message,
+			cond.LastTransitionTime.Format(time.RFC3339))
+	}
+
+	// 2. PacemakerCluster CR staleness and conditions
+	if pc, err := GetPacemakerCluster(oc); err != nil {
+		framework.Logf("diagnostics: get PacemakerCluster CR: %v", err)
+	} else {
+		lastUpdated := pc.Status.LastUpdated.Time
+		if lastUpdated.IsZero() {
+			framework.Logf("diagnostics: PacemakerCluster CR lastUpdated is zero (status never populated)")
+		} else {
+			framework.Logf("diagnostics: PacemakerCluster CR lastUpdated=%s (age %v)",
+				lastUpdated.Format(time.RFC3339), time.Since(lastUpdated).Round(time.Second))
+		}
+		for i := range pc.Status.Conditions {
+			c := &pc.Status.Conditions[i]
+			framework.Logf("diagnostics: PacemakerCluster condition %s=%s reason=%s message=%q",
+				c.Type, c.Status, c.Reason, c.Message)
+		}
+	}
+
+	// 3. status-collector CronJob last run
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	cronJob, err := oc.AdminKubeClient().BatchV1().CronJobs(pacemakerTargetNamespace).Get(ctx, statusCollectorCronJobName, metav1.GetOptions{})
+	cancel()
+	if err != nil {
+		framework.Logf("diagnostics: get CronJob %s/%s: %v", pacemakerTargetNamespace, statusCollectorCronJobName, err)
+	} else {
+		lastSchedule := "never"
+		if cronJob.Status.LastScheduleTime != nil {
+			lastSchedule = cronJob.Status.LastScheduleTime.Format(time.RFC3339)
+		}
+		lastSuccess := "never"
+		if cronJob.Status.LastSuccessfulTime != nil {
+			lastSuccess = cronJob.Status.LastSuccessfulTime.Format(time.RFC3339)
+		}
+		framework.Logf("diagnostics: CronJob %s lastSchedule=%s lastSuccessful=%s activeJobs=%d",
+			statusCollectorCronJobName, lastSchedule, lastSuccess, len(cronJob.Status.Active))
+	}
+
+	// 4. Node readiness
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	nodes, err := oc.AdminKubeClient().CoreV1().Nodes().List(ctx2, metav1.ListOptions{})
+	cancel2()
+	if err != nil {
+		framework.Logf("diagnostics: list nodes: %v", err)
+	} else {
+		for i := range nodes.Items {
+			n := &nodes.Items[i]
+			ready := "Unknown"
+			for _, c := range n.Status.Conditions {
+				if c.Type == corev1.NodeReady {
+					ready = string(c.Status)
+					break
+				}
+			}
+			framework.Logf("diagnostics: node %s Ready=%s", n.Name, ready)
+		}
+	}
+
+	framework.Logf("========== END PACEMAKER HEALTHCHECK DIAGNOSTICS ==========")
 }
 
 // describeNotDegradedCondition formats a not-yet-True PacemakerHealthCheckDegraded
@@ -57,6 +146,7 @@ func WaitForPacemakerHealthCheckDegraded(oc *exutil.CLI, expectedSubstring strin
 	for {
 		select {
 		case <-deadline:
+			dumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckDegraded timeout")
 			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded=True (last: %s)", timeout, lastErr)
 		case <-ticker.C:
 			etcd, err := getEtcdOperator(oc)
@@ -102,6 +192,7 @@ func WaitForPacemakerHealthCheckCleared(oc *exutil.CLI, timeout time.Duration) e
 	for {
 		select {
 		case <-deadline:
+			dumpHealthCheckDiagnostics(oc, "WaitForPacemakerHealthCheckCleared timeout")
 			return fmt.Errorf("timed out after %v waiting for PacemakerHealthCheckDegraded to clear (last: %s)", timeout, lastErr)
 		case <-ticker.C:
 			etcd, err := getEtcdOperator(oc)

--- a/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
+++ b/test/extended/edge_topologies/utils/apis/pacemakerhealthcheck.go
@@ -8,6 +8,7 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -134,10 +135,27 @@ func WaitForPacemakerHealthCheckCleared(oc *exutil.CLI, timeout time.Duration) e
 // PacemakerStatusCollectionError events.
 const pacemakerHealthCheckEventNamespace = "openshift-etcd-operator"
 
+// eventTime returns the most recent activity timestamp for an event, preferring
+// EventTime, then LastTimestamp, then the object's creation timestamp. This is
+// used to distinguish freshly-emitted events from stale ones left over from an
+// earlier reconcile or a previous test run.
+func eventTime(ev *corev1.Event) time.Time {
+	if !ev.EventTime.IsZero() {
+		return ev.EventTime.Time
+	}
+	if !ev.LastTimestamp.IsZero() {
+		return ev.LastTimestamp.Time
+	}
+	return ev.CreationTimestamp.Time
+}
+
 // WaitForPacemakerEvent polls events in the openshift-etcd-operator namespace
-// until one with the given Reason appears. This applies to healthcheck-controller
-// reasons (e.g. PacemakerHealthy, PacemakerClusterInMaintenance, PacemakerNodeOffline).
-func WaitForPacemakerEvent(oc *exutil.CLI, reason string, timeout time.Duration) error {
+// until one with the given Reason emitted at or after the provided lower bound
+// (since) appears. This applies to healthcheck-controller reasons (e.g.
+// PacemakerHealthy, PacemakerClusterInMaintenance, PacemakerNodeOffline). The
+// since bound prevents a stale event from a prior reconcile or test from
+// satisfying the wait.
+func WaitForPacemakerEvent(oc *exutil.CLI, reason string, since time.Time, timeout time.Duration) error {
 	deadline := time.After(timeout)
 	ticker := time.NewTicker(healthCheckPollInterval)
 	defer ticker.Stop()
@@ -145,7 +163,8 @@ func WaitForPacemakerEvent(oc *exutil.CLI, reason string, timeout time.Duration)
 	for {
 		select {
 		case <-deadline:
-			return fmt.Errorf("timed out after %v waiting for event with reason %q in %s", timeout, reason, pacemakerHealthCheckEventNamespace)
+			return fmt.Errorf("timed out after %v waiting for event with reason %q emitted at or after %s in %s",
+				timeout, reason, since.Format(time.RFC3339), pacemakerHealthCheckEventNamespace)
 		case <-ticker.C:
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			events, err := oc.AdminKubeClient().CoreV1().Events(pacemakerHealthCheckEventNamespace).List(ctx, metav1.ListOptions{
@@ -156,9 +175,13 @@ func WaitForPacemakerEvent(oc *exutil.CLI, reason string, timeout time.Duration)
 				framework.Logf("WaitForPacemakerEvent: list events: %v", err)
 				continue
 			}
-			if len(events.Items) > 0 {
-				latest := events.Items[len(events.Items)-1]
-				framework.Logf("Found event reason=%s message=%q", latest.Reason, latest.Message)
+			for i := range events.Items {
+				ev := &events.Items[i]
+				if eventTime(ev).Before(since) {
+					continue
+				}
+				framework.Logf("Found event reason=%s message=%q at %s (baseline %s)",
+					ev.Reason, ev.Message, eventTime(ev).Format(time.RFC3339), since.Format(time.RFC3339))
 				return nil
 			}
 		}

--- a/test/extended/edge_topologies/utils/common.go
+++ b/test/extended/edge_topologies/utils/common.go
@@ -16,6 +16,7 @@ import (
 	o "github.com/onsi/gomega"
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/origin/pkg/test/preconditions"
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/apis"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/services"
 	"github.com/openshift/origin/test/extended/etcd/helpers"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -48,6 +49,12 @@ const (
 	// Precondition timeouts for SkipIfClusterIsNotHealthy (exported for stage-timing logs in disruptive tests).
 	PreconditionClusterHealthyTimeout = 10 * time.Minute // nodes + cluster operators
 	PreconditionEtcdHealthyTimeout    = 1 * time.Minute  // etcd pods running, two voting members
+
+	// pacemakerCRMaxStaleness is how old the PacemakerCluster CR's LastUpdated
+	// may be before SkipIfClusterIsNotHealthy treats the status-collector
+	// pipeline as stalled and skips rather than let the test run against a gate
+	// that isn't watching PacemakerHealthCheck state.
+	pacemakerCRMaxStaleness = 2 * time.Minute
 
 	// Max time for a single debug pod exec.
 	debugContainerTimeout = 60 * time.Second
@@ -185,6 +192,23 @@ func SkipIfClusterIsNotHealthy(oc *exutil.CLI, ecf *helpers.EtcdClientFactoryImp
 	}
 	if err := ensureClusterOperatorHealthy(oc, PreconditionClusterHealthyTimeout); err != nil {
 		skipReasons = append(skipReasons, fmt.Sprintf("cluster-etcd-operator not healthy: %v", err))
+	}
+	// Light PacemakerHealthCheck gate: if the health check pipeline is already
+	// degraded or the CR is stale before the test starts, skip rather than let
+	// a PacemakerHealthCheck test run against a broken baseline and produce a
+	// confusing failure. This does not validate the pipeline's accuracy — that
+	// is the job of the dedicated PacemakerHealthCheck/fencing-credentials tests.
+	if pcAvailable, availErr := apis.IsPacemakerClusterAvailable(oc); availErr != nil {
+		skipReasons = append(skipReasons, fmt.Sprintf("failed to check PacemakerCluster CRD availability: %v", availErr))
+	} else if pcAvailable {
+		if err := apis.ExpectPacemakerHealthCheckNotDegraded(oc); err != nil {
+			skipReasons = append(skipReasons, fmt.Sprintf("PacemakerHealthCheckDegraded already set: %v", err))
+		}
+		if pc, err := apis.GetPacemakerCluster(oc); err != nil {
+			skipReasons = append(skipReasons, fmt.Sprintf("failed to get PacemakerCluster CR: %v", err))
+		} else if err := apis.ExpectPacemakerCRFresh(pc, pacemakerCRMaxStaleness); err != nil {
+			skipReasons = append(skipReasons, fmt.Sprintf("PacemakerCluster CR stale: %v", err))
+		}
 	}
 
 	if len(skipReasons) > 0 {

--- a/test/extended/edge_topologies/utils/services/pacemaker.go
+++ b/test/extended/edge_topologies/utils/services/pacemaker.go
@@ -391,6 +391,131 @@ func PcsEnableResourceViaDebug(oc *exutil.CLI, nodeName string, resourceName str
 	return nil
 }
 
+// PcsPropertySetViaDebug sets a pacemaker cluster property via debug container.
+//
+//	err := PcsPropertySetViaDebug(oc, "master-0", "maintenance-mode", "true")
+func PcsPropertySetViaDebug(oc *exutil.CLI, nodeName, property, value string) error {
+	cmd := fmt.Sprintf("sudo pcs property set %s=%s", property, value)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, nodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to set property %s=%s: %w, output: %s", property, value, err, output)
+	}
+	return nil
+}
+
+// PcsPropertySetBestEffortViaDebug is the best-effort cleanup variant of
+// PcsPropertySetViaDebug: failures are logged, not returned.
+//
+//	PcsPropertySetBestEffortViaDebug(oc, "master-0", "maintenance-mode", "false")
+func PcsPropertySetBestEffortViaDebug(oc *exutil.CLI, nodeName, property, value string) {
+	cmd := fmt.Sprintf("sudo pcs property set %s=%s 2>/dev/null; true", property, value)
+	if _, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, nodeName, "default", "bash", "-c", cmd); err != nil {
+		e2e.Logf("Warning: failed to set property %s=%s on %s: %v", property, value, nodeName, err)
+	}
+}
+
+// PcsClusterStopViaDebug stops the pacemaker cluster on targetNodeName, executed from
+// execNodeName via debug container.
+//
+//	err := PcsClusterStopViaDebug(oc, "master-0", "master-1")
+func PcsClusterStopViaDebug(oc *exutil.CLI, execNodeName, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs cluster stop %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to stop pacemaker cluster on %s: %w, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsClusterStartViaDebug starts the pacemaker cluster on targetNodeName, executed from
+// execNodeName via debug container.
+//
+//	err := PcsClusterStartViaDebug(oc, "master-0", "master-1")
+func PcsClusterStartViaDebug(oc *exutil.CLI, execNodeName, targetNodeName string) error {
+	cmd := fmt.Sprintf("sudo pcs cluster start %s", targetNodeName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to start pacemaker cluster on %s: %w, output: %s", targetNodeName, err, output)
+	}
+	return nil
+}
+
+// PcsClusterStartBestEffortViaDebug is the best-effort cleanup variant of
+// PcsClusterStartViaDebug: failures are logged, not returned.
+//
+//	PcsClusterStartBestEffortViaDebug(oc, "master-0", "master-1")
+func PcsClusterStartBestEffortViaDebug(oc *exutil.CLI, execNodeName, targetNodeName string) {
+	cmd := fmt.Sprintf("sudo pcs cluster start %s 2>/dev/null; true", targetNodeName)
+	if _, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd); err != nil {
+		e2e.Logf("Warning: failed to restart pacemaker cluster on %s: %v", targetNodeName, err)
+	}
+}
+
+// PcsStonithResourceDisableViaDebug disables a specific STONITH resource, executed from
+// execNodeName via debug container. This is distinct from PcsStonithDisable, which sets
+// the cluster-wide stonith-enabled property; pcs rejects `pcs resource disable` for
+// STONITH resources; `pcs stonith disable` must be used instead.
+//
+//	err := PcsStonithResourceDisableViaDebug(oc, "master-0", "master-1_redfish")
+func PcsStonithResourceDisableViaDebug(oc *exutil.CLI, execNodeName, resourceName string) error {
+	cmd := fmt.Sprintf("sudo pcs stonith disable %s", resourceName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to disable stonith resource %s: %w, output: %s", resourceName, err, output)
+	}
+	return nil
+}
+
+// PcsStonithResourceEnableViaDebug enables a specific STONITH resource. See
+// PcsStonithResourceDisableViaDebug for why `pcs stonith enable` is used instead of
+// `pcs resource enable`.
+//
+//	err := PcsStonithResourceEnableViaDebug(oc, "master-0", "master-1_redfish")
+func PcsStonithResourceEnableViaDebug(oc *exutil.CLI, execNodeName, resourceName string) error {
+	cmd := fmt.Sprintf("sudo pcs stonith enable %s", resourceName)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to enable stonith resource %s: %w, output: %s", resourceName, err, output)
+	}
+	return nil
+}
+
+// PcsStonithResourceEnableBestEffortViaDebug is the best-effort cleanup variant of
+// PcsStonithResourceEnableViaDebug: failures are logged, not returned.
+//
+//	PcsStonithResourceEnableBestEffortViaDebug(oc, "master-0", "master-1_redfish")
+func PcsStonithResourceEnableBestEffortViaDebug(oc *exutil.CLI, execNodeName, resourceName string) {
+	cmd := fmt.Sprintf("sudo pcs stonith enable %s 2>/dev/null; true", resourceName)
+	if _, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd); err != nil {
+		e2e.Logf("Warning: failed to re-enable stonith resource %s: %v", resourceName, err)
+	}
+}
+
+// PcsStonithSetManagedViaDebug sets whether a STONITH resource is managed by pacemaker
+// (`pcs stonith meta <resource> is-managed=<bool>`), executed from execNodeName via
+// debug container.
+//
+//	err := PcsStonithSetManagedViaDebug(oc, "master-0", "master-1_redfish", false)
+func PcsStonithSetManagedViaDebug(oc *exutil.CLI, execNodeName, resourceName string, managed bool) error {
+	cmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=%t", resourceName, managed)
+	output, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd)
+	if err != nil {
+		return fmt.Errorf("failed to set is-managed=%t for stonith resource %s: %w, output: %s", managed, resourceName, err, output)
+	}
+	return nil
+}
+
+// PcsStonithSetManagedBestEffortViaDebug is the best-effort cleanup variant of
+// PcsStonithSetManagedViaDebug: failures are logged, not returned.
+//
+//	PcsStonithSetManagedBestEffortViaDebug(oc, "master-0", "master-1_redfish", true)
+func PcsStonithSetManagedBestEffortViaDebug(oc *exutil.CLI, execNodeName, resourceName string, managed bool) {
+	cmd := fmt.Sprintf("sudo pcs stonith meta %s is-managed=%t 2>/dev/null; true", resourceName, managed)
+	if _, err := exutil.DebugNodeRetryWithOptionsAndChroot(oc, execNodeName, "default", "bash", "-c", cmd); err != nil {
+		e2e.Logf("Warning: failed to restore is-managed=%t for stonith resource %s: %v", managed, resourceName, err)
+	}
+}
+
 // CrmQueryAttributeViaDebug queries a CRM cluster attribute via debug container.
 //
 //	output, err := CrmQueryAttributeViaDebug(oc, "master-0", "learner_node")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Pacemaker health monitoring for degraded and recovered cluster states.
  * Added validation for fencing health and availability, node membership, cluster health, node counts, and current events.
* **Tests**
  * Expanded disruption coverage for etcd, kubelet, node replacement, maintenance mode, shutdown, fencing, and recovery scenarios.
  * Improved diagnostics and recovery verification when health checks or fencing operations fail.
  * Extended fencing-taint test coverage to support earlier cluster versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->