### PR TITLE
OCPBUGS-66213: add link to jira card

### DIFF
--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -458,7 +458,7 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 				} else if replicas, err := checkReplicas("openshift-image-registry", operator, clientConfig); err != nil {
 					logrus.WithError(err).Debugf("failed to determine image-registry replica count on platform type %q", platform)
 				} else if replicas == 1 && slices.Contains(tolerateSingleReplicaOn, platform) {
-					return fmt.Sprintf("image-registry has been manually configured with one replica on platform %q", platform)
+					return "https://redhat.atlassian.net/browse/OCPBUGS-66213"
 				}
 
 				// Check for alternative architectures (ppc64le, s390x) with single replica


### PR DESCRIPTION
make sure the exception links to a jira card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the single-replica image registry exception guidance to provide a direct reference to the relevant issue.
  - Replaced the previous platform-specific manual-configuration message with the issue URL, giving users a more appropriate resource when this exception is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->