### PR TITLE
NE-2816: Apply HAProxy sidecar on router e2e tests

### DIFF
--- a/test/extended/router/certs.go
+++ b/test/extended/router/certs.go
@@ -120,10 +120,9 @@ Zc0jLTXBHUisaCSN
 var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc          *exutil.CLI
-		ns          string
-		routerImage string
-		isFIPS      bool
+		oc     *exutil.CLI
+		ns     string
+		isFIPS bool
 	)
 
 	g.AfterEach(func() {
@@ -147,8 +146,6 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 		ns = oc.Namespace()
 
 		var err error
-		routerImage, err = exutil.FindRouterImage(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
 
 		isFIPS, err = exutil.IsFIPS(oc.AdminKubeClient().CoreV1())
 		o.Expect(err).NotTo(o.HaveOccurred())
@@ -165,10 +162,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 					g.Skip("skipping on non-FIPS cluster")
 				}
 
-				routerPod := createScopedRouterPod(routerImage, "test-1024bit", pemData1024, "true")
+				routerPod, err := createScopedRouterPod(oc, "test-1024bit", pemData1024, "true")
+				o.Expect(err).NotTo(o.HaveOccurred())
+
 				g.By("creating a router")
 				ns := oc.KubeFramework().Namespace.Name
-				_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+				_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
@@ -199,10 +198,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 					g.Skip("skipping on FIPS cluster")
 				}
 
-				routerPod := createScopedRouterPod(routerImage, "test-1024bit", pemData1024, "true")
+				routerPod, err := createScopedRouterPod(oc, "test-1024bit", pemData1024, "true")
+				o.Expect(err).NotTo(o.HaveOccurred())
+
 				g.By("creating a router")
 				ns := oc.KubeFramework().Namespace.Name
-				_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+				_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 
 				execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
@@ -245,8 +246,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	})
 })
 
-func createScopedRouterPod(routerImage, routerName, pemData, updateStatus string) *corev1.Pod {
-	return &corev1.Pod{
+func createScopedRouterPod(oc *exutil.CLI, routerName, pemData, updateStatus string) (*corev1.Pod, error) {
+	routerImage, err := exutil.FindRouterImage(oc)
+	if err != nil {
+		return nil, err
+	}
+	routerPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "router-scoped",
 			Labels: map[string]string{
@@ -313,4 +318,8 @@ func createScopedRouterPod(routerImage, routerName, pemData, updateStatus string
 			},
 		},
 	}
+	if err := applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec); err != nil {
+		return nil, err
+	}
+	return routerPod, nil
 }

--- a/test/extended/router/config_manager.go
+++ b/test/extended/router/config_manager.go
@@ -382,71 +382,75 @@ http {
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}
 
-		g.By("creating route Pods")
-		routerPods := []corev1.Pod{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "router-haproxy-cfgmgr",
-					Labels: map[string]string{
-						"test": "router-haproxy-cfgmgr",
-					},
+		g.By("creating router pods")
+		routerPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "router-haproxy-cfgmgr",
+				Labels: map[string]string{
+					"test": "router-haproxy-cfgmgr",
 				},
-				Spec: corev1.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64(1),
-					Containers: []corev1.Container{
-						{
-							Name:            "router",
-							Image:           routerImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
+			},
+			Spec: corev1.PodSpec{
+				TerminationGracePeriodSeconds: utilpointer.Int64(1),
+				Containers: []corev1.Container{
+					{
+						Name:            "router",
+						Image:           routerImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name: "POD_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
 									},
 								},
-								{
-									Name:  "ROUTER_IP_V4_V6_MODE",
-									Value: "v4v6",
-								},
-								{
-									Name:  "ROUTER_BLUEPRINT_ROUTE_POOL_SIZE",
-									Value: strconv.Itoa(ROUTER_BLUEPRINT_ROUTE_POOL_SIZE),
-								},
-								{
-									Name:  "ROUTER_MAX_DYNAMIC_SERVERS",
-									Value: strconv.Itoa(ROUTER_MAX_DYNAMIC_SERVERS),
-								},
 							},
-							Args: []string{
-								"--namespace=$(POD_NAMESPACE)",
-								"-v=4",
-								"--haproxy-config-manager=true",
-								"--blueprint-route-labels=select=hapcm-blueprint",
-								"--labels=select=haproxy-cfgmgr",
-								"--stats-password=password",
-								"--stats-port=1936",
-								"--stats-user=admin",
+							{
+								Name:  "ROUTER_IP_V4_V6_MODE",
+								Value: "v4v6",
 							},
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: 80,
-								},
-								{
-									ContainerPort: 443,
-								},
-								{
-									ContainerPort: 1936,
-									Name:          "stats",
-									Protocol:      corev1.ProtocolTCP,
-								},
+							{
+								Name:  "ROUTER_BLUEPRINT_ROUTE_POOL_SIZE",
+								Value: strconv.Itoa(ROUTER_BLUEPRINT_ROUTE_POOL_SIZE),
+							},
+							{
+								Name:  "ROUTER_MAX_DYNAMIC_SERVERS",
+								Value: strconv.Itoa(ROUTER_MAX_DYNAMIC_SERVERS),
+							},
+						},
+						Args: []string{
+							"--namespace=$(POD_NAMESPACE)",
+							"-v=4",
+							"--haproxy-config-manager=true",
+							"--blueprint-route-labels=select=hapcm-blueprint",
+							"--labels=select=haproxy-cfgmgr",
+							"--stats-password=password",
+							"--stats-port=1936",
+							"--stats-user=admin",
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 80,
+							},
+							{
+								ContainerPort: 443,
+							},
+							{
+								ContainerPort: 1936,
+								Name:          "stats",
+								Protocol:      corev1.ProtocolTCP,
 							},
 						},
 					},
 				},
 			},
+		}
+		err = applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		testingPods := []corev1.Pod{
+			routerPod,
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "insecure-endpoint",
@@ -552,7 +556,7 @@ http {
 			},
 		}
 		for i := range NUM_CONCURRENT_SERVICES {
-			routerPods = append(routerPods, corev1.Pod{
+			testingPods = append(testingPods, corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("insecure-concurrent-endpoint-%d", i),
 					Labels: map[string]string{
@@ -579,7 +583,7 @@ http {
 			})
 		}
 		for i := range NUM_CONCURRENT_REPLICAS {
-			routerPods = append(routerPods, corev1.Pod{
+			testingPods = append(testingPods, corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: fmt.Sprintf("insecure-concurrent-endpoint-replicas-%d", i),
 					Labels: map[string]string{
@@ -607,7 +611,7 @@ http {
 			})
 		}
 
-		for _, pod := range routerPods {
+		for _, pod := range testingPods {
 			_, err = kubeClient.CoreV1().Pods(ns).Create(context.Background(), &pod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}

--- a/test/extended/router/h2spec.go
+++ b/test/extended/router/h2spec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +24,7 @@ import (
 	e2eoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	admissionapi "k8s.io/pod-security-admission/api"
 	utilpointer "k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -270,7 +272,7 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("Creating h2spec test service h2spec-haproxy pod")
-			haProxyPod := &corev1.Pod{
+			routerPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "h2spec-haproxy",
 					Labels: map[string]string{
@@ -280,53 +282,11 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Image:   routerImage,
-							Name:    "haproxy",
-							Command: []string{"/bin/bash", "-c"},
-							Args: []string{
-								"set -e; cat /etc/serving-cert/tls.key /etc/serving-cert/tls.crt > /tmp/bundle.pem; haproxy -f /etc/haproxy/haproxy.config -db",
-							},
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: 8443,
-									Protocol:      corev1.ProtocolTCP,
-								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								FailureThreshold: 3,
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(8443),
-									},
-								},
-								InitialDelaySeconds: 10,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-							},
-							LivenessProbe: &corev1.Probe{
-								FailureThreshold: 3,
-								ProbeHandler: corev1.ProbeHandler{
-									TCPSocket: &corev1.TCPSocketAction{
-										Port: intstr.FromInt(8443),
-									},
-								},
-								InitialDelaySeconds: 10,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-							},
-							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: utilpointer.Bool(true),
-							},
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									MountPath: "/etc/serving-cert",
-									Name:      "cert",
-								},
-								{
-									MountPath: "/etc/haproxy",
-									Name:      "config",
-								},
-							},
+							Image:           routerImage,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Name:            "router",
+							Command:         []string{"sleep"},
+							Args:            []string{"infinity"},
 						},
 					},
 					Volumes: []corev1.Volume{
@@ -351,8 +311,50 @@ BFNBRELPe53ZdLKWpf2Sr96vRPRNw
 					},
 				},
 			}
+			err = applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec)
+			o.Expect(err).NotTo(o.HaveOccurred())
 
-			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), haProxyPod, metav1.CreateOptions{})
+			i := slices.IndexFunc(routerPod.Spec.InitContainers, func(c corev1.Container) bool { return c.Name == "haproxy" })
+			o.Expect(i).To(o.BeNumerically(">=", 0), "router-default has no haproxy sidecar init container")
+
+			haproxyContainer := &routerPod.Spec.InitContainers[i]
+			haproxyContainer.Command = []string{"/bin/bash", "-c"}
+			haproxyContainer.Args = []string{
+				"set -e; cat /etc/serving-cert/tls.key /etc/serving-cert/tls.crt > /tmp/bundle.pem; haproxy -f /etc/haproxy/haproxy.config -db",
+			}
+			if secctx := haproxyContainer.SecurityContext; secctx != nil {
+				secctx.ReadOnlyRootFilesystem = ptr.To(false)
+			}
+			haproxyContainer.Ports = []corev1.ContainerPort{{
+				ContainerPort: 8443,
+				Protocol:      corev1.ProtocolTCP,
+			}}
+			probe := &corev1.Probe{
+				FailureThreshold: 3,
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{
+						Port: intstr.FromInt(8443),
+					},
+				},
+				InitialDelaySeconds: 10,
+				PeriodSeconds:       30,
+				SuccessThreshold:    1,
+			}
+			haproxyContainer.ReadinessProbe = probe.DeepCopy()
+			haproxyContainer.LivenessProbe = probe.DeepCopy()
+			haproxyContainer.StartupProbe = probe.DeepCopy()
+			haproxyContainer.VolumeMounts = []corev1.VolumeMount{
+				{
+					MountPath: "/etc/serving-cert",
+					Name:      "cert",
+				},
+				{
+					MountPath: "/etc/haproxy",
+					Name:      "config",
+				},
+			}
+
+			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("Creating h2spec test service object")

--- a/test/extended/router/multi-haproxy.go
+++ b/test/extended/router/multi-haproxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -11,6 +12,7 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	securityv1 "github.com/openshift/api/security/v1"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
 
 	"github.com/openshift/origin/test/extended/router/shard"
@@ -351,4 +354,138 @@ func apiHasHAProxyVersionField(ctx context.Context, oc *exutil.CLI) (bool, error
 		}
 	}
 	return false, nil
+}
+
+// applyHAProxySidecarToPod receives a pre-configured router pod and applies the HAProxy
+// sidecar container on it, along with the needed configuration for the router to work.
+// Use this when creating the router directly via the Pod API; use applyHAProxySidecarToPodTemplate()
+// when going through a PodTemplateSpec (ReplicaSet/Deployment) instead.
+func applyHAProxySidecarToPod(ctx context.Context, oc *exutil.CLI, routerPodSpec *corev1.PodSpec) error {
+	if len(routerPodSpec.Containers) == 0 {
+		return fmt.Errorf("provided router pod has no containers")
+	}
+	routerContainer := &routerPodSpec.Containers[0]
+
+	defaultDeployment, err := oc.AdminKubeClient().AppsV1().Deployments("openshift-ingress").Get(ctx, "router-default", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if len(defaultDeployment.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("router-default deployment has no containers")
+	}
+	// Use a copy so we don't risk mutating a shared object
+	defaultDeployment = defaultDeployment.DeepCopy()
+
+	routerPodSpec.ShareProcessNamespace = ptr.To(true)
+	routerPodSpec.AutomountServiceAccountToken = ptr.To(false)
+	routerPodSpec.InitContainers = defaultDeployment.Spec.Template.Spec.InitContainers
+
+	// Defaults the ROUTER_HAPROXY_ADMIN_UNIX_SOCKET if the provided router container does not configure it.
+	// https://github.com/openshift/cluster-ingress-operator/blob/5bf72fcc4534d9ba2c4d65d29cdb8b01c83cf550/pkg/operator/controller/ingress/deployment.go#L1379-L1383
+	const haproxySocketEnvvar = "ROUTER_HAPROXY_ADMIN_UNIX_SOCKET"
+	const haproxySocketValue = "/var/lib/haproxy/run/admin.sock"
+	hasHAProxySocketEnvvar := slices.ContainsFunc(routerContainer.Env, func(e corev1.EnvVar) bool {
+		return e.Name == haproxySocketEnvvar
+	})
+	if !hasHAProxySocketEnvvar {
+		routerContainer.Env = append(routerContainer.Env, corev1.EnvVar{
+			Name:  haproxySocketEnvvar,
+			Value: haproxySocketValue,
+		})
+	}
+
+	// We want to copy only these volumes from a running router: they are required for the
+	// haproxy sidecar to run. Other volumes - default-certificate and service-ca-bundle
+	// depend on other resources the testing namespace does not provide.
+	sidecarVolumes := []string{"haproxy-config", "kube-api-access"}
+
+	for i := range routerPodSpec.InitContainers {
+		container := &routerPodSpec.InitContainers[i]
+		container.VolumeMounts = slices.DeleteFunc(container.VolumeMounts, func(v corev1.VolumeMount) bool {
+			return !slices.Contains(sidecarVolumes, v.Name)
+		})
+	}
+
+	for _, volume := range defaultDeployment.Spec.Template.Spec.Volumes {
+		if volume.Name == "kube-api-access" && volume.Projected != nil {
+			// This is the service account volume. Our testing namespace and pod do not have the
+			// proper configuration to allow the router container read the mounted token as 0400, the
+			// ingress operator default. This is simpler than configuring the correct permissions,
+			// acceptable since these tests aren't asserting on token hardening.
+			//
+			// Overriding to nil (defaults to 0644) gives the router read access to the token.
+			volume.Projected.DefaultMode = nil
+		}
+		if slices.Contains(sidecarVolumes, volume.Name) {
+			routerPodSpec.Volumes = append(routerPodSpec.Volumes, volume)
+		}
+	}
+	for _, volumeMount := range defaultDeployment.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if slices.Contains(sidecarVolumes, volumeMount.Name) {
+			routerPodSpec.Containers[0].VolumeMounts = append(routerPodSpec.Containers[0].VolumeMounts, volumeMount)
+		}
+	}
+	return nil
+}
+
+// applyHAProxySidecarToPodTemplate receives a pre-configured router pod template and applies
+// the HAProxy sidecar container on it, just like applyHAProxySidecarToPod(). It also grants
+// the namespace's default service account access to the restricted SCC, and pins the pod
+// template to require it - needed because pods created by a controller are SCC-checked
+// against their own service account, not the caller's identity, and restricted-v2 (the
+// cluster default) forbids the privilege escalation the sidecar needs.
+func applyHAProxySidecarToPodTemplate(ctx context.Context, oc *exutil.CLI, namespace string, routerPodTemplateSpec *corev1.PodTemplateSpec) error {
+	err := applyHAProxySidecarToPod(ctx, oc, &routerPodTemplateSpec.Spec)
+	if err != nil {
+		return err
+	}
+
+	if routerPodTemplateSpec.Annotations == nil {
+		routerPodTemplateSpec.Annotations = make(map[string]string)
+	}
+	// The restricted-v2 scc preempts restricted, so we must pin to restricted.
+	routerPodTemplateSpec.Annotations[securityv1.RequiredSCCAnnotation] = "restricted"
+
+	_, err = oc.AdminKubeClient().RbacV1().RoleBindings(namespace).Create(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: "default",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "system:router",
+		},
+	}, metav1.CreateOptions{})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	// The router typically runs with allowPrivilegeEscalation enabled; however, all service accounts are assigned
+	// to restricted-v2 scc by default, which disallows privilege escalation. The restricted policy permits
+	// privilege escalation.
+	_, err = oc.AdminKubeClient().RbacV1().RoleBindings(namespace).Create(ctx, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router-restricted",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: "default",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "system:openshift:scc:restricted",
+		},
+	}, metav1.CreateOptions{})
+	if client.IgnoreAlreadyExists(err) != nil {
+		return err
+	}
+
+	return nil
 }

--- a/test/extended/router/scoped.go
+++ b/test/extended/router/scoped.go
@@ -32,9 +32,8 @@ const changeTimeoutSeconds = 3 * 60
 var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc          *exutil.CLI
-		ns          string
-		routerImage string
+		oc *exutil.CLI
+		ns string
 	)
 
 	// this hook must be registered before the framework namespace teardown
@@ -54,22 +53,20 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		var err error
-		routerImage, err = exutil.FindRouterImage(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
 		configPath := exutil.FixturePath("testdata", "router", "router-common.yaml")
-		err = oc.AsAdmin().Run("apply").Args("-f", configPath).Execute()
+		err := oc.AsAdmin().Run("apply").Args("-f", configPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should serve the correct routes when scoped to a single namespace and label set", func() {
 
-			routerPod := createScopedRouterPod(routerImage, "test-scoped", defaultPemData, "true")
+			routerPod, err := createScopedRouterPod(oc, "test-scoped", defaultPemData, "true")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			g.By("creating a router")
 			ns := oc.KubeFramework().Namespace.Name
-			_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
@@ -111,10 +108,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 		g.It("should override the route host with a custom value", func() {
 
-			routerPod := createOverrideRouterPod(routerImage)
+			routerPod, err := createOverrideRouterPod(oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			g.By("creating a router")
 			ns := oc.KubeFramework().Namespace.Name
-			_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
@@ -175,10 +174,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 		g.It("should override the route host for overridden domains with a custom value [apigroup:image.openshift.io]", func() {
 
-			routerPod := createOverrideDomainRouterPod(routerImage)
+			routerPod, err := createOverrideDomainRouterPod(oc)
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			g.By("creating a router")
 			ns := oc.KubeFramework().Namespace.Name
-			_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")
@@ -343,8 +344,12 @@ func ingressForName(r *routev1.Route, name string) *routev1.RouteIngress {
 	return nil
 }
 
-func createOverrideRouterPod(routerImage string) *corev1.Pod {
-	return &corev1.Pod{
+func createOverrideRouterPod(oc *exutil.CLI) (*corev1.Pod, error) {
+	routerImage, err := exutil.FindRouterImage(oc)
+	if err != nil {
+		return nil, err
+	}
+	routerPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "router-override",
 			Labels: map[string]string{
@@ -411,10 +416,18 @@ func createOverrideRouterPod(routerImage string) *corev1.Pod {
 			},
 		},
 	}
+	if err := applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec); err != nil {
+		return nil, err
+	}
+	return routerPod, nil
 }
 
-func createOverrideDomainRouterPod(routerImage string) *corev1.Pod {
-	return &corev1.Pod{
+func createOverrideDomainRouterPod(oc *exutil.CLI) (*corev1.Pod, error) {
+	routerImage, err := exutil.FindRouterImage(oc)
+	if err != nil {
+		return nil, err
+	}
+	routerPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "router-override-domains",
 			Labels: map[string]string{
@@ -481,4 +494,8 @@ func createOverrideDomainRouterPod(routerImage string) *corev1.Pod {
 			},
 		},
 	}
+	if err := applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec); err != nil {
+		return nil, err
+	}
+	return routerPod, nil
 }

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -18,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,7 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	routev1 "github.com/openshift/api/route/v1"
-	v2 "github.com/openshift/api/security/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
 	v1 "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 	exutil "github.com/openshift/origin/test/extended/util"
@@ -41,9 +39,8 @@ import (
 var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		routerImage string
-		ns          string
-		oc          *exutil.CLI
+		ns string
+		oc *exutil.CLI
 	)
 
 	// this hook must be registered before the framework namespace teardown
@@ -62,64 +59,25 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
-
-		var err error
-		routerImage, err = exutil.FindRouterImage(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		_, err = oc.AdminKubeClient().RbacV1().RoleBindings(ns).Create(context.Background(), &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "router",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: "ServiceAccount",
-					Name: "default",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: "system:router",
-			},
-		}, metav1.CreateOptions{})
-		// The router typically runs with allowPrivilegeEscalation enabled; however, all service accounts are assigned
-		// to restricted-v2 scc by default, which disallows privilege escalation. The restricted policy permits
-		// privilege escalation.
-		_, err = oc.AdminKubeClient().RbacV1().RoleBindings(ns).Create(context.Background(), &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "router-restricted",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: "ServiceAccount",
-					Name: "default",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: "system:openshift:scc:restricted",
-			},
-		}, metav1.CreateOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.Describe("The HAProxy router", func() {
 		g.It("converges when multiple routers are writing status", func() {
 			g.By("deploying a scaled out namespace scoped router")
 			routerName := "namespaced"
+			routerRS, err := scaledRouter(
+				oc,
+				"router",
+				[]string{
+					"-v=4",
+					fmt.Sprintf("--namespace=%s", ns),
+					"--resync-interval=2m",
+					fmt.Sprintf("--name=%s", routerName),
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
 			rs, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
-				context.Background(),
-				scaledRouter(
-					"router",
-					routerImage,
-					[]string{
-						"-v=4",
-						fmt.Sprintf("--namespace=%s", ns),
-						"--resync-interval=2m",
-						fmt.Sprintf("--name=%s", routerName),
-					},
-				),
-				metav1.CreateOptions{},
+				context.Background(), routerRS, metav1.CreateOptions{},
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = waitForReadyReplicaSet(oc.KubeClient(), ns, rs.Name)
@@ -174,23 +132,23 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			g.By("deploying a scaled out namespace scoped router")
 			routerName := "conflicting"
 			numOfRoutes := 20
+			routerRS, err := scaledRouter(
+				oc,
+				"router",
+				[]string{
+					"-v=4",
+					fmt.Sprintf("--namespace=%s", ns),
+					// Make resync interval high to avoid contention flushes.
+					"--resync-interval=24h",
+					fmt.Sprintf("--name=%s", routerName),
+					"--override-hostname",
+					// causes each pod to have a different value
+					"--hostname-template=${name}-${namespace}.$(NAME).local",
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
 			rs, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
-				context.Background(),
-				scaledRouter(
-					"router",
-					routerImage,
-					[]string{
-						"-v=4",
-						fmt.Sprintf("--namespace=%s", ns),
-						// Make resync interval high to avoid contention flushes.
-						"--resync-interval=24h",
-						fmt.Sprintf("--name=%s", routerName),
-						"--override-hostname",
-						// causes each pod to have a different value
-						"--hostname-template=${name}-${namespace}.$(NAME).local",
-					},
-				),
-				metav1.CreateOptions{},
+				context.Background(), routerRS, metav1.CreateOptions{},
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = waitForReadyReplicaSet(oc.KubeClient(), ns, rs.Name)
@@ -288,21 +246,21 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 			routerName := "conflicting"
 			numOfRoutes := 20
+			routerRS, err := scaledRouter(
+				oc,
+				"router-add-condition",
+				[]string{
+					"-v=5",
+					fmt.Sprintf("--namespace=%s", ns),
+					// Make resync interval high to avoid contention flushes.
+					"--resync-interval=24h",
+					fmt.Sprintf("--name=%s", routerName),
+					"--debug-upgrade-validation-force-add-condition",
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
 			rsAdd, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
-				context.Background(),
-				scaledRouter(
-					"router-add-condition",
-					routerImage,
-					[]string{
-						"-v=5",
-						fmt.Sprintf("--namespace=%s", ns),
-						// Make resync interval high to avoid contention flushes.
-						"--resync-interval=24h",
-						fmt.Sprintf("--name=%s", routerName),
-						"--debug-upgrade-validation-force-add-condition",
-					},
-				),
-				metav1.CreateOptions{},
+				context.Background(), routerRS, metav1.CreateOptions{},
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = waitForReadyReplicaSet(oc.KubeClient(), ns, rsAdd.Name)
@@ -364,21 +322,21 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			}
 
 			g.By("deploying a scaled out namespace scoped router that removes the UnservableInFutureVersions condition")
+			routerRS, err = scaledRouter(
+				oc,
+				"router-remove-condition",
+				[]string{
+					"-v=5",
+					fmt.Sprintf("--namespace=%s", ns),
+					// Make resync interval high to avoid contention flushes.
+					"--resync-interval=24h",
+					fmt.Sprintf("--name=%s", routerName),
+					"--debug-upgrade-validation-force-remove-condition",
+				},
+			)
+			o.Expect(err).NotTo(o.HaveOccurred())
 			rsRemove, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
-				context.Background(),
-				scaledRouter(
-					"router-remove-condition",
-					routerImage,
-					[]string{
-						"-v=5",
-						fmt.Sprintf("--namespace=%s", ns),
-						// Make resync interval high to avoid contention flushes.
-						"--resync-interval=24h",
-						fmt.Sprintf("--name=%s", routerName),
-						"--debug-upgrade-validation-force-remove-condition",
-					},
-				),
-				metav1.CreateOptions{},
+				context.Background(), routerRS, metav1.CreateOptions{},
 			)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			err = waitForReadyReplicaSet(oc.KubeClient(), ns, rsRemove.Name)
@@ -576,10 +534,14 @@ func removeIngressCondition(ingress *routev1.RouteIngress, t routev1.RouteIngres
 	}
 }
 
-func scaledRouter(name, image string, args []string) *appsv1.ReplicaSet {
+func scaledRouter(oc *exutil.CLI, name string, args []string) (*appsv1.ReplicaSet, error) {
 	one := int64(1)
 	scale := int32(3)
-	return &appsv1.ReplicaSet{
+	routerImage, err := exutil.FindRouterImage(oc)
+	if err != nil {
+		return nil, err
+	}
+	routerRS := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -591,10 +553,6 @@ func scaledRouter(name, image string, args []string) *appsv1.ReplicaSet {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": name},
-					Annotations: map[string]string{
-						// The restricted-v2 scc preempts restricted, so we must pin to restricted.
-						v2.RequiredSCCAnnotation: "restricted",
-					},
 				},
 				Spec: corev1.PodSpec{
 					TerminationGracePeriodSeconds: &one,
@@ -618,7 +576,7 @@ func scaledRouter(name, image string, args []string) *appsv1.ReplicaSet {
 								},
 							},
 							Name:  "router",
-							Image: image,
+							Image: routerImage,
 							Args:  append(args, "--stats-port=1936", "--metrics-type=haproxy"),
 							Ports: []corev1.ContainerPort{
 								{
@@ -645,6 +603,10 @@ func scaledRouter(name, image string, args []string) *appsv1.ReplicaSet {
 			},
 		},
 	}
+	if err := applyHAProxySidecarToPodTemplate(context.Background(), oc, oc.Namespace(), &routerRS.Spec.Template); err != nil {
+		return nil, err
+	}
+	return routerRS, nil
 }
 
 func outputIngress(routes ...routev1.Route) {

--- a/test/extended/router/subdomain.go
+++ b/test/extended/router/subdomain.go
@@ -11,11 +11,11 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	admissionapi "k8s.io/pod-security-admission/api"
+	"k8s.io/utils/ptr"
 
 	routev1 "github.com/openshift/api/route/v1"
 	routeclientset "github.com/openshift/client-go/route/clientset/versioned"
@@ -54,23 +54,6 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 
 		clusterIngressDomain, err = getDefaultIngressClusterDomainName(oc, time.Minute)
 		o.Expect(err).NotTo(o.HaveOccurred())
-
-		_, err = oc.AdminKubeClient().RbacV1().RoleBindings(ns).Create(context.Background(), &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "router",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: "ServiceAccount",
-					Name: "default",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind: "ClusterRole",
-				Name: "system:router",
-			},
-		}, metav1.CreateOptions{})
-		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.Describe("The HAProxy router", func() {
@@ -81,40 +64,37 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 				"router2": "baz.tld",
 			}
 			for routerName, routerDomain := range routers {
-				one := int32(1)
-				container := corev1.Container{
-					Name:  routerName,
-					Image: routerImage,
-					Args: []string{
-						"-v=4",
-						fmt.Sprintf("--namespace=%s", ns),
-						fmt.Sprintf("--name=%s", routerName),
-						fmt.Sprintf("--router-domain=%s", routerDomain),
+				routerRS := &appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: routerName,
+					},
+					Spec: appsv1.ReplicaSetSpec{
+						Replicas: ptr.To[int32](1),
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": routerName},
+						},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{"app": routerName},
+							},
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  routerName,
+									Image: routerImage,
+									Args: []string{
+										"-v=4",
+										fmt.Sprintf("--namespace=%s", ns),
+										fmt.Sprintf("--name=%s", routerName),
+										fmt.Sprintf("--router-domain=%s", routerDomain),
+									},
+								}},
+							},
+						},
 					},
 				}
-				rs, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(
-					context.Background(),
-					&appsv1.ReplicaSet{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: routerName,
-						},
-						Spec: appsv1.ReplicaSetSpec{
-							Replicas: &one,
-							Selector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{"app": routerName},
-							},
-							Template: corev1.PodTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{"app": routerName},
-								},
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{container},
-								},
-							},
-						},
-					},
-					metav1.CreateOptions{},
-				)
+				err := applyHAProxySidecarToPodTemplate(context.Background(), oc, ns, &routerRS.Spec.Template)
+				o.Expect(err).NotTo(o.HaveOccurred())
+				rs, err := oc.KubeClient().AppsV1().ReplicaSets(ns).Create(context.Background(), routerRS, metav1.CreateOptions{})
 				o.Expect(err).NotTo(o.HaveOccurred())
 				err = waitForReadyReplicaSet(oc.KubeClient(), ns, rs.Name)
 				o.Expect(err).NotTo(o.HaveOccurred())

--- a/test/extended/router/unprivileged.go
+++ b/test/extended/router/unprivileged.go
@@ -22,9 +22,8 @@ import (
 var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]", func() {
 	defer g.GinkgoRecover()
 	var (
-		oc          *exutil.CLI
-		ns          string
-		routerImage string
+		oc *exutil.CLI
+		ns string
 	)
 
 	// this hook must be registered before the framework namespace teardown
@@ -44,22 +43,20 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 	g.BeforeEach(func() {
 		ns = oc.Namespace()
 
-		var err error
-		routerImage, err = exutil.FindRouterImage(oc)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
 		configPath := exutil.FixturePath("testdata", "router", "router-common.yaml")
-		err = oc.AsAdmin().Run("apply").Args("-f", configPath).Execute()
+		err := oc.AsAdmin().Run("apply").Args("-f", configPath).Execute()
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 
 	g.Describe("The HAProxy router", func() {
 		g.It("should run even if it has no access to update status [apigroup:image.openshift.io]", func() {
 
-			routerPod := createScopedRouterPod(routerImage, "test-unprivileged", defaultPemData, "false")
+			routerPod, err := createScopedRouterPod(oc, "test-unprivileged", defaultPemData, "false")
+			o.Expect(err).NotTo(o.HaveOccurred())
+
 			g.By("creating a router")
 			ns := oc.KubeFramework().Namespace.Name
-			_, err := oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
+			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), routerPod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			execPod := exutil.CreateExecPodOrFail(oc.AdminKubeClient(), ns, "execpod")

--- a/test/extended/router/weighted.go
+++ b/test/extended/router/weighted.go
@@ -174,64 +174,68 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 		}
 
 		g.By("creating route Pods")
-		routerPods := []corev1.Pod{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "weighted-router",
-					Labels: map[string]string{
-						"test": "weighted-router",
-					},
+		routerPod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "weighted-router",
+				Labels: map[string]string{
+					"test": "weighted-router",
 				},
-				Spec: corev1.PodSpec{
-					TerminationGracePeriodSeconds: utilpointer.Int64(1),
-					Containers: []corev1.Container{
-						{
-							Name:            "router",
-							Image:           routerImage,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Env: []corev1.EnvVar{
-								{
-									Name: "POD_NAMESPACE",
-									ValueFrom: &corev1.EnvVarSource{
-										FieldRef: &corev1.ObjectFieldSelector{
-											FieldPath: "metadata.namespace",
-										},
+			},
+			Spec: corev1.PodSpec{
+				TerminationGracePeriodSeconds: utilpointer.Int64(1),
+				Containers: []corev1.Container{
+					{
+						Name:            "router",
+						Image:           routerImage,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Env: []corev1.EnvVar{
+							{
+								Name: "POD_NAMESPACE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.namespace",
 									},
 								},
-								{
-									Name:  "ROUTER_IP_V4_V6_MODE",
-									Value: "v4v6",
-								},
-								{
-									Name:  "DEFAULT_CERTIFICATE",
-									Value: defaultPemData,
-								},
 							},
-							Args: []string{
-								"--namespace=$(POD_NAMESPACE)",
-								"-v=4",
-								"--labels=select=weighted",
-								"--stats-password=password",
-								"--stats-port=1936",
-								"--stats-user=admin",
+							{
+								Name:  "ROUTER_IP_V4_V6_MODE",
+								Value: "v4v6",
 							},
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: 80,
-								},
-								{
-									ContainerPort: 443,
-								},
-								{
-									ContainerPort: 1936,
-									Name:          "stats",
-									Protocol:      corev1.ProtocolTCP,
-								},
+							{
+								Name:  "DEFAULT_CERTIFICATE",
+								Value: defaultPemData,
+							},
+						},
+						Args: []string{
+							"--namespace=$(POD_NAMESPACE)",
+							"-v=4",
+							"--labels=select=weighted",
+							"--stats-password=password",
+							"--stats-port=1936",
+							"--stats-user=admin",
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: 80,
+							},
+							{
+								ContainerPort: 443,
+							},
+							{
+								ContainerPort: 1936,
+								Name:          "stats",
+								Protocol:      corev1.ProtocolTCP,
 							},
 						},
 					},
 				},
 			},
+		}
+		err = applyHAProxySidecarToPod(context.Background(), oc, &routerPod.Spec)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		testingPods := []corev1.Pod{
+			routerPod,
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "endpoint-1",
@@ -327,7 +331,7 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:image.openshift.io]",
 			},
 		}
 
-		for _, pod := range routerPods {
+		for _, pod := range testingPods {
 			_, err = oc.AdminKubeClient().CoreV1().Pods(ns).Create(context.Background(), &pod, metav1.CreateOptions{})
 			o.Expect(err).NotTo(o.HaveOccurred())
 		}


### PR DESCRIPTION
Some of the router e2e tests manually create and configure a router pod. These tests infer that HAProxy is installed in the router image, which is not true anymore - HAProxy resides now only on its own image, running as a sidecar container. This update revisits all these tests, applying the HAProxy sidecar and the shared volumes on all the manually created pods.

https://redhat.atlassian.net/browse/NE-2816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized HAProxy sidecar configuration across router test pods, templates, and deployments.
  * Improved router image discovery and preparation of test resources within individual scenarios.
  * Added clearer validation and error handling when creating router test resources.
  * Updated scoped, stress, subdomain, weighted, configuration, HTTP/2, and unprivileged router scenarios to use the shared test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->