### PR TITLE
OCPBUGS-119673,OCPEDGE-2819: Update TNF credential rotation test

### DIFF
--- a/test/extended/edge_topologies/tnf_fencing_credentials.go
+++ b/test/extended/edge_topologies/tnf_fencing_credentials.go
@@ -74,7 +74,7 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		survivedNode := peerNode
 
 		g.By(fmt.Sprintf("Reading current fencing credentials for node %s", bmcNode.Name))
-		creds, err := apis.FindFencingCredentialsByNodeName(oc, bmcNode.Name)
+		creds, err := services.FindFencingCredentialsByNodeName(oc, bmcNode.Name)
 		o.Expect(err).ToNot(o.HaveOccurred(), "expected to find fencing credentials secret")
 		framework.Logf("Found fencing credentials secret %s (address: %s, username: %s)",
 			creds.SecretName, creds.Address, creds.Username)
@@ -130,11 +130,11 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		// On sushy-tools, a single htpasswd file serves all BMC endpoints, so changing
 		// the password affects all nodes. Fetch the survived node's credentials so we
 		// can update its stonith device and secret in lockstep.
-		var survivedNodeCreds *apis.FencingCredentials
+		var survivedNodeCreds *services.FencingCredentials
 		var survivedNodeIdentifier string
 		var survivedBashCmd string
 		if isSushy {
-			survivedNodeCreds, err = apis.FindFencingCredentialsByNodeName(oc, survivedNode.Name)
+			survivedNodeCreds, err = services.FindFencingCredentialsByNodeName(oc, survivedNode.Name)
 			o.Expect(err).ToNot(o.HaveOccurred(), "expected to find survived node fencing credentials")
 			survivedNodeIdentifier = strings.TrimPrefix(survivedNodeCreds.SecretName, "fencing-credentials-")
 			survivedBashCmd = scriptPath + ` --node "$1" --username "$2" --password "$3" --address "$4"`
@@ -241,5 +241,38 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		g.By("Verifying PacemakerHealthCheckDegraded is not set after credential update")
 		o.Expect(apis.WaitForPacemakerHealthCheckCleared(oc, fencingHealthTimeout)).
 			ShouldNot(o.HaveOccurred(), "PacemakerHealthCheckDegraded should not be set after credential update")
+	})
+
+	g.It("should preserve fencing agent health when BMC secret contains invalid credentials", func() {
+		bmcNode := targetNode
+
+		// 1. Verify fencing is healthy. ExpectPacemakerBaseline reads the PacemakerCluster CR once
+		// and asserts per-node fencing health (plus cluster health), keeping the test on a single API dependency.
+		g.By("Verifying fencing is healthy before updating the fencing credentials secret")
+		o.Expect(apis.ExpectPacemakerBaseline(oc)).ToNot(o.HaveOccurred(),
+			"expected PacemakerCluster (including per-node fencing health) to be healthy before the update")
+
+		creds, err := services.FindFencingCredentialsByNodeName(oc, bmcNode.Name)
+		o.Expect(err).ToNot(o.HaveOccurred(), "expected to find fencing credentials secret")
+		ns := services.EtcdNamespace
+		secretName := creds.SecretName
+		originalPassword := []byte(creds.Password)
+
+		defer func() {
+			o.Expect(services.RestoreFencingCredentialsPassword(oc, ns, secretName, originalPassword)).ToNot(o.HaveOccurred(),
+				fmt.Sprintf("expected to restore original fencing password in %s/%s", ns, secretName))
+		}()
+
+		// 2. Change the openshift-etcd fencing secret for one node to a bogus value.
+		g.By(fmt.Sprintf("Updating the fencing credentials secret for %s with an invalid password", bmcNode.Name))
+		jobBoundary := time.Now()
+		o.Expect(services.UpdateFencingCredentialsPassword(oc, ns, secretName, []byte("invalid-password"))).ToNot(o.HaveOccurred(),
+			"expected to update fencing credentials secret")
+
+		// 3 & 4. Wait for the fencing job to be triggered (recreated after the update) and verify it
+		// refused the invalid credentials (JobFailed), leaving the live stonith config untouched.
+		g.By("Verifying the fencing job is triggered and refuses the invalid credentials")
+		o.Expect(services.WaitForFencingRejection(oc, ns, jobBoundary, ceoUpdateSetupJobWaitTimeout, utils.ThirtySecondPollInterval)).
+			ToNot(o.HaveOccurred(), "expected the fencing job to reject the invalid fencing credentials")
 	})
 })

--- a/test/extended/edge_topologies/tnf_recovery.go
+++ b/test/extended/edge_topologies/tnf_recovery.go
@@ -441,57 +441,6 @@ var _ = g.Describe("[sig-etcd][apigroup:config.openshift.io][OCPFeatureGate:Dual
 		checkPacemakerNodeOfflineObserved(oc, firstToShutdown.Name, firstOutageStart)
 	})
 
-	g.It("should recover from BMC credential rotation with fencing", func() {
-		bmcNode := targetNode
-		survivedNode := peerNode
-
-		ns, secretName, originalPassword, err := apis.RotateNodeBMCPassword(oc, &bmcNode)
-		o.Expect(err).ToNot(o.HaveOccurred(), "expected to rotate BMC credentials without error")
-
-		defer func() {
-			if err := apis.RestoreBMCPassword(oc, ns, secretName, originalPassword); err != nil {
-				fmt.Fprintf(g.GinkgoWriter,
-					"Warning: failed to restore original BMC password in %s/%s: %v\n",
-					ns, secretName, err)
-			}
-		}()
-		g.By("Ensuring etcd members remain healthy after BMC credential rotation")
-		o.Eventually(func() error {
-			if err := helpers.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, survivedNode.Name); err != nil {
-				return err
-			}
-			if err := helpers.EnsureHealthyMember(g.GinkgoT(), etcdClientFactory, bmcNode.Name); err != nil {
-				return err
-			}
-			return nil
-		}, nodeIsHealthyTimeout, utils.FiveSecondPollInterval).ShouldNot(o.HaveOccurred(), "etcd members should be healthy after BMC credential rotation")
-
-		g.By(fmt.Sprintf("Triggering a fencing-style network disruption between %s and %s", bmcNode.Name, survivedNode.Name))
-		command, err := exutil.TriggerNetworkDisruption(oc.KubeClient(), &bmcNode, &survivedNode, networkDisruptionDuration)
-		o.Expect(err).To(o.BeNil(), "Expected to disrupt network without errors")
-		framework.Logf("network disruption command: %q", command)
-
-		g.By(fmt.Sprintf("Ensuring cluster recovery with proper leader/learner roles after BMC credential rotation + network disruption (timeout: %v)", memberIsLeaderTimeout))
-		leaderNode, learnerNode, learnerStarted := validateEtcdRecoveryStateWithoutAssumingLeader(oc, etcdClientFactory,
-			&survivedNode, &bmcNode, memberIsLeaderTimeout, utils.FiveSecondPollInterval)
-
-		if learnerStarted {
-			framework.Logf("Learner node %q already started as learner after disruption", learnerNode.Name)
-		} else {
-			g.By(fmt.Sprintf("Ensuring '%s' rejoins as learner (timeout: %v)", learnerNode.Name, memberRejoinedLearnerTimeout))
-			validateEtcdRecoveryState(oc, etcdClientFactory,
-				leaderNode,
-				learnerNode, true, true,
-				memberRejoinedLearnerTimeout, utils.FiveSecondPollInterval)
-		}
-
-		g.By(fmt.Sprintf("Ensuring learner node '%s' is promoted back as voting member (timeout: %v)", learnerNode.Name, memberPromotedVotingTimeout))
-		validateEtcdRecoveryState(oc, etcdClientFactory,
-			leaderNode,
-			learnerNode, true, false,
-			memberPromotedVotingTimeout, utils.FiveSecondPollInterval)
-	})
-
 	g.It("should compute etcd revision bump and preserve backup container after kernel panic recovery", func() {
 		// Note: This test triggers a kernel panic on one node via sysrq trigger, then verifies
 		// the surviving node computes the etcd revision bump as floor(maxRaftIndex * 0.2) per

--- a/test/extended/edge_topologies/utils/apis/baremetalhost.go
+++ b/test/extended/edge_topologies/utils/apis/baremetalhost.go
@@ -10,83 +10,16 @@ import (
 	metal3v1alpha1 "github.com/metal3-io/baremetal-operator/apis/metal3.io/v1alpha1"
 	"github.com/openshift/origin/test/extended/edge_topologies/utils/core"
 	exutil "github.com/openshift/origin/test/extended/util"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/yaml"
 )
 
-const (
-	BMCSecretNamespace = "openshift-machine-api"
-	// EtcdNamespace is the OpenShift namespace for etcd static pods and related
-	// Secrets/CronJobs, including fencing-credentials secrets.
-	EtcdNamespace            = "openshift-etcd"
-	fencingCredentialsPrefix = "fencing-credentials-"
-	secretsDataPasswordKey   = "password"
-)
-
-// FencingCredentials holds the fields from a fencing-credentials secret in openshift-etcd.
-type FencingCredentials struct {
-	SecretName              string
-	Address                 string
-	Username                string
-	Password                string
-	CertificateVerification string
-}
-
-// FindFencingCredentialsByNodeName discovers the fencing-credentials secret for a node
-// by listing secrets in openshift-etcd and matching against the node's short name.
-func FindFencingCredentialsByNodeName(oc *exutil.CLI, nodeName string) (*FencingCredentials, error) {
-	shortName := strings.Split(nodeName, ".")[0]
-
-	ctx := context.Background()
-	list, err := oc.AdminKubeClient().CoreV1().Secrets(EtcdNamespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("list secrets in %s: %w", EtcdNamespace, err)
-	}
-
-	expected := map[string]struct{}{
-		fencingCredentialsPrefix + shortName: {},
-		fencingCredentialsPrefix + nodeName:  {},
-	}
-
-	for _, secret := range list.Items {
-		if _, ok := expected[secret.Name]; ok {
-			getRequired := func(key string) (string, error) {
-				v, exists := secret.Data[key]
-				if !exists || len(v) == 0 {
-					return "", fmt.Errorf("secret %s missing required key %q", secret.Name, key)
-				}
-				return string(v), nil
-			}
-			address, err := getRequired("address")
-			if err != nil {
-				return nil, err
-			}
-			username, err := getRequired("username")
-			if err != nil {
-				return nil, err
-			}
-			password, err := getRequired("password")
-			if err != nil {
-				return nil, err
-			}
-			return &FencingCredentials{
-				SecretName:              secret.Name,
-				Address:                 address,
-				Username:                username,
-				Password:                password,
-				CertificateVerification: string(secret.Data["certificateVerification"]),
-			}, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no fencing-credentials secret found matching node %q (prefix: %s, contains: %s) in %s",
-		nodeName, fencingCredentialsPrefix, shortName, EtcdNamespace)
-}
+// EtcdNamespace is the OpenShift namespace for etcd static pods and related
+// Secrets/CronJobs, including fencing-credentials secrets.
+const EtcdNamespace = "openshift-etcd"
 
 // BMHGVR is the GroupVersionResource for BareMetalHost (metal3.io/v1alpha1). Use for API-based get/delete/patch.
 var BMHGVR = schema.GroupVersionResource{
@@ -192,60 +125,4 @@ func FindBMCSecretByNodeName(oc *exutil.CLI, namespace, nodeName string) (string
 		}
 	}
 	return "", fmt.Errorf("no Secret found matching pattern %s", pattern.String())
-}
-
-// RotateNodeBMCPassword discovers the BMC Secret for the given node,
-// rotates its "password" key and returns (namespace, secretName, originalPassword).
-func RotateNodeBMCPassword(oc *exutil.CLI, node *corev1.Node) (string, string, []byte, error) {
-	// Find the BMC secret name using pattern matching (handles FQDNs)
-	secretName, err := FindBMCSecretByNodeName(oc, BMCSecretNamespace, node.Name)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	ctx := context.Background()
-	secretClient := oc.AdminKubeClient().CoreV1().Secrets(BMCSecretNamespace)
-	secret, err := secretClient.Get(ctx, secretName, metav1.GetOptions{})
-	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to get BMC secret %s/%s: %w", BMCSecretNamespace, secretName, err)
-	}
-
-	// Save original password
-	original := secret.Data[secretsDataPasswordKey]
-
-	// Rotate password using oc patch
-	newPass := k8srand.String(32)
-	updated := secret.DeepCopy()
-	updated.Data[secretsDataPasswordKey] = []byte(newPass)
-
-	if _, err := secretClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
-		return "", "", nil, fmt.Errorf("failed to update secret %s/%s: %w",
-			BMCSecretNamespace, secret.Name, err)
-	}
-
-	return BMCSecretNamespace, secret.Name, original, nil
-}
-
-// RestoreBMCPassword restores the password key on the given BMC Secret in namespace (must match
-// where the secret lives; BMC secrets for control-plane nodes are in BMCSecretNamespace).
-func RestoreBMCPassword(oc *exutil.CLI, namespace, name string, originalPassword []byte) error {
-	if originalPassword == nil {
-		return nil
-	}
-
-	ctx := context.Background()
-	secretClient := oc.AdminKubeClient().CoreV1().Secrets(namespace)
-	secret, err := secretClient.Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to re-fetch BMC secret %s/%s: %w", namespace, name, err)
-	}
-
-	updated := secret.DeepCopy()
-	updated.Data[secretsDataPasswordKey] = originalPassword
-
-	if _, err := secretClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to restore password for %s/%s: %w", namespace, name, err)
-	}
-
-	return nil
 }

--- a/test/extended/edge_topologies/utils/services/fencingcredentials.go
+++ b/test/extended/edge_topologies/utils/services/fencingcredentials.go
@@ -1,0 +1,187 @@
+// Package services: fencingcredentials.go manages the openshift-etcd fencing-credentials
+// secrets used for pacemaker-driven fencing.
+//
+// A TNF cluster keeps BMC credentials in two different secrets, owned by different
+// operators and used for different purposes:
+//   - openshift-machine-api/<host>-bmc-secret is owned by the baremetal operator and used
+//     to provision and manage the physical hosts. It plays no part in fencing.
+//   - openshift-etcd/fencing-credentials-<node> is owned by cluster-etcd-operator and drives
+//     pacemaker fencing: its values feed the fence_redfish stonith devices that power-cycle a
+//     peer during recovery.
+//
+// This file only touches the openshift-etcd secrets; the machine-api BMC secret helpers live
+// in the apis package (baremetalhost.go).
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openshift/origin/test/extended/edge_topologies/utils/core"
+	exutil "github.com/openshift/origin/test/extended/util"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	fencingCredentialsPrefix = "fencing-credentials-"
+	secretsDataPasswordKey   = "password"
+
+	// tnfFencingJobName is the static name CEO gives the TNF fencing job in openshift-etcd. CEO hashes
+	// the fencing-credentials-<node> Secret resourceVersions into this job's spec, so a fencing-credentials
+	// change makes CEO delete and recreate tnf-fencing-job to validate the new credentials via fence_redfish.
+	tnfFencingJobName = "tnf-fencing-job"
+
+	// fencingJobAPITimeout bounds each Jobs.Get request so a stalled API call cannot hang past a single
+	// poll iteration (the surrounding core.PollUntil has its own overall timeout).
+	fencingJobAPITimeout = 15 * time.Second
+)
+
+// FencingCredentials holds the fields from a fencing-credentials secret in openshift-etcd.
+type FencingCredentials struct {
+	SecretName              string
+	Address                 string
+	Username                string
+	Password                string
+	CertificateVerification string
+}
+
+// FindFencingCredentialsByNodeName discovers the fencing-credentials secret for a node
+// by listing secrets in openshift-etcd and matching against the node's short name.
+func FindFencingCredentialsByNodeName(oc *exutil.CLI, nodeName string) (*FencingCredentials, error) {
+	shortName := strings.Split(nodeName, ".")[0]
+
+	ctx := context.Background()
+	list, err := oc.AdminKubeClient().CoreV1().Secrets(EtcdNamespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets in %s: %w", EtcdNamespace, err)
+	}
+
+	expected := map[string]struct{}{
+		fencingCredentialsPrefix + shortName: {},
+		fencingCredentialsPrefix + nodeName:  {},
+	}
+
+	for _, secret := range list.Items {
+		if _, ok := expected[secret.Name]; ok {
+			getRequired := func(key string) (string, error) {
+				v, exists := secret.Data[key]
+				if !exists || len(v) == 0 {
+					return "", fmt.Errorf("secret %s missing required key %q", secret.Name, key)
+				}
+				return string(v), nil
+			}
+			address, err := getRequired("address")
+			if err != nil {
+				return nil, err
+			}
+			username, err := getRequired("username")
+			if err != nil {
+				return nil, err
+			}
+			password, err := getRequired("password")
+			if err != nil {
+				return nil, err
+			}
+			return &FencingCredentials{
+				SecretName:              secret.Name,
+				Address:                 address,
+				Username:                username,
+				Password:                password,
+				CertificateVerification: string(secret.Data["certificateVerification"]),
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no fencing-credentials secret found matching node %q (prefix: %s, contains: %s) in %s",
+		nodeName, fencingCredentialsPrefix, shortName, EtcdNamespace)
+}
+
+// UpdateFencingCredentialsPassword sets the password key on the fencing-credentials
+// secret namespace/name to newPassword.
+func UpdateFencingCredentialsPassword(oc *exutil.CLI, namespace, name string, newPassword []byte) error {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	secretClient := oc.AdminKubeClient().CoreV1().Secrets(namespace)
+	secret, err := secretClient.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get fencing credentials secret %s/%s: %w", namespace, name, err)
+	}
+
+	updated := secret.DeepCopy()
+	updated.Data[secretsDataPasswordKey] = newPassword
+
+	if _, err := secretClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to update password for fencing credentials secret %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// RestoreFencingCredentialsPassword restores the password key on the given fencing-credentials
+// secret in namespace (must match where the secret lives).
+func RestoreFencingCredentialsPassword(oc *exutil.CLI, namespace, name string, originalPassword []byte) error {
+	if originalPassword == nil {
+		return nil
+	}
+
+	ctx := context.Background()
+	secretClient := oc.AdminKubeClient().CoreV1().Secrets(namespace)
+	secret, err := secretClient.Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to re-fetch fencing credentials secret %s/%s: %w", namespace, name, err)
+	}
+
+	updated := secret.DeepCopy()
+	updated.Data[secretsDataPasswordKey] = originalPassword
+
+	if _, err := secretClient.Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("failed to restore password for %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
+// WaitForFencingRejection waits for the cluster to reject an invalid fencing-credentials update.
+// CEO hashes the fencing-credentials-<node> Secret resourceVersions into the tnf-fencing-job spec, so a
+// Secret change makes CEO delete and recreate tnf-fencing-job to validate the new credentials via
+// fence_redfish. Rejection is observed as the recreated job reaching JobFailed=True, which leaves the
+// live stonith config untouched. A job that instead completes successfully means invalid credentials
+// were accepted — a test failure. The job name is static (tnf-fencing-job); the CreationTimestamp
+// filter ensures we observe the post-update recreation rather than the pre-existing job.
+func WaitForFencingRejection(oc *exutil.CLI, namespace string, minCreationTime time.Time, timeout, pollInterval time.Duration) error {
+	e2e.Logf("Waiting for fencing job (recreated after %v) to fail (timeout: %v)", minCreationTime.UTC(), timeout)
+
+	err := core.PollUntil(func() (bool, error) {
+		getCtx, getCancel := context.WithTimeout(context.Background(), fencingJobAPITimeout)
+		job, err := oc.AdminKubeClient().BatchV1().Jobs(namespace).Get(getCtx, tnfFencingJobName, metav1.GetOptions{})
+		getCancel()
+		if err != nil {
+			e2e.Logf("Fencing job %s not found yet, waiting...", tnfFencingJobName)
+			return false, nil
+		}
+		if !job.CreationTimestamp.Time.After(minCreationTime) {
+			e2e.Logf("Fencing job %s not yet recreated after the credentials update, waiting...", tnfFencingJobName)
+			return false, nil
+		}
+		for _, cond := range job.Status.Conditions {
+			if cond.Type == batchv1.JobFailed && cond.Status == "True" {
+				e2e.Logf("Fencing job %s failed as expected (reason=%s, message=%q)", tnfFencingJobName, cond.Reason, cond.Message)
+				return true, nil
+			}
+			if cond.Type == batchv1.JobComplete && cond.Status == "True" {
+				return false, core.NewError(fmt.Sprintf("fencing job %s", tnfFencingJobName),
+					"completed successfully but invalid fencing credentials should have been rejected")
+			}
+		}
+		e2e.Logf("Fencing job %s still running...", tnfFencingJobName)
+		return false, nil
+	}, timeout, pollInterval, fmt.Sprintf("fencing job failure (recreated after %v)", minCreationTime.UTC()))
+
+	DumpJobPodLogs(tnfFencingJobName, namespace, oc)
+	return err
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded fencing recovery coverage to verify PacemakerCluster availability, skipping the test when the capability is unavailable.
  * Added validation for fencing-agent health, PacemakerCluster status, refreshed status-collector data, and non-degraded health after invalid credentials are applied.
  * Improved verification that fencing credentials are restored successfully after testing.
  * Removed network-disruption recovery checks and etcd learner rejoin and promotion validation from this test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->