### PR TITLE
OCPBUGS-83412: monitortests: skip PodSecurityViolation invariant when OpenShiftPodSecurityAdmission is disabled

### DIFF
--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
@@ -1,12 +1,17 @@
 package auditloganalyzer
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"sync"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	"strings"
-	"sync"
 )
 
 func CheckForViolations() *auditViolations {
@@ -47,10 +52,28 @@ func (v *auditViolations) HandleAuditLogEvent(auditEvent *auditv1.Event, beginni
 	}
 }
 
-func (v *auditViolations) CreateJunits() []*junitapi.JUnitTestCase {
+func (v *auditViolations) CreateJunits(psaEnforcementDisabled bool) []*junitapi.JUnitTestCase {
 	ret := []*junitapi.JUnitTestCase{}
 
 	testName := " [bz-apiserver-auth][invariant] audit analysis PodSecurityViolation"
+
+	// When the OpenShiftPodSecurityAdmission feature gate is disabled, the PSA label syncer stops
+	// setting the pod-security.kubernetes.io/enforce label on namespaces and workloads that key
+	// their security context off that label (e.g. OLM catalog registry pods) legitimately run
+	// without a restricted-compatible security context. The global PodSecurity audit configuration
+	// stays at restricted:latest, so those pod creations produce audit violations by design and
+	// this invariant does not apply.
+	if psaEnforcementDisabled {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				SkipMessage: &junitapi.SkipMessage{
+					Message: fmt.Sprintf("OpenShiftPodSecurityAdmission is disabled: pod security is not enforced and audit-level violations are expected, %d violation(s) observed, details in audit log", len(v.records)),
+				},
+			},
+		}
+	}
+
 	switch {
 	case len(v.records) > 0:
 		messages := []string{}
@@ -74,4 +97,33 @@ func (v *auditViolations) CreateJunits() []*junitapi.JUnitTestCase {
 	}
 
 	return ret
+}
+
+// isPodSecurityEnforcementDisabled reports whether the OpenShiftPodSecurityAdmission feature gate
+// is explicitly disabled for the cluster's current version. On any error or ambiguity it returns
+// false so that the PodSecurityViolation invariant keeps enforcing.
+func isPodSecurityEnforcementDisabled(ctx context.Context, configClient configclient.Interface, clusterVersion *configv1.ClusterVersion) bool {
+	featureGate, err := configClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	desiredVersion := clusterVersion.Status.Desired.Version
+	if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+		desiredVersion = clusterVersion.Status.History[0].Version
+	}
+
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			if disabled.Name == features.FeatureGateOpenShiftPodSecurityAdmission {
+				return true
+			}
+		}
+		return false
+	}
+
+	return false
 }

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation_test.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation_test.go
@@ -1,0 +1,129 @@
+package auditloganalyzer
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func violationCheckerWithRecord() *auditViolations {
+	checker := CheckForViolations()
+	checker.records = append(checker.records, auditViolationRecord{
+		auditId:   "test-audit-id",
+		violation: `would violate PodSecurity "restricted:latest"`,
+		resource:  "pods",
+		namespace: "e2e-test-default-abcde",
+		username:  "system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount",
+	})
+	return checker
+}
+
+func TestCreateJunitsWithPSAEnforcement(t *testing.T) {
+	checker := violationCheckerWithRecord()
+
+	junits := checker.CreateJunits(false)
+
+	require.Len(t, junits, 1)
+	assert.NotNil(t, junits[0].FailureOutput, "violations must fail the invariant when PSA enforcement is enabled")
+	assert.Nil(t, junits[0].SkipMessage)
+}
+
+func TestCreateJunitsWithoutPSAEnforcement(t *testing.T) {
+	checker := violationCheckerWithRecord()
+
+	junits := checker.CreateJunits(true)
+
+	require.Len(t, junits, 1)
+	assert.Nil(t, junits[0].FailureOutput, "violations are expected when PSA enforcement is disabled and must not fail the invariant")
+	require.NotNil(t, junits[0].SkipMessage)
+	assert.Contains(t, junits[0].SkipMessage.Message, "OpenShiftPodSecurityAdmission is disabled")
+}
+
+func TestCreateJunitsWithoutViolations(t *testing.T) {
+	checker := CheckForViolations()
+
+	junits := checker.CreateJunits(false)
+
+	require.Len(t, junits, 1)
+	assert.Nil(t, junits[0].FailureOutput)
+	assert.Nil(t, junits[0].SkipMessage)
+}
+
+func TestIsPodSecurityEnforcementDisabled(t *testing.T) {
+	clusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{Version: "5.0.0"},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		featureGate *configv1.FeatureGate
+		expected    bool
+	}{
+		{
+			name: "gate disabled for current version",
+			featureGate: featureGateWithStatus("5.0.0", nil, []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}),
+			expected: true,
+		},
+		{
+			name: "gate enabled for current version",
+			featureGate: featureGateWithStatus("5.0.0", []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}, nil),
+			expected: false,
+		},
+		{
+			name: "gate disabled only for another version",
+			featureGate: featureGateWithStatus("4.20.0", nil, []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}),
+			expected: false,
+		},
+		{
+			name:        "no featuregate resource keeps the invariant enforcing",
+			featureGate: nil,
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configClient := configfake.NewSimpleClientset()
+			if tc.featureGate != nil {
+				configClient = configfake.NewSimpleClientset(tc.featureGate)
+			}
+
+			actual := isPodSecurityEnforcementDisabled(context.Background(), configClient, clusterVersion)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func featureGateWithStatus(version string, enabled, disabled []configv1.FeatureGateName) *configv1.FeatureGate {
+	featureGate := &configv1.FeatureGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.FeatureGateStatus{
+			FeatureGates: []configv1.FeatureGateDetails{
+				{Version: version},
+			},
+		},
+	}
+	for _, name := range enabled {
+		featureGate.Status.FeatureGates[0].Enabled = append(featureGate.Status.FeatureGates[0].Enabled, configv1.FeatureGateAttributes{Name: name})
+	}
+	for _, name := range disabled {
+		featureGate.Status.FeatureGates[0].Disabled = append(featureGate.Status.FeatureGates[0].Disabled, configv1.FeatureGateAttributes{Name: name})
+	}
+	return featureGate
+}

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -24,6 +24,9 @@ type auditLogAnalyzer struct {
 	adminRESTConfig *rest.Config
 
 	isTechPreview bool
+	// psaEnforcementDisabled is true when the OpenShiftPodSecurityAdmission feature gate is
+	// explicitly disabled, in which case audit-level pod security violations are expected.
+	psaEnforcementDisabled bool
 
 	summarizer                    *summarizer
 	excessiveApplyChecker         *excessiveApplies
@@ -71,6 +74,7 @@ func (w *auditLogAnalyzer) StartCollection(ctx context.Context, adminRESTConfig 
 		return err
 	default:
 		w.requestCountTracking = CountsOverTime(clusterVersion.CreationTimestamp)
+		w.psaEnforcementDisabled = isPodSecurityEnforcementDisabled(ctx, configClient, clusterVersion)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(w.adminRESTConfig)
@@ -416,7 +420,7 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 		)
 	}
 
-	ret = append(ret, w.violationChecker.CreateJunits()...)
+	ret = append(ret, w.violationChecker.CreateJunits(w.psaEnforcementDisabled)...)
 
 	if w.clusterStability == monitortestframework.Stable {
 		junits, err := w.watchCountTracking.CreateJunits()


### PR DESCRIPTION
The `e2e-aws-ovn`, `e2e-azure` and `e2e-gcp` presubmits on openshift/api#3002 fail on a single monitor test, `[bz-apiserver-auth][invariant] audit analysis PodSecurityViolation` ([example junit](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_api/3002/pull-ci-openshift-api-release-5.0-e2e-aws-ovn/2092462724205252608)). Everything else in those runs is fail-then-pass flakes.

**What happens.** With `OpenShiftPodSecurityAdmission` disabled, the PSA label syncer runs in advising mode and no longer sets the `pod-security.kubernetes.io/enforce` label on namespaces ([psalabelsyncer.go#L19](https://github.com/openshift/cluster-policy-controller/blob/main/pkg/cmd/controller/psalabelsyncer.go#L19)). OLM's catalog-operator defaults the registry pod security context by reading exactly that label, no label means `legacy` pod ([reconciler.go#L412](https://github.com/openshift/operator-framework-olm/blob/release-5.0/staging/operator-lifecycle-manager/pkg/controller/registry/reconciler/reconciler.go#L412)). The global PodSecurity `audit: restricted:latest` configuration is not feature-gated, so every such pod stamps a `pod-security.kubernetes.io/audit-violations` annotation into the audit log, and this invariant fails on **any** violation. The violations are by design, the invariant asserts a property that a gate-off cluster intentionally gives up.

**What this PR does.** Skip the invariant when the gate is explicitly disabled for the cluster's current version. Reading the `FeatureGate` status follows the existing pattern in [cluster.go#L152](https://github.com/openshift/origin/blob/main/pkg/clioptions/clusterdiscovery/cluster.go#L152). Fail closed: any error or ambiguity keeps the invariant enforcing. Clusters with the gate enabled, which is every current payload including TechPreview, are unaffected.

**Test plan.**
- unit tests for `CreateJunits` and `isPodSecurityEnforcementDisabled`
- `/testwith openshift/api/release-5.0/e2e-aws-ovn openshift/origin#31561` commented on openshift/api#3002, the currently failing presubmit must go green with this PR in the payload

The same patch applies to `main`, the package is identical on both branches. Main PR follows, this one is the verification target for openshift/api#3002.

/hold until the verification on openshift/api#3002 is done
