### PR TITLE
[release-5.0] test/networking: Add TLS Profile Compliance tests for networking components

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -1030,6 +1030,9 @@ type OverlapOtherIntervalsPathologicalEventMatcher struct {
 	// allowIfWithinIntervals is the list of intervals that the incoming pathological event will
 	// match if it contained within one of these.
 	allowIfWithinIntervals monitorapi.Intervals
+	// useLastTimestamp attributes a repeated event to its most recent occurrence instead of
+	// requiring the full lifetime of the Kubernetes Event object to fit within the interval.
+	useLastTimestamp bool
 }
 
 func (ade *OverlapOtherIntervalsPathologicalEventMatcher) Name() string {
@@ -1051,9 +1054,11 @@ func (ade *OverlapOtherIntervalsPathologicalEventMatcher) Allows(i monitorapi.In
 	// but the event may have first fired much earlier. Use firstTimestamp from the
 	// annotations when available so the overlap check covers the full span of the event.
 	eventFrom := i.From
-	if ft, ok := i.Message.Annotations["firstTimestamp"]; ok {
-		if parsed, err := time.Parse(time.RFC3339, ft); err == nil {
-			eventFrom = parsed
+	if !ade.useLastTimestamp {
+		if ft, ok := i.Message.Annotations["firstTimestamp"]; ok {
+			if parsed, err := time.Parse(time.RFC3339, ft); err == nil {
+				eventFrom = parsed
+			}
 		}
 	}
 
@@ -1127,11 +1132,12 @@ func newVsphereConfigurationTestsRollOutTooOftenEventMatcher(finalIntervals moni
 			locatorKeyRegexes: map[monitorapi.LocatorKey]*regexp.Regexp{
 				monitorapi.LocatorNamespaceKey: regexp.MustCompile(`^openshift-cluster-csi-drivers$`),
 			},
-			messageReasonRegex: regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
-			messageHumanRegex:  regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*)`),
-			jira:               "https://issues.redhat.com/browse/OCPBUGS-42610",
+			messageReasonRegex: regexp.MustCompile(`(.*Create.*|.*Delete.*|.*Update.*|^ScalingReplicaSet$)`),
+			messageHumanRegex:  regexp.MustCompile(`vmware-vsphere-csi-driver`),
+			jira:               "https://redhat.atlassian.net/browse/OCPBUGS-94112",
 		},
 		allowIfWithinIntervals: configurationTestIntervals,
+		useLastTimestamp:       true,
 	}
 }
 

--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_events_special_test.go
@@ -85,6 +85,89 @@ func Test_OverlapMatcherUsesFirstTimestamp(t *testing.T) {
 		"event without firstTimestamp should fall back to From for overlap check")
 }
 
+func TestVsphereConfigurationMatcherUsesLastOccurrence(t *testing.T) {
+	testStart := time.Date(2026, 6, 28, 22, 30, 0, 0, time.UTC)
+	testEnd := testStart.Add(30 * time.Minute)
+	firstTimestamp := testStart.Add(-4 * time.Hour)
+	lastTimestamp := testStart.Add(15 * time.Minute)
+
+	testInterval := monitorapi.NewInterval(monitorapi.SourceE2ETest, monitorapi.Info).
+		Locator(monitorapi.NewLocator().E2ETest("[sig-storage] snapshot options in clusterCSIDriver should restore configuration")).
+		Message(monitorapi.NewMessage().HumanMessage("test interval")).
+		Build(testStart, testEnd)
+
+	tests := []struct {
+		name    string
+		locator monitorapi.Locator
+		reason  monitorapi.IntervalReason
+		message string
+	}{
+		{
+			name:    "daemonset update",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-operator"),
+			reason:  "DaemonSetUpdated",
+			message: "Updated DaemonSet.apps/vmware-vsphere-csi-driver-node because it changed",
+		},
+		{
+			name:    "daemonset pod creation",
+			locator: monitorapi.NewLocator().DaemonSetFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-node"),
+			reason:  "SuccessfulCreate",
+			message: "Created pod: vmware-vsphere-csi-driver-node-abcde",
+		},
+		{
+			name:    "configuration secret update",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-operator"),
+			reason:  "SecretUpdated",
+			message: "Updated Secret/vmware-vsphere-csi-driver-config",
+		},
+		{
+			name:    "deployment scaling",
+			locator: monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-controller"),
+			reason:  "ScalingReplicaSet",
+			message: "Scaled down replica set vmware-vsphere-csi-driver-controller-abcde from 2 to 1",
+		},
+	}
+
+	matcher := newVsphereConfigurationTestsRollOutTooOftenEventMatcher(monitorapi.Intervals{testInterval})
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+				Locator(test.locator).
+				Message(monitorapi.NewMessage().
+					Reason(test.reason).
+					HumanMessage(test.message).
+					WithAnnotation(monitorapi.AnnotationCount, "25").
+					WithAnnotation("firstTimestamp", firstTimestamp.Format(time.RFC3339)).
+					WithAnnotation("lastTimestamp", lastTimestamp.Format(time.RFC3339))).
+				Build(lastTimestamp, lastTimestamp.Add(time.Second))
+
+			assert.True(t, matcher.Allows(event, v1.HighlyAvailableTopologyMode),
+				"expected the rollout event's last occurrence to be attributed to the configuration test")
+		})
+	}
+
+	outsideTestWindow := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+		Locator(monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "vmware-vsphere-csi-driver-controller")).
+		Message(monitorapi.NewMessage().
+			Reason("ScalingReplicaSet").
+			HumanMessage("Scaled down replica set vmware-vsphere-csi-driver-controller-abcde from 2 to 1").
+			WithAnnotation(monitorapi.AnnotationCount, "25").
+			WithAnnotation("firstTimestamp", firstTimestamp.Format(time.RFC3339))).
+		Build(testEnd.Add(20*time.Minute), testEnd.Add(20*time.Minute+time.Second))
+	assert.False(t, matcher.Allows(outsideTestWindow, v1.HighlyAvailableTopologyMode),
+		"expected an event outside the buffered test interval to remain pathological")
+
+	unrelatedScalingEvent := monitorapi.NewInterval(monitorapi.SourceKubeEvent, monitorapi.Info).
+		Locator(monitorapi.NewLocator().DeploymentFromName("openshift-cluster-csi-drivers", "unrelated-controller")).
+		Message(monitorapi.NewMessage().
+			Reason("ScalingReplicaSet").
+			HumanMessage("some unrelated scaling operation").
+			WithAnnotation(monitorapi.AnnotationCount, "25")).
+		Build(lastTimestamp, lastTimestamp.Add(time.Second))
+	assert.False(t, matcher.Allows(unrelatedScalingEvent, v1.HighlyAvailableTopologyMode),
+		"expected an unrelated scaling event not to match the rollout allowance")
+}
+
 func Test_singleEventThresholdCheck_getNamespacedFailuresAndFlakes(t *testing.T) {
 	namespace := "openshift-etcd-operator"
 	samplePod := "etcd-operator-6f9b4d9d4f-4q9q8"

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -370,6 +370,11 @@ func testUpgradeOperatorStateTransitions(events monitorapi.Intervals, clientConf
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse && condition.Reason == "KubeStorageVersionMigrator_Deploying" {
 				return "https://issues.redhat.com/browse/OCPBUGS-65984"
 			}
+		case "olm":
+			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse &&
+				condition.Reason == "CatalogdDeploymentCatalogdControllerManager_Deploying" {
+				return "https://issues.redhat.com/browse/OCPBUGS-105876"
+			}
 		case "openshift-apiserver":
 			if condition.Type == configv1.OperatorAvailable && condition.Status == configv1.ConditionFalse {
 				if isTwoNode && condition.Reason == "APIServices_PreconditionNotReady" {

--- a/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
+++ b/pkg/monitortests/clusterversionoperator/legacycvomonitortests/operators.go
@@ -695,8 +695,6 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 			return fmt.Sprintf("%s completing its update within less than three minutes: %s", co, summary)
 		}
 		switch co {
-		case "baremetal":
-			return "https://issues.redhat.com/browse/OCPBUGS-66101"
 		case "cloud-controller-manager":
 			return "https://issues.redhat.com/browse/OCPBUGS-64852"
 		case "operator-lifecycle-manager":
@@ -755,6 +753,13 @@ func testUpgradeOperatorProgressingStateTransitions(events monitorapi.Intervals,
 
 	except = func(co string, reason string) string {
 		switch co {
+		case "baremetal":
+			// Since OCPBUGS-66101 was fixed, the baremetal operator intentionally reports Progressing=True
+			// during upgrades (reason SyncingResources, "Applying metal3 resources") while it syncs its
+			// metal3 resources, which legitimately overlaps with the machine-config progressing window.
+			if reason == "SyncingResources" {
+				return "baremetal is allowed to be Progressing=True while machine-config is progressing, as it applies metal3 resources during upgrades"
+			}
 		case "authentication":
 			if isTwoNode && (reason == "APIServerDeployment_NewGeneration" || reason == "APIServerDeployment_PodsUpdating") {
 				return "authentication operator may roll oauth-apiserver (APIServerDeployment_NewGeneration or APIServerDeployment_PodsUpdating) during DualReplica upgrades while machine-config is progressing"

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation.go
@@ -1,12 +1,17 @@
 package auditloganalyzer
 
 import (
+	"context"
 	"fmt"
+	"strings"
+	"sync"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
-	"strings"
-	"sync"
 )
 
 func CheckForViolations() *auditViolations {
@@ -47,10 +52,28 @@ func (v *auditViolations) HandleAuditLogEvent(auditEvent *auditv1.Event, beginni
 	}
 }
 
-func (v *auditViolations) CreateJunits() []*junitapi.JUnitTestCase {
+func (v *auditViolations) CreateJunits(psaEnforcementDisabled bool) []*junitapi.JUnitTestCase {
 	ret := []*junitapi.JUnitTestCase{}
 
 	testName := " [bz-apiserver-auth][invariant] audit analysis PodSecurityViolation"
+
+	// When the OpenShiftPodSecurityAdmission feature gate is disabled, the PSA label syncer stops
+	// setting the pod-security.kubernetes.io/enforce label on namespaces and workloads that key
+	// their security context off that label (e.g. OLM catalog registry pods) legitimately run
+	// without a restricted-compatible security context. The global PodSecurity audit configuration
+	// stays at restricted:latest, so those pod creations produce audit violations by design and
+	// this invariant does not apply.
+	if psaEnforcementDisabled {
+		return []*junitapi.JUnitTestCase{
+			{
+				Name: testName,
+				SkipMessage: &junitapi.SkipMessage{
+					Message: fmt.Sprintf("OpenShiftPodSecurityAdmission is disabled: pod security is not enforced and audit-level violations are expected, %d violation(s) observed, details in audit log", len(v.records)),
+				},
+			},
+		}
+	}
+
 	switch {
 	case len(v.records) > 0:
 		messages := []string{}
@@ -74,4 +97,33 @@ func (v *auditViolations) CreateJunits() []*junitapi.JUnitTestCase {
 	}
 
 	return ret
+}
+
+// isPodSecurityEnforcementDisabled reports whether the OpenShiftPodSecurityAdmission feature gate
+// is explicitly disabled for the cluster's current version. On any error or ambiguity it returns
+// false so that the PodSecurityViolation invariant keeps enforcing.
+func isPodSecurityEnforcementDisabled(ctx context.Context, configClient configclient.Interface, clusterVersion *configv1.ClusterVersion) bool {
+	featureGate, err := configClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	desiredVersion := clusterVersion.Status.Desired.Version
+	if len(desiredVersion) == 0 && len(clusterVersion.Status.History) > 0 {
+		desiredVersion = clusterVersion.Status.History[0].Version
+	}
+
+	for _, featureGateValues := range featureGate.Status.FeatureGates {
+		if featureGateValues.Version != desiredVersion {
+			continue
+		}
+		for _, disabled := range featureGateValues.Disabled {
+			if disabled.Name == features.FeatureGateOpenShiftPodSecurityAdmission {
+				return true
+			}
+		}
+		return false
+	}
+
+	return false
 }

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation_test.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/handle_audit_violation_test.go
@@ -1,0 +1,129 @@
+package auditloganalyzer
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/api/features"
+	configfake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func violationCheckerWithRecord() *auditViolations {
+	checker := CheckForViolations()
+	checker.records = append(checker.records, auditViolationRecord{
+		auditId:   "test-audit-id",
+		violation: `would violate PodSecurity "restricted:latest"`,
+		resource:  "pods",
+		namespace: "e2e-test-default-abcde",
+		username:  "system:serviceaccount:openshift-operator-lifecycle-manager:olm-operator-serviceaccount",
+	})
+	return checker
+}
+
+func TestCreateJunitsWithPSAEnforcement(t *testing.T) {
+	checker := violationCheckerWithRecord()
+
+	junits := checker.CreateJunits(false)
+
+	require.Len(t, junits, 1)
+	assert.NotNil(t, junits[0].FailureOutput, "violations must fail the invariant when PSA enforcement is enabled")
+	assert.Nil(t, junits[0].SkipMessage)
+}
+
+func TestCreateJunitsWithoutPSAEnforcement(t *testing.T) {
+	checker := violationCheckerWithRecord()
+
+	junits := checker.CreateJunits(true)
+
+	require.Len(t, junits, 1)
+	assert.Nil(t, junits[0].FailureOutput, "violations are expected when PSA enforcement is disabled and must not fail the invariant")
+	require.NotNil(t, junits[0].SkipMessage)
+	assert.Contains(t, junits[0].SkipMessage.Message, "OpenShiftPodSecurityAdmission is disabled")
+}
+
+func TestCreateJunitsWithoutViolations(t *testing.T) {
+	checker := CheckForViolations()
+
+	junits := checker.CreateJunits(false)
+
+	require.Len(t, junits, 1)
+	assert.Nil(t, junits[0].FailureOutput)
+	assert.Nil(t, junits[0].SkipMessage)
+}
+
+func TestIsPodSecurityEnforcementDisabled(t *testing.T) {
+	clusterVersion := &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Status: configv1.ClusterVersionStatus{
+			Desired: configv1.Release{Version: "5.0.0"},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		featureGate *configv1.FeatureGate
+		expected    bool
+	}{
+		{
+			name: "gate disabled for current version",
+			featureGate: featureGateWithStatus("5.0.0", nil, []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}),
+			expected: true,
+		},
+		{
+			name: "gate enabled for current version",
+			featureGate: featureGateWithStatus("5.0.0", []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}, nil),
+			expected: false,
+		},
+		{
+			name: "gate disabled only for another version",
+			featureGate: featureGateWithStatus("4.20.0", nil, []configv1.FeatureGateName{
+				features.FeatureGateOpenShiftPodSecurityAdmission,
+			}),
+			expected: false,
+		},
+		{
+			name:        "no featuregate resource keeps the invariant enforcing",
+			featureGate: nil,
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configClient := configfake.NewSimpleClientset()
+			if tc.featureGate != nil {
+				configClient = configfake.NewSimpleClientset(tc.featureGate)
+			}
+
+			actual := isPodSecurityEnforcementDisabled(context.Background(), configClient, clusterVersion)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func featureGateWithStatus(version string, enabled, disabled []configv1.FeatureGateName) *configv1.FeatureGate {
+	featureGate := &configv1.FeatureGate{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Status: configv1.FeatureGateStatus{
+			FeatureGates: []configv1.FeatureGateDetails{
+				{Version: version},
+			},
+		},
+	}
+	for _, name := range enabled {
+		featureGate.Status.FeatureGates[0].Enabled = append(featureGate.Status.FeatureGates[0].Enabled, configv1.FeatureGateAttributes{Name: name})
+	}
+	for _, name := range disabled {
+		featureGate.Status.FeatureGates[0].Disabled = append(featureGate.Status.FeatureGates[0].Disabled, configv1.FeatureGateAttributes{Name: name})
+	}
+	return featureGate
+}

--- a/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
+++ b/pkg/monitortests/kubeapiserver/auditloganalyzer/monitortest.go
@@ -24,6 +24,9 @@ type auditLogAnalyzer struct {
 	adminRESTConfig *rest.Config
 
 	isTechPreview bool
+	// psaEnforcementDisabled is true when the OpenShiftPodSecurityAdmission feature gate is
+	// explicitly disabled, in which case audit-level pod security violations are expected.
+	psaEnforcementDisabled bool
 
 	summarizer                    *summarizer
 	excessiveApplyChecker         *excessiveApplies
@@ -71,6 +74,7 @@ func (w *auditLogAnalyzer) StartCollection(ctx context.Context, adminRESTConfig 
 		return err
 	default:
 		w.requestCountTracking = CountsOverTime(clusterVersion.CreationTimestamp)
+		w.psaEnforcementDisabled = isPodSecurityEnforcementDisabled(ctx, configClient, clusterVersion)
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(w.adminRESTConfig)
@@ -416,7 +420,7 @@ func (w *auditLogAnalyzer) EvaluateTestsFromConstructedIntervals(ctx context.Con
 		)
 	}
 
-	ret = append(ret, w.violationChecker.CreateJunits()...)
+	ret = append(ret, w.violationChecker.CreateJunits(w.psaEnforcementDisabled)...)
 
 	if w.clusterStability == monitortestframework.Stable {
 		junits, err := w.watchCountTracking.CreateJunits()

--- a/test/extended/apiserver/pull_secrets.go
+++ b/test/extended/apiserver/pull_secrets.go
@@ -58,6 +58,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Feature:PullSecret]",
 			username := oc.Username()
 			err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("policy", "add-cluster-role-to-user", "cluster-admin", username).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() {
+				if err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("policy", "remove-cluster-role-from-user", "cluster-admin", username).Execute(); err != nil {
+					e2e.Failf("failed to remove cluster-admin from %s: %v", username, err)
+				}
+			}()
 
 			g.By("Create secret for private image under project")
 			err = oc.WithoutNamespace().AsAdmin().Run("create").Args("secret", "docker-registry", "user1-dockercfg", "--docker-email=any@any.com", "--docker-server="+dockerServer[0], "--docker-username="+username, "--docker-password="+token, "-n", oc.Namespace()).NotShowInfo().Execute()
@@ -112,6 +117,11 @@ var _ = g.Describe("[sig-api-machinery][Feature:APIServer][Feature:PullSecret]",
 			username := oc.Username()
 			err = oc.AsAdmin().WithoutNamespace().Run("adm").Args("policy", "add-cluster-role-to-user", "cluster-admin", username).Execute()
 			o.Expect(err).NotTo(o.HaveOccurred())
+			defer func() {
+				if err := oc.AsAdmin().WithoutNamespace().Run("adm").Args("policy", "remove-cluster-role-from-user", "cluster-admin", username).Execute(); err != nil {
+					e2e.Failf("failed to remove cluster-admin from %s: %v", username, err)
+				}
+			}()
 
 			g.By("Create secret for private image under project with wrong password")
 			err = oc.WithoutNamespace().AsAdmin().Run("create").Args("secret", "docker-registry", "user1-dockercfg", "--docker-email=any@any.com", "--docker-server="+dockerServer[0], "--docker-username="+username, "--docker-password=password", "-n", oc.Namespace()).NotShowInfo().Execute()

--- a/test/extended/networking/tls.go
+++ b/test/extended/networking/tls.go
@@ -55,7 +55,7 @@ var _ = g.Describe("[sig-network][Serial][Disruptive][Suite:openshift/tls-observ
 
 	oc := exutil.NewCLIWithoutNamespace("networking-tls")
 
-	g.It("should verify TLS compliance across Modern and Intermediate profiles with different adherence policies", func(ctx context.Context) {
+	g.It("should verify TLS compliance across Modern and Intermediate profiles with different adherence policies", ote.Informing(), func(ctx context.Context) {
 		isOpenShift, err := IsOpenShiftCluster(ctx, oc)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to check if cluster is OpenShift")
 		if !isOpenShift {

--- a/test/extended/networking/tls.go
+++ b/test/extended/networking/tls.go
@@ -1,0 +1,880 @@
+package networking
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned"
+	machineconfigclient "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
+	node "github.com/openshift/origin/test/extended/node"
+	exutil "github.com/openshift/origin/test/extended/util"
+	operatorutil "github.com/openshift/origin/test/extended/util/operator"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	MCPRolloutStartTimeout          = 10 * time.Minute
+	MCPRolloutCompleteTimeout       = 120 * time.Minute
+	NodeStabilityTimeout            = 90 * time.Minute
+	OperatorSettleTimeMinutes       = 60
+	OperatorProgressingStartTimeout = 5 * time.Minute
+	APIServerOperatorTimeout        = 10 * time.Minute
+)
+
+type TLSAdherenceNotSupportedError struct {
+	Message string
+}
+
+func (e *TLSAdherenceNotSupportedError) Error() string {
+	return e.Message
+}
+
+func IsTLSAdherenceNotSupported(err error) bool {
+	_, ok := err.(*TLSAdherenceNotSupportedError)
+	return ok
+}
+
+var _ = g.Describe("[sig-network][Serial][Disruptive][Suite:openshift/tls-observed-config] TLS Profile Compliance", func() {
+	defer g.GinkgoRecover()
+
+	oc := exutil.NewCLIWithoutNamespace("networking-tls")
+
+	g.It("should verify TLS compliance across Modern and Intermediate profiles with different adherence policies", func(ctx context.Context) {
+		isOpenShift, err := IsOpenShiftCluster(ctx, oc)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to check if cluster is OpenShift")
+		if !isOpenShift {
+			g.Skip("TLS Profile Compliance testing requires OpenShift cluster with config.openshift.io APIs")
+		}
+
+		// Scenario 1: Modern TLS Profile with LegacyAdheringComponentsOnly
+		g.By("Configuring and verifying Modern TLS Profile with LegacyAdheringComponentsOnly")
+		err = ConfigureTLSProfileWithAdherence(ctx, oc, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly)
+		if IsTLSAdherenceNotSupported(err) {
+			g.Skip(fmt.Sprintf("Skipping test - tlsAdherence API field not supported in this cluster version: %s", err.Error()))
+		}
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to configure Modern TLS profile with LegacyAdheringComponentsOnly")
+		verifyAllComponentsCompliance(ctx, oc)
+
+		// Scenario 2: Modern TLS Profile with StrictAllComponents
+		g.By("Configuring and verifying Modern TLS Profile with StrictAllComponents")
+		err = ConfigureTLSProfileWithAdherence(ctx, oc, configv1.TLSProfileModernType, configv1.TLSAdherencePolicyStrictAllComponents)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to configure Modern TLS profile with StrictAllComponents")
+		verifyAllComponentsCompliance(ctx, oc)
+
+		// Scenario 3: Intermediate TLS Profile with StrictAllComponents
+		g.By("Configuring and verifying Intermediate TLS Profile with StrictAllComponents")
+		err = ConfigureTLSProfileWithAdherence(ctx, oc, configv1.TLSProfileIntermediateType, configv1.TLSAdherencePolicyStrictAllComponents)
+		o.Expect(err).NotTo(o.HaveOccurred(), "Failed to configure Intermediate TLS profile with StrictAllComponents")
+		verifyAllComponentsCompliance(ctx, oc)
+	})
+})
+
+func verifyAllComponentsCompliance(ctx context.Context, oc *exutil.CLI) {
+	k8sClient := oc.AdminKubeClient()
+	configClient := oc.AdminConfigClient()
+
+	e2e.Logf("Starting TLS compliance checks with retry (timeout: %v, interval: %v)", 5*time.Minute, 30*time.Second)
+	err := wait.PollUntilContextTimeout(ctx, 30*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var checkErr error
+
+		// Test multus-cni
+		g.By("Testing TLS compliance for multus-admission-controller in openshift-multus (ports 6443 & 8443)")
+		checkErr = VerifyMultusTLSComplianceInPod(ctx, oc, configClient, k8sClient, "openshift-multus", "app=multus-admission-controller")
+		if checkErr != nil {
+			e2e.Logf("Multus TLS check failed (will retry): %v", checkErr)
+			return false, nil
+		}
+
+		// Test ovn-kubernetes nodes
+		g.By("Testing TLS compliance for ovn-kubernetes nodes in openshift-ovn-kubernetes (ports 9103, 9105)")
+		checkErr = VerifyOVNKubernetesNodeTLSComplianceInPod(ctx, oc, configClient, k8sClient, "openshift-ovn-kubernetes", "app=ovnkube-node")
+		if checkErr != nil {
+			e2e.Logf("OVN-Kubernetes node TLS check failed (will retry): %v", checkErr)
+			return false, nil
+		}
+
+		// Test cluster-network-operator
+		g.By("Testing TLS compliance for cluster-network-operator in openshift-network-operator (ports 9104, 9103, 9105)")
+		checkErr = VerifyCNOTLSComplianceInPod(ctx, oc, configClient, k8sClient, "openshift-network-operator", "name=network-operator")
+		if checkErr != nil {
+			e2e.Logf("CNO TLS check failed (will retry): %v", checkErr)
+			return false, nil
+		}
+
+		// Test networking-console-plugin
+		g.By("Testing TLS compliance for networking-console-plugin in openshift-network-console (port 9443)")
+		checkErr = VerifyNetworkConsoleTLSComplianceInPod(ctx, oc, configClient, k8sClient, "openshift-network-console", "app.kubernetes.io/name=networking-console-plugin")
+		if checkErr != nil {
+			e2e.Logf("Networking Console Plugin TLS check failed (will retry): %v", checkErr)
+			return false, nil
+		}
+
+		e2e.Logf("All TLS compliance checks passed")
+		return true, nil
+	})
+	o.Expect(err).NotTo(o.HaveOccurred(), "TLS compliance verification failed after retries")
+}
+
+func IsOpenShiftCluster(ctx context.Context, oc *exutil.CLI) (bool, error) {
+	configClient, err := configv1client.NewForConfig(oc.AdminConfig())
+	if err != nil {
+		return false, err
+	}
+
+	_, err = configClient.ConfigV1().FeatureGates().Get(
+		ctx,
+		"cluster",
+		metav1.GetOptions{},
+	)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func ConfigureTLSProfileWithAdherence(ctx context.Context, oc *exutil.CLI, tlsProfileType configv1.TLSProfileType, tlsAdherencePolicy configv1.TLSAdherencePolicy) error {
+	configClient, err := configv1client.NewForConfig(oc.AdminConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create config client: %w", err)
+	}
+
+	machineConfigClient, err := machineconfigclient.NewForConfig(oc.AdminConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create machine config client: %w", err)
+	}
+
+	k8sClient, err := kubernetes.NewForConfig(oc.AdminConfig())
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	e2e.Logf("=== Configuring %s TLS Profile with %s ===", tlsProfileType, tlsAdherencePolicy)
+
+	e2e.Logf("Enabling TLSAdherence feature gate")
+	fg, err := configClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get featuregate: %w", err)
+	}
+
+	tlsFeatureAlreadyEnabled := isAlreadyEnabled(fg)
+	if tlsFeatureAlreadyEnabled {
+		e2e.Logf("TLSAdherence feature gate already enabled - proceeding to TLS profile configuration")
+	} else {
+		// Capture time BEFORE feature gate change
+		featureGateChangeTime := metav1.Now()
+
+		if err := patchFeatureGate(ctx, configClient, fg); err != nil {
+			return fmt.Errorf("failed to patch FeatureGate: %w", err)
+		}
+		e2e.Logf("TLSAdherence feature gate enabled")
+
+		e2e.Logf("Waiting for MCP rollout to start after feature gate enablement (timeout: %v)", MCPRolloutStartTimeout)
+		if err := waitForMCPRolloutStart(ctx, machineConfigClient, MCPRolloutStartTimeout); err != nil {
+			e2e.Logf("WARNING: MCP rollout did not start within timeout: %v", err)
+		} else {
+			e2e.Logf("Waiting for MCP rollout to complete (this may take up to %v minutes)", MCPRolloutCompleteTimeout/time.Minute)
+			if err := waitForAllMCPsComplete(ctx, machineConfigClient, MCPRolloutCompleteTimeout); err != nil {
+				return fmt.Errorf("failed waiting for MCP rollout after feature gate enablement: %w", err)
+			}
+			e2e.Logf("MCP rollout completed after feature gate enablement")
+		}
+
+		e2e.Logf("Waiting for all nodes to be ready after feature gate enablement")
+		if err := waitForNodesStability(ctx, k8sClient, NodeStabilityTimeout, featureGateChangeTime); err != nil {
+			return fmt.Errorf("failed waiting for nodes after feature gate enablement: %w", err)
+		}
+		e2e.Logf("All nodes are ready after feature gate enablement")
+
+		e2e.Logf("Waiting for cluster operators to settle after feature gate enablement")
+		if err := operatorutil.WaitForOperatorsToSettle(ctx, configClient, OperatorSettleTimeMinutes); err != nil {
+			return fmt.Errorf("failed waiting for operators after feature gate enablement: %w", err)
+		}
+		e2e.Logf("All cluster operators settled after feature gate enablement")
+	}
+
+	// Capture time BEFORE APIServer TLS profile change
+	tlsProfileChangeTime := metav1.Now()
+
+	e2e.Logf("Configuring APIServer with %s TLS profile and tlsAdherence=%s", tlsProfileType, tlsAdherencePolicy)
+	if err := patchAPIServerTLSProfile(ctx, configClient, tlsProfileType, tlsAdherencePolicy); err != nil {
+		return err
+	}
+	e2e.Logf("APIServer TLS profile configured successfully")
+
+	// TODO: This hardcodes implementation details about when MCP rollouts are triggered.
+	// Consider either (a) dynamically checking MCP status to detect if rollout was triggered,
+	// or (b) making the waiting logic work uniformly regardless of whether MCP rollout occurs.
+	requiresMCPRollout := ((tlsProfileType == configv1.TLSProfileModernType &&
+		tlsAdherencePolicy == configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly) ||
+		(tlsProfileType == configv1.TLSProfileIntermediateType &&
+			tlsAdherencePolicy == configv1.TLSAdherencePolicyStrictAllComponents))
+
+	if requiresMCPRollout {
+		e2e.Logf("Waiting for MCP rollout to start after TLS profile configuration (timeout: %v)", MCPRolloutStartTimeout)
+		if err := waitForMCPRolloutStart(ctx, machineConfigClient, MCPRolloutStartTimeout); err != nil {
+			return fmt.Errorf("MCP rollout did not start within timeout: %w", err)
+		}
+
+		e2e.Logf("Waiting for MCP rollout to complete (this may take up to %v minutes)", MCPRolloutCompleteTimeout/time.Minute)
+		if err := waitForAllMCPsComplete(ctx, machineConfigClient, MCPRolloutCompleteTimeout); err != nil {
+			return fmt.Errorf("failed waiting for MCP rollout: %w", err)
+		}
+		e2e.Logf("MCP rollout completed")
+
+		e2e.Logf("Waiting for TLS-related operators to stabilize with new configuration")
+		if err := waitForAPIServerOperatorStable(ctx, configClient, APIServerOperatorTimeout); err != nil {
+			return fmt.Errorf("TLS-related operators did not stabilize: %w", err)
+		}
+
+		e2e.Logf("Waiting for all nodes to be ready and stable (timeout: %v)", NodeStabilityTimeout)
+		if err := waitForNodesStability(ctx, k8sClient, NodeStabilityTimeout, tlsProfileChangeTime); err != nil {
+			return err
+		}
+		e2e.Logf("All nodes are ready and stable")
+
+		e2e.Logf("Waiting for cluster operators to settle (timeout: %v)", time.Duration(OperatorSettleTimeMinutes)*time.Minute)
+		if err := operatorutil.WaitForOperatorsToSettle(ctx, configClient, OperatorSettleTimeMinutes); err != nil {
+			return err
+		}
+		e2e.Logf("All cluster operators settled")
+	} else {
+		// No MCP rollout path (e.g., Modern + StrictAllComponents)
+		// Wait for TLS-related operators only - don't use timestamp check as operators
+		// may already be settled from previous scenario with old timestamps
+		e2e.Logf("Waiting for TLS-related operators to stabilize with new configuration")
+		if err := waitForAPIServerOperatorStable(ctx, configClient, APIServerOperatorTimeout); err != nil {
+			return fmt.Errorf("TLS-related operators did not stabilize: %w", err)
+		}
+
+		// Wait for all operators to settle (no timestamp check to avoid race with sequential scenarios)
+		e2e.Logf("Waiting for cluster operators to settle (timeout: %v)", time.Duration(OperatorSettleTimeMinutes)*time.Minute)
+		if err := operatorutil.WaitForOperatorsToSettle(ctx, configClient, OperatorSettleTimeMinutes); err != nil {
+			return fmt.Errorf("cluster operators did not settle: %w", err)
+		}
+		e2e.Logf("All cluster operators settled")
+
+		e2e.Logf("TLS configuration applied (no MCP rollout required for this profile)")
+	}
+
+	e2e.Logf("Verifying TLSAdherence is active in feature gate status")
+	if err := verifyTLSAdherenceActive(ctx, configClient); err != nil {
+		return err
+	}
+	e2e.Logf("TLSAdherence is active in feature gate status")
+
+	e2e.Logf("Verifying APIServer TLS profile configuration")
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer: %w", err)
+	}
+
+	if apiserver.Spec.TLSSecurityProfile == nil || apiserver.Spec.TLSSecurityProfile.Type != tlsProfileType {
+		return fmt.Errorf("APIServer TLS profile is not %s", tlsProfileType)
+	}
+
+	if apiserver.Spec.TLSAdherence != tlsAdherencePolicy {
+		return fmt.Errorf("APIServer tlsAdherence is %s, expected %s", apiserver.Spec.TLSAdherence, tlsAdherencePolicy)
+	}
+
+	if apiserver.Spec.TLSAdherence == "" {
+		e2e.Logf("APIServer configuration verified: tlsSecurityProfile.type=%s, tlsAdherence=<empty> (default)", tlsProfileType)
+		e2e.Logf("APIServer %s TLS profile and tlsAdherence=<empty> (default) verified", tlsProfileType)
+	} else {
+		e2e.Logf("APIServer configuration verified: tlsSecurityProfile.type=%s, tlsAdherence=%s", tlsProfileType, apiserver.Spec.TLSAdherence)
+		e2e.Logf("APIServer %s TLS profile and tlsAdherence=%s verified", tlsProfileType, apiserver.Spec.TLSAdherence)
+	}
+
+	e2e.Logf("=== %s TLS Profile successfully configured and cluster is stable ===", tlsProfileType)
+
+	return nil
+}
+
+func isAlreadyEnabled(fg *configv1.FeatureGate) bool {
+	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade && fg.Spec.CustomNoUpgrade != nil {
+		for _, enabled := range fg.Spec.CustomNoUpgrade.Enabled {
+			if enabled == "TLSAdherence" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func patchFeatureGate(ctx context.Context, configClient configv1client.Interface, fg *configv1.FeatureGate) error {
+	if fg.Spec.FeatureSet == configv1.CustomNoUpgrade && fg.Spec.CustomNoUpgrade != nil {
+		fg.Spec.CustomNoUpgrade.Enabled = append(fg.Spec.CustomNoUpgrade.Enabled, "TLSAdherence")
+	} else {
+		fg.Spec.FeatureSet = configv1.CustomNoUpgrade
+		fg.Spec.CustomNoUpgrade = &configv1.CustomFeatureGates{
+			Enabled: []configv1.FeatureGateName{"TLSAdherence"},
+		}
+	}
+
+	_, err := configClient.ConfigV1().FeatureGates().Update(ctx, fg, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update featuregate: %w", err)
+	}
+	return nil
+}
+
+func patchAPIServerTLSProfile(ctx context.Context, configClient configv1client.Interface, tlsProfileType configv1.TLSProfileType, tlsAdherencePolicy configv1.TLSAdherencePolicy) error {
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get apiserver: %w", err)
+	}
+
+	switch tlsProfileType {
+	case configv1.TLSProfileModernType:
+		apiserver.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+			Type:   configv1.TLSProfileModernType,
+			Modern: &configv1.ModernTLSProfile{},
+		}
+	case configv1.TLSProfileIntermediateType:
+		apiserver.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+			Type:         configv1.TLSProfileIntermediateType,
+			Intermediate: &configv1.IntermediateTLSProfile{},
+		}
+	case configv1.TLSProfileOldType:
+		apiserver.Spec.TLSSecurityProfile = &configv1.TLSSecurityProfile{
+			Type: configv1.TLSProfileOldType,
+			Old:  &configv1.OldTLSProfile{},
+		}
+	default:
+		return fmt.Errorf("unsupported TLS profile type: %s (must be Modern, Intermediate, or Old)", tlsProfileType)
+	}
+
+	apiserver.Spec.TLSAdherence = tlsAdherencePolicy
+
+	_, err = configClient.ConfigV1().APIServers().Update(ctx, apiserver, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update apiserver: %w", err)
+	}
+
+	return nil
+}
+
+func waitForMCPRolloutStart(ctx context.Context, client machineconfigclient.Interface, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		mcps, err := client.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if apierrors.IsTimeout(err) ||
+				apierrors.IsServerTimeout(err) ||
+				apierrors.IsServiceUnavailable(err) ||
+				apierrors.IsTooManyRequests(err) {
+				e2e.Logf("Transient API error listing MCPs (will retry): %v", err)
+				return false, nil
+			}
+
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "connection refused") ||
+				strings.Contains(errMsg, "i/o timeout") ||
+				strings.Contains(errMsg, "context deadline exceeded") ||
+				strings.Contains(errMsg, "time allotted") {
+				e2e.Logf("Transient API error listing MCPs (will retry): %v", err)
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		for _, mcp := range mcps.Items {
+			for _, cond := range mcp.Status.Conditions {
+				if cond.Type == "Updating" && cond.Status == corev1.ConditionTrue {
+					e2e.Logf("MCP %s has started updating", mcp.Name)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+}
+
+func areAllMCPsComplete(ctx context.Context, client machineconfigclient.Interface) (bool, error) {
+	mcps, err := client.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list MCPs: %w", err)
+	}
+
+	for _, mcp := range mcps.Items {
+		if mcp.Status.MachineCount == 0 {
+			continue
+		}
+
+		updated := false
+		updating := false
+
+		for _, cond := range mcp.Status.Conditions {
+			if cond.Type == "Updated" && cond.Status == corev1.ConditionTrue {
+				updated = true
+			}
+			if cond.Type == "Updating" && cond.Status == corev1.ConditionTrue {
+				updating = true
+			}
+		}
+
+		if !updated || updating {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func waitForAllMCPsComplete(ctx context.Context, client machineconfigclient.Interface, timeout time.Duration) error {
+	clientset, ok := client.(*machineconfigclient.Clientset)
+	if !ok {
+		return fmt.Errorf("failed to convert client to Clientset")
+	}
+
+	var mcps *machineconfigv1.MachineConfigPoolList
+	listErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+		var err error
+		mcps, err = client.MachineconfigurationV1().MachineConfigPools().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			e2e.Logf("Error listing MCPs (will retry): %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if listErr != nil {
+		return fmt.Errorf("failed to list MCPs after retries: %w", listErr)
+	}
+
+	for _, mcp := range mcps.Items {
+		if mcp.Status.MachineCount == 0 {
+			e2e.Logf("Skipping MCP %s (no machines)", mcp.Name)
+			continue
+		}
+
+		e2e.Logf("Waiting for MCP %s (%d machines) to complete rollout", mcp.Name, mcp.Status.MachineCount)
+
+		mcpErr := wait.PollUntilContextTimeout(ctx, 30*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+			err := node.WaitForMCP(ctx, clientset, mcp.Name, timeout, node.WaitMCPAllowDegraded())
+			if err != nil {
+				if apierrors.IsTimeout(err) ||
+					apierrors.IsServerTimeout(err) ||
+					apierrors.IsServiceUnavailable(err) ||
+					apierrors.IsTooManyRequests(err) {
+					e2e.Logf("Transient API error waiting for MCP %s (will retry): %v", mcp.Name, err)
+					return false, nil
+				}
+
+				errMsg := err.Error()
+				if strings.Contains(errMsg, "connection refused") ||
+					strings.Contains(errMsg, "TLS handshake timeout") ||
+					strings.Contains(errMsg, "i/o timeout") ||
+					strings.Contains(errMsg, "context deadline exceeded") ||
+					strings.Contains(errMsg, "stream error") ||
+					strings.Contains(errMsg, "time allotted") {
+					e2e.Logf("Transient API error waiting for MCP %s (will retry): %v", mcp.Name, err)
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		})
+
+		if mcpErr != nil {
+			return fmt.Errorf("MCP %s did not complete: %w", mcp.Name, mcpErr)
+		}
+		e2e.Logf("MCP %s complete: %d/%d machines ready", mcp.Name, mcp.Status.ReadyMachineCount, mcp.Status.MachineCount)
+	}
+
+	e2e.Logf("All MCPs completed successfully")
+	return nil
+}
+
+func waitForNodesStability(ctx context.Context, client kubernetes.Interface, timeout time.Duration, afterTime metav1.Time) error {
+	return wait.PollUntilContextTimeout(ctx, 30*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			e2e.Logf("Error getting nodes: %v", err)
+			return false, nil
+		}
+
+		notReady := []string{}
+		notUpdated := []string{}
+		for _, node := range nodes.Items {
+			readyTime, ready := getNodeReadyTime(&node)
+			if !ready {
+				notReady = append(notReady, node.Name)
+			} else if !readyTime.After(afterTime.Time) {
+				// Node is Ready but hasn't transitioned to Ready after the config change
+				notUpdated = append(notUpdated, fmt.Sprintf("%s(ready-since:%s)", node.Name, readyTime.Format(time.RFC3339)))
+			}
+		}
+
+		if len(notReady) > 0 {
+			e2e.Logf("Waiting for nodes to be ready: %s", strings.Join(notReady, ", "))
+			return false, nil
+		}
+
+		if len(notUpdated) > 0 {
+			e2e.Logf("Waiting for nodes to process config change (ready before %s): %s",
+				afterTime.Format(time.RFC3339), strings.Join(notUpdated, ", "))
+			return false, nil
+		}
+
+		e2e.Logf("All %d nodes are ready and updated after config change", len(nodes.Items))
+		return true, nil
+	})
+}
+
+func getNodeReadyTime(node *corev1.Node) (metav1.Time, bool) {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			if cond.Status == corev1.ConditionTrue {
+				return cond.LastTransitionTime, true
+			}
+			return metav1.Time{}, false
+		}
+	}
+	return metav1.Time{}, false
+}
+
+// waitForOperatorsToSettleAfter waits for all cluster operators to be settled
+// (Available=True, Degraded=False, Progressing=False) with a transition timestamp
+// after the specified time. This ensures operators have reacted to a config change.
+func waitForOperatorsToSettleAfter(ctx context.Context, configClient configv1client.Interface, timeout time.Duration, afterTime metav1.Time) error {
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		coList, err := configClient.ConfigV1().ClusterOperators().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			e2e.Logf("Error getting ClusterOperators: %v", err)
+			return false, nil
+		}
+
+		unsettled := []string{}
+		notUpdated := []string{}
+
+		for _, co := range coList.Items {
+			available := getCondition(co.Status.Conditions, configv1.OperatorAvailable)
+			degraded := getCondition(co.Status.Conditions, configv1.OperatorDegraded)
+			progressing := getCondition(co.Status.Conditions, configv1.OperatorProgressing)
+
+			// Check if operator is settled
+			isSettled := available.Status == configv1.ConditionTrue &&
+				degraded.Status == configv1.ConditionFalse &&
+				progressing.Status == configv1.ConditionFalse
+
+			if !isSettled {
+				unsettled = append(unsettled, fmt.Sprintf("%s(A=%s,D=%s,P=%s)",
+					co.Name, available.Status, degraded.Status, progressing.Status))
+				continue
+			}
+
+			// Operator is settled, but check if it transitioned after the config change
+			// Use Progressing transition time since it's the last condition to become False
+			// after operators finish processing a change
+			if !progressing.LastTransitionTime.After(afterTime.Time) {
+				notUpdated = append(notUpdated, fmt.Sprintf("%s(progressing-since:%s)",
+					co.Name, progressing.LastTransitionTime.Format(time.RFC3339)))
+			}
+		}
+
+		if len(unsettled) > 0 {
+			e2e.Logf("Waiting for operators to settle: %s", strings.Join(unsettled, ", "))
+			return false, nil
+		}
+
+		if len(notUpdated) > 0 {
+			e2e.Logf("Waiting for operators to transition after config change: %s", strings.Join(notUpdated, ", "))
+			return false, nil
+		}
+
+		e2e.Logf("All operators settled with transitions after %s", afterTime.Format(time.RFC3339))
+		return true, nil
+	})
+}
+
+// getCondition finds a specific condition type from a list of conditions
+func getCondition(conditions []configv1.ClusterOperatorStatusCondition, condType configv1.ClusterStatusConditionType) configv1.ClusterOperatorStatusCondition {
+	for _, cond := range conditions {
+		if cond.Type == condType {
+			return cond
+		}
+	}
+	return configv1.ClusterOperatorStatusCondition{
+		Type:   condType,
+		Status: configv1.ConditionUnknown,
+	}
+}
+
+func waitForOperatorsToStartProgressing(ctx context.Context, configClient configv1client.Interface, timeout time.Duration) error {
+	relevantOperators := []string{"kube-apiserver", "openshift-apiserver", "network"}
+
+	return wait.PollUntilContextTimeout(ctx, 5*time.Second, timeout, false, func(ctx context.Context) (bool, error) {
+		for _, coName := range relevantOperators {
+			co, err := configClient.ConfigV1().ClusterOperators().Get(ctx, coName, metav1.GetOptions{})
+			if err != nil {
+				e2e.Logf("Error getting ClusterOperator %s: %v (retrying)", coName, err)
+				return false, nil
+			}
+
+			// Check if operator is progressing
+			for _, cond := range co.Status.Conditions {
+				if cond.Type == configv1.OperatorProgressing && cond.Status == configv1.ConditionTrue {
+					e2e.Logf("Operator %s started progressing", coName)
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	})
+}
+
+func waitForAPIServerOperatorStable(ctx context.Context, configClient configv1client.Interface, timeout time.Duration) error {
+	relevantOperators := []string{"kube-apiserver", "openshift-apiserver", "network"}
+	e2e.Logf("Waiting for operators to be stable with new TLS configuration (timeout: %v)", timeout)
+
+	return wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, false,
+		func(ctx context.Context) (bool, error) {
+			allStable := true
+			for _, coName := range relevantOperators {
+				co, err := configClient.ConfigV1().ClusterOperators().Get(ctx, coName, metav1.GetOptions{})
+				if err != nil {
+					if apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) {
+						e2e.Logf("API server not responsive yet (retrying): %v", err)
+						return false, nil
+					}
+					e2e.Logf("Error getting %s operator (retrying): %v", coName, err)
+					return false, nil
+				}
+
+				available := false
+				progressing := false
+				degraded := false
+
+				for _, cond := range co.Status.Conditions {
+					switch cond.Type {
+					case configv1.OperatorAvailable:
+						available = (cond.Status == configv1.ConditionTrue)
+					case configv1.OperatorProgressing:
+						progressing = (cond.Status == configv1.ConditionTrue)
+					case configv1.OperatorDegraded:
+						degraded = (cond.Status == configv1.ConditionTrue)
+					}
+				}
+
+				if !available {
+					e2e.Logf("Operator %s not available yet", coName)
+					allStable = false
+					break
+				}
+				if progressing {
+					e2e.Logf("Operator %s still progressing", coName)
+					allStable = false
+					break
+				}
+				if degraded {
+					e2e.Logf("Operator %s is degraded", coName)
+					allStable = false
+					break
+				}
+			}
+
+			if allStable {
+				e2e.Logf("All TLS-related operators are stable (Available=True, Progressing=False, Degraded=False)")
+				return true, nil
+			}
+			return false, nil
+		})
+}
+
+func verifyTLSAdherenceActive(ctx context.Context, configClient configv1client.Interface) error {
+	cv, err := configClient.ConfigV1().ClusterVersions().Get(ctx, "version", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get cluster version: %w", err)
+	}
+	version := cv.Status.Desired.Version
+
+	e2e.Logf("Verifying TLSAdherence is active for cluster version %s", version)
+
+	return wait.PollUntilContextTimeout(ctx, 15*time.Second, 15*time.Minute, true, func(ctx context.Context) (bool, error) {
+		fg, err := configClient.ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Error getting FeatureGate: %v", err)
+			return false, nil
+		}
+
+		for _, fgStatus := range fg.Status.FeatureGates {
+			if fgStatus.Version == version {
+				for _, enabled := range fgStatus.Enabled {
+					if enabled.Name == "TLSAdherence" {
+						return true, nil
+					}
+				}
+			}
+		}
+
+		e2e.Logf("TLSAdherence not yet in status for version %s (waiting...)", version)
+		return false, nil
+	})
+}
+
+func verifyTLSComplianceInPods(
+	ctx context.Context,
+	oc *exutil.CLI,
+	configClient configv1client.Interface,
+	k8sClient kubernetes.Interface,
+	namespace, labelSelector string,
+	ports []string,
+	componentName string,
+	isAdheringComponent bool,
+	skipTLS12ForModernStrict bool,
+) error {
+	apiserver, err := configClient.ConfigV1().APIServers().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get APIServer config: %w", err)
+	}
+
+	var expectTLS12Reject bool
+	var testDescription string
+
+	if apiserver.Spec.TLSSecurityProfile != nil {
+		profileType := apiserver.Spec.TLSSecurityProfile.Type
+		adherencePolicy := apiserver.Spec.TLSAdherence
+
+		switch {
+		case profileType == configv1.TLSProfileModernType && adherencePolicy == configv1.TLSAdherencePolicyStrictAllComponents:
+			expectTLS12Reject = true
+			testDescription = "Modern + StrictAllComponents: TLS 1.3 only, TLS 1.2 should be rejected"
+
+		case profileType == configv1.TLSProfileModernType && adherencePolicy == configv1.TLSAdherencePolicyLegacyAdheringComponentsOnly:
+			expectTLS12Reject = isAdheringComponent
+			if isAdheringComponent {
+				testDescription = "Modern + LegacyAdheringComponentsOnly (adhering component): TLS 1.3 only, TLS 1.2 should be rejected"
+			} else {
+				testDescription = "Modern + LegacyAdheringComponentsOnly (non-adhering component): both TLS 1.2 and TLS 1.3 should work"
+			}
+
+		case profileType == configv1.TLSProfileIntermediateType && adherencePolicy == configv1.TLSAdherencePolicyStrictAllComponents:
+			expectTLS12Reject = false
+			testDescription = "Intermediate + StrictAllComponents: both TLS 1.2 and TLS 1.3 should work"
+
+		default:
+			expectTLS12Reject = false
+			testDescription = fmt.Sprintf("Profile %s with adherence %s: both TLS 1.2 and TLS 1.3 should work", profileType, adherencePolicy)
+		}
+
+		e2e.Logf("Testing %s with profile: %s, adherence: %s, adhering: %v", componentName, profileType, adherencePolicy, isAdheringComponent)
+		e2e.Logf("%s", testDescription)
+	} else {
+		expectTLS12Reject = false
+		testDescription = "No profile configured: both TLS 1.2 and TLS 1.3 should work"
+		e2e.Logf("Testing %s with profile: %s", componentName, configv1.TLSProfileIntermediateType)
+		e2e.Logf("%s", testDescription)
+	}
+
+	pods, err := k8sClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to list pods with selector %s: %w", labelSelector, err)
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no pods found with selector %s in namespace %s", labelSelector, namespace)
+	}
+
+	var testPod string
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+		if slices.ContainsFunc(pod.Status.Conditions, func(condition corev1.PodCondition) bool {
+			return condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue
+		}) {
+			testPod = pod.Name
+			break
+		}
+	}
+
+	if testPod == "" {
+		return fmt.Errorf("no ready pods found with selector %s in namespace %s", labelSelector, namespace)
+	}
+
+	for _, port := range ports {
+		resourceName := fmt.Sprintf("pod/%s", testPod)
+		e2e.Logf("Testing TLS on %s/%s port %s", namespace, resourceName, port)
+
+		err := exutil.ForwardPortAndExecute(resourceName, namespace, port, func(localPort int) error {
+			tls13Config := &tls.Config{MinVersion: tls.VersionTLS13, MaxVersion: tls.VersionTLS13, InsecureSkipVerify: true}
+			e2e.Logf("Testing TLS 1.3 on port %s (should succeed)", port)
+			if err := exutil.CheckTLSConnection(localPort, tls13Config, nil); err != nil {
+				return fmt.Errorf("TLS 1.3 test failed: %w", err)
+			}
+			e2e.Logf("TLS 1.3 test PASSED on port %s", port)
+
+			if skipTLS12ForModernStrict &&
+				apiserver.Spec.TLSSecurityProfile != nil &&
+				apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType &&
+				apiserver.Spec.TLSAdherence == configv1.TLSAdherencePolicyStrictAllComponents {
+				e2e.Logf("Skipping TLS 1.2 test for %s on port %s (Modern + StrictAllComponents)", componentName, port)
+			} else {
+				tls12Config := &tls.Config{MinVersion: tls.VersionTLS12, MaxVersion: tls.VersionTLS12, InsecureSkipVerify: true}
+				if expectTLS12Reject {
+					e2e.Logf("Testing TLS 1.2 on port %s (should be REJECTED)", port)
+					if err := exutil.CheckTLSConnection(localPort, tls12Config, nil); err == nil {
+						return fmt.Errorf("TLS 1.2 connection on port %s SUCCEEDED but should have been REJECTED", port)
+					}
+					e2e.Logf("TLS 1.2 correctly REJECTED on port %s", port)
+				} else {
+					e2e.Logf("Testing TLS 1.2 on port %s (should succeed)", port)
+					if err := exutil.CheckTLSConnection(localPort, tls12Config, nil); err != nil {
+						return fmt.Errorf("TLS 1.2 test failed: %w", err)
+					}
+					e2e.Logf("TLS 1.2 test PASSED on port %s", port)
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("TLS test failed on port %s: %w", port, err)
+		}
+	}
+
+	e2e.Logf("All %s TLS endpoints verified in %s/%s", componentName, namespace, testPod)
+	return nil
+}
+
+func VerifyMultusTLSComplianceInPod(ctx context.Context, oc *exutil.CLI, configClient configv1client.Interface, k8sClient kubernetes.Interface, namespace, labelSelector string) error {
+	return verifyTLSComplianceInPods(ctx, oc, configClient, k8sClient, namespace, labelSelector,
+		[]string{"6443", "8443"}, "Multus", true, false)
+}
+
+func VerifyOVNKubernetesTLSComplianceInPod(ctx context.Context, oc *exutil.CLI, configClient configv1client.Interface, k8sClient kubernetes.Interface, namespace, labelSelector string) error {
+	return verifyTLSComplianceInPods(ctx, oc, configClient, k8sClient, namespace, labelSelector,
+		[]string{"9108"}, "OVN-Kubernetes Control Plane", false, false)
+}
+
+func VerifyOVNKubernetesNodeTLSComplianceInPod(ctx context.Context, oc *exutil.CLI, configClient configv1client.Interface, k8sClient kubernetes.Interface, namespace, labelSelector string) error {
+	return verifyTLSComplianceInPods(ctx, oc, configClient, k8sClient, namespace, labelSelector,
+		[]string{"9103", "9105"}, "OVN-Kubernetes Node", false, false)
+}
+
+func VerifyCNOTLSComplianceInPod(ctx context.Context, oc *exutil.CLI, configClient configv1client.Interface, k8sClient kubernetes.Interface, namespace, labelSelector string) error {
+	return verifyTLSComplianceInPods(ctx, oc, configClient, k8sClient, namespace, labelSelector,
+		[]string{"9104", "9103", "9105"}, "CNO", false, false)
+}
+
+func VerifyNetworkConsoleTLSComplianceInPod(ctx context.Context, oc *exutil.CLI, configClient configv1client.Interface, k8sClient kubernetes.Interface, namespace, labelSelector string) error {
+	return verifyTLSComplianceInPods(ctx, oc, configClient, k8sClient, namespace, labelSelector,
+		[]string{"9443"}, "Network Console", false, true)
+}

--- a/test/extended/networking/tls.go
+++ b/test/extended/networking/tls.go
@@ -10,6 +10,7 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
+	ote "github.com/openshift-eng/openshift-tests-extension/pkg/ginkgo"
 
 	configv1 "github.com/openshift/api/config/v1"
 	machineconfigv1 "github.com/openshift/api/machineconfiguration/v1"

--- a/test/extended/node/node_e2e/probe_termination.go
+++ b/test/extended/node/node_e2e/probe_termination.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/utils/ptr"
 
 	nodeutils "github.com/openshift/origin/test/extended/node"
@@ -200,87 +201,81 @@ var _ = g.Describe("[sig-node] Probe configuration", func() {
 	})
 })
 
-// findLatestEventByReason finds the latest event matching the given reason and message filter
-func findLatestEventByReason(events *corev1.EventList, reason string, msgFilter func(string) bool) *corev1.Event {
-	var latestEvent *corev1.Event
-	for i := range events.Items {
-		event := &events.Items[i]
-		if event.Reason == reason && msgFilter(event.Message) {
-			if latestEvent == nil || event.LastTimestamp.Time.After(latestEvent.LastTimestamp.Time) {
-				latestEvent = event
-			}
-		}
-	}
-	return latestEvent
-}
-
-// findEarliestEventAfter finds the earliest event matching the reason and filter that occurred after the given time
-// Uses LastTimestamp to properly detect repeated events (container restarts)
-func findEarliestEventAfter(events *corev1.EventList, reason string, msgFilter func(string) bool, afterTime time.Time) *corev1.Event {
-	var earliestEvent *corev1.Event
-	for i := range events.Items {
-		event := &events.Items[i]
-		// Use LastTimestamp instead of FirstTimestamp to catch repeated events (e.g., container restarts)
-		// FirstTimestamp stays at the original event time, but LastTimestamp updates on each occurrence
-		if event.Reason == reason && msgFilter(event.Message) && event.LastTimestamp.Time.After(afterTime) {
-			if earliestEvent == nil || event.LastTimestamp.Time.Before(earliestEvent.LastTimestamp.Time) {
-				earliestEvent = event
-			}
-		}
-	}
-	return earliestEvent
-}
-
-// verifyProbeTermination verifies that the probe termination grace period is honored
-// by checking the time difference between probe failure (Killing) and container restart (Started) events
-// Returns the time difference in seconds, or an error if events are not found
+// verifyProbeTermination returns the seconds between the "Killing" event (FirstTimestamp) and
+// the container's restart (pod.Status, gated on RestartCount==1 for the same cycle) - avoids
+// matching the "Started" event's message text, which varies across kubelet versions.
 func verifyProbeTermination(ctx context.Context, oc *exutil.CLI, namespace, podName, containerName string, expectedTerminationSec int) (int, error) {
 	var timeDiff int
 	// Timeout needs to account for: pod start (~30s) + probe period (60s) + termination (up to 60s) + restart (~30s) = ~3 minutes minimum
 	// Use 6 minutes to be safe for tests with 60s termination grace period
-	err := wait.PollUntilContextTimeout(ctx, 10*time.Second, 6*time.Minute, true, func(ctx context.Context) (bool, error) {
-		// Get events using the Events API
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 6*time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := oc.KubeClient().CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+		if err != nil {
+			e2e.Logf("Error getting pod %s: %v", podName, err)
+			return false, nil
+		}
+
+		status := e2epod.FindContainerStatusInPod(pod, containerName)
+		if status == nil {
+			e2e.Logf("Waiting for container status of %q to appear", containerName)
+			return false, nil
+		}
+
+		// Gate strictly on the first restart so the "Killing" event's FirstTimestamp below
+		// is guaranteed to correspond to the same cycle as this restart, not a later one.
+		if status.RestartCount != 1 {
+			e2e.Logf("Waiting for the first restart of %q (restartCount=%d)", containerName, status.RestartCount)
+			return false, nil
+		}
+
+		if status.State.Running == nil {
+			e2e.Logf("Waiting for container %q to be running again after restart", containerName)
+			return false, nil
+		}
+
 		events, err := oc.KubeClient().CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod", podName),
+			FieldSelector: fmt.Sprintf("involvedObject.name=%s,involvedObject.kind=Pod,reason=Killing", podName),
 		})
 		if err != nil {
-			e2e.Logf("Error getting events: %v", err)
+			e2e.Logf("Error listing events for pod %s: %v", podName, err)
 			return false, nil
 		}
 
-		// Find probe failure (Killing) event for the container
-		killingEvent := findLatestEventByReason(events, "Killing", func(msg string) bool {
-			return strings.Contains(msg, containerName) &&
-				strings.Contains(msg, "failed") &&
-				strings.Contains(msg, "probe")
-		})
-
+		killingEvent := findProbeKillingEvent(events, containerName)
 		if killingEvent == nil {
-			e2e.Logf("Waiting for probe failure (Killing) event")
+			e2e.Logf("Waiting for probe-failure (Killing) event for container %q", containerName)
 			return false, nil
 		}
 
-		// Find container restart (Started) event that occurred after the Killing event
-		startedEvent := findEarliestEventAfter(events, "Started", func(msg string) bool {
-			return strings.Contains(msg, "Container started")
-		}, killingEvent.LastTimestamp.Time)
-
-		if startedEvent == nil {
-			e2e.Logf("Waiting for container restart (Started) event after Killing event")
+		killedAt := killingEvent.FirstTimestamp.Time
+		startedAt := status.State.Running.StartedAt.Time
+		if !startedAt.After(killedAt) {
+			// The status hasn't caught up yet (e.g. reporting a stale running instance); keep polling.
+			e2e.Logf("Waiting for a fresh Running state after kill decision at %v", killedAt)
 			return false, nil
 		}
 
-		e2e.Logf("Killing event: %s at %v", killingEvent.Message, killingEvent.LastTimestamp)
-		e2e.Logf("Started event: %s at %v", startedEvent.Message, startedEvent.LastTimestamp)
-
-		// Calculate time difference using the helper function
-		timeDiff = int(nodeutils.CalculateEventTimeDiff(killingEvent, startedEvent).Seconds())
-		e2e.Logf("Time difference: %d seconds (expected: %d ±10 seconds)", timeDiff, expectedTerminationSec)
+		timeDiff = int(startedAt.Sub(killedAt).Seconds())
+		e2e.Logf("Container %q: probe failure detected at %v, restarted at %v, time difference: %d seconds (expected: %d seconds)",
+			containerName, killedAt, startedAt, timeDiff, expectedTerminationSec)
 
 		return true, nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("failed to observe probe termination and restart for container %q: %w", containerName, err)
 	}
 	return timeDiff, nil
+}
+
+// findProbeKillingEvent finds the "Killing" event kubelet records when a probe failure
+// triggers container termination. The message format is "Container <name> failed
+// liveness/startup probe, will be restarted" (see kuberuntime_manager.go).
+func findProbeKillingEvent(events *corev1.EventList, containerName string) *corev1.Event {
+	for i := range events.Items {
+		event := &events.Items[i]
+		if strings.Contains(event.Message, containerName) && strings.Contains(event.Message, "failed") && strings.Contains(event.Message, "probe") {
+			return event
+		}
+	}
+	return nil
 }

--- a/test/extended/node/node_utils.go
+++ b/test/extended/node/node_utils.go
@@ -917,23 +917,6 @@ func GetFirstReadyWorkerNode(oc *exutil.CLI) string {
 	return ""
 }
 
-// CalculateEventTimeDiff calculates the time difference between two Kubernetes events.
-// It uses LastTimestamp for both events to handle repeated events correctly.
-// For repeated events (like container restarts), Kubernetes reuses the event object and updates
-// LastTimestamp while keeping FirstTimestamp at the original occurrence.
-// Falls back to FirstTimestamp if LastTimestamp is zero.
-func CalculateEventTimeDiff(startEvent, endEvent *corev1.Event) time.Duration {
-	startTime := startEvent.LastTimestamp.Time
-	if startTime.IsZero() {
-		startTime = startEvent.FirstTimestamp.Time
-	}
-	endTime := endEvent.LastTimestamp.Time
-	if endTime.IsZero() {
-		endTime = endEvent.FirstTimestamp.Time
-	}
-	return endTime.Sub(startTime)
-}
-
 // GetPodNetNs retrieves the network namespace path for a pod using crictl.
 // It uses crictl to get the sandbox ID and then inspects it to extract the NetNS path.
 // Returns the NetNS path and an error if not found.

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -903,7 +903,9 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			// this alert to fire while we investigate why the taint is not added at node birth.
 			isManagedService, err := exutil.IsManagedServiceCluster(ctx, oc.AdminKubeClient())
 			o.Expect(err).NotTo(o.HaveOccurred())
-			if isManagedService {
+			isExternalPlatform, err := exutil.IsExternalPlatformCluster(ctx, oc.AdminConfigClient())
+			o.Expect(err).NotTo(o.HaveOccurred())
+			if isManagedService || isExternalPlatform {
 				allowedAlertNames = append(allowedAlertNames, "KubeDaemonSetMisScheduled")
 			}
 			// https://issues.redhat.com/browse/OCPBUGS-48340

--- a/test/extended/prometheus/prometheus.go
+++ b/test/extended/prometheus/prometheus.go
@@ -908,6 +908,12 @@ var _ = g.Describe("[sig-instrumentation] Prometheus [apigroup:image.openshift.i
 			if isManagedService || isExternalPlatform {
 				allowedAlertNames = append(allowedAlertNames, "KubeDaemonSetMisScheduled")
 			}
+			// OCPBUGS-114674: The same root cause also triggers KubeDaemonSetRolloutStuck on the same
+			// DaemonSets (dns-default, ingress-canary, insights-runtime-extractor). Allow this alert
+			// on External platform clusters as well.
+			if isExternalPlatform {
+				allowedAlertNames = append(allowedAlertNames, "KubeDaemonSetRolloutStuck")
+			}
 			// https://issues.redhat.com/browse/OCPBUGS-48340
 			if SkipOperatorHubMetricsCheck(oc) {
 				allowedAlertNames = append(allowedAlertNames, "OperatorHubSourceError")

--- a/test/extended/router/metrics.go
+++ b/test/extended/router/metrics.go
@@ -53,19 +53,7 @@ var _ = g.Describe("[sig-network][Feature:Router]", func() {
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
 		platformType := infra.Status.Platform
-		dualStackIPFamily := false
-		if infra.Status.PlatformStatus != nil {
-			platformType = infra.Status.PlatformStatus.Type
-			if infra.Status.PlatformStatus.AWS != nil {
-				ipFamily := infra.Status.PlatformStatus.AWS.IPFamily
-				if ipFamily == configv1.DualStackIPv4Primary || ipFamily == configv1.DualStackIPv6Primary {
-					dualStackIPFamily = true
-				}
-			}
-		}
-		// Dual-stack installations on AWS are forced to use NLB type, which
-		// doesn't accept proxy protocol (yet).
-		proxyProtocol = (platformType == configv1.AWSPlatformType) && !dualStackIPFamily
+		proxyProtocol = platformType == configv1.AWSPlatformType
 
 		// This test needs to make assertions against a single router pod, so all access
 		// to the router should happen through a single endpoint.

--- a/test/extended/router/stress.go
+++ b/test/extended/router/stress.go
@@ -210,7 +210,11 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			o.Expect(err).NotTo(o.HaveOccurred())
 
 			g.By("waiting for sufficient routes to have a status")
-			err = wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+
+			// The leader election lease lasts 1 minute. Normally all route statuses are written
+			// within 1-2 lease cycles when handling conflicts. Under heavier contention a replica
+			// may need to re-acquire the lease 3 or more times until all routes are updated.
+			err = wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
 				routes, err := client.List(context.Background(), metav1.ListOptions{})
 				if err != nil {
 					return false, err
@@ -249,10 +253,12 @@ var _ = g.Describe("[sig-network][Feature:Router][apigroup:route.openshift.io]",
 			// Next, we expect 1-2 more writes per route until per-route contention activates.
 			// Next, we expect the maxContention logic to activate and stop all updates when the routers detect > 5
 			// contentions.
-			// In total, we expect around 30-35 writes, but we generously allow for up to 50 writes to accommodate for
-			// minor discrepancies in contention tracker logic.
+			// In total, we expect around 30-35 writes. The actual count can be higher when the
+			// asynchronous contention detector lags behind update events, allowing a few extra
+			// writes before updates are suppressed. The previous limit of 50 caused intermittent
+			// failures; 75 is a more conservative bound.
 			o.Expect(writes).To(o.BeNumerically(">=", numOfRoutes))
-			o.Expect(writes).To(o.BeNumerically("<=", 50))
+			o.Expect(writes).To(o.BeNumerically("<=", 75))
 
 			// the os_http_be.map file will vary, so only check the haproxy config
 			verifyCommandEquivalent(oc.KubeClient(), rs, "md5sum /var/lib/haproxy/conf/haproxy.config")

--- a/test/extended/util/framework.go
+++ b/test/extended/util/framework.go
@@ -2313,6 +2313,17 @@ func IsHypershift(ctx context.Context, configClient clientconfigv1.Interface) (b
 	return infrastructure.Status.ControlPlaneTopology == configv1.ExternalTopologyMode, nil
 }
 
+// IsExternalPlatformCluster checks if the cluster is running on the External platform type.
+func IsExternalPlatformCluster(ctx context.Context, configClient clientconfigv1.Interface) (bool, error) {
+	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return false, nil
+	}
+
+	return infrastructure.Status.PlatformStatus != nil &&
+		infrastructure.Status.PlatformStatus.Type == configv1.ExternalPlatformType, nil
+}
+
 // IsMicroShiftCluster returns "true" if a cluster is MicroShift,
 // "false" otherwise. It needs kube-admin client as input.
 //

--- a/test/extended/util/tls.go
+++ b/test/extended/util/tls.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
@@ -15,7 +16,10 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
@@ -26,13 +30,29 @@ type CertInfo struct {
 	Issuer  string
 }
 
-// ForwardPortAndExecute forwards a port to a service and executes a function with the local port.
-// It retries up to 3 times on failure.
-func ForwardPortAndExecute(serviceName, namespace, remotePort string, toExecute func(localPort int) error) error {
+// ForwardPortAndExecute forwards a port to a service or pod and executes a function with the local port.
+func ForwardPortAndExecute(resourceName, namespace, remotePort string, toExecute func(localPort int) error) error {
+	resource := resourceName
+	port := remotePort
+
+	if !strings.Contains(resourceName, "/") {
+		resource = fmt.Sprintf("svc/%s", resourceName)
+		if ClusterDegraded {
+			resolveCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			podResource, podPort, resolveErr := portForwardTargetOnReadyNode(resolveCtx, resourceName, namespace, remotePort)
+			if resolveErr != nil {
+				e2e.Logf("degraded cluster: unable to select Ready-node pod for %s/%s, falling back to service: %v", namespace, resourceName, resolveErr)
+			} else {
+				resource, port = podResource, podPort
+				e2e.Logf("degraded cluster: port-forwarding to %s port %s instead of svc/%s", resource, port, resourceName)
+			}
+		}
+	}
 	var err error
 	for i := 0; i < 3; i++ {
 		if err = func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			localPort := rand.Intn(65534-1025) + 1025
 			args := []string{"port-forward", fmt.Sprintf("svc/%s", serviceName), fmt.Sprintf("%d:%s", localPort, remotePort), "-n", namespace}
@@ -46,8 +66,12 @@ func ForwardPortAndExecute(serviceName, namespace, remotePort string, toExecute 
 			defer stderr.Close()
 			defer e2e.TryKill(cmd)
 
-			// Read and discard port-forward output to avoid logging sensitive cluster metadata
 			_ = ReadPartialFrom(stdout, 1024)
+
+			if err := waitForLocalPort(ctx, localPort, 5*time.Second); err != nil {
+				return fmt.Errorf("port-forward failed to become ready: %w", err)
+			}
+
 			return toExecute(localPort)
 		}(); err == nil {
 			return nil
@@ -59,6 +83,110 @@ func ForwardPortAndExecute(serviceName, namespace, remotePort string, toExecute 
 	return err
 }
 
+// waitForLocalPort waits until the forwarded local port accepts TCP connections.
+func waitForLocalPort(ctx context.Context, localPort int, timeout time.Duration) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", localPort)
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			conn, err := (&net.Dialer{}).DialContext(ctx, "tcp", addr)
+			if err != nil {
+				return false, nil
+			}
+			conn.Close()
+			return true, nil
+		})
+}
+
+// portForwardTargetOnReadyNode returns pod/<name> and the service's target port for a
+// Ready Running pod backing serviceName that is scheduled on a Ready node.
+func portForwardTargetOnReadyNode(ctx context.Context, serviceName, namespace, remotePort string) (string, string, error) {
+	kubeClient, err := e2e.LoadClientset(true)
+	if err != nil {
+		return "", "", err
+	}
+
+	svc, err := kubeClient.CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	if len(svc.Spec.Selector) == 0 {
+		return "", "", fmt.Errorf("service %s/%s has no selector", namespace, serviceName)
+	}
+
+	targetPort, err := servicePortToTargetPort(svc, remotePort)
+	if err != nil {
+		return "", "", err
+	}
+
+	nodes, err := kubeClient.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	readyNodes := map[string]struct{}{}
+	for i := range nodes.Items {
+		if isNodeReadyConditionTrue(&nodes.Items[i]) {
+			readyNodes[nodes.Items[i].Name] = struct{}{}
+		}
+	}
+	if len(readyNodes) == 0 {
+		return "", "", fmt.Errorf("no Ready nodes found")
+	}
+
+	pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
+	})
+	if err != nil {
+		return "", "", err
+	}
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning || !isPodReadyConditionTrue(&pod) {
+			continue
+		}
+		if _, ok := readyNodes[pod.Spec.NodeName]; !ok {
+			continue
+		}
+		return "pod/" + pod.Name, targetPort, nil
+	}
+	return "", "", fmt.Errorf("no Ready Running pods for service %s/%s on Ready nodes", namespace, serviceName)
+}
+
+func servicePortToTargetPort(svc *corev1.Service, remotePort string) (string, error) {
+	for _, p := range svc.Spec.Ports {
+		if strconv.Itoa(int(p.Port)) != remotePort && p.Name != remotePort {
+			continue
+		}
+		switch p.TargetPort.Type {
+		case intstr.String:
+			if p.TargetPort.StrVal != "" {
+				return p.TargetPort.StrVal, nil
+			}
+		default:
+			if p.TargetPort.IntVal != 0 {
+				return strconv.Itoa(int(p.TargetPort.IntVal)), nil
+			}
+		}
+		return strconv.Itoa(int(p.Port)), nil
+	}
+	return "", fmt.Errorf("port %q not found on service %s/%s", remotePort, svc.Namespace, svc.Name)
+}
+
+func isNodeReadyConditionTrue(node *corev1.Node) bool {
+	for _, c := range node.Status.Conditions {
+		if c.Type == corev1.NodeReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func isPodReadyConditionTrue(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}
 // ReadPartialFrom reads up to maxBytes from a reader and returns the content as a string.
 func ReadPartialFrom(r io.Reader, maxBytes int) string {
 	buf := make([]byte, maxBytes)
@@ -71,7 +199,14 @@ func ReadPartialFrom(r io.Reader, maxBytes int) string {
 
 // CheckTLSConnection verifies that a TLS connection works with the expected config and fails with the other.
 func CheckTLSConnection(port int, tlsShouldWork, tlsShouldNotWork *tls.Config) error {
-	conn, err := tls.Dial("tcp", fmt.Sprintf("localhost:%d", port), tlsShouldWork)
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{
+			Timeout: 10 * time.Second,
+		},
+		Config: tlsShouldWork,
+	}
+
+	conn, err := dialer.DialContext(context.Background(), "tcp", fmt.Sprintf("localhost:%d", port))
 	if err != nil {
 		return fmt.Errorf("should work: %w", err)
 	}
@@ -80,7 +215,18 @@ func CheckTLSConnection(port int, tlsShouldWork, tlsShouldNotWork *tls.Config) e
 		return fmt.Errorf("failed to close connection: %w", err)
 	}
 
-	conn, err = tls.Dial("tcp", fmt.Sprintf("localhost:%d", port), tlsShouldNotWork)
+	if tlsShouldNotWork == nil {
+		return nil
+	}
+
+	negDialer := &tls.Dialer{
+		NetDialer: &net.Dialer{
+			Timeout: 10 * time.Second,
+		},
+		Config: tlsShouldNotWork,
+	}
+
+	conn, err = negDialer.DialContext(context.Background(), "tcp", fmt.Sprintf("localhost:%d", port))
 	if err == nil {
 		return fmt.Errorf("should not work: connection unexpectedly succeeded, closing conn status: %v", conn.Close())
 	}
@@ -327,8 +473,9 @@ func EnsureEncryptionEnabled(ctx context.Context, oc *CLI) (encryptionType strin
 	}
 
 	// Wait for kube-apiserver to stabilize
-	e2e.Logf("waiting for kube-apiserver operator to stabilize (≤1800s)")
-	err = WaitCoBecomes(ctx, oc, "kube-apiserver", 1800, map[string]string{
+	kubeAPIServerTimeout := 1800
+	e2e.Logf("waiting for kube-apiserver operator to stabilize (timeout: %v)", time.Duration(kubeAPIServerTimeout)*time.Second)
+	err = WaitCoBecomes(ctx, oc, "kube-apiserver", kubeAPIServerTimeout, map[string]string{
 		"Available":   "True",
 		"Progressing": "False",
 		"Degraded":    "False",
@@ -338,8 +485,9 @@ func EnsureEncryptionEnabled(ctx context.Context, oc *CLI) (encryptionType strin
 	}
 
 	// Wait for openshift-apiserver to stabilize
-	e2e.Logf("waiting for openshift-apiserver operator to stabilize (≤1800s)")
-	err = WaitCoBecomes(ctx, oc, "openshift-apiserver", 1800, map[string]string{
+	openshiftAPIServerTimeout := 1800
+	e2e.Logf("waiting for openshift-apiserver operator to stabilize (timeout: %v)", time.Duration(openshiftAPIServerTimeout)*time.Second)
+	err = WaitCoBecomes(ctx, oc, "openshift-apiserver", openshiftAPIServerTimeout, map[string]string{
 		"Available":   "True",
 		"Progressing": "False",
 		"Degraded":    "False",


### PR DESCRIPTION
## Summary

Backport of PR #31500 from main branch to release-5.0.

This PR adds TLS Profile Compliance tests for networking components to the release-5.0 branch.

### Changes

- **test/extended/networking/tls.go** (new file): TLS Profile Compliance test suite covering:
  - Profile type detection (Modern, Intermediate, Old)
  - TLS version enforcement
  - Cipher suite validation
  - Component configuration validation
  - Profile change propagation and reconciliation

- **test/extended/util/tls.go** (enhancements):
  - Added `portForwardTargetOnReadyNode()` for degraded cluster support
  - Added helper utilities for TLS connection verification
  - Improved port-forwarding logic to handle degraded clusters
  - Added certificate info retrieval utilities

### Testing

The TLS tests validate that all OpenShift networking components (ingress router, API servers, etcd, etc.) correctly reconcile TLS profile changes and enforce the expected configuration.

Tests are marked as informing and won't block CI.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive TLS profile compliance coverage across networking components.
  - Added support for detecting external platform clusters and applying appropriate alert expectations.
  - Added handling for Pod Security Admission configurations when evaluating audit violations.

- **Bug Fixes**
  - Improved event matching for vSphere configuration rollouts using the latest event timestamp.
  - Improved probe termination timing verification.
  - Improved TLS checks and port-forwarding reliability in degraded clusters.
  - Updated router stress-test thresholds for contention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->