### PR TITLE
OCPEDGE-3039: Fixes TNF PHC flaky tests

### DIFF
--- a/test/extended/edge_topologies/tnf_etcd_disruption.go
+++ b/test/extended/edge_topologies/tnf_etcd_disruption.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
@@ -331,62 +330,6 @@ func killEtcdViaSSH(node *corev1.Node) {
 	framework.Logf("Killed etcd on %s via SSH (stdout: %s)", node.Name, strings.TrimSpace(stdout))
 }
 
-// pacemakerDegradedObserver polls PacemakerHealthCheckDegraded in a background
-// goroutine so a test can detect a transient degraded state that Pacemaker
-// recovers from before it becomes observable. The PacemakerCluster CR (and thus
-// a blocking WaitForPacemakerHealthCheckDegraded call) is only refreshed by a
-// once-per-minute status-collector CronJob snapshot; when the resource agent's
-// own out-of-band detection and restart of a killed etcd container complete
-// faster than that, the fault can be fully recovered within a single snapshot
-// gap and never be caught by a snapshot-driven wait (see the equivalent race
-// documented in tnf_kubelet_disruption.go).
-type pacemakerDegradedObserver struct {
-	oc       *exutil.CLI
-	interval time.Duration
-
-	mu       sync.Mutex
-	observed bool
-	message  string
-	stopCh   chan struct{}
-	stopOnce sync.Once
-}
-
-func newPacemakerDegradedObserver(oc *exutil.CLI, interval time.Duration) *pacemakerDegradedObserver {
-	return &pacemakerDegradedObserver{oc: oc, interval: interval, stopCh: make(chan struct{})}
-}
-
-func (p *pacemakerDegradedObserver) Start() {
-	go func() {
-		for {
-			select {
-			case <-p.stopCh:
-				return
-			default:
-				if degraded, msg, err := apis.IsPacemakerHealthCheckDegraded(p.oc); err == nil && degraded {
-					p.mu.Lock()
-					if !p.observed {
-						framework.Logf("pacemakerDegradedObserver: detected PacemakerHealthCheckDegraded=True (message: %q)", msg)
-					}
-					p.observed = true
-					p.message = msg
-					p.mu.Unlock()
-				}
-				time.Sleep(p.interval)
-			}
-		}
-	}()
-}
-
-func (p *pacemakerDegradedObserver) Stop() {
-	p.stopOnce.Do(func() { close(p.stopCh) })
-}
-
-func (p *pacemakerDegradedObserver) WasObserved() (message string, observed bool) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.message, p.observed
-}
-
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] Two Node with Fencing etcd disruption", func() {
 	defer g.GinkgoRecover()
 
@@ -637,49 +580,48 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
-		g.By("Starting background PacemakerHealthCheckDegraded observer")
-		degradedObserver := newPacemakerDegradedObserver(oc, 5*time.Second)
-		degradedObserver.Start()
-		defer degradedObserver.Stop()
-
 		g.By(fmt.Sprintf("Killing etcd container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
 
-		// Wait for the cluster to self-heal.
+		// Verify that the coordinated failure was recorded. We only check that etcd
+		// appears in Failed Resource Actions — recovery success (both nodes started,
+		// etcd healthy) is verified below. Per-node assertions are omitted because
+		// they depend on RA internals that may evolve. Poll rather than read once:
+		// Pacemaker records the failed action on the resource's own recurring monitor
+		// interval, which can lag the kill, and the entry persists in the CIB even
+		// after the resource recovers, so this survives a fast self-heal.
+		g.By("Waiting for pcs status to show 'Failed Resource Actions' referencing etcd")
+		var failedSection string
+		o.Eventually(func() error {
+			pcsOutput, statusErr := exutil.DebugNodeRetryWithOptionsAndChroot(
+				oc, execNode.Name, "default", "bash", "-c", "sudo pcs status")
+			if statusErr != nil {
+				return fmt.Errorf("failed to get pcs status: %w", statusErr)
+			}
+			failedSection = services.ExtractPcsFailedActions(pcsOutput)
+			if failedSection == "" {
+				framework.Logf("PCS status (no Failed Resource Actions yet):\n%s", pcsOutput)
+				return fmt.Errorf("pcs status has no 'Failed Resource Actions' section yet")
+			}
+			if !strings.Contains(failedSection, "etcd") {
+				return fmt.Errorf("Failed Resource Actions section does not reference etcd yet: %s", failedSection)
+			}
+			return nil
+		}, etcdResourceRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"Expected pcs status to show a 'Failed Resource Actions' section referencing etcd")
+		framework.Logf("Failed Resource Actions section:\n%s", failedSection)
+
 		g.By("Waiting for etcd cluster to self-heal after container kill")
 		o.Eventually(func() error {
 			return utils.LogEtcdClusterStatus(oc, "after container kill", etcdClientFactory)
 		}, longRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "etcd cluster should self-heal after container kill")
 
-		g.By("Verifying PacemakerHealthCheckDegraded was observed during container kill/recovery")
-		degradedMsg, wasDegraded := degradedObserver.WasObserved()
-		o.Expect(wasDegraded).To(o.BeTrue(),
-			"expected PacemakerHealthCheckDegraded=True to be observed at some point during etcd container kill recovery")
-		framework.Logf("PacemakerHealthCheckDegraded observed message: %q", degradedMsg)
-
 		g.By("Verifying pcs status shows etcd-clone Started on both nodes")
 		o.Eventually(func() error {
 			return verifyEtcdCloneStartedOnAllNodes(oc, execNode.Name, nodes)
 		}, longRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(
 			o.HaveOccurred(), "etcd-clone should be Started on both nodes after recovery")
-
-		// Verify that the coordinated failure was observed. We only check that
-		// etcd appears in Failed Resource Actions — recovery success (both nodes
-		// started, etcd healthy) is already verified above. Per-node assertions
-		// are omitted because they depend on RA internals that may evolve.
-		g.By("Checking pcs status for 'Failed Resource Actions' referencing etcd")
-		pcsOutput, statusErr := exutil.DebugNodeRetryWithOptionsAndChroot(
-			oc, execNode.Name, "default", "bash", "-c", "sudo pcs status")
-		o.Expect(statusErr).To(o.BeNil(), "Expected to get pcs status without error")
-		framework.Logf("PCS status after recovery:\n%s", pcsOutput)
-
-		failedSection := services.ExtractPcsFailedActions(pcsOutput)
-		o.Expect(failedSection).NotTo(o.BeEmpty(),
-			"Expected pcs status to contain 'Failed Resource Actions' section after container kill")
-		o.Expect(failedSection).To(o.ContainSubstring("etcd"),
-			"Expected Failed Resource Actions to reference etcd")
-		framework.Logf("Failed Resource Actions section:\n%s", failedSection)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after coordinated recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, longRecoveryTimeout)).
@@ -688,6 +630,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 
 	// This test verifies that Pacemaker detects an etcd process crash and automatically
 	// restarts it, resulting in both nodes becoming healthy voting members.
+	// The fault is confirmed via "Failed Resource Actions" in pcs status
 	g.It("should recover from etcd process crash [Requires:HypervisorSSHConfig]", func() {
 		originalThreshold, err := getMigrationThreshold(oc, execNode.Name)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Must read existing migration-threshold before mutating it")
@@ -697,25 +640,37 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
-		g.By("Starting background PacemakerHealthCheckDegraded observer")
-		degradedObserver := newPacemakerDegradedObserver(oc, 5*time.Second)
-		degradedObserver.Start()
-		defer degradedObserver.Stop()
-
 		g.By(fmt.Sprintf("Killing etcd process/container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
+
+		// Verify that the crash was recorded as a failure. Checking Failed Resource
+		// Actions confirms Pacemaker actually observed the process crash.
+		g.By("Waiting for pcs status to show 'Failed Resource Actions' referencing etcd")
+		var failedSection string
+		o.Eventually(func() error {
+			pcsOutput, statusErr := exutil.DebugNodeRetryWithOptionsAndChroot(
+				oc, execNode.Name, "default", "bash", "-c", "sudo pcs status")
+			if statusErr != nil {
+				return fmt.Errorf("failed to get pcs status: %w", statusErr)
+			}
+			failedSection = services.ExtractPcsFailedActions(pcsOutput)
+			if failedSection == "" {
+				framework.Logf("PCS status (no Failed Resource Actions yet):\n%s", pcsOutput)
+				return fmt.Errorf("pcs status has no 'Failed Resource Actions' section yet")
+			}
+			if !strings.Contains(failedSection, "etcd") {
+				return fmt.Errorf("Failed Resource Actions section does not reference etcd yet: %s", failedSection)
+			}
+			return nil
+		}, etcdResourceRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+			"Expected pcs status to show a 'Failed Resource Actions' section referencing etcd")
+		framework.Logf("Failed Resource Actions section:\n%s", failedSection)
 
 		g.By("Waiting for cluster to recover - both nodes become started voting members")
 		validateEtcdRecoveryState(oc, etcdClientFactory,
 			&execNode,
 			&targetNode, true, false,
 			6*time.Minute, 45*time.Second)
-
-		g.By("Verifying PacemakerHealthCheckDegraded was observed during process crash/recovery")
-		degradedMsg, wasDegraded := degradedObserver.WasObserved()
-		o.Expect(wasDegraded).To(o.BeTrue(),
-			"expected PacemakerHealthCheckDegraded=True to be observed at some point during etcd process crash recovery")
-		framework.Logf("PacemakerHealthCheckDegraded observed message: %q", degradedMsg)
 
 		g.By("Waiting for PacemakerHealthCheckDegraded to clear after etcd process crash recovery")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, 6*time.Minute)).

--- a/test/extended/edge_topologies/tnf_etcd_disruption.go
+++ b/test/extended/edge_topologies/tnf_etcd_disruption.go
@@ -330,6 +330,32 @@ func killEtcdViaSSH(node *corev1.Node) {
 	framework.Logf("Killed etcd on %s via SSH (stdout: %s)", node.Name, strings.TrimSpace(stdout))
 }
 
+// clearEtcdFailedActionsBaseline clears any pre-existing Failed Resource Actions so a
+// later check for an etcd failure reflects only the fault this test injects. Failed
+// actions persist in the CIB until an explicit cleanup, so a stale etcd entry left by an
+// earlier test could otherwise satisfy the post-kill check without the current kill ever
+// being observed. It runs `pcs resource cleanup` and waits until etcd no longer appears in
+// the Failed Resource Actions section before returning.
+func clearEtcdFailedActionsBaseline(oc *exutil.CLI, execNodeName string) {
+	g.By("Clearing Failed Resource Actions baseline (etcd) before disruption")
+	o.Eventually(func() error {
+		if _, err := exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNodeName, "default", "bash", "-c", "sudo pcs resource cleanup"); err != nil {
+			return fmt.Errorf("failed to run pcs resource cleanup: %w", err)
+		}
+		pcsOutput, statusErr := exutil.DebugNodeRetryWithOptionsAndChroot(
+			oc, execNodeName, "default", "bash", "-c", "sudo pcs status")
+		if statusErr != nil {
+			return fmt.Errorf("failed to get pcs status: %w", statusErr)
+		}
+		if failedSection := services.ExtractPcsFailedActions(pcsOutput); strings.Contains(failedSection, "etcd") {
+			return fmt.Errorf("stale etcd entry still present in Failed Resource Actions: %s", failedSection)
+		}
+		return nil
+	}, etcdResourceRecoveryTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(),
+		"Expected Failed Resource Actions baseline to be clear of etcd before disruption")
+}
+
 var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:DualReplica][Suite:openshift/two-node][Serial][Disruptive] Two Node with Fencing etcd disruption", func() {
 	defer g.GinkgoRecover()
 
@@ -580,13 +606,16 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
+		clearEtcdFailedActionsBaseline(oc, execNode.Name)
+
 		g.By(fmt.Sprintf("Killing etcd container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
 
 		// Verify that the coordinated failure was recorded. We only check that etcd
 		// appears in Failed Resource Actions — recovery success (both nodes started,
 		// etcd healthy) is verified below. Per-node assertions are omitted because
-		// they depend on RA internals that may evolve. Poll rather than read once:
+		// they depend on RA internals that may evolve. The baseline was cleared above,
+		// so any etcd entry here is from this kill. Poll rather than read once:
 		// Pacemaker records the failed action on the resource's own recurring monitor
 		// interval, which can lag the kill, and the entry persists in the CIB even
 		// after the resource recovers, so this survives a fast self-heal.
@@ -640,11 +669,14 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			restoreMigrationThreshold(oc, execNode.Name, originalThreshold)
 		})
 
+		clearEtcdFailedActionsBaseline(oc, execNode.Name)
+
 		g.By(fmt.Sprintf("Killing etcd process/container on %s via SSH", targetNode.Name))
 		killEtcdViaSSH(&targetNode)
 
-		// Verify that the crash was recorded as a failure. Checking Failed Resource
-		// Actions confirms Pacemaker actually observed the process crash.
+		// Verify that the crash was recorded as a failure. The baseline was cleared
+		// above, so any etcd entry in Failed Resource Actions here reflects this crash
+		// and confirms Pacemaker actually observed it.
 		g.By("Waiting for pcs status to show 'Failed Resource Actions' referencing etcd")
 		var failedSection string
 		o.Eventually(func() error {

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -30,7 +30,7 @@ const (
 	memberIsLeaderTimeout           = 20 * time.Minute
 	memberRejoinedLearnerTimeout    = 20 * time.Minute
 	memberPromotedVotingTimeout     = 15 * time.Minute
-	networkDisruptionDuration       = 15 * time.Second
+	networkDisruptionDuration       = 25 * time.Second // networkDisruptionDuration must exceed the fencing-priority delay (20s)
 	vmRestartTimeout                = 5 * time.Minute
 	vmUngracefulShutdownTimeout     = 30 * time.Second // Ungraceful VM shutdown is typically fast
 	vmGracefulShutdownTimeout       = 10 * time.Minute // Graceful VM shutdown is typically slow
@@ -211,9 +211,16 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 	g.It("should recover from network disruption with etcd member re-addition", func() {
 		// Note: In network disruption, the targetNode runs the disruption command that
 		// isolates the nodes from each other, creating a split-brain where pacemaker
-		// determines which node gets fenced and which becomes the etcd leader.
+		// determines which node gets fenced and which becomes the etcd leader. Even once
+		// a fence is triggered, the offline window can be short enough — and can even
+		// evict the etcd-operator pod itself, since it only runs on these same two nodes
+		// — that the once-per-minute status-collector snapshot never lands inside it. So,
+		// like the other outage scenarios in this file, whether the fault surfaced is
+		// checked informationally after recovery (checkPacemakerNodeOfflineObserved)
+		// instead of gating the test on it.
 		g.GinkgoT().Printf("Randomly selected %s (%s) to run the network disruption command\n", targetNode.Name, targetNode.Status.Addresses[0].Address)
 		g.By(fmt.Sprintf("Blocking network communication between %s and %s for %v ", targetNode.Name, peerNode.Name, networkDisruptionDuration))
+		disruptionStart := time.Now()
 		command, err := exutil.TriggerNetworkDisruption(oc.KubeClient(), &targetNode, &peerNode, networkDisruptionDuration)
 		o.Expect(err).To(o.BeNil(), "Expected to disrupt network without errors")
 		g.GinkgoT().Printf("command: '%s'\n", command)
@@ -241,12 +248,12 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 			learnerNode, true, false, // targetNode expected started == true, learner == false
 			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
 
-		g.By("Checking PacemakerHealthCheckDegraded after short network disruption (informational)")
-		if checkErr := apis.ExpectPacemakerHealthCheckNotDegraded(oc); checkErr != nil {
-			framework.Logf("[sig-etcd][PHCMiss] PacemakerHealthCheckDegraded was True after network disruption (may be expected): %v", checkErr)
-		} else {
-			framework.Logf("[sig-etcd][PHCCheck] PacemakerHealthCheckDegraded remained False after short network disruption (fault window shorter than healthcheck resync)")
-		}
+		g.By("Waiting for PacemakerHealthCheckDegraded to clear after network disruption recovery")
+		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
+			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
+
+		g.By("Checking for PacemakerNodeOffline event during target node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, targetNode.Name, disruptionStart)
 	})
 
 	g.It("should recover from a double node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -252,8 +252,8 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, memberPromotedVotingTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should clear after etcd recovery")
 
-		g.By("Checking for PacemakerNodeOffline event during target node outage (informational)")
-		checkPacemakerNodeOfflineObserved(oc, targetNode.Name, disruptionStart)
+		g.By("Checking for PacemakerNodeOffline event during fenced node outage (informational)")
+		checkPacemakerNodeOfflineObserved(oc, learnerNode.Name, disruptionStart)
 	})
 
 	g.It("should recover from a double node failure (cold-boot) [Requires:HypervisorSSHConfig]", func() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved etcd disruption recovery validation by clearing stale failure status before each scenario.
  - Extended simulated network disruptions to better align with fencing timing.
  - Updated recovery checks to confirm degraded health clears after network restoration.
  - Added informational validation for offline events on the node actually fenced during recovery.
  - Adjusted event validation to account for timing differences and cases where status events may not be captured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->