### PR TITLE
NO-ISSUE: Fix pre-OS Image Stream OS validation for OKD clusters

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -196,14 +196,23 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	})
 })
 
-func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface) {
-	// In clusters with no OSImageStreams the nodes should be always RHEL 9
+func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface, isOKD bool) {
 	nodes, err := coreClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error listing nodes")
 
+	// OKD SCOS clusters use CentOS Stream CoreOS 10 even in pre-OS Image Stream
+	// releases (4.22 and earlier). OCP clusters use RHEL CoreOS 9.
+	expectedSubstring := "CoreOS 9."
+	expectedDesc := "RHEL 9"
+	if isOKD {
+		expectedSubstring = "CentOS Stream CoreOS 10"
+		expectedDesc = "CentOS Stream CoreOS 10"
+	}
+
 	for _, node := range nodes.Items {
 		osImage := node.Status.NodeInfo.OSImage
-		o.Expect(osImage).To(o.ContainSubstring("CoreOS 9."), "Pre OS Image Stream cluster should use RHEL 9 nodes")
+		o.Expect(osImage).To(o.ContainSubstring(expectedSubstring),
+			"Pre OS Image Stream cluster should use %s nodes", expectedDesc)
 	}
 }
 
@@ -307,8 +316,8 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName, rawJobName string) {
 		clusterSemver, err := utilversion.ParseGeneric(clusterVersion.Status.Desired.Version)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error parsing ClusterVersion desired version %v", err)
 		if clusterSemver.LessThan(utilversion.MustParseSemantic("4.23.0")) {
-			// Pre-OS Image Streams GA. OS was always RHEL 9
-			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient())
+			// Pre-OS Image Streams GA. OS was always RHEL 9 for OCP, CentOS Stream CoreOS 10 for OKD
+			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient(), isOKD)
 			// Return now, the rest of the test is based on the presence of OSImageStream
 			return
 		}


### PR DESCRIPTION
## Problem

The `validatePreOSImageStreamsNodeOS` function in `test/extended/ci/job_names.go` hardcodes an assertion that pre-OS Image Stream clusters should use RHEL CoreOS 9 nodes (`"CoreOS 9."`). However, **OKD SCOS clusters use CentOS Stream CoreOS 10** even in pre-OS Image Stream releases (4.22 and earlier).

This causes the `[sig-ci] [Early] prow job name should match os version` test to **fail deterministically** on every OKD SCOS `aws-upgrade-minor` job (`4.22 → 5.0 upgrade`):

```
fail [job_names.go:206]: Pre OS Image Stream cluster should use RHEL 9 nodes
Expected
    <string>: CentOS Stream CoreOS 10.0.20260806-0 (Coughlan)
to contain substring
    <string>: CoreOS 9.
```

**The `[Early]` tests run BEFORE the upgrade** against the 4.22 OKD SCOS cluster, which uses CentOS Stream CoreOS 10. The test then hits the pre-OSImageStream code path (since 4.22 < 4.23 and OSImageStream CR does not exist), which unconditionally expects CoreOS 9.

The actual cluster upgrade itself succeeds — this is purely a test assertion bug.

## Root Cause

PR #31487 (`ff28c753e9`) correctly added OKD detection and set `targetStream = "centos-10"` for the OSImageStream-enabled code path. However, it did **not** update the `validatePreOSImageStreamsNodeOS` fallback, which is reached when:
1. The `OSImageStream` CR does not exist (all pre-4.23 clusters), AND
2. The cluster desired version is < 4.23.0

This fallback unconditionally asserts `"CoreOS 9."` regardless of whether the cluster is OKD.

## Fix

Pass the `isOKD` flag into `validatePreOSImageStreamsNodeOS` so it expects:
- `"CentOS Stream CoreOS 10"` for OKD SCOS clusters
- `"CoreOS 9."` for OCP clusters (unchanged behavior)

## Evidence

Confirmed on multiple failing nightly runs:
- [Run 2093066617431789568](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-okd-scos-5.0-upgrade-from-okd-scos-4.22-e2e-aws-ovn-upgrade/2093066617431789568) (Aug 27)
- [Run 2096974572954849280](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-okd-scos-5.0-upgrade-from-okd-scos-4.22-e2e-aws-ovn-upgrade/2096974572954849280) (Sep 7, latest nightly)

Tests binary `5.0.0-202609050031.p2.g6bffdda` (Sep 5 build, includes PR #31487) still fails, confirming the fix is incomplete.

## Cherry-pick Plan

After merge to `main`, cherry-pick to `release-5.0` is needed (the 5.0 OKD nightly `aws-upgrade-minor` job is the one failing).

/cc @pablintino

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pre-OS image stream validation to recognize the appropriate operating system for both OpenShift and OKD clusters.
  * Improved validation messaging to clearly identify the detected cluster type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->