### PR TITLE
OCPBUGS-85519: Add Agent conformance test that uses the global pull secret

### DIFF
--- a/test/extended/internalreleaseimage/helper.go
+++ b/test/extended/internalreleaseimage/helper.go
@@ -24,6 +24,10 @@ import (
 
 const (
 	IRIResourceName = "cluster"
+
+	// cleanupTimeout bounds best-effort deletions so cleanup always terminates,
+	// even when the spec context has already been cancelled.
+	cleanupTimeout = 30 * time.Second
 )
 
 // IRITestHelper is a helper class for InternalReleaseImage tests
@@ -47,15 +51,15 @@ func NewIRITestHelper(oc *exutil.CLI) *IRITestHelper {
 }
 
 // GetIRI gets the InternalReleaseImage resource and fails the test if not found
-func (h *IRITestHelper) GetIRI() *v1.InternalReleaseImage {
-	iri, err := h.McClientV1.InternalReleaseImages().Get(context.Background(), IRIResourceName, metav1.GetOptions{})
+func (h *IRITestHelper) GetIRI(ctx context.Context) *v1.InternalReleaseImage {
+	iri, err := h.McClientV1.InternalReleaseImages().Get(ctx, IRIResourceName, metav1.GetOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get InternalReleaseImage resource")
 	return iri
 }
 
 // GetIRIMachineConfigs returns all MachineConfigs owned by InternalReleaseImage
-func (h *IRITestHelper) tryGetIRIMachineConfigs() ([]*v1.MachineConfig, error) {
-	mcList, err := h.McClientV1.MachineConfigs().List(context.Background(), metav1.ListOptions{})
+func (h *IRITestHelper) tryGetIRIMachineConfigs(ctx context.Context) ([]*v1.MachineConfig, error) {
+	mcList, err := h.McClientV1.MachineConfigs().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -70,29 +74,29 @@ func (h *IRITestHelper) tryGetIRIMachineConfigs() ([]*v1.MachineConfig, error) {
 	return iriMCs, nil
 }
 
-func (h *IRITestHelper) GetIRIMachineConfigs() []*v1.MachineConfig {
-	iriMCs, err := h.tryGetIRIMachineConfigs()
+func (h *IRITestHelper) GetIRIMachineConfigs(ctx context.Context) []*v1.MachineConfig {
+	iriMCs, err := h.tryGetIRIMachineConfigs(ctx)
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to list MachineConfigs")
 	return iriMCs
 }
 
 // DeleteMachineConfig deletes a MachineConfig by name
-func (h *IRITestHelper) DeleteMachineConfig(name string) {
-	err := h.McClientV1.MachineConfigs().Delete(context.Background(), name, metav1.DeleteOptions{})
+func (h *IRITestHelper) DeleteMachineConfig(ctx context.Context, name string) {
+	err := h.McClientV1.MachineConfigs().Delete(ctx, name, metav1.DeleteOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to delete MachineConfig %s", name)
 }
 
 // DeleteIRI attempts to delete the InternalReleaseImage resource
-func (h *IRITestHelper) DeleteIRI() error {
-	return h.McClientV1.InternalReleaseImages().Delete(context.Background(), IRIResourceName, metav1.DeleteOptions{})
+func (h *IRITestHelper) DeleteIRI(ctx context.Context) error {
+	return h.McClientV1.InternalReleaseImages().Delete(ctx, IRIResourceName, metav1.DeleteOptions{})
 }
 
 // VerifyIDMSConfigured verifies that the test image repo is present as a mirror in at least one IDMS
-func (h *IRITestHelper) VerifyIDMSConfigured(releaseImage string) {
+func (h *IRITestHelper) VerifyIDMSConfigured(ctx context.Context, releaseImage string) {
 	e2e.Logf("Verifying image repo is present in image-digest-mirror IDMS: %s", releaseImage)
 
 	// List all IDMS resources
-	idmsList, err := h.oc.AdminConfigClient().ConfigV1().ImageDigestMirrorSets().List(context.Background(), metav1.ListOptions{})
+	idmsList, err := h.oc.AdminConfigClient().ConfigV1().ImageDigestMirrorSets().List(ctx, metav1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to list ImageDigestMirrorSets")
 
 	// Extract the repo from the release image (remove @sha256:... digest)
@@ -125,7 +129,7 @@ func (h *IRITestHelper) VerifyIDMSConfigured(releaseImage string) {
 }
 
 // CreateTestPod creates a test pod with the specified release image in the given namespace
-func (h *IRITestHelper) CreateTestPod(namespace, releaseImage string) *corev1.Pod {
+func (h *IRITestHelper) CreateTestPod(ctx context.Context, namespace, releaseImage string) *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "iri-registry-test-" + string(uuid.NewUUID()),
@@ -145,16 +149,20 @@ func (h *IRITestHelper) CreateTestPod(namespace, releaseImage string) *corev1.Po
 		},
 	}
 
-	createdPod, err := h.oc.AdminKubeClient().CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{})
+	createdPod, err := h.oc.AdminKubeClient().CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create test pod")
 	e2e.Logf("Created test pod: %s/%s", createdPod.Namespace, createdPod.Name)
 
 	return createdPod
 }
 
-// DeleteTestPod deletes a test pod by name from the specified namespace
-func (h *IRITestHelper) DeleteTestPod(namespace, name string) {
-	err := h.oc.AdminKubeClient().CoreV1().Pods(namespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+// DeleteTestPod deletes a test pod by name from the specified namespace. It bounds the
+// deletion with its own timeout derived from ctx so cleanup terminates promptly even when
+// invoked with a fresh cleanup context.
+func (h *IRITestHelper) DeleteTestPod(ctx context.Context, namespace, name string) {
+	ctx, cancel := context.WithTimeout(ctx, cleanupTimeout)
+	defer cancel()
+	err := h.oc.AdminKubeClient().CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		e2e.Logf("Warning: failed to delete test pod %s/%s: %v", namespace, name, err)
 	}
@@ -163,7 +171,7 @@ func (h *IRITestHelper) DeleteTestPod(namespace, name string) {
 // CreateSimpleNamespace creates a namespace with pod security labels and waits
 // for SCC annotations. It uses admin client only, avoiding the user/OAuth/project
 // request flow in SetupProject that breaks in proxied CI environments.
-func (h *IRITestHelper) CreateSimpleNamespace() string {
+func (h *IRITestHelper) CreateSimpleNamespace(ctx context.Context) string {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "e2e-test-" + string(uuid.NewUUID()),
@@ -176,28 +184,30 @@ func (h *IRITestHelper) CreateSimpleNamespace() string {
 		},
 	}
 
-	createdNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Create(context.Background(), ns, metav1.CreateOptions{})
+	createdNs, err := h.oc.AdminKubeClient().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Failed to create namespace")
 	e2e.Logf("Created namespace: %s", createdNs.Name)
 
-	err = exutil.WaitForNamespaceSCCAnnotations(h.oc.AdminKubeClient().CoreV1(), createdNs.Name)
+	err = exutil.WaitForNamespaceSCCAnnotationsContext(ctx, h.oc.AdminKubeClient().CoreV1(), createdNs.Name)
 	if err != nil {
-		h.DeleteNamespace(createdNs.Name)
+		h.DeleteNamespace(ctx, createdNs.Name)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for namespace %s to get SCC annotations", createdNs.Name)
 	}
 
-	err = exutil.WaitForServiceAccount(h.oc.AdminKubeClient().CoreV1().ServiceAccounts(createdNs.Name), "default")
+	err = exutil.WaitForServiceAccountContext(ctx, h.oc.AdminKubeClient().CoreV1().ServiceAccounts(createdNs.Name), "default")
 	if err != nil {
-		h.DeleteNamespace(createdNs.Name)
+		h.DeleteNamespace(ctx, createdNs.Name)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Timed out waiting for default ServiceAccount in namespace %s", createdNs.Name)
 	}
 
 	return createdNs.Name
 }
 
-// DeleteNamespace deletes a namespace
-func (h *IRITestHelper) DeleteNamespace(name string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// DeleteNamespace deletes a namespace. It bounds the deletion with its own cleanupTimeout,
+// derived from a non-canceled parent (context.WithoutCancel) so cleanup can still proceed
+// even when the caller's ctx has already been canceled (e.g. a failed/canceled wait above).
+func (h *IRITestHelper) DeleteNamespace(ctx context.Context, name string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
 	defer cancel()
 	err := h.oc.AdminKubeClient().CoreV1().Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -209,11 +219,11 @@ func (h *IRITestHelper) DeleteNamespace(name string) {
 
 // skipIfNoRegistryFeatureUnsupported skips the test if NoRegistryClusterInstall is not supported
 // This checks: platform type (BareMetal/None) and feature gate enablement
-func skipIfNoRegistryFeatureUnsupported(oc *exutil.CLI) {
+func skipIfNoRegistryFeatureUnsupported(ctx context.Context, oc *exutil.CLI) {
 	g.By("Checking if NoRegistryClusterInstall feature is supported")
 
 	// Platform must be BareMetal or None
-	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+	infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		g.Skip(fmt.Sprintf("Failed to get Infrastructure: %v", err))
 	}
@@ -228,7 +238,7 @@ func skipIfNoRegistryFeatureUnsupported(oc *exutil.CLI) {
 	}
 
 	// Feature gate NoRegistryClusterInstall must be enabled
-	featureGate, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(context.Background(), "cluster", metav1.GetOptions{})
+	featureGate, err := oc.AdminConfigClient().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
 		g.Skip(fmt.Sprintf("Failed to get FeatureGate: %v", err))
 	}
@@ -250,7 +260,7 @@ func skipIfNoRegistryFeatureUnsupported(oc *exutil.CLI) {
 	}
 
 	// Check if InternalReleaseImage resource is present. If not present, the feature is not enabled.
-	_, err = oc.MachineConfigurationClient().MachineconfigurationV1().InternalReleaseImages().Get(context.Background(), IRIResourceName, metav1.GetOptions{})
+	_, err = oc.MachineConfigurationClient().MachineconfigurationV1().InternalReleaseImages().Get(ctx, IRIResourceName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			g.Skip("InternalReleaseImage resource not found, feature not enabled")

--- a/test/extended/internalreleaseimage/internalreleaseimage.go
+++ b/test/extended/internalreleaseimage/internalreleaseimage.go
@@ -23,23 +23,23 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] InternalRe
 	var oc = exutil.NewCLIWithoutNamespace("no-registry")
 	var helper *IRITestHelper
 
-	g.BeforeEach(func() {
-		skipIfNoRegistryFeatureUnsupported(oc)
+	g.BeforeEach(func(ctx context.Context) {
+		skipIfNoRegistryFeatureUnsupported(ctx, oc)
 		helper = NewIRITestHelper(oc)
 	})
 
 	g.Context("when the NoRegistryClusterInstall feature is enabled", func() {
-		g.It("should have a exactly one InternalReleaseImage resource [apigroup:machineconfiguration.openshift.io]", func() {
+		g.It("should have a exactly one InternalReleaseImage resource [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
 			g.By("Verifying IRI resource exists and spec release is installed and available")
-			iri := helper.GetIRI()
+			iri := helper.GetIRI(ctx)
 			o.Expect(iri.Spec.Releases).Should(o.HaveLen(1), "IRI should have exactly one release in spec")
 			o.Expect(iri.Status.Releases).Should(o.HaveLen(1), "IRI should have exactly one release in status")
 			o.Expect(iri.Status.Releases[0].Name).Should(o.Equal(iri.Spec.Releases[0].Name), "Status release name should match spec release name")
 		})
 
-		g.It("should create MachineConfigs [apigroup:machineconfiguration.openshift.io]", func() {
+		g.It("should create MachineConfigs [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
 			g.By("Verifying MachineConfigs for IRI exist")
-			iriMCs := helper.GetIRIMachineConfigs()
+			iriMCs := helper.GetIRIMachineConfigs(ctx)
 			o.Expect(iriMCs).NotTo(o.BeEmpty(), "IRI should have created at least one MachineConfig")
 			e2e.Logf("Verified %d MachineConfigs with IRI owner references", len(iriMCs))
 		})
@@ -52,17 +52,17 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall][Serial] In
 	var oc = exutil.NewCLIWithoutNamespace("no-registry")
 	var helper *IRITestHelper
 
-	g.BeforeEach(func() {
-		skipIfNoRegistryFeatureUnsupported(oc)
+	g.BeforeEach(func(ctx context.Context) {
+		skipIfNoRegistryFeatureUnsupported(ctx, oc)
 		helper = NewIRITestHelper(oc)
 	})
 
 	g.Context("when IRI-owned MachineConfigs are deleted", func() {
-		g.It("should restore all deleted MachineConfigs [apigroup:machineconfiguration.openshift.io]", func() {
+		g.It("should restore all deleted MachineConfigs [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
 			g.By("Deleting all IRI-owned MachineConfigs and verifying controller recreates them")
 
 			// Get all IRI-owned MachineConfigs with UIDs and timestamps
-			originalMCs := helper.GetIRIMachineConfigs()
+			originalMCs := helper.GetIRIMachineConfigs(ctx)
 			o.Expect(originalMCs).NotTo(o.BeEmpty(), "IRI should have created at least one MachineConfig")
 			originalCount := len(originalMCs)
 			e2e.Logf("Found %d IRI-owned MachineConfigs maintained by the controller", originalCount)
@@ -76,17 +76,17 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall][Serial] In
 			// Delete all IRI-owned MachineConfigs
 			e2e.Logf("Deleting all %d IRI-owned MachineConfigs to test controller reconciliation", originalCount)
 			for _, mc := range originalMCs {
-				helper.DeleteMachineConfig(mc.Name)
+				helper.DeleteMachineConfig(ctx, mc.Name)
 			}
 
 			// Wait for controller to recreate all MachineConfigs with new UIDs and newer timestamps
 			// Track which MCs are pending verification, remove them as they're confirmed recreated
 			e2e.Logf("Waiting for controller to recreate all MachineConfigs with new UIDs and newer timestamps")
 
-			err := wait.PollUntilContextTimeout(context.TODO(), 5*time.Second, 5*time.Minute, true,
-				func(_ context.Context) (bool, error) {
+			err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 5*time.Minute, true,
+				func(ctx context.Context) (bool, error) {
 					// Get current state of all IRI-owned MachineConfigs
-					newMCs, err := helper.tryGetIRIMachineConfigs()
+					newMCs, err := helper.tryGetIRIMachineConfigs(ctx)
 					if err != nil {
 						e2e.Logf("Transient error listing MachineConfigs, retrying: %v", err)
 						return false, nil
@@ -126,17 +126,17 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] InternalRe
 	var oc = exutil.NewCLIWithoutNamespace("no-registry")
 	var helper *IRITestHelper
 
-	g.BeforeEach(func() {
-		skipIfNoRegistryFeatureUnsupported(oc)
+	g.BeforeEach(func(ctx context.Context) {
+		skipIfNoRegistryFeatureUnsupported(ctx, oc)
 		helper = NewIRITestHelper(oc)
 	})
 
 	g.Context("when the cluster is using a release from the InternalReleaseImage resource", func() {
-		g.It("should block deletion attempts with a ValidatingAdmissionPolicy error [apigroup:machineconfiguration.openshift.io]", func() {
+		g.It("should block deletion attempts with a ValidatingAdmissionPolicy error [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
 			g.By("Attempting to delete IRI resource and verifying ValidatingAdmissionPolicy blocks it")
 
 			e2e.Logf("Attempting to delete InternalReleaseImage resource while cluster is using it")
-			err := helper.DeleteIRI()
+			err := helper.DeleteIRI(ctx)
 			o.Expect(err).To(o.HaveOccurred(), "Deletion should be blocked when resource is in use")
 			o.Expect(apierrors.IsInvalid(err) || apierrors.IsForbidden(err)).To(o.BeTrue(), "Deletion should be blocked by ValidatingAdmissionPolicy")
 
@@ -154,33 +154,33 @@ var _ = g.Describe("[sig-installer][Feature:NoRegistryClusterInstall] Cluster op
 	var oc = exutil.NewCLIWithoutNamespace("no-registry")
 	var helper *IRITestHelper
 
-	g.BeforeEach(func() {
-		skipIfNoRegistryFeatureUnsupported(oc)
+	g.BeforeEach(func(ctx context.Context) {
+		skipIfNoRegistryFeatureUnsupported(ctx, oc)
 		helper = NewIRITestHelper(oc)
 	})
 
 	g.Context("when a workload based on the maintained OCP release bundle images is created", func() {
-		g.It("should run successfully [apigroup:machineconfiguration.openshift.io]", func() {
-			iri := helper.GetIRI()
+		g.It("should run successfully [apigroup:machineconfiguration.openshift.io]", func(ctx context.Context) {
+			iri := helper.GetIRI(ctx)
 			releaseImage := iri.Status.Releases[0].Image
 			e2e.Logf("Using OCP release bundle image: %s", releaseImage)
 
 			// Verify the image repo is present in IDMS (proves it will be pulled from mirror)
 			g.By("Verifying image repo is present in ImageDigestMirrorSet")
-			helper.VerifyIDMSConfigured(releaseImage)
+			helper.VerifyIDMSConfigured(ctx, releaseImage)
 			g.By("Creating test namespace and pod")
-			ns := helper.CreateSimpleNamespace()
-			defer helper.DeleteNamespace(ns)
+			ns := helper.CreateSimpleNamespace(ctx)
+			g.DeferCleanup(helper.DeleteNamespace, ns)
 
-			pod := helper.CreateTestPod(ns, releaseImage)
-			defer helper.DeleteTestPod(ns, pod.Name)
+			pod := helper.CreateTestPod(ctx, ns, releaseImage)
+			g.DeferCleanup(helper.DeleteTestPod, ns, pod.Name)
 
 			g.By("Waiting for pod to complete successfully")
-			err := e2epod.WaitForPodSuccessInNamespace(context.Background(), oc.AdminKubeClient(), pod.Name, ns)
+			err := e2epod.WaitForPodSuccessInNamespace(ctx, oc.AdminKubeClient(), pod.Name, ns)
 			o.Expect(err).NotTo(o.HaveOccurred(), "Pod should pull image from mirror registry and run successfully")
 
 			// Get final pod status to log image ID
-			completedPod, err := oc.AdminKubeClient().CoreV1().Pods(ns).Get(context.Background(), pod.Name, metav1.GetOptions{})
+			completedPod, err := oc.AdminKubeClient().CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred(), "Failed to get completed pod status")
 			o.Expect(completedPod.Status.ContainerStatuses).NotTo(o.BeEmpty(), "Pod should have at least one container status")
 			e2e.Logf("Workload successfully pulled image from mirror registry (ImageID: %s)", completedPod.Status.ContainerStatuses[0].ImageID)

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -1141,8 +1141,15 @@ func CheckBuildCancelled(b *buildv1.Build) bool {
 // WaitForServiceAccount waits until the named service account gets fully
 // provisioned. Does not wait for dockercfg secrets
 func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) error {
-	waitFn := func() (bool, error) {
-		_, err := c.Get(context.Background(), name, metav1.GetOptions{})
+	return WaitForServiceAccountContext(context.Background(), c, name)
+}
+
+// WaitForServiceAccountContext is the context-aware variant of WaitForServiceAccount.
+// The provided ctx bounds both the polling loop and the underlying Get calls, so
+// cancellation stops the wait promptly.
+func WaitForServiceAccountContext(ctx context.Context, c corev1client.ServiceAccountInterface, name string) error {
+	waitFn := func(ctx context.Context) (bool, error) {
+		_, err := c.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			// If we can't access the service accounts, let's wait till the controller
 			// create it.
@@ -1154,7 +1161,7 @@ func WaitForServiceAccount(c corev1client.ServiceAccountInterface, name string) 
 		}
 		return true, nil
 	}
-	return wait.Poll(100*time.Millisecond, 3*time.Minute, waitFn)
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Minute, false, waitFn)
 }
 
 // WaitForServiceAccountWithSecret waits until the named service account gets fully
@@ -1207,8 +1214,15 @@ func WaitForServiceAccountWithSecret(config configclient.ClusterVersionInterface
 // WaitForNamespaceSCCAnnotations waits up to 30s for the cluster-policy-controller to add the SCC related
 // annotations to the provided namespace.
 func WaitForNamespaceSCCAnnotations(c corev1client.CoreV1Interface, name string) error {
-	waitFn := func() (bool, error) {
-		ns, err := c.Namespaces().Get(context.Background(), name, metav1.GetOptions{})
+	return WaitForNamespaceSCCAnnotationsContext(context.Background(), c, name)
+}
+
+// WaitForNamespaceSCCAnnotationsContext is the context-aware variant of
+// WaitForNamespaceSCCAnnotations. The provided ctx bounds both the polling loop
+// and the underlying Get calls, so cancellation stops the wait promptly.
+func WaitForNamespaceSCCAnnotationsContext(ctx context.Context, c corev1client.CoreV1Interface, name string) error {
+	waitFn := func(ctx context.Context) (bool, error) {
+		ns, err := c.Namespaces().Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			// it is assumed the project was created prior to calling this, so we
 			// do not distinguish not found errors
@@ -1227,7 +1241,7 @@ func WaitForNamespaceSCCAnnotations(c corev1client.CoreV1Interface, name string)
 		e2e.Logf("namespace %s current annotation set: %#v", name, ns.Annotations)
 		return false, nil
 	}
-	return wait.Poll(time.Duration(250*time.Millisecond), 30*time.Minute, waitFn)
+	return wait.PollUntilContextTimeout(ctx, 250*time.Millisecond, 30*time.Minute, false, waitFn)
 }
 
 // WaitForAnImageStream waits for an ImageStream to fulfill the isOK function


### PR DESCRIPTION
Add a new Agent conformance test that used the global pull secret to pull images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved release image end-to-end test coverage for resource validation, MachineConfig reconciliation, deletion protection, and successful release-image execution.
  * Added context-aware operations and polling so interrupted or time-limited test runs stop promptly.
  * Improved namespace and pod cleanup with bounded timeouts and more reliable lifecycle handling.
  * Preserved error reporting for cleanup failures while allowing expected “not found” conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->