### PR TITLE
OCPBUGS-112662: Fix the number of requests in repeated exec

### DIFF
--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -290,8 +290,8 @@ func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, status
 
 	cmd := fmt.Sprintf(`
 		set -e
-		STOP=$(($(date '+%%s') + %d))
-		while [ $(date '+%%s') -lt $STOP ]; do
+		cnt=0
+		while [ $cnt -lt %d ]; do
 			rc=0
 			code=$( curl %s -s -m 5 -o /dev/null -w '%%{http_code}\n' --header 'Host: %s' %q ) || rc=$?
 			if [[ "${rc:-0}" -eq 0 ]]; then
@@ -302,6 +302,8 @@ func expectRouteStatusCodeRepeatedExec(ns, execPodName, url, host string, status
 			else
 				echo "error ${rc}" 1>&2
 			fi
+			sleep 0.5
+			cnt=$((cnt+1))
 		done
 		`, times, args, host, url, statusCode)
 	output, err := e2eoutput.RunHostCmd(ns, execPodName, cmd)


### PR DESCRIPTION
`expectRouteStatusCodeRepeatedExec` treated `times` as a deadline in seconds, not a request count. The loop ran curl back-to-back for `times` seconds with no delay between requests — a tight loop. So callers actually fired an unbounded, load-dependent number of requests in 100 seconds - far more than 100 reqs, and hammering the router unnecessarily fast.

Fix:

* Replaced the time-based loop with a counter that increments once per iteration, so the loop runs exactly `times` times - matching what every caller's variable name and comments already implied.
* Added `sleep 0.5` between iterations so requests are paced instead of fired in a tight loop.

Net effect: times now means what it says (number of requests), and the requests are spaced out rather than bursted.

https://redhat.atlassian.net/browse/OCPBUGS-112662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated route status polling tests to use a fixed number of attempts with consistent half-second intervals.
  * Improved test execution predictability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->