### PR TITLE
OCPSTRAT-3618: Fix check in auth test for 1.37 given new NamedAuthorizer behavior

### DIFF
--- a/test/extended/authorization/authorization.go
+++ b/test/extended/authorization/authorization.go
@@ -1202,7 +1202,9 @@ var _ = g.Describe("[sig-auth][Feature:OpenShiftAuthorization] authorization", f
 						return false
 					}
 					return strings.Contains(errProxy.Error(), `cannot proxy resource "pods" in API group "" in the namespace "ns": proxy verb changed to unsafeproxy`) ||
-						strings.Contains(errProxy.Error(), `cannot get resource "pods/proxy" in API group "" in the namespace "ns": proxy subresource changed to unsafeproxy`)
+						strings.Contains(errProxy.Error(), `cannot get resource "pods/proxy" in API group "" in the namespace "ns": proxy subresource changed to unsafeproxy`) ||
+						strings.Contains(errProxy.Error(), `cannot proxy resource "pods" in API group "" in the namespace "ns": scope: proxy verb changed to unsafeproxy`) ||
+						strings.Contains(errProxy.Error(), `cannot get resource "pods/proxy" in API group "" in the namespace "ns": scope: proxy subresource changed to unsafeproxy`)
 				}
 
 				for _, tc := range []struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authorization validation to recognize both legacy and Kubernetes 1.37 `scope:`-prefixed denial messages.
  * Improved proxy access-denial matching across supported proxy verbs and subresources.
  * Increased reliability when validating authorization failures that include additional authorizer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->