### PR TITLE
OCPBUGS-86789: Bump network config timeout to 25 minutes

### DIFF
--- a/test/extended/networking/util.go
+++ b/test/extended/networking/util.go
@@ -295,7 +295,7 @@ func makeNamespaceScheduleToAllNodes(f *e2e.Framework) {
 
 func modifyNetworkConfig(configClient configv1client.Interface, autoAssignCIDRs, allowedCIDRs, rejectedCIDRs []string) {
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 25*time.Minute)
 	defer cancel()
 
 	kubeAPIServerRollout := exutil.WaitForOperatorToRollout(ctx, configClient, "kube-apiserver")


### PR DESCRIPTION
This is needed because KAS rollout on AWS now has a 300 sec (x3) rollout delay due to long LB drain times, which pushes the whole process now slightly over 20 min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Increased the wait time for network configuration updates and kube-apiserver rollouts to reduce failures caused by slow operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->