### PR TITLE
OCPBUGS-57177: Update PIS test to validate a MachineConfigPool degrades on a PinnedImageSet degrade

### DIFF
--- a/test/extended/imagepolicy/imagepolicy.go
+++ b/test/extended/imagepolicy/imagepolicy.go
@@ -131,11 +131,9 @@ var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Di
 
 		err = waitForTestPodContainerToFailSignatureValidation(tctx, imgpolicyClif, pod)
 		o.Expect(err).NotTo(o.HaveOccurred())
-
 	})
 
 	g.It("Should pass imagepolicy signature validation with signed image in namespaces", func() {
-
 		createImagePolicy(oc, testImagePolicies[publiKeyRekorImagePolicyName], imgpolicyClif.Namespace.Name)
 		g.DeferCleanup(deleteImagePolicy, oc, publiKeyRekorImagePolicyName, imgpolicyClif.Namespace.Name)
 
@@ -185,7 +183,6 @@ var _ = g.Describe("[sig-imagepolicy][Suite:openshift/disruptive-longrunning][Di
 		g.Entry("fail with PKI root of trust does not match the identity in the signature", invalidPKIImagePolicyName, false, testPKISignedPolicyScope, verifyPodSignature),
 		g.Entry("pass with valid PKI", pkiImagePolicyName, true, testPKISignedPolicyScope, verifyPodSignature),
 	)
-
 })
 
 func updateImageConfig(oc *exutil.CLI, allowedRegistries []string) {
@@ -691,7 +688,7 @@ func WaitForMCPConfigSpecChangeAndUpdated(oc *exutil.CLI, pool string, initialSp
 		if mcp.Spec.Configuration.Name != mcp.Status.Configuration.Name {
 			return false
 		}
-		return machineconfighelper.IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated)
+		return machineconfighelper.IsMachineConfigPoolConditionExpected(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, kapiv1.ConditionTrue)
 	}, 15*time.Minute, 10*time.Second).Should(o.BeTrue())
 }
 
@@ -712,11 +709,11 @@ func WaitForMCPsConfigSpecChangeAndUpdated(oc *exutil.CLI, workerInitialSpec, ma
 
 		workerReady := workerMCP.Status.Configuration.Name != workerInitialSpec &&
 			workerMCP.Spec.Configuration.Name == workerMCP.Status.Configuration.Name &&
-			machineconfighelper.IsMachineConfigPoolConditionTrue(workerMCP.Status.Conditions, mcfgv1.MachineConfigPoolUpdated)
+			machineconfighelper.IsMachineConfigPoolConditionExpected(workerMCP.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, kapiv1.ConditionTrue)
 
 		masterReady := masterMCP.Status.Configuration.Name != masterInitialSpec &&
 			masterMCP.Spec.Configuration.Name == masterMCP.Status.Configuration.Name &&
-			machineconfighelper.IsMachineConfigPoolConditionTrue(masterMCP.Status.Conditions, mcfgv1.MachineConfigPoolUpdated)
+			machineconfighelper.IsMachineConfigPoolConditionExpected(masterMCP.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, kapiv1.ConditionTrue)
 
 		if !workerReady {
 			e2e.Logf("Worker MCP not ready yet")

--- a/test/extended/machine_config/helpers.go
+++ b/test/extended/machine_config/helpers.go
@@ -187,11 +187,12 @@ func WaitForMachineConfigurationStatusUpdate(oc *exutil.CLI) {
 	}, 3*time.Minute, 1*time.Second).MustPassRepeatedly(3).Should(o.BeTrue())
 }
 
-// IsMachineConfigPoolConditionTrue returns true when the conditionType is present and set to `ConditionTrue`
-func IsMachineConfigPoolConditionTrue(conditions []mcfgv1.MachineConfigPoolCondition, conditionType mcfgv1.MachineConfigPoolConditionType) bool {
+// IsMachineConfigPoolConditionExpected returns true when the conditionType is present and set to
+// the expected conditionStatus
+func IsMachineConfigPoolConditionExpected(conditions []mcfgv1.MachineConfigPoolCondition, conditionType mcfgv1.MachineConfigPoolConditionType, conditionStatus corev1.ConditionStatus) bool {
 	for _, condition := range conditions {
 		if condition.Type == conditionType {
-			return condition.Status == corev1.ConditionTrue
+			return condition.Status == conditionStatus
 		}
 	}
 	return false
@@ -249,8 +250,8 @@ func WaitForOneMasterNodeToBeReady(oc *exutil.CLI) error {
 		}
 		// Check if the pool has atleast one updated node(mid-upgrade), or if the pool has completed the upgrade to the new config(the additional check for spec==status here is
 		// to ensure we are not checking an older "Updated" condition and the MCP fields haven't caught up yet
-		if (IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating) && mcp.Status.UpdatedMachineCount > 0) ||
-			(IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) && (mcp.Spec.Configuration.Name == mcp.Status.Configuration.Name)) {
+		if (IsMachineConfigPoolConditionExpected(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdating, corev1.ConditionTrue) && mcp.Status.UpdatedMachineCount > 0) ||
+			(IsMachineConfigPoolConditionExpected(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, corev1.ConditionTrue) && (mcp.Spec.Configuration.Name == mcp.Status.Configuration.Name)) {
 			return true
 		}
 		framework.Logf("Waiting for atleast one ready control-plane node")
@@ -431,7 +432,7 @@ func WaitForMCPToBeReady(oc *exutil.CLI, machineConfigClient *machineconfigclien
 			return false
 		}
 		// Check if the pool is in an updated state with the correct number of ready machines
-		if IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) && mcp.Status.UpdatedMachineCount == readyMachineCount {
+		if IsMachineConfigPoolConditionExpected(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, corev1.ConditionTrue) && mcp.Status.UpdatedMachineCount == readyMachineCount {
 			framework.Logf("MCP '%v' has the desired %v ready machines.", poolName, mcp.Status.UpdatedMachineCount)
 			return true
 		}
@@ -468,7 +469,6 @@ func CleanupCustomMCP(oc *exutil.CLI, clientSet *machineconfigclient.Clientset, 
 		deleteMCErr := oc.Run("delete").Args("machineconfig", *mcName).Execute()
 		if deleteMCErr != nil {
 			return fmt.Errorf("could delete MachineConfig '%v'; err: %v", mcName, deleteMCErr)
-
 		}
 	}
 
@@ -575,8 +575,8 @@ func WaitForMCPConditionStatus(oc *exutil.CLI, mcpName string, conditionType mcf
 // "Unknown," the function will also return true if the condition is "True," which ensures that we
 // do not fail when an update progresses quickly through the intermediary "Unknown" phase.
 func WaitForMCNConditionStatus(clientSet *machineconfigclient.Clientset, mcnName string, conditionType mcfgv1.StateProgress, status metav1.ConditionStatus,
-	timeout time.Duration, interval time.Duration) (bool, error) {
-
+	timeout time.Duration, interval time.Duration,
+) (bool, error) {
 	conditionMet := false
 	var conditionErr error
 	var workerNodeMCN *mcfgv1.MachineConfigNode
@@ -868,9 +868,9 @@ func WaitForMachineInState(machineClient *machineclient.Clientset, machineName s
 func GetNodeInMachine(oc *exutil.CLI, machineName string) (corev1.Node, error) {
 	// Get name of nodes associated with the desired machine
 	nodeNames, nodeNamesErr := oc.Run("get").Args("nodes", "-o", fmt.Sprintf(`jsonpath='{.items[?(@.metadata.annotations.machine\.openshift\.io/machine=="openshift-machine-api/%v")].metadata.name}'`, machineName)).Output()
-	if nodeNamesErr != nil { //error getting filtered node names
+	if nodeNamesErr != nil { // error getting filtered node names
 		return corev1.Node{}, nodeNamesErr
-	} else if nodeNames == "" { //error when no nodes are found
+	} else if nodeNames == "" { // error when no nodes are found
 		return corev1.Node{}, fmt.Errorf("no node is linked to Machine: %s", machineName)
 	}
 
@@ -878,12 +878,12 @@ func GetNodeInMachine(oc *exutil.CLI, machineName string) (corev1.Node, error) {
 	// Note: the format of `nodeNames` is the names of nodes seperated by a space (ex: "node-name-1 node-name-2"),
 	// so the number of nodes is equal to one more than the number of spaces
 	numberOfNodeNames := strings.Count(nodeNames, " ") + 1
-	if numberOfNodeNames > 1 { //error when a machine has more than one node
+	if numberOfNodeNames > 1 { // error when a machine has more than one node
 		return corev1.Node{}, fmt.Errorf("more than one node is linked to Machine: %s; number of nodes: %d", machineName, numberOfNodeNames)
 	}
 
 	node, nodeErr := oc.AsAdmin().KubeClient().CoreV1().Nodes().Get(context.TODO(), strings.ReplaceAll(nodeNames, "'", ""), metav1.GetOptions{})
-	if nodeErr != nil { //error getting filtered node names
+	if nodeErr != nil { // error getting filtered node names
 		return corev1.Node{}, nodeErr
 	}
 
@@ -1031,7 +1031,8 @@ func ScaleMachineSetDown(oc *exutil.CLI, machineSet machinev1beta1.MachineSet, d
 // `CleanupProvisionedMachine` scales down the replica count for a given MachineSet and checks whether the
 // provisioned Machine provided is deleted.
 func CleanupProvisionedMachine(oc *exutil.CLI, machineClient *machineclient.Clientset, machineSetName string, desiredReplicaValue int,
-	machineName string, cleanupCompleted bool) error {
+	machineName string, cleanupCompleted bool,
+) error {
 	// Skip when cleanup is not needed
 	if cleanupCompleted {
 		return nil
@@ -1182,10 +1183,12 @@ func execCmdOnNode(oc *exutil.CLI, node corev1.Node, subArgs ...string) (*exec.C
 	mcdName := mcd.ObjectMeta.Name
 
 	entryPoint := path
-	args := []string{"rsh",
+	args := []string{
+		"rsh",
 		"-n", "openshift-machine-config-operator",
 		"-c", "machine-config-daemon",
-		mcdName}
+		mcdName,
+	}
 	args = append(args, subArgs...)
 
 	cmd := exec.Command(entryPoint, args...)
@@ -1296,7 +1299,7 @@ func WaitForPoolComplete(oc *exutil.CLI, pool, target string) error {
 		if mcp.Status.Configuration.Name != target {
 			return false
 		}
-		if IsMachineConfigPoolConditionTrue(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated) {
+		if IsMachineConfigPoolConditionExpected(mcp.Status.Conditions, mcfgv1.MachineConfigPoolUpdated, corev1.ConditionTrue) {
 			return true
 		}
 		return false

--- a/test/extended/machine_config/pinnedimages.go
+++ b/test/extended/machine_config/pinnedimages.go
@@ -57,7 +57,7 @@ var _ = g.Describe("[Suite:openshift/machine-config-operator/disruptive][sig-mco
 	)
 
 	g.BeforeEach(func(ctx context.Context) {
-		//skip these tests on hypershift platforms
+		// skip these tests on hypershift platforms
 		if ok, _ := exutil.IsHypershift(ctx, oc.AdminConfigClient()); ok {
 			g.Skip("PinnedImages is not supported on hypershift. Skipping tests.")
 		}
@@ -464,10 +464,10 @@ func detectXCondition(oc *exutil.CLI, node corev1.Node, mcn *mcfgv1.MachineConfi
 //  3. Get the nodes part of the MCP from step 2
 //  4. Loop through the nodes to see if the desired conditions are met
 //     - If the PIS is expected to be invalid, it checks that the degrade condition in the
-//     corresponding MCN becomes "true"
+//     corresponding MCN becomes "true" and that the associated MCP degrades
 //     - If the PIS is expected to be valid, it checks that the desired images are pinned on the
 //     corresponding nodes and that the MCN conditions properly report the success
-func waitForPISStatusX(ctx context.Context, oc *exutil.CLI, kubeClient *kubernetes.Clientset, clientSet *mcClient.Clientset, pisName string, success bool, isMetalDisconnected bool) error {
+func waitForPISStatusX(ctx context.Context, oc *exutil.CLI, kubeClient *kubernetes.Clientset, clientSet *mcClient.Clientset, pisName string, success, isMetalDisconnected bool) error {
 	return wait.PollUntilContextCancel(ctx, time.Second, true, func(ctx context.Context) (done bool, err error) {
 		// Wait for PIS object to get created
 		appliedPIS, err := clientSet.MachineconfigurationV1().PinnedImageSets().Get(context.TODO(), pisName, metav1.GetOptions{})
@@ -493,11 +493,24 @@ func waitForPISStatusX(ctx context.Context, oc *exutil.CLI, kubeClient *kubernet
 		// Loop through nodes to see if the conditions required to consider the pis apply "done" are met
 		doneNodes := 0
 		for _, node := range nodes.Items {
-			if !success { // handle case when we are expecting the PIS application to fail, so the PIS degraded condition should become true
+			if !success { // handle case when we are expecting the PIS application to fail
+				// The `PinnedImageSetsDegraded` MachineConfigNode condition should be `True`
 				framework.Logf("Waiting for PinnedImageSetsDegraded=True")
 				conditionMet, err := WaitForMCNConditionStatus(clientSet, node.Name, mcfgv1.MachineConfigNodePinnedImageSetsDegraded, metav1.ConditionTrue, 2*time.Minute, 5*time.Second)
 				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for PinnedImageSetsDegraded=True: %v", err))
 				o.Expect(conditionMet).To(o.BeTrue(), "Error, could not detect PinnedImageSetsDegraded=True.")
+
+				// The associated MachineConfigPool should degrade
+				framework.Logf("Waiting for MCP `%v` to be Degraded=True", pool.Name)
+				err = WaitForMCPConditionStatus(oc, pool.Name, mcfgv1.MachineConfigPoolDegraded, corev1.ConditionTrue, 30*time.Second, 5*time.Second)
+				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error occured while waiting for MachineConfigPoolDegraded=True: %v", err))
+
+				// The associated MachineConfigPool should not be in an "Updating" state
+				framework.Logf("Ensuring MCP `%v` is in Updating=False", pool.Name)
+				pool, err = clientSet.MachineconfigurationV1().MachineConfigPools().Get(ctx, appliedPIS.Labels["machineconfiguration.openshift.io/role"], metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred(), fmt.Sprintf("Error getting MCP: %v", err))
+				isExpected := IsMachineConfigPoolConditionExpected(pool.Status.Conditions, mcfgv1.MachineConfigPoolUpdating, corev1.ConditionFalse)
+				o.Expect(isExpected).To(o.BeTrue(), fmt.Sprintf("MCP `%v` does not have condition Updating=False", pool.Name))
 			} else { // handle cases where we are expecting the PIS application to succeed
 				mcn, err := clientSet.MachineconfigurationV1().MachineConfigNodes().Get(ctx, node.Name, metav1.GetOptions{})
 				if err != nil {


### PR DESCRIPTION
Note that this should not merge until after https://github.com/openshift/machine-config-operator/pull/6443

This updates the PinnedImages tests for invalid PIS applications to ensure that the corresponding `PinnedImageSetsDegraded` MCN condition becomes True and that the node's associated MCP degrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of invalid pinned image configurations by confirming the targeted pool reports a degraded state and is no longer updating.
  * Preserved existing skip behavior for applicable environments.
  * Improved readiness verification for machine configuration pools by checking both the expected condition and status.
* **Refactor**
  * Standardized machine configuration pool condition checks for more reliable test validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->