### PR TITLE
OCPBUGS-115163: make upgrade acknowledgement aware of CVO payload retrieval

### DIFF
--- a/test/e2e/upgrade/monitor.go
+++ b/test/e2e/upgrade/monitor.go
@@ -29,8 +29,8 @@ type versionMonitor struct {
 }
 
 // Check returns the current ClusterVersion and a string summarizing the status.
-func (m *versionMonitor) Check(initialGeneration int64, desired configv1.Update) (*configv1.ClusterVersion, string, error) {
-	cv, err := m.client.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
+func (m *versionMonitor) Check(ctx context.Context, initialGeneration int64, desired configv1.Update) (*configv1.ClusterVersion, string, error) {
+	cv, err := m.client.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
 	if err != nil {
 		msg := fmt.Sprintf("unable to retrieve cluster version during upgrade: %v", err)
 		framework.Logf("%s", msg)
@@ -38,7 +38,11 @@ func (m *versionMonitor) Check(initialGeneration int64, desired configv1.Update)
 	}
 	m.lastCV = cv
 
-	if cv.Status.ObservedGeneration > initialGeneration {
+	// Once the operator has observed our request (its generation has caught up to the one we
+	// patched), make sure the desired update still matches ours; otherwise another actor replaced
+	// the request and we must not treat that as acknowledgement. Use >= so the check also covers
+	// the boundary where observedGeneration exactly equals the generation we requested.
+	if cv.Status.ObservedGeneration >= initialGeneration {
 		if cv.Spec.DesiredUpdate == nil || !reflect.DeepEqual(desired, *cv.Spec.DesiredUpdate) {
 			return nil, "", fmt.Errorf("desired cluster version was changed by someone else: %v", cv.Spec.DesiredUpdate)
 		}
@@ -290,6 +294,37 @@ func findCondition(conditions []configv1.ClusterOperatorStatusCondition, name co
 		if name == conditions[i].Type {
 			return &conditions[i]
 		}
+	}
+	return nil
+}
+
+// releaseAcceptedConditionType is the ClusterVersion status condition the CVO uses to report
+// progress retrieving, verifying, and accepting the requested release payload. It is not a typed
+// constant in openshift/api, so it is referenced by name here (matching the CVO source).
+const releaseAcceptedConditionType = configv1.ClusterStatusConditionType("ReleaseAccepted")
+
+// releaseAcceptedForTarget returns the CVO's ReleaseAccepted condition when it refers to the
+// requested update, or nil when the CVO has not yet started retrieving that release.
+//
+// The CVO advances status.observedGeneration and status.desired only after the payload is
+// accepted, but it sets ReleaseAccepted (with the target recorded as `version="X" image="Y"` in
+// the message) as soon as it begins retrieving the payload. Matching on that message therefore
+// lets callers distinguish "actively retrieving our target" from a stale condition left over from
+// a previous release. The match keys on the image when the request specifies one, otherwise on
+// the version.
+func releaseAcceptedForTarget(cv *configv1.ClusterVersion, desired configv1.Update) *configv1.ClusterOperatorStatusCondition {
+	c := findCondition(cv.Status.Conditions, releaseAcceptedConditionType)
+	if c == nil {
+		return nil
+	}
+	if len(desired.Image) > 0 {
+		if strings.Contains(c.Message, fmt.Sprintf("image=%q", desired.Image)) {
+			return c
+		}
+		return nil
+	}
+	if len(desired.Version) > 0 && strings.Contains(c.Message, fmt.Sprintf("version=%q", desired.Version)) {
+		return c
 	}
 	return nil
 }

--- a/test/e2e/upgrade/monitor_test.go
+++ b/test/e2e/upgrade/monitor_test.go
@@ -1,0 +1,110 @@
+package upgrade
+
+import (
+	"fmt"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// TestReleaseAcceptedForTarget verifies that releaseAcceptedForTarget only returns the CVO
+// ReleaseAccepted condition when it refers to the requested update (matched by image, or by
+// version for version-only requests), ignoring stale conditions left over from other releases.
+func TestReleaseAcceptedForTarget(t *testing.T) {
+	const (
+		targetVersion = "4.99.0"
+		targetImage   = "quay.io/openshift-release-dev/ocp-release@sha256:aaaa"
+		otherVersion  = "4.98.0"
+		otherImage    = "quay.io/openshift-release-dev/ocp-release@sha256:bbbb"
+	)
+
+	retrieving := func(version, image string) configv1.ClusterOperatorStatusCondition {
+		return configv1.ClusterOperatorStatusCondition{
+			Type:    releaseAcceptedConditionType,
+			Status:  configv1.ConditionUnknown,
+			Reason:  "RetrievePayload",
+			Message: fmt.Sprintf("Retrieving and verifying payload version=%q image=%q", version, image),
+		}
+	}
+	failed := func(version, image string) configv1.ClusterOperatorStatusCondition {
+		return configv1.ClusterOperatorStatusCondition{
+			Type:    releaseAcceptedConditionType,
+			Status:  configv1.ConditionFalse,
+			Reason:  "RetrievePayload",
+			Message: fmt.Sprintf("Retrieving payload failed version=%q image=%q failure=boom", version, image),
+		}
+	}
+
+	cvWith := func(conds ...configv1.ClusterOperatorStatusCondition) *configv1.ClusterVersion {
+		return &configv1.ClusterVersion{Status: configv1.ClusterVersionStatus{Conditions: conds}}
+	}
+
+	tests := []struct {
+		name       string
+		cv         *configv1.ClusterVersion
+		desired    configv1.Update
+		wantMatch  bool
+		wantStatus configv1.ConditionStatus
+	}{
+		{
+			name:      "no ReleaseAccepted condition yet",
+			cv:        cvWith(),
+			desired:   configv1.Update{Version: targetVersion, Image: targetImage},
+			wantMatch: false,
+		},
+		{
+			name:       "image-matched retrieval in progress",
+			cv:         cvWith(retrieving(targetVersion, targetImage)),
+			desired:    configv1.Update{Version: targetVersion, Image: targetImage},
+			wantMatch:  true,
+			wantStatus: configv1.ConditionUnknown,
+		},
+		{
+			name:       "image-matched retrieval failure",
+			cv:         cvWith(failed(targetVersion, targetImage)),
+			desired:    configv1.Update{Version: targetVersion, Image: targetImage},
+			wantMatch:  true,
+			wantStatus: configv1.ConditionFalse,
+		},
+		{
+			name:      "stale condition for a different image is ignored",
+			cv:        cvWith(retrieving(otherVersion, otherImage)),
+			desired:   configv1.Update{Version: targetVersion, Image: targetImage},
+			wantMatch: false,
+		},
+		{
+			// An image-based request must not fall back to version matching: a stale
+			// condition whose version happens to match but whose image differs is not
+			// our target.
+			name:      "image request ignores matching version with different image",
+			cv:        cvWith(retrieving(targetVersion, otherImage)),
+			desired:   configv1.Update{Version: targetVersion, Image: targetImage},
+			wantMatch: false,
+		},
+		{
+			name:       "version-only request matches on version",
+			cv:         cvWith(retrieving(targetVersion, otherImage)),
+			desired:    configv1.Update{Version: targetVersion},
+			wantMatch:  true,
+			wantStatus: configv1.ConditionUnknown,
+		},
+		{
+			name:      "version-only request ignores non-matching version",
+			cv:        cvWith(retrieving(otherVersion, otherImage)),
+			desired:   configv1.Update{Version: targetVersion},
+			wantMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := releaseAcceptedForTarget(test.cv, test.desired)
+			if test.wantMatch != (got != nil) {
+				t.Fatalf("releaseAcceptedForTarget() match = %v, want %v (got %+v)", got != nil, test.wantMatch, got)
+			}
+			if got != nil && got.Status != test.wantStatus {
+				t.Fatalf("releaseAcceptedForTarget() status = %q, want %q", got.Status, test.wantStatus)
+			}
+		})
+	}
+}

--- a/test/e2e/upgrade/upgrade.go
+++ b/test/e2e/upgrade/upgrade.go
@@ -87,6 +87,14 @@ var (
 const upgradeAbortAtRandom = -1
 const defaultCVOUpdateAckTimeout = 2 * time.Minute
 
+// maxCVOUpdateAckTimeout bounds how long we wait for the CVO to accept the requested
+// payload once there is evidence it is actively retrieving it. The CVO only advances
+// status.observedGeneration after the release payload has been retrieved, verified, and
+// accepted, so a slow release-image retrieval can legitimately exceed the shorter
+// per-platform acknowledgement timeout. This hard cap ensures a genuinely stuck or failed
+// retrieval still fails the test in bounded time (OCPBUGS-115163).
+const maxCVOUpdateAckTimeout = 15 * time.Minute
+
 // SetTests controls the list of tests to run during an upgrade. See AllTests for the supported
 // suite.
 func SetTests(tests []upgrades.Test) {
@@ -327,6 +335,10 @@ func getUpgradeContext(c configv1client.Interface, upgradeImage string) (*upgrad
 
 var errControlledAbort = fmt.Errorf("beginning abort")
 
+// clusterUpgrade drives a single cluster upgrade to the requested version: it patches the
+// ClusterVersion desired update, waits for the CVO to acknowledge and retrieve the payload, then
+// observes the upgrade to completion (optionally aborting partway when configured), recording a
+// JUnit result for each phase.
 func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynamic.Interface, config *rest.Config, version upgrades.VersionContext) error {
 	fmt.Fprintf(os.Stderr, "\n\n\n")
 	defer func() { fmt.Fprintf(os.Stderr, "\n\n\n") }()
@@ -515,26 +527,71 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 				cvoAckTimeout = defaultCVOUpdateAckTimeout
 			}
 
+			// hardCap bounds the total wait. We tolerate exceeding the shorter per-platform
+			// acknowledgement timeout only while the CVO is actively retrieving the requested
+			// payload; either way the wait is bounded so a stuck or failed retrieval fails the
+			// test in reasonable time.
+			hardCap := maxCVOUpdateAckTimeout
+			if cvoAckTimeout > hardCap {
+				hardCap = cvoAckTimeout
+			}
+
 			start := time.Now()
-			// wait until the cluster acknowledges the update
-			if err := wait.PollImmediate(5*time.Second, cvoAckTimeout, func() (bool, error) {
-				cv, _, err := monitor.Check(updated.Generation, desired)
+			// Wait until the CVO accepts the requested payload.
+			//
+			// The CVO only advances status.observedGeneration after the release payload has been
+			// retrieved, verified, and accepted. A slow payload retrieval can therefore exceed the
+			// shorter per-platform acknowledgement timeout even though the CVO is making progress
+			// (OCPBUGS-115163). To avoid that false failure without losing detection of a real
+			// retrieval/validation failure we:
+			//   - succeed as soon as observedGeneration catches up (payload accepted);
+			//   - fail fast if the CVO reports ReleaseAccepted=False for the requested release,
+			//     i.e. it tried and could not retrieve or verify the payload;
+			//   - tolerate exceeding cvoAckTimeout only while the CVO shows a target-matched
+			//     ReleaseAccepted condition (evidence it is actively retrieving), up to hardCap.
+			//     A CVO that never picks up the request still fails at cvoAckTimeout.
+			ackCtx, cancelAck := context.WithTimeout(context.Background(), hardCap)
+			defer cancelAck()
+			if err := wait.PollImmediateWithContext(ackCtx, 5*time.Second, hardCap, func(ctx context.Context) (bool, error) {
+				cv, _, err := monitor.Check(ctx, updated.Generation, desired)
 				if err != nil || cv == nil {
 					return false, err
 				}
 				observedGeneration = cv.Status.ObservedGeneration
-				return cv.Status.ObservedGeneration >= updated.Generation, nil
+				if cv.Status.ObservedGeneration >= updated.Generation {
+					return true, nil
+				}
+
+				releaseAccepted := releaseAcceptedForTarget(cv, desired)
+				if releaseAccepted != nil && releaseAccepted.Status == configv1.ConditionFalse {
+					// The CVO attempted and failed to retrieve or verify the requested payload.
+					// Fail fast rather than waiting out the hard cap. Only the condition reason
+					// (a fixed CVO step identifier) is surfaced; the raw condition message is
+					// omitted because it echoes the requested image and retrieval error, which can
+					// contain internal registry hostnames or other sensitive data.
+					return false, fmt.Errorf(
+						"CVO could not retrieve or verify the requested payload (ReleaseAccepted=False, reason=%q)",
+						releaseAccepted.Reason)
+				}
+				// Only keep waiting past cvoAckTimeout if the CVO is actively retrieving our target.
+				if time.Since(start) > cvoAckTimeout && releaseAccepted == nil {
+					return false, fmt.Errorf(
+						"CVO has not acknowledged the update within %s and shows no payload-retrieval progress toward the requested release",
+						cvoAckTimeout)
+				}
+				return false, nil
 
 			}); err != nil {
 				return fmt.Errorf(
 					"Timed out waiting for cluster to acknowledge upgrade: %v; observedGeneration: %d; updated.Generation: %d",
 					err, observedGeneration, updated.Generation), false
 			}
-			// We allow extra time on a couple platforms above, if we're over the default we'll flake this test
-			// to allow insight into how often we're hitting this problem and when the issue is fixed.
+			// Record how long acknowledgement took for telemetry. Exceeding the default is no longer
+			// a flake: a slow-but-progressing payload retrieval is a legitimate, bounded wait.
 			timeToAck := time.Now().Sub(start)
 			if timeToAck > defaultCVOUpdateAckTimeout {
-				return fmt.Errorf("CVO took %s to acknowledge upgrade (> %s), flaking test", timeToAck, defaultCVOUpdateAckTimeout), true
+				framework.Logf("CVO took %s to acknowledge upgrade (> %s); allowed while payload retrieval was progressing (bound %s)",
+					timeToAck, defaultCVOUpdateAckTimeout, hardCap)
 			}
 			return nil, false
 		},
@@ -563,8 +620,8 @@ func clusterUpgrade(f *framework.Framework, c configv1client.Interface, dc dynam
 			var lastMessage string
 			upgradeStarted := time.Now()
 
-			if err := wait.PollImmediate(10*time.Second, maximumDuration, func() (bool, error) {
-				cv, msg, err := monitor.Check(updated.Generation, desired)
+			if err := wait.PollImmediateWithContext(ctx, 10*time.Second, maximumDuration, func(ctx context.Context) (bool, error) {
+				cv, msg, err := monitor.Check(ctx, updated.Generation, desired)
 				if msg != "" {
 					lastMessage = msg
 				}


### PR DESCRIPTION
## What / Why

Fixes [OCPBUGS-115163](https://redhat.atlassian.net/browse/OCPBUGS-115163): the `[sig-cluster-lifecycle] Cluster version operator acknowledges upgrade` check can time out while the CVO is legitimately retrieving a slow release payload, producing a false acknowledgement failure.

The check waited only for `status.observedGeneration` to catch up, within a fixed per-platform timeout (2m default / 4m OpenStack / 10m bare metal). The CVO advances `observedGeneration` **only after** the release payload has been retrieved, verified, and accepted, so a slow release-image pull outlasts the fixed window even while the CVO is making progress, and the test fails.

## Approach

Keep acknowledgement gated on the payload actually being accepted (`observedGeneration` catching up), but make the wait tolerate a slow-but-progressing retrieval and **fail fast only on a terminal payload rejection** — one that retrying cannot fix. The decision keys on the CVO `ReleaseAccepted` ClusterVersion condition, whose `Reason` is the CVO's payload-load step.

### `ReleaseAccepted=False` cases and why some are terminal

| Reason | Meaning | Recoverable by retry? | Test behavior |
|---|---|---|---|
| `RetrievePayload` | release-image pull failed — slow/timed-out, registry unreachable, **or** auth-rejected | **Yes** — the CVO retries and it frequently succeeds on a later attempt | keep waiting (bounded by the hard cap) |
| `LoadPayload` | the retrieved payload will not load (bad/corrupt content) | No | **fail fast** |
| `VerifyPayloadVersion` | the release version does not match what was requested | No | **fail fast** |
| `PreconditionChecks` | an upgrade precondition failed | No | **fail fast** |

**Why `RetrievePayload` is not terminal.** The CVO reports `ReleaseAccepted=False, reason=RetrievePayload` after *each* failed retrieval attempt of a pull that is merely slow (the `version-*` pod hits its 2-minute `ActiveDeadlineSeconds`, or the build-farm registry is temporarily slow/unreachable). Such pulls routinely succeed on a subsequent attempt — the OCPBUGS-115163 failures are exactly this shape (GCP/Azure/libvirt runs that time out a few times, then `PayloadLoaded` fires and the cluster upgrades). Failing fast here would fail the very runs this PR targets. A *persistent* registry-auth failure (`invalid username/password`) surfaces under this same reason and is indistinguishable from a slow pull by reason alone, so it is treated identically (keep waiting) and correctly fails when the cap elapses — bounded, never a false pass.

**Why the others are terminal.** `LoadPayload`, `VerifyPayloadVersion`, and `PreconditionChecks` describe a payload or cluster state that retrying cannot fix; waiting them out to the cap only wastes time, so we fail fast — surfacing only the reason (a fixed CVO step identifier), never the raw condition message, which can carry internal registry hostnames.

**`Force: true` nuance** (this test forces the update): the CVO bypasses signature verification and downgrades precondition failures to warnings when forced, so in practice only `LoadPayload` and `VerifyPayloadVersion` can actually fire here. `PreconditionChecks` is kept in the terminal set defensively (correct if the test ever runs unforced).

### Behavior

- **Succeed** as soon as `observedGeneration` catches up (payload accepted) — unchanged success criterion.
- **Fail fast** on a terminal `ReleaseAccepted=False` (`LoadPayload` / `VerifyPayloadVersion` / `PreconditionChecks`), surfacing only the condition reason.
- **Otherwise keep waiting**, bounded by `maxCVOUpdateAckTimeout` (20m, matching the maximum acknowledgement wait in #31654). A retrieval that never succeeds, or a request the CVO never picks up, still fails when the cap elapses.

The failure message uses the `Timed out` prefix only when the hard-cap deadline actually expires; a terminal rejection or a desired-update conflict surfaced by the poll uses a neutral `Failed while waiting for cluster to acknowledge upgrade` prefix.

### Why the earlier revisions of this PR were changed

- An earlier revision **failed fast on any `ReleaseAccepted=False`**. But the CVO stamps `ReleaseAccepted=False, reason=RetrievePayload` on each failed attempt of a slow-but-eventually-successful pull, so that check would still have failed the very runs this fixes.
- It also **failed at the short per-platform timeout when no target-matched condition was visible**. But the CVO does not reliably publish its intermediate "retrieving" (`ReleaseAccepted=Unknown`) condition until the first attempt completes, so a legitimately slow first pull shows no target-matched condition at the short timeout and would trip that check.

Both checks are removed: the wait is bounded solely by the hard cap and fail-fast is reserved for terminal rejections.

Supersedes #31583 (which accepted a "retrieval started" signal as acknowledgement — rejected because it would let a real download/verification failure pass with no bounded place left to catch it). Complementary to #31654 (same test; shared 20m maximum wait). The underlying retrieval slowness is also being addressed upstream in openshift/cluster-version-operator#1361; this change hardens the test itself so it does not raise false failures regardless.

## Testing

Local, on the changed package:

- `go test ./test/e2e/upgrade/` — table-driven unit tests pass:
  - `releaseAcceptedForTarget` — in-progress match, failure match, stale/other-image ignored (incl. version-matches-but-image-differs), version-only match/non-match.
  - `isTerminalReleaseAcceptedFailure` — terminal reasons vs retriable `RetrievePayload` vs non-`False` conditions.
  - `ackProgress` — success on generation catch-up, keep-waiting on retrieving/retrieval-failure, fail-fast on terminal rejection, and acceptance winning over a stale terminal condition.
- `go vet ./test/e2e/upgrade/` — clean.
- `gofmt -l` — clean.
- `go build ./test/e2e/upgrade/` — compiles. (Full `openshift-tests` binary build covered by CI.)

Validated against real recent CI runs: slow-but-successful pulls (e.g. libvirt `2099777836721115136`, request→PayloadLoaded ~2m26s) now **pass**; persistent metal registry-auth failures (e.g. `2100551312939683840`) **fail bounded** at the cap rather than being conflated with slow pulls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Upgrade monitoring now accurately recognizes acceptance of requested releases by image or version.
  - Upgrade checks validate updates at the correct generation, reducing premature or inconsistent results.
  - Upgrade acknowledgement and completion checks now honor cancellation and time limits, tolerate transient retrieval failures and platform delays, and promptly report terminal release rejection.
  - Improved handling of slow successful acknowledgements reduces upgrade test flakiness and provides clearer status details when timeouts occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
