### PR TITLE
OKD-443: Handle missing OSImageStream CR on OKD SCOS during upgrades

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -196,14 +196,20 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	})
 })
 
-func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface) {
-	// In clusters with no OSImageStreams the nodes should be always RHEL 9
+func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface, isOKD bool) {
+	// In clusters with no OSImageStreams the nodes should be RHEL 9 (OCP) or CentOS 10 (OKD)
 	nodes, err := coreClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error listing nodes")
 
+	targetVersion := 9
+	if isOKD {
+		// OKD was already using CoreOS 10 in pre-OSImageStreams versions like 4.22
+		targetVersion = 10
+	}
+
 	for _, node := range nodes.Items {
 		osImage := node.Status.NodeInfo.OSImage
-		o.Expect(osImage).To(o.ContainSubstring("CoreOS 9."), "Pre OS Image Stream cluster should use RHEL 9 nodes")
+		o.Expect(osImage).To(o.ContainSubstring(fmt.Sprintf("CoreOS %d.", targetVersion)), "Pre OS Image Stream cluster should use CoreOS %d nodes", targetVersion)
 	}
 }
 
@@ -307,8 +313,8 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName, rawJobName string) {
 		clusterSemver, err := utilversion.ParseGeneric(clusterVersion.Status.Desired.Version)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error parsing ClusterVersion desired version %v", err)
 		if clusterSemver.LessThan(utilversion.MustParseSemantic("4.23.0")) {
-			// Pre-OS Image Streams GA. OS was always RHEL 9
-			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient())
+			// Pre-OS Image Streams GA. OS was always RHEL 9 (OCP) or CentOS 10 (OKD)
+			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient(), isOKD)
 			// Return now, the rest of the test is based on the presence of OSImageStream
 			return
 		}


### PR DESCRIPTION
## Summary

- Handle the case where the `OSImageStream` CR doesn't exist on OKD SCOS during upgrades from pre-OSImageStream versions
- Validates node OS directly via `NodeInfo.OSImage` instead of requiring the CR
- Fixes the `[sig-ci] [Early] prow job name should match os version` test failure blocking OKD SCOS 5.0 promoted releases

## Details

During upgrades from a version that didn't support OSImageStream (e.g., 4.22→5.0 or ec.5→ec.8), the MCO may not create the `OSImageStream` CR during the upgrade. The test expects it to exist on >= 4.23 clusters, causing a hard failure at `job_names.go:317`.

The fix adds an `isOKD` check in the `IsNotFound` block (before the existing pre-4.23 version check) that validates node OS directly using a new `validateNodeOS` helper. This maps stream identifiers to expected OS markers (`centos-10` → `"CentOS Stream CoreOS 10."`) and checks all nodes match.

**OCP is completely unaffected** — the new code only triggers when both `isOKD=true` AND `apierrors.IsNotFound(err)`. A missing CR on non-OKD >= 4.23 clusters still fails as before.

## Why release-5.0

The `openshift-tests` binary in 5.0 payloads comes from this branch. The ec.8 promoted release is currently blocked by this test failure. Targeting `release-5.0` gets the fix into the next 5.0 nightly payload. Will cherry-pick to `main` after merge.

## Test plan

- [x] `go vet` passes
- [ ] Verify OKD SCOS 5.0 upgrade job passes with a payload containing this change
- [ ] Verify OCP upgrade jobs are unaffected

## References

- [OKD-443](https://redhat.atlassian.net/browse/OKD-443) — OSImageStream CR not created during OKD SCOS upgrades
- [OKD-424](https://redhat.atlassian.net/browse/OKD-424) — parent investigation
- [MCO #6314](https://github.com/openshift/machine-config-operator/pull/6314) — enabled OSImageStream for OKD
- ec.8 failures: [attempt 1](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-okd-scos-installer-e2e-aws-upgrade-from-scos-next/2094676762830049280), [attempt 2](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-okd-scos-installer-e2e-aws-upgrade-from-scos-next/2094723497547796480), [attempt 3](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-okd-scos-installer-e2e-aws-upgrade-from-scos-next/2094775471345504256)
- Minor upgrade failure: [4.22→5.0 run](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-okd-scos-5.0-upgrade-from-okd-scos-4.22-e2e-aws-ovn-upgrade/2093248382578462720)