### PR TITLE
CORENET-6746: Allow EgressIP NoMatchingNodeFound events to repeat pathologically

### DIFF
--- a/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
+++ b/pkg/monitortestlibrary/pathologicaleventlibrary/duplicated_event_patterns.go
@@ -577,6 +577,15 @@ func NewUniversalPathologicalEventMatchers(kubeConfig *rest.Config, finalInterva
 		jira:               "https://redhat.atlassian.net/browse/OCPBUGS-84917",
 	})
 
+	// EgressIP e2e tests create EgressIP resources before labeling nodes with
+	// k8s.ovn.org/egress-assignable, so NoMatchingNodeFound events fire repeatedly
+	// until the label is applied. This is expected test behavior, not a real problem.
+	registry.AddPathologicalEventMatcherOrDie(&SimplePathologicalEventMatcher{
+		name:               "EgressIPNoMatchingNodeFound",
+		messageReasonRegex: regexp.MustCompile(`^NoMatchingNodeFound$`),
+		messageHumanRegex:  regexp.MustCompile(`no assignable nodes for EgressIP`),
+	})
+
 	return registry
 }
 


### PR DESCRIPTION
EgressIP e2e tests create EgressIP resources before labeling nodes with `k8s.ovn.org/egress-assignable`, causing `NoMatchingNodeFound` events to fire repeatedly until the label is applied. This is expected test behavior and should not be flagged as a pathological event.

Sample runs:
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/3227/pull-ci-openshift-ovn-kubernetes-main-e2e-aws-core-networking-serial-ote/2095870485823754240
https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_ovn-kubernetes/3227/pull-ci-openshift-ovn-kubernetes-main-e2e-azure-core-networking-serial-ote/2095870485857308672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added matching support for repeated EgressIP test events that occur before nodes receive the required egress-assignable label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->