### PR TITLE
OKD-443: Fix pre-OSImageStreams node OS validation for OKD

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -196,14 +196,20 @@ var _ = g.Describe("[sig-ci] [Early] prow job name", func() {
 	})
 })
 
-func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface) {
-	// In clusters with no OSImageStreams the nodes should be always RHEL 9
+func validatePreOSImageStreamsNodeOS(coreClient kclientset.Interface, isOKD bool) {
+	// In clusters with no OSImageStreams the nodes should be RHEL 9 (OCP) or CentOS 10 (OKD)
 	nodes, err := coreClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	o.Expect(err).NotTo(o.HaveOccurred(), "Error listing nodes")
 
+	targetVersion := 9
+	if isOKD {
+		// OKD was already using CoreOS 10 in pre-OSImageStreams versions like 4.22
+		targetVersion = 10
+	}
+
 	for _, node := range nodes.Items {
 		osImage := node.Status.NodeInfo.OSImage
-		o.Expect(osImage).To(o.ContainSubstring("CoreOS 9."), "Pre OS Image Stream cluster should use RHEL 9 nodes")
+		o.Expect(osImage).To(o.ContainSubstring(fmt.Sprintf("CoreOS %d.", targetVersion)), "Pre OS Image Stream cluster should use CoreOS %d nodes", targetVersion)
 	}
 }
 
@@ -307,8 +313,8 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName, rawJobName string) {
 		clusterSemver, err := utilversion.ParseGeneric(clusterVersion.Status.Desired.Version)
 		o.Expect(err).NotTo(o.HaveOccurred(), "Error parsing ClusterVersion desired version %v", err)
 		if clusterSemver.LessThan(utilversion.MustParseSemantic("4.23.0")) {
-			// Pre-OS Image Streams GA. OS was always RHEL 9
-			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient())
+			// Pre-OS Image Streams GA. OS was always RHEL 9 (OCP) or CentOS 10 (OKD)
+			validatePreOSImageStreamsNodeOS(oc.AdminKubeClient(), isOKD)
 			// Return now, the rest of the test is based on the presence of OSImageStream
 			return
 		}


### PR DESCRIPTION
## Summary

- Make `validatePreOSImageStreamsNodeOS` OKD-aware: check CoreOS 10 for OKD clusters instead of hardcoding CoreOS 9
- Fixes the `[sig-ci] [Early] prow job name should match os version` test failure during 4.22→5.x OKD upgrades

## Details

The `validatePreOSImageStreamsNodeOS` function hardcoded `"CoreOS 9."` which is correct for OCP (RHEL 9) but wrong for OKD, which was already using CoreOS 10 in pre-OSImageStreams versions like 4.22. During 4.22→5.0 OKD upgrades, the test correctly identified the cluster as pre-OSImageStreams (`< 4.23`) but then failed because the nodes were running CentOS Stream CoreOS 10, not CoreOS 9.

This is the `main` branch counterpart of [openshift/origin#31592](https://github.com/openshift/origin/pull/31592) (targeting `release-5.0`). The change is identical.

OCP behavior is unchanged — `isOKD` is false for OCP clusters, so `targetVersion` remains 9.

## Test plan

- [x] `go vet` passes
- [ ] Verify OKD SCOS upgrade jobs pass with this change
- [ ] Verify OCP upgrade jobs are unaffected

## References

- [OKD-443](https://redhat.atlassian.net/browse/OKD-443)
- [OKD-424](https://redhat.atlassian.net/browse/OKD-424) — parent investigation
- [openshift/origin#31592](https://github.com/openshift/origin/pull/31592) — same fix on `release-5.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated pre-OSImageStreams validation to correctly recognize the expected CoreOS version for OKD clusters.
  - Improved standalone node validation across supported cluster types by applying the appropriate operating system version expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->