### PR TITLE
OCPBUGS-77068: Porting Duplicate MAC Test to Origin

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -650,7 +650,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			o.Expect(baselineMAC).To(o.Equal(expectedMAC1), "EgressIP should resolve to node 1 MAC before migration")
 
 			g.By("6. Getting ovnkube-node pod name on egress node 1")
-			pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+			pods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
 				FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
 				LabelSelector: "app=ovnkube-node",
 			})
@@ -727,7 +727,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 			g.By("12. Waiting for ovnkube-node pod to restart and cluster to be healthy")
 			err = wait.PollImmediate(5*time.Second, 120*time.Second, func() (bool, error) {
-				pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+				pods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
 					FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
 					LabelSelector: "app=ovnkube-node",
 				})

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -694,13 +694,13 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			framework.Logf("✓ ovnkube-node pod %s deleted and terminated", ovnkubeNodePod)
 
 			g.By("9. Verifying nftables chain was created during pod shutdown")
-			close(stopChecking)
 			select {
 			case chainFound := <-nftChainFound:
 				o.Expect(chainFound).To(o.BeTrue(), "nftables egressip-drop chain should exist during pod shutdown")
 			case <-time.After(10 * time.Second):
 				o.ExpectWithOffset(1, false).To(o.BeTrue(), "timeout waiting for nftables chain detection")
 			}
+			close(stopChecking)
 			framework.Logf("✓ Nftables chain egressip-drop verified on node %s", egressNode1Name)
 
 			g.By("10. Waiting for EgressIP to migrate to node 2")

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/skipper"
@@ -563,6 +565,196 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				g.By(fmt.Sprintf("Sending requests from prober and making sure that %d requests with search string and EgressIPs %v were seen", numberOfRequestsToSend, egressIPSet))
 				spawnProberSendEgressIPTrafficCheckLogs(oc, externalNamespace, probePodName, routeName, targetProtocol, targetHost, targetPort, numberOfRequestsToSend, numberOfRequestsToSend, packetSnifferDaemonSet, egressIPSet)
 			}
+		})
+
+		g.It("should prevent duplicate MAC responses when egress node is rebooted", func() {
+			g.By("Checking platform compatibility - baremetal only")
+			infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if infra.Status.PlatformStatus == nil {
+				skipper.Skipf("Platform status not available, skipping baremetal-only test")
+			}
+			if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+				skipper.Skipf("This test requires baremetal platform, got %s", infra.Status.PlatformStatus.Type)
+			}
+
+			g.By("Checking if we have at least 2 egress nodes for failover")
+			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1),
+				"need at least 2 egress-capable nodes for failover test")
+
+			g.By("1. Setting node 1 as egress-assignable")
+			egressNode1Name := egressIPNodesOrderedNames[0]
+			egressNode2Name := egressIPNodesOrderedNames[1]
+			framework.Logf("EgressIP node 1: %s", egressNode1Name)
+			framework.Logf("EgressIP node 2: %s", egressNode2Name)
+
+			g.By("2. Creating EgressIP object assigned to node 1")
+			egressIPSet := make(map[string]string)
+			egressIPsPerNode := 1
+			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, []string{egressNode1Name}, cloudType, egressIPsPerNode)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			// Get first available EgressIP for node 1
+			var egressIP1 string
+			for nodeName, eips := range nodeEgressIPMap {
+				if nodeName == egressNode1Name && len(eips) > 0 {
+					egressIP1 = eips[0]
+					egressIPSet[egressIP1] = egressNode1Name
+					break
+				}
+			}
+			o.Expect(egressIP1).NotTo(o.BeEmpty(), "should allocate EgressIP for node 1")
+
+			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+			egressIPObjectName := egressIPNamespace
+			createEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+			applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+
+			g.By("3. Getting node MAC addresses")
+			egressNode1MAC, err := getNodeMAC(oc, egressNode1Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Node 1 MAC: %s", egressNode1MAC)
+
+			egressNode2MAC, err := getNodeMAC(oc, egressNode2Name)
+			o.Expect(err).NotTo(o.HaveOccurred())
+			framework.Logf("Node 2 MAC: %s", egressNode2MAC)
+
+			g.By("4. Installing network utilities in external container")
+			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "-c", "sh", "-c", "apk add --no-cache iputils").Output()
+			if err != nil {
+				framework.Logf("Network utilities installation note: %v", err)
+			}
+
+			g.By("5. Verifying baseline - EgressIP resolves to Node 1 MAC")
+			isIPv6 := strings.Contains(egressIP1, ":")
+			var discoveryCmd string
+			var macRegex *regexp.Regexp
+
+			if isIPv6 {
+				discoveryCmd = fmt.Sprintf("ndisc6 -1 -w 1000 %s eth0 2>&1", egressIP1)
+				macRegex = regexp.MustCompile(`Target link-layer address:\s+([0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2})`)
+			} else {
+				discoveryCmd = fmt.Sprintf("arping -c 1 -I eth0 %s 2>&1", egressIP1)
+				macRegex = regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
+			}
+
+			output, err := oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "-c", "sh", "-c", discoveryCmd).Output()
+			o.Expect(err).NotTo(o.HaveOccurred(), "baseline MAC discovery should succeed")
+
+			matches := macRegex.FindStringSubmatch(output)
+			o.Expect(matches).To(o.HaveLen(2), "should extract MAC from discovery output")
+
+			baselineMAC := strings.ToLower(strings.TrimSpace(matches[1]))
+			expectedMAC1 := strings.ToLower(egressNode1MAC)
+			framework.Logf("Baseline MAC: %s (expected: %s)", baselineMAC, expectedMAC1)
+			o.Expect(baselineMAC).To(o.Equal(expectedMAC1), "EgressIP should resolve to node 1 MAC before migration")
+
+			g.By("6. Getting ovnkube-node pod name on egress node 1")
+			pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
+				LabelSelector: "app=ovnkube-node",
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), "should list ovnkube-node pods")
+			o.Expect(pods.Items).To(o.HaveLen(1), "should have exactly one ovnkube-node pod on egress node 1")
+			ovnkubeNodePod := pods.Items[0].Name
+			framework.Logf("Found ovnkube-node pod: %s on node %s", ovnkubeNodePod, egressNode1Name)
+
+			g.By("7. Starting goroutine to monitor for nftables chain creation during pod deletion")
+			nftChainFound := make(chan bool, 1)
+			stopChecking := make(chan bool, 1)
+			goroutineReady := make(chan bool, 1)
+			nftChainCheckCmd := "nft -j list chains | jq '.nftables[] | select(.chain.table==\"ovn-kubernetes-egressip\" and .chain.family==\"netdev\" and .chain.name==\"egressip-drop\").chain'"
+
+			go func() {
+				defer close(nftChainFound)
+				ticker := time.NewTicker(100 * time.Millisecond)
+				defer ticker.Stop()
+				goroutineReady <- true
+
+				for {
+					select {
+					case <-stopChecking:
+						return
+					case <-ticker.C:
+						output, err := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", nftChainCheckCmd)).Output()
+						if err == nil && strings.Contains(output, "egressip-drop") {
+							nftChainFound <- true
+							return
+						}
+					}
+				}
+			}()
+
+			<-goroutineReady
+			framework.Logf("Nftables chain monitoring goroutine started")
+
+			g.By("8. Deleting ovnkube-node pod to trigger EIP migration")
+			err = deleteOvnkubeNodePod(oc, egressNode1Name)
+			o.Expect(err).NotTo(o.HaveOccurred(), "should delete ovnkube-node pod")
+			framework.Logf("✓ ovnkube-node pod %s deleted and terminated", ovnkubeNodePod)
+
+			g.By("9. Verifying nftables chain was created during pod shutdown")
+			close(stopChecking)
+			select {
+			case chainFound := <-nftChainFound:
+				o.Expect(chainFound).To(o.BeTrue(), "nftables egressip-drop chain should exist during pod shutdown")
+			case <-time.After(10 * time.Second):
+				o.Fail("timeout waiting for nftables chain detection")
+			}
+			framework.Logf("✓ Nftables chain egressip-drop verified on node %s", egressNode1Name)
+
+			g.By("10. Waiting for EgressIP to migrate to node 2")
+			err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
+				eip, err := getEgressIP(oc, egressIPObjectName)
+				if err != nil {
+					return false, err
+				}
+				if len(eip.Status) == 1 && eip.Status[0].Node == egressNode2Name {
+					return true, nil
+				}
+				return false, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), "EgressIP should migrate to node 2")
+			framework.Logf("✓ Egress IP successfully migrated to node %s", egressNode2Name)
+
+			g.By("11. CRITICAL: Checking for duplicate MAC responses (20 iterations)")
+			expectedMAC2 := strings.ToLower(egressNode2MAC)
+			err = checkForDuplicateMAC(oc, externalNamespace, "eth0", egressIP1,
+				expectedMAC1, expectedMAC2, isIPv6, 20, 500*time.Millisecond)
+			o.Expect(err).NotTo(o.HaveOccurred(),
+				"duplicate MAC detection check failed - old node should NOT respond due to nftables rules")
+			framework.Logf("✓ All 20 MAC checks passed - only new node responded")
+
+			g.By("12. Waiting for ovnkube-node pod to restart and cluster to be healthy")
+			err = wait.PollImmediate(5*time.Second, 120*time.Second, func() (bool, error) {
+				pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
+					LabelSelector: "app=ovnkube-node",
+				})
+				if err != nil {
+					return false, err
+				}
+				return len(pods.Items) > 0, nil
+			})
+			o.Expect(err).NotTo(o.HaveOccurred(), "ovnkube-node pod should restart")
+			framework.Logf("✓ ovnkube-node pod restarted on node %s", egressNode1Name)
+
+			g.By("13. Verifying nftables cleanup on node 1 after pod restart")
+			verifyCmd := "nft list table netdev ovn-kubernetes-egressip 2>&1"
+			output, err := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", verifyCmd)).Output()
+			// Command should fail because table should be deleted
+			if err == nil && !strings.Contains(output, "No such file") && !strings.Contains(output, "Error") {
+				o.Fail(fmt.Sprintf("nftables table should be deleted but still exists: %s", output))
+			}
+			framework.Logf("✓ Nftables table cleaned up on node %s", egressNode1Name)
+
+			g.By("14. Cleaning up - removing EgressIP object")
+			_, err = oc.AsAdmin().Run("delete").Args("egressip", egressIPObjectName).Output()
+			if err != nil {
+				framework.Logf("Warning: could not delete EgressIP: %v", err)
+			}
+
+			framework.Logf("✓ Test passed: Egress IP migrated cleanly without duplicate MAC responses")
 		})
 	}) // end testing to external targets
 })

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -620,7 +620,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			framework.Logf("Node 2 MAC: %s", egressNode2MAC)
 
 			g.By("4. Installing network utilities in external container")
-			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "-c", "sh", "-c", "apk add --no-cache iputils").Output()
+			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "apk add --no-cache iputils").Output()
 			if err != nil {
 				framework.Logf("Network utilities installation note: %v", err)
 			}
@@ -638,7 +638,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				macRegex = regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
 			}
 
-			output, err := oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "-c", "sh", "-c", discoveryCmd).Output()
+			output, err := oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", discoveryCmd).Output()
 			o.Expect(err).NotTo(o.HaveOccurred(), "baseline MAC discovery should succeed")
 
 			matches := macRegex.FindStringSubmatch(output)
@@ -676,7 +676,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 					case <-stopChecking:
 						return
 					case <-ticker.C:
-						output, err := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", nftChainCheckCmd)).Output()
+						output, err := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "--", "chroot", "/host", "sh", "-c", nftChainCheckCmd).Output()
 						if err == nil && strings.Contains(output, "egressip-drop") {
 							nftChainFound <- true
 							return
@@ -741,7 +741,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 			g.By("13. Verifying nftables cleanup on node 1 after pod restart")
 			verifyCmd := "nft list table netdev ovn-kubernetes-egressip 2>&1"
-			output2, err2 := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", verifyCmd)).Output()
+			output2, err2 := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "--", "chroot", "/host", "sh", "-c", verifyCmd).Output()
 			// Command should fail because table should be deleted
 			if err2 == nil && !strings.Contains(output2, "No such file") && !strings.Contains(output2, "Error") {
 				o.ExpectWithOffset(1, false).To(o.BeTrue(), fmt.Sprintf("nftables table should be deleted but still exists: %s", output2))

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -699,7 +699,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			case chainFound := <-nftChainFound:
 				o.Expect(chainFound).To(o.BeTrue(), "nftables egressip-drop chain should exist during pod shutdown")
 			case <-time.After(10 * time.Second):
-				o.Fail("timeout waiting for nftables chain detection")
+				o.ExpectWithOffset(1, false).To(o.BeTrue(), "timeout waiting for nftables chain detection")
 			}
 			framework.Logf("✓ Nftables chain egressip-drop verified on node %s", egressNode1Name)
 
@@ -709,7 +709,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				if err != nil {
 					return false, err
 				}
-				if len(eip.Status) == 1 && eip.Status[0].Node == egressNode2Name {
+				if len(eip.Status.Items) == 1 && eip.Status.Items[0].Node == egressNode2Name {
 					return true, nil
 				}
 				return false, nil
@@ -741,10 +741,10 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 			g.By("13. Verifying nftables cleanup on node 1 after pod restart")
 			verifyCmd := "nft list table netdev ovn-kubernetes-egressip 2>&1"
-			output, err := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", verifyCmd)).Output()
+			output2, err2 := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", verifyCmd)).Output()
 			// Command should fail because table should be deleted
-			if err == nil && !strings.Contains(output, "No such file") && !strings.Contains(output, "Error") {
-				o.Fail(fmt.Sprintf("nftables table should be deleted but still exists: %s", output))
+			if err2 == nil && !strings.Contains(output2, "No such file") && !strings.Contains(output2, "Error") {
+				o.ExpectWithOffset(1, false).To(o.BeTrue(), fmt.Sprintf("nftables table should be deleted but still exists: %s", output2))
 			}
 			framework.Logf("✓ Nftables table cleaned up on node %s", egressNode1Name)
 

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -568,15 +568,17 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 		})
 
 		g.It("should prevent duplicate MAC responses when egress node is rebooted", func() {
-			g.By("Checking platform compatibility - baremetal only")
-			infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-			o.Expect(err).NotTo(o.HaveOccurred())
-			if infra.Status.PlatformStatus == nil {
-				skipper.Skipf("Platform status not available, skipping baremetal-only test")
-			}
-			if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
-				skipper.Skipf("This test requires baremetal platform, got %s", infra.Status.PlatformStatus.Type)
-			}
+			/*
+				g.By("Checking platform compatibility - baremetal only")
+				infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+				o.Expect(err).NotTo(o.HaveOccurred())
+				if infra.Status.PlatformStatus == nil {
+					skipper.Skipf("Platform status not available, skipping baremetal-only test")
+				}
+				if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+					skipper.Skipf("This test requires baremetal platform, got %s", infra.Status.PlatformStatus.Type)
+				}
+			*/
 
 			g.By("Checking if we have at least 2 egress nodes for failover")
 			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1),

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -568,29 +568,19 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 		})
 
 		g.It("should prevent duplicate MAC responses when egress node is rebooted", func() {
-			/*
-				g.By("Checking platform compatibility - baremetal only")
-				infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
-				o.Expect(err).NotTo(o.HaveOccurred())
-				if infra.Status.PlatformStatus == nil {
-					skipper.Skipf("Platform status not available, skipping baremetal-only test")
-				}
-				if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
-					skipper.Skipf("This test requires baremetal platform, got %s", infra.Status.PlatformStatus.Type)
-				}
-			*/
-
 			g.By("Checking if we have at least 2 egress nodes for failover")
 			o.Expect(len(egressIPNodesOrderedNames)).Should(o.BeNumerically(">", 1),
 				"need at least 2 egress-capable nodes for failover test")
 
-			g.By("1. Setting node 1 as egress-assignable")
+			g.By("Step-1. Labeling node 1 as egress-assignable for EgressIP assignment")
 			egressNode1Name := egressIPNodesOrderedNames[0]
 			egressNode2Name := egressIPNodesOrderedNames[1]
+			_, err := runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable=")
+			o.Expect(err).NotTo(o.HaveOccurred())
 			framework.Logf("EgressIP node 1: %s", egressNode1Name)
-			framework.Logf("EgressIP node 2: %s", egressNode2Name)
+			framework.Logf("EgressIP node 2 (for failover): %s", egressNode2Name)
 
-			g.By("2. Creating EgressIP object assigned to node 1")
+			g.By("Step-2. Creating EgressIP object assigned to node 1")
 			egressIPSet := make(map[string]string)
 			egressIPsPerNode := 1
 			nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, []string{egressNode1Name}, cloudType, egressIPsPerNode)
@@ -610,9 +600,13 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
 			egressIPObjectName := egressIPNamespace
 			createEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
-			applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+			applyEgressIPObject(oc, nil, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
 
-			g.By("3. Getting node MAC addresses")
+			g.By("Step-3. Labeling node 2 as egress-assignable for failover")
+			_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode2Name, "k8s.ovn.org/egress-assignable=")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
+			g.By("Step-4. Getting node MAC addresses of both the Node 1 and Node 2 for later verification")
 			egressNode1MAC, err := getNodeMAC(oc, egressNode1Name)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			framework.Logf("Node 1 MAC: %s", egressNode1MAC)
@@ -621,13 +615,19 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			o.Expect(err).NotTo(o.HaveOccurred())
 			framework.Logf("Node 2 MAC: %s", egressNode2MAC)
 
-			g.By("4. Installing network utilities in external container")
-			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "apk add --no-cache iputils").Output()
+			g.By("Step-5. Installing network utilities in external container")
+			// Check and install iputils (provides arping for IPv4)
+			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "command -v arping >/dev/null 2>&1 || apk add --no-cache iputils").Output()
 			if err != nil {
-				framework.Logf("Network utilities installation note: %v", err)
+				framework.Logf("iputils installation note: %v", err)
+			}
+			// Check and install ndisc6 (for IPv6)
+			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "command -v ndisc6 >/dev/null 2>&1 || apk add --no-cache ndisc6").Output()
+			if err != nil {
+				framework.Logf("ndisc6 installation note: %v", err)
 			}
 
-			g.By("5. Verifying baseline - EgressIP resolves to Node 1 MAC")
+			g.By("Step-6. Verifying baseline - EgressIP resolves to Node 1 MAC")
 			isIPv6 := strings.Contains(egressIP1, ":")
 			var discoveryCmd string
 			var macRegex *regexp.Regexp
@@ -651,7 +651,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			framework.Logf("Baseline MAC: %s (expected: %s)", baselineMAC, expectedMAC1)
 			o.Expect(baselineMAC).To(o.Equal(expectedMAC1), "EgressIP should resolve to node 1 MAC before migration")
 
-			g.By("6. Getting ovnkube-node pod name on egress node 1")
+			g.By("Step-7. Getting ovnkube-node pod name on egress node 1")
 			pods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
 				FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
 				LabelSelector: "app=ovnkube-node",
@@ -661,7 +661,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			ovnkubeNodePod := pods.Items[0].Name
 			framework.Logf("Found ovnkube-node pod: %s on node %s", ovnkubeNodePod, egressNode1Name)
 
-			g.By("7. Starting goroutine to monitor for nftables chain creation during pod deletion")
+			g.By("Step-8. Starting goroutine to monitor for nftables chain creation during pod deletion")
 			nftChainFound := make(chan bool, 1)
 			stopChecking := make(chan bool, 1)
 			goroutineReady := make(chan bool, 1)
@@ -690,12 +690,12 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			<-goroutineReady
 			framework.Logf("Nftables chain monitoring goroutine started")
 
-			g.By("8. Deleting ovnkube-node pod to trigger EIP migration")
+			g.By("Step-9. Deleting ovnkube-node pod to trigger EIP migration")
 			err = deleteOvnkubeNodePod(oc, egressNode1Name)
 			o.Expect(err).NotTo(o.HaveOccurred(), "should delete ovnkube-node pod")
 			framework.Logf("✓ ovnkube-node pod %s deleted and terminated", ovnkubeNodePod)
 
-			g.By("9. Verifying nftables chain was created during pod shutdown")
+			g.By("Step-10. Verifying nftables chain was created during pod shutdown")
 			select {
 			case chainFound := <-nftChainFound:
 				o.Expect(chainFound).To(o.BeTrue(), "nftables egressip-drop chain should exist during pod shutdown")
@@ -705,7 +705,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			close(stopChecking)
 			framework.Logf("✓ Nftables chain egressip-drop verified on node %s", egressNode1Name)
 
-			g.By("10. Waiting for EgressIP to migrate to node 2")
+			g.By("Step-11. Waiting for EgressIP to migrate to node 2")
 			err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
 				eip, err := getEgressIP(oc, egressIPObjectName)
 				if err != nil {
@@ -719,7 +719,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			o.Expect(err).NotTo(o.HaveOccurred(), "EgressIP should migrate to node 2")
 			framework.Logf("✓ Egress IP successfully migrated to node %s", egressNode2Name)
 
-			g.By("11. CRITICAL: Checking for duplicate MAC responses (20 iterations)")
+			g.By("Step-12. CRITICAL: Checking for duplicate MAC responses (20 iterations)")
 			expectedMAC2 := strings.ToLower(egressNode2MAC)
 			err = checkForDuplicateMAC(oc, externalNamespace, "prober-pod", "eth0", egressIP1,
 				expectedMAC1, expectedMAC2, isIPv6, 20, 500*time.Millisecond)
@@ -727,7 +727,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				"duplicate MAC detection check failed - old node should NOT respond due to nftables rules")
 			framework.Logf("✓ All 20 MAC checks passed - only new node responded")
 
-			g.By("12. Waiting for ovnkube-node pod to restart and cluster to be healthy")
+			g.By("Step-13. Waiting for ovnkube-node pod to restart and cluster to be healthy")
 			err = wait.PollImmediate(5*time.Second, 120*time.Second, func() (bool, error) {
 				pods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
 					FieldSelector: fmt.Sprintf("spec.nodeName=%s", egressNode1Name),
@@ -741,7 +741,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			o.Expect(err).NotTo(o.HaveOccurred(), "ovnkube-node pod should restart")
 			framework.Logf("✓ ovnkube-node pod restarted on node %s", egressNode1Name)
 
-			g.By("13. Verifying nftables cleanup on node 1 after pod restart")
+			g.By("Step-14. Verifying nftables cleanup on node 1 after pod restart")
 			verifyCmd := "nft list table netdev ovn-kubernetes-egressip 2>&1"
 			output2, err2 := oc.AsAdmin().Run("debug").Args("node/"+egressNode1Name, "--", "chroot", "/host", "sh", "-c", verifyCmd).Output()
 			// Command should fail because table should be deleted
@@ -750,7 +750,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 			}
 			framework.Logf("✓ Nftables table cleaned up on node %s", egressNode1Name)
 
-			g.By("14. Cleaning up - removing EgressIP object")
+			g.By("Step-15. Cleaning up - removing EgressIP object")
 			_, err = oc.AsAdmin().Run("delete").Args("egressip", egressIPObjectName).Output()
 			if err != nil {
 				framework.Logf("Warning: could not delete EgressIP: %v", err)

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -617,12 +617,12 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 			g.By("Step-5. Installing network utilities in external container")
 			// Check and install iputils (provides arping for IPv4)
-			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "command -v arping >/dev/null 2>&1 || apk add --no-cache iputils").Output()
+			_, err = oc.AsAdmin().Run("exec").Args("-n", externalNamespace, probePodName, "--", "sh", "-c", "command -v arping >/dev/null 2>&1 || apk add --no-cache iputils").Output()
 			if err != nil {
 				framework.Logf("iputils installation note: %v", err)
 			}
 			// Check and install ndisc6 (for IPv6)
-			_, err = oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", "command -v ndisc6 >/dev/null 2>&1 || apk add --no-cache ndisc6").Output()
+			_, err = oc.AsAdmin().Run("exec").Args("-n", externalNamespace, probePodName, "--", "sh", "-c", "command -v ndisc6 >/dev/null 2>&1 || apk add --no-cache ndisc6").Output()
 			if err != nil {
 				framework.Logf("ndisc6 installation note: %v", err)
 			}
@@ -640,7 +640,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 				macRegex = regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
 			}
 
-			output, err := oc.AsAdmin().Run("exec").Args("-i", externalNamespace, "--", "sh", "-c", discoveryCmd).Output()
+			output, err := oc.AsAdmin().Run("exec").Args("-n", externalNamespace, probePodName, "--", "sh", "-c", discoveryCmd).Output()
 			o.Expect(err).NotTo(o.HaveOccurred(), "baseline MAC discovery should succeed")
 
 			matches := macRegex.FindStringSubmatch(output)

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -719,7 +719,7 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 			g.By("11. CRITICAL: Checking for duplicate MAC responses (20 iterations)")
 			expectedMAC2 := strings.ToLower(egressNode2MAC)
-			err = checkForDuplicateMAC(oc, externalNamespace, "eth0", egressIP1,
+			err = checkForDuplicateMAC(oc, externalNamespace, "prober-pod", "eth0", egressIP1,
 				expectedMAC1, expectedMAC2, isIPv6, 20, 500*time.Millisecond)
 			o.Expect(err).NotTo(o.HaveOccurred(),
 				"duplicate MAC detection check failed - old node should NOT respond due to nftables rules")

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1846,7 +1846,7 @@ func monitorNftablesChain(oc *exutil.CLI, nodeName string) (<-chan bool, chan<- 
 func deleteOvnkubeNodePod(oc *exutil.CLI, nodeName string) error {
 	// Get ovnkube-node pod on the node
 	clientset := oc.KubeFramework().ClientSet
-	pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+	pods, err := clientset.CoreV1().Pods(ovnNamespace).List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
 		LabelSelector: "app=ovnkube-node",
 	})

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1742,7 +1742,7 @@ func getEgressIP(oc *exutil.CLI, name string) (*EgressIP, error) {
 // getNodeMAC retrieves the br-ex interface MAC address of a node
 func getNodeMAC(oc *exutil.CLI, nodeName string) (string, error) {
 	// Use oc debug node to get node info
-	output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "-c", "chroot /host ip link show br-ex").Output()
+	output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "--", "chroot", "/host", "ip", "link", "show", "br-ex").Output()
 	if err != nil {
 		return "", fmt.Errorf("failed to get MAC for node %s: %v", nodeName, err)
 	}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1760,7 +1760,7 @@ func getNodeMAC(oc *exutil.CLI, nodeName string) (string, error) {
 
 // checkForDuplicateMAC performs repeated MAC discovery checks to ensure
 // only the new node responds, and the old node does not respond
-func checkForDuplicateMAC(oc *exutil.CLI, externalContainer, interfaceName, egressIP, oldNodeMAC, newNodeMAC string, isIPv6 bool, maxChecks int, checkInterval time.Duration) error {
+func checkForDuplicateMAC(oc *exutil.CLI, externalNamespace, externalPodName, interfaceName, egressIP, oldNodeMAC, newNodeMAC string, isIPv6 bool, maxChecks int, checkInterval time.Duration) error {
 	var discoveryCmd string
 	var macRegex *regexp.Regexp
 
@@ -1778,7 +1778,7 @@ func checkForDuplicateMAC(oc *exutil.CLI, externalContainer, interfaceName, egre
 	newNodeMAC = strings.ToLower(newNodeMAC)
 
 	for i := 0; i < maxChecks; i++ {
-		output, err := oc.AsAdmin().Run("exec").Args("-i", externalContainer, "-c", "sh", "-c", discoveryCmd).Output()
+		output, err := oc.AsAdmin().Run("exec").Args("-n", externalNamespace, externalPodName, "--", "sh", "-c", discoveryCmd).Output()
 		if err != nil {
 			return fmt.Errorf("discovery check %d failed: %v", i+1, err)
 		}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1738,3 +1738,140 @@ func getEgressIP(oc *exutil.CLI, name string) (*EgressIP, error) {
 	}
 	return egressip, nil
 }
+
+// getNodeMAC retrieves the br-ex interface MAC address of a node
+func getNodeMAC(oc *exutil.CLI, nodeName string) (string, error) {
+	// Use oc debug node to get node info
+	output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "-c", "chroot /host ip link show br-ex").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get MAC for node %s: %v", nodeName, err)
+	}
+
+	// Parse output to extract MAC address
+	// Format: <index>: br-ex: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500
+	//         link/ether aa:bb:cc:dd:ee:ff brd ff:ff:ff:ff:ff:ff
+	macRegex := regexp.MustCompile(`link/ether\s+([0-9a-fA-F:]+)`)
+	matches := macRegex.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("could not extract MAC address from node %s output: %s", nodeName, output)
+	}
+	return strings.ToLower(strings.TrimSpace(matches[1])), nil
+}
+
+// checkForDuplicateMAC performs repeated MAC discovery checks to ensure
+// only the new node responds, and the old node does not respond
+func checkForDuplicateMAC(oc *exutil.CLI, externalContainer, interfaceName, egressIP, oldNodeMAC, newNodeMAC string, isIPv6 bool, maxChecks int, checkInterval time.Duration) error {
+	var discoveryCmd string
+	var macRegex *regexp.Regexp
+
+	if isIPv6 {
+		// IPv6: Use ndisc6
+		discoveryCmd = fmt.Sprintf("ndisc6 -1 -w 1000 %s %s 2>&1", egressIP, interfaceName)
+		macRegex = regexp.MustCompile(`Target link-layer address:\s+([0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2})`)
+	} else {
+		// IPv4: Use arping
+		discoveryCmd = fmt.Sprintf("arping -c 1 -I %s %s 2>&1", interfaceName, egressIP)
+		macRegex = regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
+	}
+
+	oldNodeMAC = strings.ToLower(oldNodeMAC)
+	newNodeMAC = strings.ToLower(newNodeMAC)
+
+	for i := 0; i < maxChecks; i++ {
+		output, err := oc.AsAdmin().Run("exec").Args("-i", externalContainer, "-c", "sh", "-c", discoveryCmd).Output()
+		if err != nil {
+			return fmt.Errorf("discovery check %d failed: %v", i+1, err)
+		}
+
+		matches := macRegex.FindStringSubmatch(output)
+		if len(matches) < 2 {
+			return fmt.Errorf("could not extract MAC from discovery output at check %d: %s", i+1, output)
+		}
+
+		responseMac := strings.ToLower(strings.TrimSpace(matches[1]))
+
+		// Check if old node is responding (BAD)
+		if responseMac == oldNodeMAC {
+			return fmt.Errorf("check %d: old node MAC %s still responding (should be blocked by nftables)", i+1, oldNodeMAC)
+		}
+
+		// Check if response is from new node (GOOD)
+		if responseMac != newNodeMAC {
+			return fmt.Errorf("check %d: unexpected MAC %s (expected %s from new node)", i+1, responseMac, newNodeMAC)
+		}
+
+		framework.Logf("MAC check %d/%d: PASS (MAC = %s)", i+1, maxChecks, responseMac)
+
+		// Wait before next check (except last one)
+		if i < maxChecks-1 {
+			time.Sleep(checkInterval)
+		}
+	}
+
+	return nil
+}
+
+// monitorNftablesChain monitors if the nftables egressip-drop chain is created
+// Returns: (resultChannel, stopChannel, error)
+// The goroutine will send true on resultChannel if chain is detected
+func monitorNftablesChain(oc *exutil.CLI, nodeName string) (<-chan bool, chan<- bool, error) {
+	resultChan := make(chan bool, 1)
+	stopChan := make(chan bool, 1)
+
+	go func() {
+		defer close(resultChan)
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-stopChan:
+				return
+			case <-ticker.C:
+				// Check if chain exists
+				nftCmd := "nft -j list chains | jq '.nftables[] | select(.chain.table==\"ovn-kubernetes-egressip\" and .chain.family==\"netdev\" and .chain.name==\"egressip-drop\").chain'"
+				output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", nftCmd)).Output()
+				if err == nil && strings.Contains(output, "egressip-drop") {
+					resultChan <- true
+					return
+				}
+			}
+		}
+	}()
+
+	return resultChan, stopChan, nil
+}
+
+// deleteOvnkubeNodePod deletes the ovnkube-node pod on the specified node
+func deleteOvnkubeNodePod(oc *exutil.CLI, nodeName string) error {
+	// Get ovnkube-node pod on the node
+	clientset := oc.KubeFramework().ClientSet
+	pods, err := clientset.CoreV1().Pods("ovn-kubernetes").List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+		LabelSelector: "app=ovnkube-node",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list ovnkube-node pods on node %s: %v", nodeName, err)
+	}
+	if len(pods.Items) != 1 {
+		return fmt.Errorf("expected 1 ovnkube-node pod on node %s, found %d", nodeName, len(pods.Items))
+	}
+
+	podName := pods.Items[0].Name
+	gracePeriod := int64(0) // Immediate deletion for testing
+	deleteOptions := metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}
+
+	// Delete the pod
+	if err := clientset.CoreV1().Pods("ovn-kubernetes").Delete(context.TODO(), podName, deleteOptions); err != nil {
+		return fmt.Errorf("failed to delete ovnkube-node pod %s: %v", podName, err)
+	}
+
+	// Wait for pod to be fully deleted
+	return wait.PollImmediate(1*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := clientset.CoreV1().Pods("ovn-kubernetes").Get(context.TODO(), podName, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1830,7 +1830,7 @@ func monitorNftablesChain(oc *exutil.CLI, nodeName string) (<-chan bool, chan<- 
 			case <-ticker.C:
 				// Check if chain exists
 				nftCmd := "nft -j list chains | jq '.nftables[] | select(.chain.table==\"ovn-kubernetes-egressip\" and .chain.family==\"netdev\" and .chain.name==\"egressip-drop\").chain'"
-				output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "-c", "chroot /host sh -c "+fmt.Sprintf("'%s'", nftCmd)).Output()
+				output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "--", "chroot", "/host", "sh", "-c", nftCmd).Output()
 				if err == nil && strings.Contains(output, "egressip-drop") {
 					resultChan <- true
 					return

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1783,21 +1783,36 @@ func checkForDuplicateMAC(oc *exutil.CLI, externalNamespace, externalPodName, in
 			return fmt.Errorf("discovery check %d failed: %v", i+1, err)
 		}
 
-		matches := macRegex.FindStringSubmatch(output)
-		if len(matches) < 2 {
+		// Use FindAllStringSubmatch to get ALL MAC addresses in the probe output
+		// arping and ndisc6 can print several replies when two nodes answer for the same address
+		allMatches := macRegex.FindAllStringSubmatch(output, -1)
+		if len(allMatches) == 0 {
 			return fmt.Errorf("could not extract MAC from discovery output at check %d: %s", i+1, output)
 		}
 
-		responseMac := strings.ToLower(strings.TrimSpace(matches[1]))
+		// Inspect every MAC in the probe output
+		var responseMac string
+		for _, match := range allMatches {
+			if len(match) < 2 {
+				continue
+			}
+			mac := strings.ToLower(strings.TrimSpace(match[1]))
 
-		// Check if old node is responding (BAD)
-		if responseMac == oldNodeMAC {
-			return fmt.Errorf("check %d: old node MAC %s still responding (should be blocked by nftables)", i+1, oldNodeMAC)
+			// Check if old node is responding (BAD)
+			if mac == oldNodeMAC {
+				return fmt.Errorf("check %d: old node MAC %s still responding (should be blocked by nftables)", i+1, oldNodeMAC)
+			}
+
+			// Check if response is from new node (GOOD)
+			if mac == newNodeMAC {
+				responseMac = mac
+			}
 		}
 
-		// Check if response is from new node (GOOD)
-		if responseMac != newNodeMAC {
-			return fmt.Errorf("check %d: unexpected MAC %s (expected %s from new node)", i+1, responseMac, newNodeMAC)
+		// Reject the check if any match equals oldNodeMAC (already handled above)
+		// Accept only if we found the expected new node MAC
+		if responseMac == "" {
+			return fmt.Errorf("check %d: expected MAC %s from new node not found (expected %s from new node)", i+1, newNodeMAC, newNodeMAC)
 		}
 
 		framework.Logf("MAC check %d/%d: PASS (MAC = %s)", i+1, maxChecks, responseMac)
@@ -1809,37 +1824,6 @@ func checkForDuplicateMAC(oc *exutil.CLI, externalNamespace, externalPodName, in
 	}
 
 	return nil
-}
-
-// monitorNftablesChain monitors if the nftables egressip-drop chain is created
-// Returns: (resultChannel, stopChannel, error)
-// The goroutine will send true on resultChannel if chain is detected
-func monitorNftablesChain(oc *exutil.CLI, nodeName string) (<-chan bool, chan<- bool, error) {
-	resultChan := make(chan bool, 1)
-	stopChan := make(chan bool, 1)
-
-	go func() {
-		defer close(resultChan)
-		ticker := time.NewTicker(100 * time.Millisecond)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-stopChan:
-				return
-			case <-ticker.C:
-				// Check if chain exists
-				nftCmd := "nft -j list chains | jq '.nftables[] | select(.chain.table==\"ovn-kubernetes-egressip\" and .chain.family==\"netdev\" and .chain.name==\"egressip-drop\").chain'"
-				output, err := oc.AsAdmin().Run("debug").Args("node/"+nodeName, "--", "chroot", "/host", "sh", "-c", nftCmd).Output()
-				if err == nil && strings.Contains(output, "egressip-drop") {
-					resultChan <- true
-					return
-				}
-			}
-		}
-	}()
-
-	return resultChan, stopChan, nil
 }
 
 // deleteOvnkubeNodePod deletes the ovnkube-node pod on the specified node


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added bare-metal EgressIP failover coverage for IPv4 and IPv6.
  * Verifies EgressIP migration when the hosting node’s networking pod is disrupted.
  * Checks baseline and post-failover MAC address resolution, including repeated duplicate-MAC detection.
  * Validates temporary network traffic controls during failover and confirms their removal after recovery.
  * Skips environments that are not bare metal or do not meet the required node conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->