### PR TITLE
TRT-2930: skip regional-PD e2e on GCP families without pd-standard

### DIFF
--- a/test/extended/storage/gce_pd_regional.go
+++ b/test/extended/storage/gce_pd_regional.go
@@ -38,6 +38,15 @@ const (
 	labelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
 )
 
+// gcpFamiliesWithoutPDStandard lists GCP machine families that cannot attach a
+// pd-standard Persistent Disk, including the regional pd-standard volume this
+// test provisions. C4/C4A/C4D and N4 are Hyperdisk-only; C3/C3D support
+// pd-ssd/pd-balanced but not pd-standard. On these families the attach fails with
+// "Regional disks is not supported for <type> machine type", so the test is
+// skipped rather than run to a deterministic failure. Keep this in sync with
+// GCP's machine-family disk-support matrix.
+var gcpFamiliesWithoutPDStandard = []string{"c3", "c3d", "c4", "c4a", "c4d", "n4"}
+
 var _ = g.Describe(`[sig-storage][Jira:"Storage"][Driver: pd.csi.storage.gke.io]`, func() {
 	defer g.GinkgoRecover()
 
@@ -67,6 +76,13 @@ var _ = g.Describe(`[sig-storage][Jira:"Storage"][Driver: pd.csi.storage.gke.io]
 		o.Expect(err).NotTo(o.HaveOccurred())
 		if zones.Len() < 2 {
 			g.Skip("skipping, cluster has fewer than 2 zones")
+		}
+
+		// The regional pd-standard volume must attach to the worker that runs the
+		// test pod. Some GCP families (e.g. N4) cannot attach pd-standard at all, so
+		// skip rather than fail deterministically on such clusters.
+		if anyNodeLacksPDStandard(ctx, oc.AdminKubeClient(), labelNodeRoleWorker) {
+			g.Skip("skipping, worker nodes use a GCP machine family (e.g. n4) that cannot attach regional Persistent Disk (pd-standard)")
 		}
 	})
 
@@ -129,12 +145,12 @@ var _ = g.Describe(`[sig-storage][Jira:"Storage"][Driver: pd.csi.storage.gke.io]
 		o.Expect(volZones).To(o.HaveLen(2), "regional PD should list 2 zones in PV nodeAffinity, got %v", volZones)
 
 		// Cross-zone attach may land on a control-plane node; skip when that
-		// node type cannot attach pd-standard (hyperdisk-oriented families).
+		// node type cannot attach pd-standard.
 		if len(workers) < 2 {
 			e2e.Logf("Skipping cross-zone sync verification: need workers in >=2 zones, got %d", len(workers))
 			return
 		}
-		if controlPlaneIsHyperDiskFamily(ctx, client) {
+		if anyNodeLacksPDStandard(ctx, client, labelNodeRoleControlPlane, labelNodeRoleMaster) {
 			e2e.Logf("Skipping cross-zone sync verification: control-plane instance type may not attach pd-standard")
 			return
 		}
@@ -216,24 +232,40 @@ func schedulableWorkersPerZone(ctx context.Context, client clientset.Interface) 
 	return workers, nil
 }
 
-// controlPlaneIsHyperDiskFamily reports whether a control-plane node uses a machine
-// family that may not support attaching pd-standard volumes.
-func controlPlaneIsHyperDiskFamily(ctx context.Context, client clientset.Interface) bool {
-	for _, selector := range []string{labelNodeRoleControlPlane, labelNodeRoleMaster} {
+// anyNodeLacksPDStandard reports whether any node matching one of the given role
+// label selectors uses a GCP machine family that cannot attach a pd-standard
+// Persistent Disk (see gcpFamiliesWithoutPDStandard). A List error for a selector
+// is treated as "not found" so the caller falls back to running the test.
+func anyNodeLacksPDStandard(ctx context.Context, client clientset.Interface, roleSelectors ...string) bool {
+	for _, selector := range roleSelectors {
 		nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector})
 		if err != nil {
 			continue
 		}
-		for _, node := range nodes.Items {
-			t := node.Labels[v1.LabelInstanceTypeStable]
-			if t == "" {
-				t = node.Labels[v1.LabelInstanceType]
+		for i := range nodes.Items {
+			if familyLacksPDStandard(nodeInstanceType(&nodes.Items[i])) {
+				return true
 			}
-			for _, family := range []string{"c3", "c3d", "c4", "c4a", "n4"} {
-				if t == family || strings.HasPrefix(t, family+"-") {
-					return true
-				}
-			}
+		}
+	}
+	return false
+}
+
+// nodeInstanceType returns the node's GCP machine type from its well-known labels,
+// preferring the stable label and falling back to the beta label.
+func nodeInstanceType(node *v1.Node) string {
+	if t := node.Labels[v1.LabelInstanceTypeStable]; t != "" {
+		return t
+	}
+	return node.Labels[v1.LabelInstanceType]
+}
+
+// familyLacksPDStandard reports whether instanceType belongs to a GCP machine
+// family that cannot attach a pd-standard Persistent Disk.
+func familyLacksPDStandard(instanceType string) bool {
+	for _, family := range gcpFamiliesWithoutPDStandard {
+		if instanceType == family || strings.HasPrefix(instanceType, family+"-") {
+			return true
 		}
 	}
 	return false

--- a/test/extended/storage/gce_pd_regional_test.go
+++ b/test/extended/storage/gce_pd_regional_test.go
@@ -1,0 +1,210 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestFamilyLacksPDStandard(t *testing.T) {
+	tests := []struct {
+		instanceType string
+		want         bool
+	}{
+		// Bare families in the list.
+		{"c3", true},
+		{"c3d", true},
+		{"c4", true},
+		{"c4a", true},
+		{"c4d", true},
+		{"n4", true},
+		// family+"-" variants.
+		{"n4-standard-8", true},
+		{"c3-highmem-4", true},
+		{"c3d-standard-8", true},
+		{"c4-standard-4", true},
+		{"c4a-standard-16", true},
+		{"c4d-standard-8", true},
+		{"n4-custom-4-16384", true},
+		// Prefix present but not followed by "-": must NOT match (delimiter guard).
+		{"n4x-standard-8", false},
+		{"c40-standard-4", false},
+		// Substring but not prefix: HasPrefix, not Contains.
+		{"custom-n4-foo", false},
+		// Unrelated PD-capable families.
+		{"n1-standard-8", false},
+		{"n2-standard-4", false},
+		{"e2-medium", false},
+		// Case sensitivity: node labels are lowercase, contract is case-sensitive.
+		{"N4-standard-8", false},
+		// Empty.
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := familyLacksPDStandard(tc.instanceType); got != tc.want {
+			t.Errorf("familyLacksPDStandard(%q) = %v, want %v", tc.instanceType, got, tc.want)
+		}
+	}
+}
+
+func TestNodeInstanceType(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   string
+	}{
+		{
+			name:   "stable label only",
+			labels: map[string]string{v1.LabelInstanceTypeStable: "n4-standard-8"},
+			want:   "n4-standard-8",
+		},
+		{
+			name:   "beta label only",
+			labels: map[string]string{v1.LabelInstanceType: "n4-standard-8"},
+			want:   "n4-standard-8",
+		},
+		{
+			name: "stable preferred over beta",
+			labels: map[string]string{
+				v1.LabelInstanceTypeStable: "c3-standard-4",
+				v1.LabelInstanceType:       "n1-standard-4",
+			},
+			want: "c3-standard-4",
+		},
+		{
+			name: "empty stable falls back to beta",
+			labels: map[string]string{
+				v1.LabelInstanceTypeStable: "",
+				v1.LabelInstanceType:       "n1-standard-4",
+			},
+			want: "n1-standard-4",
+		},
+		{
+			name:   "no instance-type label",
+			labels: map[string]string{"foo": "bar"},
+			want:   "",
+		},
+		{
+			name:   "nil labels does not panic",
+			labels: nil,
+			want:   "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "n", Labels: tc.labels}}
+			if got := nodeInstanceType(node); got != tc.want {
+				t.Errorf("nodeInstanceType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func roleNode(name, role, instanceType string) *v1.Node {
+	labels := map[string]string{role: ""}
+	if instanceType != "" {
+		labels[v1.LabelInstanceTypeStable] = instanceType
+	}
+	return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+func TestAnyNodeLacksPDStandard(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodes     []runtime.Object
+		selectors []string
+		want      bool
+	}{
+		{
+			name:      "no nodes",
+			nodes:     nil,
+			selectors: []string{labelNodeRoleWorker},
+			want:      false,
+		},
+		{
+			name:      "single hyperdisk-only worker",
+			nodes:     []runtime.Object{roleNode("w0", labelNodeRoleWorker, "n4-standard-8")},
+			selectors: []string{labelNodeRoleWorker},
+			want:      true,
+		},
+		{
+			name:      "single pd-capable worker",
+			nodes:     []runtime.Object{roleNode("w0", labelNodeRoleWorker, "n1-standard-8")},
+			selectors: []string{labelNodeRoleWorker},
+			want:      false,
+		},
+		{
+			name: "mixed workers - any hyperdisk-only",
+			nodes: []runtime.Object{
+				roleNode("w0", labelNodeRoleWorker, "n1-standard-8"),
+				roleNode("w1", labelNodeRoleWorker, "n4-standard-8"),
+			},
+			selectors: []string{labelNodeRoleWorker},
+			want:      true,
+		},
+		{
+			name: "all pd-capable workers",
+			nodes: []runtime.Object{
+				roleNode("w0", labelNodeRoleWorker, "n1-standard-8"),
+				roleNode("w1", labelNodeRoleWorker, "n2-standard-4"),
+			},
+			selectors: []string{labelNodeRoleWorker},
+			want:      false,
+		},
+		{
+			name: "worker with beta instance-type label",
+			nodes: []runtime.Object{
+				&v1.Node{ObjectMeta: metav1.ObjectMeta{
+					Name:   "w0",
+					Labels: map[string]string{labelNodeRoleWorker: "", v1.LabelInstanceType: "n4-standard-8"},
+				}},
+			},
+			selectors: []string{labelNodeRoleWorker},
+			want:      true,
+		},
+		{
+			name:      "worker with no instance-type label",
+			nodes:     []runtime.Object{roleNode("w0", labelNodeRoleWorker, "")},
+			selectors: []string{labelNodeRoleWorker},
+			want:      false,
+		},
+		{
+			name:      "hyperdisk control-plane ignored under worker selector",
+			nodes:     []runtime.Object{roleNode("m0", labelNodeRoleControlPlane, "n4-standard-8")},
+			selectors: []string{labelNodeRoleWorker},
+			want:      false,
+		},
+		{
+			name:      "hyperdisk control-plane matched under control-plane selectors",
+			nodes:     []runtime.Object{roleNode("m0", labelNodeRoleControlPlane, "n4-standard-8")},
+			selectors: []string{labelNodeRoleControlPlane, labelNodeRoleMaster},
+			want:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewClientset(tc.nodes...)
+			if got := anyNodeLacksPDStandard(context.Background(), client, tc.selectors...); got != tc.want {
+				t.Errorf("anyNodeLacksPDStandard() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnyNodeLacksPDStandardListErrorFailsOpen locks in the fail-open behavior: a
+// Nodes().List error is treated as "not found" so the test runs instead of skipping.
+func TestAnyNodeLacksPDStandardListErrorFailsOpen(t *testing.T) {
+	client := fake.NewClientset(roleNode("w0", labelNodeRoleWorker, "n4-standard-8"))
+	client.PrependReactor("list", "nodes", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("injected list error")
+	})
+	if got := anyNodeLacksPDStandard(context.Background(), client, labelNodeRoleWorker); got != false {
+		t.Errorf("anyNodeLacksPDStandard() with list error = %v, want false (fail open)", got)
+	}
+}


### PR DESCRIPTION
## What

Skip the `[sig-storage][Jira:"Storage"][Driver: pd.csi.storage.gke.io] regional PD should store data and sync across zones` e2e test when the cluster's **worker** nodes use a GCP machine family that cannot attach a **pd-standard** Persistent Disk (`n4`, `c4`, `c4a`, `c4d`, `c3`, `c3d`).

## Why

The test provisions a **regional `pd-standard` Persistent Disk** and attaches it to the worker that runs the test pod. Those families cannot attach pd-standard, so the attach fails deterministically:

```
[sig-storage][Driver: pd.csi.storage.gke.io] regional PD should store data and sync across zones
  → AttachVolume.Attach failed: googleapi: Error 400:
    Regional disks is not supported for n4-standard-8 machine type
```

The test already guarded the *cross-zone reattach* against such a **control plane**, but it did **not** guard the **primary pod's worker**, which is where the deterministic failure happens. This surfaced while migrating GCP CI jobs from N2 to N4 (`openshift/release` #84090, #84091): jobs that run `openshift/conformance/parallel` on N4 workers fail this one test every time.

## What changed

- `BeforeEach` guard that `Skip`s the whole test when any worker uses a family without pd-standard.
- Consolidated the machine-family check into a single `anyNodeLacksPDStandard(...selectors)` helper (shared by the worker and control-plane guards), backed by `familyLacksPDStandard` / `nodeInstanceType`; family list is `{c3, c3d, c4, c4a, c4d, n4}`.
- Added table-driven + fake-clientset unit tests for the new helpers.

On pd-standard-capable workers (e.g. N2) the test runs exactly as before — coverage is unchanged there.

## ⚠️ Backport required

This fix must be **backported** to the branches that carry this test:

- **release-5.1**
- **release-5.0**
- **release-4.23**

(The test does not exist in ≤4.22.) Until the backports land in the payloads, `openshift/release` #84090 / #84091 carry a **temporary per-job `TEST_SKIPS`** to unblock the N4 migration; those `TEST_SKIPS` lines should be removed once this fix + backports are in the respective payloads.

## Test lineage / reviewers

Test was added in [STOR-3063](https://redhat.atlassian.net/browse/STOR-3063) (`test/extended/storage/gce_pd_regional.go`) by @radeore. /cc @jsafrane @tsmetana @gnufied @bertinatto @dobsonj (storage-approvers).

---
*This description was generated using AI. Please verify before acting on it.*
