### PR TITLE
OCPBUGS-99273: Add origin e2e test for EgressIP orphan node skip

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -185,6 +186,58 @@ var _ = g.Describe("[sig-network][Feature:EgressIP][apigroup:operator.openshift.
 
 		g.By("Removing the temp directory")
 		os.RemoveAll(tmpDirEgressIP)
+	})
+
+	g.It("should skip nodes without host-cidrs annotation when assigning EgressIPs", func() {
+		g.By("Creating a bare node without host-cidrs annotation to simulate an orphan")
+		orphanNodeName := fmt.Sprintf("eip-orphan-%d", time.Now().UnixNano())
+		_, err := clientset.CoreV1().Nodes().Create(context.TODO(), &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: orphanNodeName,
+				Labels: map[string]string{
+					"k8s.ovn.org/egress-assignable": "",
+				},
+			},
+		}, metav1.CreateOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		defer func() {
+			err := clientset.CoreV1().Nodes().Delete(context.TODO(), orphanNodeName, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				o.Expect(err).NotTo(o.HaveOccurred(), "Failed to clean up orphan node %s", orphanNodeName)
+			}
+		}()
+
+		g.By("Getting EgressIPs for two real nodes")
+		egressIPsPerNode := 1
+		nodeEgressIPMap, err := findNodeEgressIPs(oc, clientset, cloudNetworkClientset, egressIPNodesOrderedNames[:2], cloudType, egressIPsPerNode)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		framework.Logf("nodeEgressIPMap: %v", nodeEgressIPMap)
+
+		egressIPSet := make(map[string]string)
+		validNodes := make(map[string]bool)
+		for nodeName, eip := range nodeEgressIPMap {
+			egressIPSet[eip[0]] = nodeName
+			validNodes[nodeName] = true
+		}
+
+		g.By("Creating and applying the EgressIP object")
+		egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+		egressIPObjectName := egressIPNamespace
+		createEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, egressIPNamespace, "", egressIPSet)
+		applyEgressIPObject(oc, cloudNetworkClientset, egressIPYamlPath, egressIPNamespace, egressIPSet, egressUpdateTimeout)
+
+		g.By("Verifying both EgressIPs are assigned to valid nodes and none to the orphan node")
+		eip, err := getEgressIP(oc, egressIPObjectName)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(eip.Status.Items).To(o.HaveLen(2),
+			"Expected 2 EgressIP assignments despite orphan node presence")
+		for _, item := range eip.Status.Items {
+			framework.Logf("EgressIP %s assigned to node %s", item.EgressIP, item.Node)
+			o.Expect(item.Node).NotTo(o.Equal(orphanNodeName),
+				"EgressIP %s was incorrectly assigned to orphan node %s which has no host-cidrs annotation", item.EgressIP, orphanNodeName)
+			o.Expect(validNodes).To(o.HaveKey(item.Node),
+				"EgressIP %s assigned to unexpected node %s, valid nodes: %v", item.EgressIP, item.Node, validNodes)
+		}
 	})
 
 	g.Context("[internal-targets]", func() {


### PR DESCRIPTION
## Summary

- Adds origin e2e test for the core OCPBUGS-99273 bug scenario: one node
  with missing host-cidrs must not block EgressIP assignment cluster-wide
- Uses two real nodes with two EgressIPs to prove the controller does not
  abort the entire assignment pass when an orphan node is present
- Aligns with upstream ovn-kubernetes e2e (PR #[6773](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/6773) )

## Test approach

1. Creates a bare Node object labeled `k8s.ovn.org/egress-assignable`
   but with no host-cidrs annotation (simulates orphaned/stale node)
2. Allocates EgressIPs for two real egress-assignable nodes
3. Creates an EgressIP object with both IPs
4. Verifies both EgressIPs are assigned (controller did not abort)
5. Verifies each EgressIP maps to the correct valid node
6. Verifies neither EgressIP is assigned to the orphan node

## Related

- Upstream fix: https://github.com/ovn-org/ovn-kubernetes/pull/6773
- Upstream flake fix: https://github.com/ovn-org/ovn-kubernetes/pull/6863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming that nodes without a host-cidrs annotation are skipped during EgressIP assignment.
  - Verified EgressIP status assigns addresses only to eligible worker nodes, excluding unconfigured orphan nodes.
  - Strengthened cleanup validation to handle already-removed nodes and report unexpected deletion failures.
  - Improved coverage of EgressIP node eligibility and assignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->