### PR TITLE
OCPBUGS-113538: Filter both [FeatureGate:] and [OCPFeatureGate:]

### DIFF
--- a/pkg/test/filters/cluster_state.go
+++ b/pkg/test/filters/cluster_state.go
@@ -104,7 +104,7 @@ func (f *ClusterStateFilter) ShouldApply() bool {
 // Regular expressions for parsing test labels
 var (
 	apiGroupRegex    = regexp.MustCompile(`\[apigroup:([^]]*)\]`)
-	featureGateRegex = regexp.MustCompile(`\[OCPFeatureGate:([^]]*)\]`)
+	featureGateRegex = regexp.MustCompile(`\[(?:OCP)?FeatureGate:([^]]*)\]`)
 )
 
 // matchTest implements the cluster-based test matching logic

--- a/pkg/test/filters/cluster_state_test.go
+++ b/pkg/test/filters/cluster_state_test.go
@@ -137,6 +137,63 @@ func TestClusterStateFilter(t *testing.T) {
 	assert.Equal(t, "test [Feature:Networking-IPv4]", result[1].Name)
 }
 
+func TestClusterStateFilterFeatureGateTags(t *testing.T) {
+	filter := NewClusterStateFilter(&clusterdiscovery.ClusterConfiguration{
+		ProviderName:         "aws",
+		NetworkPlugin:        "OVNKubernetes",
+		HasIPv4:              true,
+		HasIPv6:              false,
+		EnabledFeatureGates:  sets.New("FeatureA", "FeatureB"),
+		DisabledFeatureGates: sets.New("DisabledFeature"),
+		APIGroups:            sets.New[string](),
+	})
+
+	testCases := []struct {
+		name     string
+		testName string
+		wantRun  bool
+	}{
+		{
+			name:     "upstream enabled gate",
+			testName: "test [FeatureGate:FeatureA]",
+			wantRun:  true,
+		},
+		{
+			name:     "upstream disabled gate",
+			testName: "test [FeatureGate:DisabledFeature]",
+			wantRun:  false,
+		},
+		{
+			name:     "upstream unknown gate",
+			testName: "test [FeatureGate:UnknownFeature]",
+			wantRun:  true,
+		},
+		{
+			name:     "multiple upstream gates",
+			testName: "test [FeatureGate:FeatureA][FeatureGate:FeatureB]",
+			wantRun:  true,
+		},
+		{
+			name:     "mixed gate tags with disabled gate",
+			testName: "test [OCPFeatureGate:FeatureA][FeatureGate:DisabledFeature]",
+			wantRun:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tests := extensions.ExtensionTestSpecs{
+				&extensions.ExtensionTestSpec{ExtensionTestSpec: &extensiontests.ExtensionTestSpec{Name: tc.testName}},
+			}
+
+			result, err := filter.Filter(context.Background(), tests)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRun, len(result) == 1)
+		})
+	}
+}
+
 // Test data for comprehensive cluster state filter testing
 var e2eTestNames = map[string]string{
 	"everyone":              "[Skipped:Wednesday]",


### PR DESCRIPTION
Now that `openshift-tests` read real feature gates enabled in the cluster from the API server, it should be safe to filter all tests by `[FeatureGate:]`

CSI certification tests have code in openshift/origin (vendor/k8s.io/kubernetes/test/e2e/storage/testsuites) and it needs to be filtered with `[FeatureGate:`.

I'm going to compare nr. of tests + test names from AWS payload jobs with and without this PR to make sure nothing gets lost or added unexpectedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Feature-gate labels now support both standard and OCP-prefixed formats while preserving gate-name matching.
  * Cluster-state filtering correctly handles enabled, disabled, unknown, multiple, and mixed feature-gate labels.

* **Tests**
  * Added coverage for feature-gate filtering across supported label formats and configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->