### PR TITLE
OCPNODE-4664: Add DRA e2e tests for OpenShift on NVIDIA hardware

### DIFF
--- a/test/extended/node/dra/nvidia/DESIGN.md
+++ b/test/extended/node/dra/nvidia/DESIGN.md
@@ -1,0 +1,511 @@
+# DRA Node E2E Test Design for OpenShift on NVIDIA Hardware
+
+**JIRA:** [OCPNODE-4664](https://redhat.atlassian.net/browse/OCPNODE-4664)
+**Author:** Sai Ramesh Vanka
+**Date:** 2026-08-25
+**Status:** Draft
+
+---
+
+## 1. Objective
+
+Design and implement sig-node focused DRA (Dynamic Resource Allocation) e2e tests for
+OpenShift that validate kubelet, CRI-O runtime, and node-level behaviors on real NVIDIA
+GPU hardware. These tests must **not duplicate** existing upstream or OpenShift tests but
+instead cover OpenShift-specific node concerns that are currently untested.
+
+**Scope:** All DRA node features **except** DRA Partitionable Devices (KEP-4815).
+
+**Target Repository:** `openshift/origin` under `test/extended/node/dra/`
+
+---
+
+## 2. Existing Test Landscape
+
+### 2.1 Upstream kubernetes/kubernetes
+
+| Suite | Location | Driver | Focus |
+|-------|----------|--------|-------|
+| Cluster E2E | `test/e2e/dra/dra.go` (~4800 lines) | Mock test-driver | Scheduling, API lifecycle, conformance |
+| Node E2E | `test/e2e_node/dra_test.go` (~2170 lines) | Mock test-driver | Kubelet plugin registration, prepare/unprepare, ResourceSlice lifecycle, health monitoring, kubelet restart recovery |
+| Upgrade E2E | `test/e2e_dra/*.go` | Mock test-driver | Feature gate lifecycle (enable/disable/re-enable) |
+| Integration | `test/integration/dra/` | None (unit) | Scheduler logic, binding conditions |
+
+**Key detail:** All upstream e2e tests use an in-tree mock DRA driver with gRPC proxy
+into the test binary. They test *mechanisms* but never exercise a real hardware driver or
+CRI-O as the runtime.
+
+### 2.2 OpenShift origin (`test/extended/node/dra/`)
+
+| Suite | Driver | Tests |
+|-------|--------|-------|
+| `example/example_dra.go` | `gpu.example.com` (mock) | Single/multi device alloc, sharing, template, cleanup |
+| `nvidia/nvidia_dra.go` | NVIDIA DRA driver | Single/multi GPU alloc, sharing, template, cleanup (validates nvidia-smi + CDI) |
+| `partitionable/partitionable_dra.go` | `gpu.example.com` | SharedCounters, partition alloc, counter exhaustion |
+| `dra.go` (API test) | None | Confirms only `resource.k8s.io/v1` API is available |
+
+**Key detail:** The NVIDIA tests validate basic allocation scenarios (5 tests) but do not
+exercise any node-level behaviors like kubelet restart, health monitoring, PodResources
+API, SCC enforcement, SELinux, or CRI-O CDI specifics.
+
+### 2.3 Coverage Gap Summary
+
+| Area | Upstream | OCP Origin | Gap? |
+|------|:--------:|:----------:|:----:|
+| Basic device allocation on real GPU | - | Yes | No |
+| Kubelet plugin lifecycle (mock) | Yes | - | No (mock is fine) |
+| **CRI-O CDI injection validation** | - | - | **YES** |
+| **SELinux with DRA devices** | - | - | **YES** |
+| **SCC enforcement for DRA workloads** | - | - | **YES** |
+| **Node drain with DRA-claimed pods** | - | - | **YES** |
+| **Kubelet restart with real GPU claims** | Mock only | - | **YES** |
+| **PodResources API for DRA (gRPC)** | - | - | **YES** |
+| **Device health in pod status (real HW)** | Mock only | - | **YES** |
+| **ResourceClaim status fields (real HW)** | Mock only | - | **YES** |
+| **Admin access namespace gating** | Mock only | - | **YES** |
+| **Device taints (real HW)** | Mock only | - | **YES** |
+| **Node reboot with active DRA claims** | - | - | **YES** |
+| **Multiple containers sharing GPU claim** | Mock only | - | **YES** |
+| **DRA + extended resources (real HW)** | Mock only | - | **YES** |
+| **CDI hot-reload on CRI-O** | - | - | **YES** |
+| **DRA metrics (kubelet)** | Mock only | - | **YES** |
+
+---
+
+## 3. Proposed Test Categories
+
+All tests are `[sig-node]` labeled and require real NVIDIA GPU hardware. They are
+organized by node-level concern rather than by DRA feature, to emphasize the Kubelet/
+runtime angle.
+
+### Category 1: CRI-O CDI Integration
+
+**Why this matters:** Upstream tests run on containerd. CRI-O has its own CDI
+implementation with different hot-reload behavior, directory scanning, and SELinux
+integration. These tests validate the runtime layer that is unique to OpenShift.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 1.1 | CDI device injection via CRI-O | Deploy pod with GPU claim, verify `/dev/nvidia*` devices present inside container, verify environment variables injected by CDI spec | None (GA) |
+| 1.2 | CDI spec file presence | After GPU claim is allocated and pod is running, verify CDI spec JSON files exist under `/var/run/cdi/` on the node with correct structure | None (GA) |
+| 1.3 | Multiple CDI devices in single container | Pod claiming 2+ GPUs, verify all CDI device IDs appear in the CRI ContainerConfig and all devices accessible in container | None (GA) |
+| 1.4 | CDI injection with init containers | Pod with init container referencing GPU claim, verify CDI devices available in init container, then main container | None (GA) |
+
+**Validation approach:**
+- `oc debug node/<gpu-node>` or privileged pod to inspect `/var/run/cdi/` on the host
+- `nvidia-smi` inside the container to confirm GPU visibility
+- `oc get pod -o jsonpath` to inspect container device annotations
+- Check CRI-O logs for CDI processing messages
+
+### Category 2: SELinux and Security Context
+
+**Why this matters:** OpenShift enforces SELinux in Enforcing mode by default. GPU device
+nodes carry SELinux types (`nv_device_t`, `dri_device_t`) that must be accessible from
+the container's `container_t` domain. CDI specs must handle relabeling. This is entirely
+untested upstream.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 2.1 | GPU access under SELinux Enforcing | Deploy GPU workload pod, verify `nvidia-smi` works, verify no SELinux AVC denials in audit log | None (GA) |
+| 2.2 | Restricted SCC with DRA workload | Deploy GPU pod using `restricted-v2` SCC (not privileged), verify GPU access works via CDI injection without privilege escalation | None (GA) |
+| 2.3 | Non-privileged user with GPU | Pod with `runAsNonRoot: true` and a non-root user, verify GPU device access via DRA claim | None (GA) |
+| 2.4 | SCC audit for DRA driver pods | Verify NVIDIA DRA driver DaemonSet pods run with expected SCC (privileged/custom), verify workload pods do NOT require privileged SCC | None (GA) |
+
+**Validation approach:**
+- `oc get pod -o jsonpath='{.metadata.annotations.openshift\.io/scc}'` to verify SCC
+- `oc debug node/<gpu-node> -- ausearch -m AVC -ts recent` for SELinux denials
+- `getenforce` inside debug pod to confirm Enforcing mode
+- Run `nvidia-smi` and CUDA workload inside restricted pod
+
+### Category 3: Kubelet Restart and State Recovery
+
+**Why this matters:** Upstream tests this with a mock driver. On real hardware, kubelet
+restart must re-discover the DRA driver plugin, re-read the checkpoint file, and ensure
+active GPU claims remain prepared. CRI-O must continue serving containers with CDI
+devices. This validates the real checkpoint + re-registration flow.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 3.1 | Pod survives kubelet restart with active GPU claim | Deploy GPU pod, verify running, restart kubelet (via `systemctl restart kubelet` on debug node), verify pod continues running with GPU access | None (GA) |
+| 3.2 | DRA driver re-registers after kubelet restart | After kubelet restart, verify DRA driver plugin re-registers via plugin watcher, ResourceSlices are re-published | None (GA) |
+| 3.3 | Pending GPU pod completes after kubelet restart | Create ResourceClaim + pod, before claim is fully prepared restart kubelet, verify pod eventually starts with GPU | None (GA) |
+| 3.4 | Checkpoint integrity after kubelet restart | After kubelet restart with active GPU claims, verify `dra_manager_state` checkpoint file exists and is valid JSON with CRC32 | None (GA) |
+
+**Validation approach:**
+- `oc debug node/<gpu-node> -- systemctl restart kubelet` (requires privileged access)
+- Monitor pod status transitions via `oc get pod -w`
+- Inspect `/var/lib/kubelet/device-plugins/dra_manager_state` on the node
+- Verify `oc get resourceslice` shows GPU resources after restart
+
+### Category 4: Node Drain and Pod Lifecycle
+
+**Why this matters:** Node drain with DRA-claimed pods exercises the
+NodeUnprepareResources path on real hardware and validates that GPU resources are properly
+released. This is a critical operational scenario not tested anywhere.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 4.1 | Node drain evicts DRA pods and releases claims | Deploy GPU pod, drain the node (`oc adm drain`), verify pod evicted, ResourceClaim released, GPU unprepared | None (GA) |
+| 4.2 | Pod with PDB and GPU claim during drain | Deploy GPU pod with PodDisruptionBudget, drain node, verify PDB is respected before eviction | None (GA) |
+| 4.3 | Uncordon restores GPU availability | After drain + uncordon, verify ResourceSlices re-published, new GPU pod can be scheduled | None (GA) |
+| 4.4 | Graceful termination with GPU cleanup | Deploy GPU pod with `terminationGracePeriodSeconds: 60`, delete pod, verify NodeUnprepareResources called after graceful shutdown | None (GA) |
+
+**Validation approach:**
+- `oc adm drain <node> --ignore-daemonsets --delete-emptydir-data`
+- `oc adm uncordon <node>`
+- `oc get resourceclaim -o yaml` to check allocation status transitions
+- `oc get resourceslice` to verify GPU re-availability
+- Monitor kubelet logs for `NodeUnprepareResources` calls
+
+### Category 5: PodResources API
+
+**Why this matters:** The PodResources gRPC API (KEP-3695, GA in 1.36) exposes DRA device
+information to monitoring agents (DCGM, GPU Feature Discovery). This is never tested in
+any e2e suite despite being GA. OpenShift monitoring stack depends on this.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 5.1 | PodResources List returns DRA devices | Deploy GPU pod, call PodResources `List()` gRPC on kubelet socket, verify response includes DRA device info with correct driver name and CDI device IDs | None (GA) |
+| 5.2 | PodResources Get returns DRA devices | Call PodResources `Get()` for specific GPU pod, verify DRA resource entries match allocated claim | None (GA) |
+| 5.3 | PodResources after pod deletion | Delete GPU pod, call PodResources `List()`, verify DRA entries removed | None (GA) |
+
+**Validation approach:**
+- Deploy a privileged pod on the GPU node that mounts `/var/lib/kubelet/pod-resources/kubelet.sock`
+- Use `grpcurl` or a small Go binary to call `v1.PodResourcesLister/List` and `v1.PodResourcesLister/Get`
+- Parse the response for `dynamicResources` field entries
+- Alternatively: use the existing `oc debug node` approach to access the kubelet socket
+
+### Category 6: Device Health Status
+
+**Why this matters:** ResourceHealthStatus (beta in 1.36) exposes device health in pod
+status. This is tested upstream with mock driver health injection but never on real
+hardware where actual GPU health transitions matter.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 6.1 | Healthy GPU reflected in pod status | Deploy GPU pod, verify `pod.status.containerStatuses[].allocatedResourcesStatus` shows `Healthy` for GPU device | `ResourceHealthStatus` (Beta, default on) |
+| 6.2 | Device health fields populated | Verify health entry includes correct `name` (CDI device ID), `health` status, and `resourceClaimName` | `ResourceHealthStatus` |
+| 6.3 | ResourceClaim status devices field | Verify `resourceclaim.status.devices` has populated entries with driver, pool, device names matching the allocation | `DRAResourceClaimDeviceStatus` (Beta) |
+
+**Validation approach:**
+- `oc get pod -o jsonpath='{.status.containerStatuses[0].allocatedResourcesStatus}'`
+- `oc get resourceclaim <name> -o jsonpath='{.status.devices}'`
+- These are read-only validations on running GPU pods
+
+### Category 7: ResourceClaim Lifecycle on Real Hardware
+
+**Why this matters:** Upstream tests ResourceClaim transitions with mock. These tests
+validate the full lifecycle on real NVIDIA hardware, exercising the real driver's
+prepare/unprepare implementation and verifying that claim status accurately reflects
+hardware state.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 7.1 | Claim transitions: Pending -> Allocated -> Reserved -> Released | Create claim, deploy pod (triggers allocation + reservation), delete pod (triggers release), verify status transitions | None (GA) |
+| 7.2 | Multi-container single claim | Pod with 2 containers both referencing same GPU claim, verify both containers see the GPU, verify single NodePrepareResources call | None (GA) |
+| 7.3 | Claim reuse across pod recreations | Create persistent ResourceClaim, deploy pod, delete pod, deploy new pod with same claim, verify GPU re-prepared without re-allocation | None (GA) |
+| 7.4 | ResourceClaim with CEL selector on GPU attributes | Create claim selecting GPU by attribute (e.g., `device.driver == 'gpu.nvidia.com'`), verify correct GPU allocated | None (GA) |
+| 7.5 | Claim deletion with running pod | Attempt to delete a ResourceClaim while pod is running, verify finalizer prevents deletion until pod terminates | None (GA) |
+
+**Validation approach:**
+- `oc get resourceclaim -w` to monitor status transitions
+- `nvidia-smi` inside both containers of multi-container pod
+- `oc get resourceclaim -o yaml` for full status inspection
+
+### Category 8: Admin Access on OpenShift
+
+**Why this matters:** DRA admin access (KEP-5018, Beta in 1.34+) allows namespace-level
+control over device access. This interacts with OpenShift RBAC/SCC model and namespace
+management. The namespace label gating (`resource.kubernetes.io/admin-access`) is not
+tested on OpenShift.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 8.1 | Admin access denied without namespace label | Create ResourceClaim with `adminAccess: true` in namespace WITHOUT the admin label, verify claim rejected / pod stays pending | None (Beta, default on) |
+| 8.2 | Admin access granted with namespace label | Label namespace with `resource.kubernetes.io/admin-access: "true"`, create admin claim, verify GPU allocated | None (Beta, default on) |
+| 8.3 | Admin claim coexists with normal claim | Both admin and non-admin pods on same node, verify both get GPU access, verify admin claim has expected additional access | None (Beta, default on) |
+
+**Validation approach:**
+- `oc label namespace <ns> resource.kubernetes.io/admin-access=true`
+- `oc get resourceclaim -o yaml` to check allocation
+- `oc describe pod` for events showing rejection
+
+### Category 9: Device Taints and Tolerations
+
+**Why this matters:** Device taints (KEP-5055) are GA in K8s 1.37 (OCP 5.0). Testing on
+real hardware validates that taint/toleration logic works with the NVIDIA driver's
+ResourceSlice publishing.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 9.1 | Pod stays pending with NoSchedule device taint | Apply NoSchedule taint to GPU device via DeviceTaintRule, deploy pod requesting that GPU, verify pod stays Pending | `DRADeviceTaints` + `DRADeviceTaintRules` |
+| 9.2 | Pod tolerates device taint | Deploy pod with matching toleration, verify GPU allocated despite taint | `DRADeviceTaints` + `DRADeviceTaintRules` |
+| 9.3 | NoExecute taint evicts running pod | Pod running with GPU, apply NoExecute DeviceTaintRule, verify pod evicted | `DRADeviceTaints` + `DRADeviceTaintRules` |
+
+**Validation approach:**
+- Create `DeviceTaintRule` objects targeting NVIDIA devices
+- Monitor pod scheduling events for taint-related messages
+- Verify eviction behavior with `oc get pod -w`
+
+**Note:** These tests depend on the OCP version supporting DeviceTaintRule (K8s 1.37+/OCP 5.0+).
+If the target cluster is < 1.37, these should be skipped.
+
+### Category 10: DRA Metrics Validation
+
+**Why this matters:** Kubelet exposes DRA-specific metrics that are critical for
+monitoring GPU utilization at scale. These are never validated in e2e tests.
+
+| # | Test | Description | Feature Gate |
+|---|------|-------------|-------------|
+| 10.1 | `dra_resource_claims_in_use` metric | Deploy GPU pod, scrape kubelet `/metrics`, verify `dra_resource_claims_in_use` gauge shows correct count per driver | None (GA) |
+| 10.2 | `dra_operations_duration_seconds` metric | After GPU claim prepare/unprepare cycle, verify `dra_operations_duration_seconds` histogram has entries for `PrepareResources` and `UnprepareResources` methods | None (GA) |
+
+**Validation approach:**
+- `curl -sk https://<node-ip>:10250/metrics` (via debug pod or service account token)
+- Parse Prometheus text format for `dra_` prefixed metrics
+- Alternatively use OpenShift monitoring stack's Prometheus to query
+
+---
+
+## 4. Test Infrastructure Design
+
+### 4.1 Location in openshift/origin
+
+```
+test/extended/node/dra/
+  nvidia/
+    nvidia_dra.go            -- existing basic tests
+    node_lifecycle.go        -- NEW: Category 3, 4 (kubelet restart, drain)
+    crio_cdi.go              -- NEW: Category 1 (CDI integration)
+    security.go              -- NEW: Category 2 (SELinux, SCC)
+    podresources.go          -- NEW: Category 5 (PodResources API)
+    health_status.go         -- NEW: Category 6 (device health)
+    claim_lifecycle.go       -- NEW: Category 7 (claim state transitions)
+    admin_access.go          -- NEW: Category 8 (admin access)
+    device_taints.go         -- NEW: Category 9 (device taints)
+    metrics.go               -- NEW: Category 10 (kubelet metrics)
+    gpu_validator.go         -- existing, may need extensions
+    prerequisites_installer.go -- existing
+    resource_builder.go      -- existing, extend for new test patterns
+  common/
+    node_ops.go              -- NEW: shared utilities for node operations
+                                (kubelet restart, drain, debug pod, checkpoint read)
+    podresources_client.go   -- NEW: PodResources gRPC client helper
+    metrics_client.go        -- NEW: kubelet metrics scraper helper
+```
+
+### 4.2 Test Labels and Filtering
+
+```go
+// All new tests use these labels:
+// [sig-node] - primary SIG ownership
+// [Feature:NVIDIA-DRA] - requires NVIDIA GPU hardware
+// [Suite:openshift/nvidia-dra] - test suite grouping
+// [Serial] - cannot run in parallel (node-level operations)
+
+// Category-specific additional labels:
+// [Disruptive] - tests that restart kubelet or drain nodes (Cat 3, 4)
+// [Slow] - tests with extended wait times (Cat 3, 4)
+```
+
+### 4.3 Ginkgo Test Structure
+
+```go
+var _ = g.Describe("[sig-node][Feature:NVIDIA-DRA][Suite:openshift/nvidia-dra]", func() {
+
+    // Non-disruptive tests (can run on shared clusters)
+    g.Context("CRI-O CDI Integration", func() { ... })
+    g.Context("SELinux and Security", func() { ... })
+    g.Context("PodResources API", func() { ... })
+    g.Context("Device Health Status", func() { ... })
+    g.Context("ResourceClaim Lifecycle", func() { ... })
+    g.Context("Admin Access", func() { ... })
+    g.Context("Kubelet Metrics", func() { ... })
+
+    // Disruptive tests (require dedicated node or cluster)
+    g.Context("[Disruptive] Kubelet Restart Recovery", func() { ... })
+    g.Context("[Disruptive] Node Drain", func() { ... })
+    g.Context("[Disruptive] Device Taints", func() { ... })
+})
+```
+
+### 4.4 Node Operations Helper
+
+A shared utility for tests that need to perform node-level operations:
+
+```go
+// NodeOps provides methods for node-level operations on GPU nodes
+type NodeOps struct {
+    client    kubernetes.Interface
+    nodeName  string
+}
+
+// RestartKubelet restarts kubelet via systemctl and waits for ready
+func (n *NodeOps) RestartKubelet(ctx context.Context) error
+
+// DrainNode cordons and drains the node
+func (n *NodeOps) DrainNode(ctx context.Context) error
+
+// UncordonNode uncordons the node
+func (n *NodeOps) UncordonNode(ctx context.Context) error
+
+// ReadCheckpoint reads and returns the DRA manager checkpoint
+func (n *NodeOps) ReadCheckpoint(ctx context.Context) (*DRACheckpoint, error)
+
+// GetSELinuxAVCDenials returns recent AVC denials from audit log
+func (n *NodeOps) GetSELinuxAVCDenials(ctx context.Context, since time.Time) ([]string, error)
+
+// InspectCDISpecs lists CDI spec files on the node
+func (n *NodeOps) InspectCDISpecs(ctx context.Context) ([]CDISpec, error)
+
+// ScrapeKubeletMetrics returns kubelet Prometheus metrics
+func (n *NodeOps) ScrapeKubeletMetrics(ctx context.Context) (map[string]float64, error)
+```
+
+These operations use `oc debug node/<name>` internally with appropriate privilege.
+
+### 4.5 Prerequisites
+
+| Prerequisite | Details |
+|-------------|---------|
+| NVIDIA GPU node(s) | At least 1 worker node with NVIDIA GPU |
+| GPU Operator installed | NVIDIA GPU Operator with driver loaded |
+| NVIDIA DRA driver installed | `nvidia-dra-driver` Helm chart deployed |
+| ResourceSlices present | `oc get resourceslice` shows GPU devices |
+| DeviceClass available | `gpu.nvidia.com` DeviceClass exists |
+| Feature gates (for Cat 6,9) | `ResourceHealthStatus`, `DRADeviceTaints` enabled if testing those |
+
+The existing `prerequisites_installer.go` handles driver setup. Tests should skip
+gracefully if prerequisites are not met (e.g., no GPU node, driver not installed).
+
+---
+
+## 5. Priority and Phasing
+
+### Phase 1: Core Node Validation (High Priority)
+
+These tests provide the most unique value - they validate OpenShift-specific node
+behavior that no other test suite covers.
+
+| Category | Tests | Effort | Risk Coverage |
+|----------|-------|--------|--------------|
+| 1. CRI-O CDI Integration | 1.1, 1.2, 1.3 | Low | CRI-O CDI regression |
+| 2. SELinux and Security | 2.1, 2.2, 2.3, 2.4 | Medium | Security policy breaks DRA |
+| 7. ResourceClaim Lifecycle | 7.1, 7.2, 7.4 | Low | Real HW claim state machine |
+
+**Estimated effort:** 2-3 days
+
+### Phase 2: Operational Resilience (High Priority)
+
+These tests validate that DRA survives real operational scenarios on OpenShift.
+
+| Category | Tests | Effort | Risk Coverage |
+|----------|-------|--------|--------------|
+| 3. Kubelet Restart | 3.1, 3.2, 3.3 | Medium | GPU state lost on restart |
+| 4. Node Drain | 4.1, 4.2, 4.3 | Medium | Drain fails with DRA pods |
+
+**Estimated effort:** 2-3 days
+
+### Phase 3: Observability and API (Medium Priority)
+
+These tests validate monitoring and API surfaces.
+
+| Category | Tests | Effort | Risk Coverage |
+|----------|-------|--------|--------------|
+| 5. PodResources API | 5.1, 5.2, 5.3 | Medium | Monitoring stack blind to GPUs |
+| 6. Device Health Status | 6.1, 6.2, 6.3 | Low | Health not propagated to pod status |
+| 10. Kubelet Metrics | 10.1, 10.2 | Low | Metrics missing/wrong |
+
+**Estimated effort:** 2-3 days
+
+### Phase 4: Advanced Features (Lower Priority, version-dependent)
+
+| Category | Tests | Effort | Risk Coverage |
+|----------|-------|--------|--------------|
+| 8. Admin Access | 8.1, 8.2, 8.3 | Low | Privilege escalation via DRA |
+| 9. Device Taints | 9.1, 9.2, 9.3 | Medium | Taint/eviction breaks on real HW |
+| 7. Claim Lifecycle (rest) | 7.3, 7.5 | Low | Claim reuse/finalizer edge cases |
+
+**Estimated effort:** 2-3 days
+
+---
+
+## 6. Non-Duplication Matrix
+
+This table maps each proposed test to what already exists and confirms no duplication.
+
+| Proposed Test | Upstream `test/e2e/dra/` | Upstream `test/e2e_node/` | OCP `nvidia_dra.go` | Why Ours is Different |
+|--------------|:---:|:---:|:---:|------|
+| 1.1 CDI via CRI-O | - | - | Partial (just nvidia-smi) | Validates CDI spec files + CRI-O processing, not just GPU visibility |
+| 1.2 CDI spec files | - | - | - | Node-level CDI directory inspection |
+| 2.1 SELinux | - | - | - | **OpenShift-only concern** |
+| 2.2 Restricted SCC | - | - | - | **OpenShift-only concern** |
+| 3.1 Kubelet restart | - | Yes (mock) | - | Real HW driver re-registration, real checkpoint |
+| 3.2 Driver re-register | - | Yes (mock) | - | Real NVIDIA plugin socket discovery |
+| 4.1 Node drain | - | - | - | **Not tested anywhere** |
+| 5.1 PodResources API | - | - | - | **Not tested in any e2e suite** (GA feature) |
+| 6.1 Health in pod status | Yes (mock health) | Yes (mock health) | - | Real GPU health values, not injected |
+| 7.1 Claim transitions | Yes (mock) | - | - | Real HW state transitions |
+| 7.2 Multi-container claim | Yes (mock) | - | - | Real GPU sharing across containers |
+| 8.1 Admin access denied | Yes (mock) | - | - | OpenShift namespace management + SCC interaction |
+| 9.1 Device taint NoSchedule | Yes (mock) | - | - | Real NVIDIA DeviceTaintRule |
+| 10.1 DRA metrics | - | Yes (mock, partial) | - | Real metric values with real driver |
+
+---
+
+## 7. Test Environment Requirements
+
+### Minimum Hardware
+- 1 OpenShift cluster (4.21+ / K8s 1.34+)
+- At least 1 worker node with NVIDIA GPU (any generation: T4, A100, H100, Blackwell)
+- GPU Operator + NVIDIA DRA driver installed and functional
+
+### CI Integration Options
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **NVIDIA DGX CI** | Real GPUs, NVIDIA-maintained | Access restrictions, scheduling |
+| **AWS p-type instances** | On-demand, scriptable | Cost, limited GPU models |
+| **Internal GPU lab** | Full control, diverse GPUs | Maintenance overhead |
+| **ClusterBot with GPU profile** | Standard OCP CI | Limited GPU availability |
+
+### Recommended Approach
+Run disruptive tests (Cat 3, 4) on a dedicated SNO or single-worker cluster to avoid
+impacting other workloads. Non-disruptive tests (Cat 1, 2, 5, 6, 7, 8, 10) can run on
+shared GPU clusters.
+
+---
+
+## 8. Open Questions
+
+1. **Target OCP version:** Should tests target OCP 4.21 (K8s 1.34, DRA GA) or also
+   support OCP 5.0 (K8s 1.35+) with newer features (device taints GA, extended resources)?
+
+2. **CI pipeline:** Which CI system will run these tests? Prow with GPU-equipped nodes?
+   NVIDIA's internal CI? Both?
+
+3. **Disruption tolerance:** For kubelet restart and node drain tests, is it acceptable
+   to run on a dedicated cluster, or do we need to support shared multi-tenant GPU
+   clusters?
+
+4. **PodResources API client:** Should we build a small Go gRPC client for PodResources
+   API testing, or use `grpcurl` via exec? The Go client is more robust but adds code.
+
+5. **Device taints scope:** The NVIDIA DRA driver may not yet support reporting device
+   taints. Should we test DeviceTaintRule (admin-applied) only, or also driver-reported
+   taints?
+
+---
+
+## 9. References
+
+- [KEP-4381: DRA Structured Parameters](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4381-dra-structured-parameters)
+- [KEP-5018: DRA Admin Access](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5018-dra-admin-access)
+- [KEP-5055: Device Taints](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/5055-dra-device-taints)
+- [KEP-4680: Resource Health Status](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4680-dra-health-status)
+- [KEP-3695: PodResources API for DRA](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [Kubelet DRA Manager](https://github.com/kubernetes/kubernetes/tree/master/pkg/kubelet/cm/dra)
+- [Upstream DRA E2E Tests](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/dra)
+- [Upstream Node DRA E2E Tests](https://github.com/kubernetes/kubernetes/tree/master/test/e2e_node/dra_test.go)
+- [OpenShift Origin DRA Tests](https://github.com/openshift/origin/tree/master/test/extended/node/dra)
+- [CDI Specification](https://github.com/cncf-tags/container-device-interface)

--- a/test/extended/node/dra/nvidia/claim_lifecycle.go
+++ b/test/extended/node/dra/nvidia/claim_lifecycle.go
@@ -1,0 +1,191 @@
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Feature:NVIDIA-DRA][Suite:openshift/nvidia-dra][Serial]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("nvidia-dra-lifecycle", admissionapi.LevelPrivileged)
+
+	var (
+		validator *GPUValidator
+		builder   *ResourceBuilder
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		validator = NewGPUValidator(oc.KubeFramework())
+		builder = NewResourceBuilder(oc.Namespace())
+
+		nodes, err := validator.GetGPUNodes(ctx)
+		if err != nil {
+			g.Fail(fmt.Sprintf("Failed to discover GPU nodes: %v", err))
+		}
+		if len(nodes) == 0 {
+			g.Skip("No GPU nodes available in the cluster - skipping ResourceClaim lifecycle tests")
+		}
+
+		if prerequisitesError != nil {
+			g.Fail(fmt.Sprintf("Prerequisites validation failed: %v", prerequisitesError))
+		}
+		if !prerequisitesInstalled {
+			g.Skip("Prerequisites not installed - skipping ResourceClaim lifecycle tests")
+		}
+	})
+
+	g.Context("ResourceClaim Lifecycle on Real Hardware", func() {
+		g.It("should transition claim through Pending -> Allocated -> Reserved -> Released", func(ctx context.Context) {
+			deviceClassName := "test-lifecycle-" + oc.Namespace()
+			claimName := "test-lifecycle-claim"
+			podName := "test-lifecycle-pod"
+
+			g.By("Creating DeviceClass")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			g.By("Creating ResourceClaim and verifying it starts unallocated")
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			status, err := validator.ValidateClaimStatus(ctx, oc.Namespace(), claimName)
+			framework.ExpectNoError(err)
+			o.Expect(status.Allocated).To(o.BeFalse(), "Claim should start unallocated")
+			o.Expect(status.ReservedFor).To(o.BeEmpty(), "Claim should have no reservations initially")
+			framework.Logf("Claim %s is pending (not yet allocated)", claimName)
+
+			g.By("Creating Pod to trigger allocation and reservation")
+			pod := builder.BuildLongRunningPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod failed to start")
+
+			g.By("Verifying claim is now Allocated and Reserved")
+			status, err = validator.ValidateClaimStatus(ctx, oc.Namespace(), claimName)
+			framework.ExpectNoError(err)
+			o.Expect(status.Allocated).To(o.BeTrue(), "Claim should be allocated after pod starts")
+			o.Expect(status.ReservedFor).NotTo(o.BeEmpty(), "Claim should be reserved for the pod")
+			o.Expect(status.DeviceCount).To(o.BeNumerically(">", 0), "Claim should have allocated devices")
+			for _, device := range status.Devices {
+				o.Expect(device.Driver).To(o.Equal("gpu.nvidia.com"), "Device driver should be NVIDIA")
+				o.Expect(device.Pool).NotTo(o.BeEmpty(), "Device pool should not be empty")
+				o.Expect(device.Device).NotTo(o.BeEmpty(), "Device name should not be empty")
+			}
+			framework.Logf("Claim %s is allocated with %d device(s), reserved for %d consumer(s)",
+				claimName, status.DeviceCount, len(status.ReservedFor))
+
+			g.By("Deleting pod to trigger release")
+			err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Delete(ctx, podName, metav1.DeleteOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodNotFoundInNamespace(ctx, oc.KubeFramework().ClientSet, podName, oc.Namespace(), 2*time.Minute)
+			framework.ExpectNoError(err, "Pod should be deleted")
+
+			g.By("Verifying claim is released (allocated but no longer reserved)")
+			err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+				status, err = validator.ValidateClaimStatus(ctx, oc.Namespace(), claimName)
+				if err != nil {
+					return false, err
+				}
+				return len(status.ReservedFor) == 0, nil
+			})
+			framework.ExpectNoError(err, "Claim should be released after pod deletion")
+			o.Expect(status.Allocated).To(o.BeTrue(), "Claim should remain allocated after pod deletion")
+			o.Expect(status.ReservedFor).To(o.BeEmpty(), "Claim should not be reserved after pod deletion")
+			framework.Logf("Claim %s is allocated but released (no reservations)", claimName)
+		})
+
+		g.It("should allow multiple containers in a single pod to share one GPU claim", func(ctx context.Context) {
+			deviceClassName := "test-multi-container-" + oc.Namespace()
+			claimName := "test-multi-container-claim"
+			podName := "test-multi-container-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod with two containers sharing the same GPU claim")
+			pod := builder.BuildMultiContainerPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create multi-container pod")
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Multi-container pod failed to start")
+
+			g.By("Verifying GPU access in first container")
+			err = validator.ValidateGPUInContainer(ctx, oc.Namespace(), podName, "gpu-container-1", 1)
+			framework.ExpectNoError(err, "First container should have GPU access")
+
+			g.By("Verifying GPU access in second container")
+			err = validator.ValidateGPUInContainer(ctx, oc.Namespace(), podName, "gpu-container-2", 1)
+			framework.ExpectNoError(err, "Second container should have GPU access")
+
+			g.By("Verifying only one ResourceClaim reservation exists (single NodePrepareResources)")
+			status, err := validator.ValidateClaimStatus(ctx, oc.Namespace(), claimName)
+			framework.ExpectNoError(err)
+			o.Expect(status.Allocated).To(o.BeTrue())
+			o.Expect(status.DeviceCount).To(o.Equal(1), "Should have exactly 1 GPU allocated for the shared claim")
+			framework.Logf("Multi-container pod shares claim %s with %d device(s)", claimName, status.DeviceCount)
+		})
+
+		g.It("should allocate GPU using CEL selector on device attributes", func(ctx context.Context) {
+			claimName := "test-cel-selector-claim"
+			podName := "test-cel-selector-pod"
+
+			g.By("Creating ResourceClaim with CEL selector targeting NVIDIA driver")
+			claim := builder.BuildResourceClaimWithCELSelector(claimName, `device.driver == "gpu.nvidia.com"`, 1)
+			err := createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err, "Failed to create ResourceClaim with CEL selector")
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod using the CEL-selected claim")
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create pod with CEL selector claim")
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod with CEL selector claim failed to start")
+
+			g.By("Verifying GPU is accessible")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "GPU should be accessible with CEL-selected claim")
+
+			g.By("Verifying allocation used the correct NVIDIA driver")
+			status, err := validator.ValidateClaimStatus(ctx, oc.Namespace(), claimName)
+			framework.ExpectNoError(err)
+			o.Expect(status.Allocated).To(o.BeTrue())
+			o.Expect(status.DeviceCount).To(o.BeNumerically(">", 0))
+			for _, device := range status.Devices {
+				o.Expect(device.Driver).To(o.Equal("gpu.nvidia.com"),
+					"CEL selector should have matched NVIDIA GPU driver")
+			}
+			framework.Logf("CEL selector correctly allocated %d NVIDIA GPU(s)", status.DeviceCount)
+		})
+	})
+})

--- a/test/extended/node/dra/nvidia/crio_cdi.go
+++ b/test/extended/node/dra/nvidia/crio_cdi.go
@@ -1,0 +1,211 @@
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Feature:NVIDIA-DRA][Suite:openshift/nvidia-dra][Serial]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("nvidia-dra-cdi", admissionapi.LevelPrivileged)
+
+	var (
+		validator *GPUValidator
+		builder   *ResourceBuilder
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		validator = NewGPUValidator(oc.KubeFramework())
+		builder = NewResourceBuilder(oc.Namespace())
+
+		nodes, err := validator.GetGPUNodes(ctx)
+		if err != nil {
+			g.Fail(fmt.Sprintf("Failed to discover GPU nodes: %v", err))
+		}
+		if len(nodes) == 0 {
+			g.Skip("No GPU nodes available in the cluster - skipping CRI-O CDI tests")
+		}
+
+		if prerequisitesError != nil {
+			g.Fail(fmt.Sprintf("Prerequisites validation failed: %v", prerequisitesError))
+		}
+		if !prerequisitesInstalled {
+			g.Skip("Prerequisites not installed - skipping CRI-O CDI tests")
+		}
+	})
+
+	g.Context("CRI-O CDI Integration", func() {
+		g.It("should inject CDI devices into container via CRI-O", func(ctx context.Context) {
+			deviceClassName := "test-cdi-inject-" + oc.Namespace()
+			claimName := "test-cdi-inject-claim"
+			podName := "test-cdi-inject-pod"
+
+			g.By("Creating DeviceClass for NVIDIA GPUs")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err, "Failed to create DeviceClass")
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			g.By("Creating ResourceClaim requesting 1 GPU")
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err, "Failed to create ResourceClaim")
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod using the ResourceClaim")
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create pod")
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod failed to start")
+
+			g.By("Verifying /dev/nvidia* devices are present inside container")
+			err = validator.ValidateCDISpec(ctx, podName, oc.Namespace())
+			framework.ExpectNoError(err, "CDI device injection validation failed")
+
+			g.By("Verifying nvidia-smi works (confirms CDI injection functional)")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "GPU not accessible via CDI injection")
+
+			g.By("Verifying CUDA_VISIBLE_DEVICES environment variable is set")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			envCmd := []string{"sh", "-c", "echo $CUDA_VISIBLE_DEVICES"}
+			stdout, _, err := e2epod.ExecWithOptions(oc.KubeFramework(), e2epod.ExecOptions{
+				Command:       envCmd,
+				Namespace:     oc.Namespace(),
+				PodName:       podName,
+				ContainerName: pod.Spec.Containers[0].Name,
+				CaptureStdout: true,
+				CaptureStderr: true,
+			})
+			framework.ExpectNoError(err, "Failed to read CUDA_VISIBLE_DEVICES")
+			cudaDevices := strings.TrimSpace(stdout)
+			framework.Logf("CUDA_VISIBLE_DEVICES=%s", cudaDevices)
+		})
+
+		g.It("should have CDI spec files present on the GPU node", func(ctx context.Context) {
+			deviceClassName := "test-cdi-spec-" + oc.Namespace()
+			claimName := "test-cdi-spec-claim"
+			podName := "test-cdi-spec-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating and running GPU pod to trigger CDI spec generation")
+			pod := builder.BuildLongRunningPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod failed to start")
+
+			g.By("Identifying the GPU node where pod is scheduled")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			o.Expect(pod.Spec.NodeName).NotTo(o.BeEmpty(), "Pod should be scheduled on a node")
+
+			g.By("Verifying CDI spec files exist under /var/run/cdi/ on the node")
+			err = validator.ValidateCDISpecFilesOnNode(ctx, pod.Spec.NodeName)
+			framework.ExpectNoError(err, "CDI spec files not found on GPU node")
+		})
+
+		g.It("should inject multiple CDI devices into single container", func(ctx context.Context) {
+			totalGPUs, err := validator.GetTotalGPUCount(ctx)
+			framework.ExpectNoError(err, "Failed to count GPUs")
+			if totalGPUs < 2 {
+				g.Skip(fmt.Sprintf("Multiple CDI device test requires at least 2 GPUs, but only %d available", totalGPUs))
+			}
+
+			deviceClassName := "test-cdi-multi-" + oc.Namespace()
+			claimName := "test-cdi-multi-claim"
+			podName := "test-cdi-multi-pod"
+
+			g.By("Creating DeviceClass")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err = createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			g.By("Creating ResourceClaim requesting 2 GPUs")
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 2)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod with 2 GPUs")
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod failed to start with 2 GPUs")
+
+			g.By("Verifying both GPUs accessible via nvidia-smi")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 2)
+			framework.ExpectNoError(err, "Expected 2 GPUs accessible in container")
+
+			g.By("Verifying ResourceClaim has 2 devices allocated")
+			err = validator.ValidateDeviceAllocation(ctx, oc.Namespace(), claimName)
+			framework.ExpectNoError(err, "Claim allocation validation failed")
+		})
+
+		g.It("should inject CDI devices into init containers", func(ctx context.Context) {
+			deviceClassName := "test-cdi-init-" + oc.Namespace()
+			claimName := "test-cdi-init-claim"
+			podName := "test-cdi-init-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod with init container referencing GPU claim")
+			pod := builder.BuildPodWithInitContainerAndClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create pod with init container")
+
+			g.By("Waiting for pod to be running (init container must complete first)")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Pod with init container failed to start")
+
+			g.By("Verifying init container completed successfully (nvidia-smi ran)")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			o.Expect(pod.Status.InitContainerStatuses).NotTo(o.BeEmpty(), "Init container status should be present")
+			initStatus := pod.Status.InitContainerStatuses[0]
+			o.Expect(initStatus.State.Terminated).NotTo(o.BeNil(), "Init container should have terminated")
+			o.Expect(initStatus.State.Terminated.ExitCode).To(o.Equal(int32(0)), "Init container nvidia-smi should exit 0")
+
+			g.By("Verifying main container has GPU access")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "Main container should have GPU access after init container")
+		})
+	})
+})

--- a/test/extended/node/dra/nvidia/gpu_validator.go
+++ b/test/extended/node/dra/nvidia/gpu_validator.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -378,4 +379,284 @@ func (gv *GPUValidator) GetGPUCountInPod(ctx context.Context, namespace, podName
 	}
 
 	return count, nil
+}
+
+const debugPodImage = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
+
+// ClaimStatusInfo holds structured status info for a ResourceClaim
+type ClaimStatusInfo struct {
+	Allocated   bool
+	ReservedFor []string
+	DeviceCount int
+	Devices     []DeviceInfo
+}
+
+// DeviceInfo describes an allocated device
+type DeviceInfo struct {
+	Driver  string
+	Pool    string
+	Device  string
+	Request string
+}
+
+// createDebugPod creates a privileged host-access pod on the specified node
+func (gv *GPUValidator) createDebugPod(ctx context.Context, nodeName, podName string) (*corev1.Pod, error) {
+	hostPathType := corev1.HostPathDirectory
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: gv.framework.Namespace.Name,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			HostPID:       true,
+			HostNetwork:   true,
+			NodeSelector:  map[string]string{"kubernetes.io/hostname": nodeName},
+			Containers: []corev1.Container{
+				{
+					Name:    "debug",
+					Image:   debugPodImage,
+					Command: []string{"sleep", "3600"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "host-root",
+							MountPath: "/host",
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: ptr.To(true),
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "host-root",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/",
+							Type: &hostPathType,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	created, err := gv.client.CoreV1().Pods(gv.framework.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create debug pod %s: %w", podName, err)
+	}
+
+	if err := e2epod.WaitForPodRunningInNamespace(ctx, gv.client, created); err != nil {
+		gv.deleteDebugPod(ctx, podName)
+		return nil, fmt.Errorf("debug pod %s failed to start: %w", podName, err)
+	}
+
+	return created, nil
+}
+
+// deleteDebugPod removes a debug pod
+func (gv *GPUValidator) deleteDebugPod(ctx context.Context, podName string) {
+	gracePeriod := int64(0)
+	err := gv.client.CoreV1().Pods(gv.framework.Namespace.Name).Delete(ctx, podName, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriod,
+	})
+	if err != nil {
+		framework.Logf("Warning: failed to delete debug pod %s: %v", podName, err)
+	}
+}
+
+// ValidateGPUInContainer validates GPU accessibility in a specific container
+func (gv *GPUValidator) ValidateGPUInContainer(ctx context.Context, namespace, podName, containerName string, expectedGPUCount int) error {
+	framework.Logf("Validating GPU accessibility in pod %s/%s container %s (expected %d GPUs)", namespace, podName, containerName, expectedGPUCount)
+
+	nvidiaSmiCmd := []string{"nvidia-smi", "--query-gpu=index,name", "--format=csv,noheader"}
+	stdout, stderr, err := e2epod.ExecWithOptions(gv.framework, e2epod.ExecOptions{
+		Command:       nvidiaSmiCmd,
+		Namespace:     namespace,
+		PodName:       podName,
+		ContainerName: containerName,
+		CaptureStdout: true,
+		CaptureStderr: true,
+	})
+	output := stdout + stderr
+	if err != nil {
+		return fmt.Errorf("failed to execute nvidia-smi in pod %s/%s container %s: %w\nOutput: %s",
+			namespace, podName, containerName, err, output)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	actualGPUCount := 0
+	for _, line := range lines {
+		if strings.TrimSpace(line) != "" {
+			actualGPUCount++
+		}
+	}
+
+	if actualGPUCount != expectedGPUCount {
+		return fmt.Errorf("expected %d GPUs but found %d in pod %s/%s container %s\nnvidia-smi output:\n%s",
+			expectedGPUCount, actualGPUCount, namespace, podName, containerName, output)
+	}
+
+	framework.Logf("Successfully validated %d GPU(s) in pod %s/%s container %s", actualGPUCount, namespace, podName, containerName)
+	return nil
+}
+
+// ValidateCDISpecFilesOnNode checks that CDI spec files exist under /var/run/cdi/ on the node
+func (gv *GPUValidator) ValidateCDISpecFilesOnNode(ctx context.Context, nodeName string) error {
+	framework.Logf("Validating CDI spec files on node %s", nodeName)
+
+	debugPodName := "cdi-spec-check-" + nodeName
+	_, err := gv.createDebugPod(ctx, nodeName, debugPodName)
+	if err != nil {
+		return fmt.Errorf("failed to create debug pod on node %s: %w", nodeName, err)
+	}
+	defer gv.deleteDebugPod(ctx, debugPodName)
+
+	lsCmd := []string{"ls", "/host/var/run/cdi/"}
+	stdout, stderr, err := e2epod.ExecWithOptions(gv.framework, e2epod.ExecOptions{
+		Command:       lsCmd,
+		Namespace:     gv.framework.Namespace.Name,
+		PodName:       debugPodName,
+		ContainerName: "debug",
+		CaptureStdout: true,
+		CaptureStderr: true,
+	})
+	output := stdout + stderr
+	if err != nil {
+		return fmt.Errorf("failed to list CDI spec files on node %s: %w\nOutput: %s", nodeName, err, output)
+	}
+
+	files := strings.TrimSpace(output)
+	if files == "" {
+		return fmt.Errorf("no CDI spec files found under /var/run/cdi/ on node %s", nodeName)
+	}
+
+	framework.Logf("Found CDI spec files on node %s:\n%s", nodeName, files)
+	return nil
+}
+
+// ValidateNoSELinuxDenials checks that there are no recent AVC denials matching the given keyword
+func (gv *GPUValidator) ValidateNoSELinuxDenials(ctx context.Context, nodeName string, processKeyword string) error {
+	framework.Logf("Checking for SELinux AVC denials on node %s matching %q", nodeName, processKeyword)
+
+	debugPodName := "selinux-check-" + nodeName
+	_, err := gv.createDebugPod(ctx, nodeName, debugPodName)
+	if err != nil {
+		return fmt.Errorf("failed to create debug pod on node %s: %w", nodeName, err)
+	}
+	defer gv.deleteDebugPod(ctx, debugPodName)
+
+	ausearchCmd := []string{"chroot", "/host", "bash", "-c", "ausearch -m AVC -ts recent 2>/dev/null || true"}
+	stdout, stderr, err := e2epod.ExecWithOptions(gv.framework, e2epod.ExecOptions{
+		Command:       ausearchCmd,
+		Namespace:     gv.framework.Namespace.Name,
+		PodName:       debugPodName,
+		ContainerName: "debug",
+		CaptureStdout: true,
+		CaptureStderr: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to run ausearch on node %s: %w\nStderr: %s", nodeName, err, stderr)
+	}
+
+	output := strings.TrimSpace(stdout)
+	if output == "" || strings.Contains(output, "<no matches>") {
+		framework.Logf("No AVC denials found on node %s", nodeName)
+		return nil
+	}
+
+	var matchingDenials []string
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(strings.ToLower(line), strings.ToLower(processKeyword)) {
+			matchingDenials = append(matchingDenials, line)
+		}
+	}
+
+	if len(matchingDenials) > 0 {
+		return fmt.Errorf("found %d SELinux AVC denial(s) matching %q on node %s:\n%s",
+			len(matchingDenials), processKeyword, nodeName, strings.Join(matchingDenials, "\n"))
+	}
+
+	framework.Logf("No AVC denials matching %q on node %s", processKeyword, nodeName)
+	return nil
+}
+
+// ValidateSELinuxEnforcing verifies that SELinux is in Enforcing mode on the node
+func (gv *GPUValidator) ValidateSELinuxEnforcing(ctx context.Context, nodeName string) error {
+	framework.Logf("Checking SELinux mode on node %s", nodeName)
+
+	debugPodName := "selinux-mode-" + nodeName
+	_, err := gv.createDebugPod(ctx, nodeName, debugPodName)
+	if err != nil {
+		return fmt.Errorf("failed to create debug pod on node %s: %w", nodeName, err)
+	}
+	defer gv.deleteDebugPod(ctx, debugPodName)
+
+	getenforceCmd := []string{"chroot", "/host", "getenforce"}
+	stdout, stderr, err := e2epod.ExecWithOptions(gv.framework, e2epod.ExecOptions{
+		Command:       getenforceCmd,
+		Namespace:     gv.framework.Namespace.Name,
+		PodName:       debugPodName,
+		ContainerName: "debug",
+		CaptureStdout: true,
+		CaptureStderr: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to run getenforce on node %s: %w\nStderr: %s", nodeName, err, stderr)
+	}
+
+	mode := strings.TrimSpace(stdout)
+	if mode != "Enforcing" {
+		return fmt.Errorf("SELinux is %q on node %s, expected Enforcing", mode, nodeName)
+	}
+
+	framework.Logf("SELinux is Enforcing on node %s", nodeName)
+	return nil
+}
+
+// GetPodSCC returns the SCC annotation value for a pod
+func (gv *GPUValidator) GetPodSCC(ctx context.Context, namespace, podName string) (string, error) {
+	pod, err := gv.client.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to get pod %s/%s: %w", namespace, podName, err)
+	}
+
+	scc := pod.Annotations["openshift.io/scc"]
+	framework.Logf("Pod %s/%s SCC annotation: %q", namespace, podName, scc)
+	return scc, nil
+}
+
+// ValidateClaimStatus returns structured status information for a ResourceClaim
+func (gv *GPUValidator) ValidateClaimStatus(ctx context.Context, namespace, claimName string) (*ClaimStatusInfo, error) {
+	framework.Logf("Getting ResourceClaim status for %s/%s", namespace, claimName)
+
+	claim, err := gv.client.ResourceV1().ResourceClaims(namespace).Get(ctx, claimName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ResourceClaim %s/%s: %w", namespace, claimName, err)
+	}
+
+	info := &ClaimStatusInfo{}
+	info.Allocated = claim.Status.Allocation != nil
+
+	for _, ref := range claim.Status.ReservedFor {
+		info.ReservedFor = append(info.ReservedFor, string(ref.UID))
+	}
+
+	if claim.Status.Allocation != nil {
+		results := claim.Status.Allocation.Devices.Results
+		info.DeviceCount = len(results)
+		for _, result := range results {
+			info.Devices = append(info.Devices, DeviceInfo{
+				Driver:  result.Driver,
+				Pool:    result.Pool,
+				Device:  result.Device,
+				Request: result.Request,
+			})
+		}
+	}
+
+	framework.Logf("ResourceClaim %s/%s: allocated=%v, reservedFor=%d, devices=%d",
+		namespace, claimName, info.Allocated, len(info.ReservedFor), info.DeviceCount)
+	return info, nil
 }

--- a/test/extended/node/dra/nvidia/resource_builder.go
+++ b/test/extended/node/dra/nvidia/resource_builder.go
@@ -182,6 +182,168 @@ func (rb *ResourceBuilder) BuildLongRunningPodWithClaim(name, claimName, image s
 	return pod
 }
 
+// BuildMultiContainerPodWithClaim creates a Pod with two containers sharing the same GPU claim
+func (rb *ResourceBuilder) BuildMultiContainerPodWithClaim(name, claimName, image string) *corev1.Pod {
+	if image == "" {
+		image = defaultCudaImage
+	}
+
+	secCtx := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: rb.namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "gpu-container-1",
+					Image:   image,
+					Command: []string{"sh", "-c", "nvidia-smi && sleep infinity"},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{
+								Name: "gpu",
+							},
+						},
+					},
+					SecurityContext: secCtx,
+				},
+				{
+					Name:    "gpu-container-2",
+					Image:   image,
+					Command: []string{"sh", "-c", "nvidia-smi && sleep infinity"},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{
+								Name: "gpu",
+							},
+						},
+					},
+					SecurityContext: secCtx,
+				},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu",
+					ResourceClaimName: &claimName,
+				},
+			},
+		},
+	}
+}
+
+// BuildPodWithInitContainerAndClaim creates a Pod with an init container and main container both using the GPU claim
+func (rb *ResourceBuilder) BuildPodWithInitContainerAndClaim(name, claimName, image string) *corev1.Pod {
+	if image == "" {
+		image = defaultCudaImage
+	}
+
+	secCtx := &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: rb.namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			InitContainers: []corev1.Container{
+				{
+					Name:    "gpu-init",
+					Image:   image,
+					Command: []string{"nvidia-smi"},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{
+								Name: "gpu",
+							},
+						},
+					},
+					SecurityContext: secCtx,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:    "gpu-container",
+					Image:   image,
+					Command: []string{"sh", "-c", "nvidia-smi && sleep infinity"},
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{
+							{
+								Name: "gpu",
+							},
+						},
+					},
+					SecurityContext: secCtx,
+				},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu",
+					ResourceClaimName: &claimName,
+				},
+			},
+		},
+	}
+}
+
+// BuildNonRootPodWithClaim creates a Pod that runs as a non-root user with the GPU claim
+func (rb *ResourceBuilder) BuildNonRootPodWithClaim(name, claimName, image string) *corev1.Pod {
+	pod := rb.BuildPodWithClaim(name, claimName, image)
+	pod.Spec.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To[int64](1000),
+		RunAsGroup:   ptr.To[int64](1000),
+	}
+	return pod
+}
+
+// BuildResourceClaimWithCELSelector creates a ResourceClaim with a direct CEL selector instead of a DeviceClass
+func (rb *ResourceBuilder) BuildResourceClaimWithCELSelector(name, celExpression string, count int) *resourceapi.ResourceClaim {
+	if count <= 0 {
+		panic(fmt.Sprintf("BuildResourceClaimWithCELSelector: count must be > 0, got %d", count))
+	}
+
+	return &resourceapi.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: rb.namespace,
+		},
+		Spec: resourceapi.ResourceClaimSpec{
+			Devices: resourceapi.DeviceClaim{
+				Requests: []resourceapi.DeviceRequest{
+					{
+						Name: "gpu",
+						Exactly: &resourceapi.ExactDeviceRequest{
+							Count: int64(count),
+							Selectors: []resourceapi.DeviceSelector{
+								{
+									CEL: &resourceapi.CELDeviceSelector{
+										Expression: celExpression,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // BuildResourceClaimTemplate creates a ResourceClaimTemplate
 func (rb *ResourceBuilder) BuildResourceClaimTemplate(name, deviceClassName string, count int) *resourceapi.ResourceClaimTemplate {
 	if count <= 0 {

--- a/test/extended/node/dra/nvidia/security.go
+++ b/test/extended/node/dra/nvidia/security.go
@@ -1,0 +1,223 @@
+package nvidia
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+
+	exutil "github.com/openshift/origin/test/extended/util"
+)
+
+var _ = g.Describe("[sig-node][Feature:NVIDIA-DRA][Suite:openshift/nvidia-dra][Serial]", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithPodSecurityLevel("nvidia-dra-security", admissionapi.LevelPrivileged)
+
+	var (
+		validator *GPUValidator
+		builder   *ResourceBuilder
+	)
+
+	g.BeforeEach(func(ctx context.Context) {
+		validator = NewGPUValidator(oc.KubeFramework())
+		builder = NewResourceBuilder(oc.Namespace())
+
+		nodes, err := validator.GetGPUNodes(ctx)
+		if err != nil {
+			g.Fail(fmt.Sprintf("Failed to discover GPU nodes: %v", err))
+		}
+		if len(nodes) == 0 {
+			g.Skip("No GPU nodes available in the cluster - skipping SELinux/Security tests")
+		}
+
+		if prerequisitesError != nil {
+			g.Fail(fmt.Sprintf("Prerequisites validation failed: %v", prerequisitesError))
+		}
+		if !prerequisitesInstalled {
+			g.Skip("Prerequisites not installed - skipping SELinux/Security tests")
+		}
+	})
+
+	g.Context("SELinux and Security", func() {
+		g.It("should allow GPU access under SELinux Enforcing mode with no AVC denials", func(ctx context.Context) {
+			deviceClassName := "test-selinux-" + oc.Namespace()
+			claimName := "test-selinux-claim"
+			podName := "test-selinux-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating GPU pod")
+			pod := builder.BuildLongRunningPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "GPU pod failed to start")
+
+			g.By("Identifying the GPU node")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gpuNode := pod.Spec.NodeName
+			o.Expect(gpuNode).NotTo(o.BeEmpty())
+
+			g.By("Verifying SELinux is in Enforcing mode on the GPU node")
+			err = validator.ValidateSELinuxEnforcing(ctx, gpuNode)
+			framework.ExpectNoError(err, "SELinux should be Enforcing on OpenShift nodes")
+
+			g.By("Verifying nvidia-smi works under SELinux Enforcing")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "GPU should be accessible under SELinux Enforcing")
+
+			g.By("Checking for SELinux AVC denials related to NVIDIA/GPU")
+			err = validator.ValidateNoSELinuxDenials(ctx, gpuNode, "nvidia")
+			framework.ExpectNoError(err, "No SELinux AVC denials should exist for NVIDIA GPU access")
+
+			err = validator.ValidateNoSELinuxDenials(ctx, gpuNode, "crio")
+			framework.ExpectNoError(err, "No SELinux AVC denials should exist for CRI-O CDI processing")
+		})
+
+		g.It("should allow GPU access with restricted SCC (non-privileged workload)", func(ctx context.Context) {
+			deviceClassName := "test-restricted-scc-" + oc.Namespace()
+			claimName := "test-restricted-scc-claim"
+			podName := "test-restricted-scc-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating GPU pod with restricted security context (no privilege escalation, drop ALL caps)")
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create restricted GPU pod")
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Restricted GPU pod failed to start")
+
+			g.By("Verifying GPU access works without privileged SCC")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "GPU should be accessible via CDI without privileged SCC")
+
+			g.By("Verifying pod is NOT running with privileged SCC")
+			scc, err := validator.GetPodSCC(ctx, oc.Namespace(), podName)
+			framework.ExpectNoError(err)
+			o.Expect(scc).NotTo(o.Equal("privileged"),
+				"Workload pod should NOT require privileged SCC for GPU access via DRA/CDI")
+			framework.Logf("GPU workload pod running with SCC: %s", scc)
+		})
+
+		g.It("should allow non-root user to access GPU via DRA claim", func(ctx context.Context) {
+			deviceClassName := "test-nonroot-" + oc.Namespace()
+			claimName := "test-nonroot-claim"
+			podName := "test-nonroot-pod"
+
+			g.By("Creating DeviceClass and ResourceClaim")
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err := createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			g.By("Creating Pod with runAsNonRoot and non-root UID")
+			pod := builder.BuildNonRootPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Failed to create non-root GPU pod")
+
+			g.By("Waiting for pod to be running")
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err, "Non-root GPU pod failed to start")
+
+			g.By("Verifying the container is running as non-root")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Get(ctx, podName, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			idCmd := []string{"id", "-u"}
+			stdout, _, err := e2epod.ExecWithOptions(oc.KubeFramework(), e2epod.ExecOptions{
+				Command:       idCmd,
+				Namespace:     oc.Namespace(),
+				PodName:       podName,
+				ContainerName: pod.Spec.Containers[0].Name,
+				CaptureStdout: true,
+				CaptureStderr: true,
+			})
+			framework.ExpectNoError(err, "Failed to check user ID in container")
+			uid := strings.TrimSpace(stdout)
+			o.Expect(uid).NotTo(o.Equal("0"), "Container should not be running as root")
+			framework.Logf("Container running as UID: %s", uid)
+
+			g.By("Verifying GPU access as non-root user")
+			err = validator.ValidateGPUInPod(ctx, oc.Namespace(), podName, 1)
+			framework.ExpectNoError(err, "GPU should be accessible as non-root user via DRA/CDI")
+		})
+
+		g.It("should use expected SCCs for DRA driver and workload pods", func(ctx context.Context) {
+			g.By("Checking NVIDIA DRA driver DaemonSet pods run with privileged SCC")
+			driverPods, err := oc.KubeFramework().ClientSet.CoreV1().Pods("nvidia-dra-driver").List(ctx, metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/name=nvidia-dra-driver-gpu",
+			})
+			framework.ExpectNoError(err, "Failed to list DRA driver pods")
+			o.Expect(driverPods.Items).NotTo(o.BeEmpty(), "DRA driver pods should be running")
+
+			for _, driverPod := range driverPods.Items {
+				scc, err := validator.GetPodSCC(ctx, driverPod.Namespace, driverPod.Name)
+				framework.ExpectNoError(err)
+				o.Expect(scc).To(o.Equal("privileged"),
+					fmt.Sprintf("DRA driver pod %s should run with privileged SCC", driverPod.Name))
+				framework.Logf("DRA driver pod %s running with SCC: %s", driverPod.Name, scc)
+			}
+
+			g.By("Creating a GPU workload pod and verifying it does NOT require privileged SCC")
+			deviceClassName := "test-scc-audit-" + oc.Namespace()
+			claimName := "test-scc-audit-claim"
+			podName := "test-scc-audit-pod"
+
+			deviceClass := builder.BuildDeviceClass(deviceClassName)
+			err = createDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClass)
+			framework.ExpectNoError(err)
+			defer deleteDeviceClass(ctx, oc.KubeFramework().DynamicClient, deviceClassName)
+
+			claim := builder.BuildResourceClaim(claimName, deviceClassName, 1)
+			err = createResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claim)
+			framework.ExpectNoError(err)
+			defer deleteResourceClaim(ctx, oc.KubeFramework().DynamicClient, oc.Namespace(), claimName)
+
+			pod := builder.BuildPodWithClaim(podName, claimName, "")
+			pod, err = oc.KubeFramework().ClientSet.CoreV1().Pods(oc.Namespace()).Create(ctx, pod, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			err = e2epod.WaitForPodRunningInNamespace(ctx, oc.KubeFramework().ClientSet, pod)
+			framework.ExpectNoError(err)
+
+			workloadSCC, err := validator.GetPodSCC(ctx, oc.Namespace(), podName)
+			framework.ExpectNoError(err)
+			o.Expect(workloadSCC).NotTo(o.Equal("privileged"),
+				"GPU workload pod should NOT need privileged SCC")
+			framework.Logf("GPU workload pod %s running with SCC: %s (expected non-privileged)", podName, workloadSCC)
+		})
+	})
+})


### PR DESCRIPTION
Implements a new set of tests covering 
- CRI-O CDI integration,
- SELinux/SCC security enforcement,
- ResourceClaim lifecycle 

on real NVIDIA GPU hardware i.e. areas with no existing upstream or OpenShift test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for NVIDIA GPU resource allocation and claim lifecycles.
  - Added validation for CRI-O CDI integration, including GPU injection, CUDA access, multi-GPU workloads, and init containers.
  - Added security coverage for SELinux enforcement, restricted workloads, non-root access, and security context assignments.
  - Added checks for GPU visibility, device health, claim status, and node configuration.

- **Documentation**
  - Added a draft testing strategy outlining coverage areas, prerequisites, execution priorities, and CI considerations for NVIDIA hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->