### PR TITLE
OCPBUGS-112332: Add missing `securityContextConfig: restricted` to catalog source templates

### DIFF
--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-address.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-address.yaml
@@ -16,6 +16,8 @@ objects:
       mediatype: ""
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
+    grpcPodConfig:
+      securityContextConfig: restricted
 parameters:
 - name: NAME
 - name: NAMESPACE

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-configmap.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-configmap.yaml
@@ -16,6 +16,8 @@ objects:
       mediatype: ""
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
+    grpcPodConfig:
+      securityContextConfig: restricted
 parameters:
 - name: NAME
 - name: NAMESPACE

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-image-cacheless.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-image-cacheless.yaml
@@ -13,6 +13,7 @@ objects:
     grpcPodConfig:
       extractContent:
         catalogDir: /configs
+      securityContextConfig: restricted
     secrets:
     - "${SECRET}"  
     displayName: "${DISPLAYNAME}"

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-image-extract.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-image-extract.yaml
@@ -14,6 +14,7 @@ objects:
       extractContent:
         cacheDir: /tmp/cache
         catalogDir: /configs
+      securityContextConfig: restricted
     secrets:
     - "${SECRET}"  
     displayName: "${DISPLAYNAME}"

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-image-incorrect-updatestrategy.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-image-incorrect-updatestrategy.yaml
@@ -18,8 +18,10 @@ objects:
       mediatype: ""
     publisher: "${PUBLISHER}"
     sourceType: "${SOURCETYPE}"
-    updateStrategy: 
+    updateStrategy:
       registryPoll: {}
+    grpcPodConfig:
+      securityContextConfig: restricted
 parameters:
 - name: NAME
 - name: NAMESPACE

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-image.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-image.yaml
@@ -21,6 +21,8 @@ objects:
     updateStrategy:
       registryPoll:
         interval: "${INTERVAL}"
+    grpcPodConfig:
+      securityContextConfig: restricted
 parameters:
 - name: NAME
 - name: NAMESPACE

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-namespace.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-namespace.yaml
@@ -9,3 +9,5 @@ spec:
   configMap: scenario3
   displayName: Scenario 3 Operators
   publisher: Red Hat
+  grpcPodConfig:
+    securityContextConfig: restricted

--- a/test/extended/util/compat_otp/testdata/olm/catalogsource-opm.yaml
+++ b/test/extended/util/compat_otp/testdata/olm/catalogsource-opm.yaml
@@ -14,6 +14,7 @@ objects:
         cacheDir: /tmp/cache
         catalogDir: /configs
       memoryTarget: 30Mi
+      securityContextConfig: restricted
     image: "${ADDRESS}"
     secrets:
     - "${SECRET}"  


### PR DESCRIPTION
Add missing `securityContextConfig: restricted` to catalog source templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CatalogSource configurations to use restricted security contexts for gRPC pods.
  * Preserved existing update strategies while applying the security configuration across supported CatalogSource scenarios.

* **Tests**
  * Updated compatibility test coverage to validate restricted security settings for address-based, ConfigMap, image-based, namespace, and OPM CatalogSources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->