### PR TITLE
[NA] Backup ds openshift origin eip duplicate mac issue v2

### DIFF
--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -712,6 +712,12 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		workerNodesOrderedNames []string
 	)
 
+	var (
+		egressNode1Name string
+		egressNode2Name string
+		egressIPObjectName = "egressip-mac-test"
+	)
+
 	g.BeforeEach(func() {
 		g.By("Verifying that this cluster uses a network plugin that is supported for this test")
 		if networkPluginName() != OVNKubernetesPluginName {
@@ -736,36 +742,36 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		if len(workerNodesOrdered) < 3 {
 			skipper.Skipf("This test requires a minimum of 3 worker nodes. However, this environment has %d worker nodes.", len(workerNodesOrdered))
 		}
+
+		egressNode1Name = workerNodesOrderedNames[1]
+		egressNode2Name = workerNodesOrderedNames[2]
 	})
 
 	g.AfterEach(func() {
+		g.By("Cleaning up EgressIP object")
+		runOcWithRetry(oc.AsAdmin(), "delete", "egressip", egressIPObjectName, "--ignore-not-found=true", "-n", "default")
+
+		g.By("Cleaning up node labels")
+		runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable-", "--overwrite=true", "--ignore-not-found=true")
+		runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode2Name, "k8s.ovn.org/egress-assignable-", "--overwrite=true", "--ignore-not-found=true")
+
 		g.By("Removing the temp directory")
-		os.RemoveAll(tmpDirEgressIP)
+		err := os.RemoveAll(tmpDirEgressIP)
+		o.Expect(err).NotTo(o.HaveOccurred(), "failed to cleanup temporary directory")
 	})
 
 	g.It("should prevent duplicate MAC responses during EgressIP failover [Serial]", func() {
 		g.By("Checking platform type - this test requires L2 network adjacency")
 		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
 		o.Expect(err).NotTo(o.HaveOccurred())
-		if infra.Status.PlatformStatus != nil {
-			platformType := infra.Status.PlatformStatus.Type
-			cloudPlatforms := []configv1.PlatformType{
-				configv1.AWSPlatformType,
-				configv1.GCPPlatformType,
-				configv1.AzurePlatformType,
-				configv1.OpenStackPlatformType,
-			}
-			for _, cp := range cloudPlatforms {
-				if platformType == cp {
-					skipper.Skipf("This test requires L2 network adjacency (baremetal); cloud platform %s is not supported", platformType)
-				}
-			}
+		if infra.Status.PlatformStatus == nil {
+			skipper.Skipf("This test requires L2 network adjacency (baremetal); PlatformStatus is nil")
+		}
+		if infra.Status.PlatformStatus.Type != configv1.BareMetalPlatformType {
+			skipper.Skipf("This test requires L2 network adjacency (baremetal); current platform %s is not supported", infra.Status.PlatformStatus.Type)
 		}
 
 		probeNodeName := workerNodesOrderedNames[0]
-		egressNode1Name := workerNodesOrderedNames[1]
-		egressNode2Name := workerNodesOrderedNames[2]
-		const egressIPObjectName = "egressip-mac-test"
 
 		g.By("Labeling egress nodes as egress-assignable")
 		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable=")
@@ -819,13 +825,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 		}, 120*time.Second, 5*time.Second).Should(o.BeTrue())
 
 		g.By("Checking for duplicate MAC responses")
-		err = checkForDuplicateMACOnNode(oc, probeNodeName, probeInterface, egressIPStr, mac1, mac2, false, 20, 500*time.Millisecond)
-		o.Expect(err).NotTo(o.HaveOccurred())
-
-		g.By("Cleaning up labels")
-		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable-")
-		o.Expect(err).NotTo(o.HaveOccurred())
-		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode2Name, "k8s.ovn.org/egress-assignable-")
+		isIPv6 := strings.Contains(egressIPStr, ":")
+		err = checkForDuplicateMACOnNode(oc, probeNodeName, probeInterface, egressIPStr, mac1, mac2, isIPv6, 20, 500*time.Millisecond)
 		o.Expect(err).NotTo(o.HaveOccurred())
 	})
 })

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -713,8 +713,8 @@ var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
 	)
 
 	var (
-		egressNode1Name string
-		egressNode2Name string
+		egressNode1Name    string
+		egressNode2Name    string
 		egressIPObjectName = "egressip-mac-test"
 	)
 

--- a/test/extended/networking/egressip.go
+++ b/test/extended/networking/egressip.go
@@ -702,3 +702,130 @@ func waitForCloudPrivateIPConfigsDeletion(oc *exutil.CLI, cloudNetworkClientset 
 		return true
 	}, time.Duration(timeout)*time.Second, 5*time.Second).Should(o.BeTrue())
 }
+
+var _ = g.Describe("[sig-network][Feature:EgressIP]", func() {
+	oc := exutil.NewCLIWithPodSecurityLevel(namespacePrefix, admissionapi.LevelPrivileged)
+
+	var (
+		clientset               kubernetes.Interface
+		tmpDirEgressIP          string
+		workerNodesOrderedNames []string
+	)
+
+	g.BeforeEach(func() {
+		g.By("Verifying that this cluster uses a network plugin that is supported for this test")
+		if networkPluginName() != OVNKubernetesPluginName {
+			skipper.Skipf("This cluster does not use OVN Kubernetes")
+		}
+
+		g.By("Creating a temp directory")
+		var err error
+		tmpDirEgressIP, err = ioutil.TempDir("", "egressip-e2e")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Getting the kubernetes clientset")
+		clientset = oc.KubeFramework().ClientSet
+
+		g.By("Getting all worker nodes in alphabetical order")
+		workerNodesOrdered, err := getWorkerNodesOrdered(clientset)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		workerNodesOrderedNames = nil
+		for _, s := range workerNodesOrdered {
+			workerNodesOrderedNames = append(workerNodesOrderedNames, s.Name)
+		}
+		if len(workerNodesOrdered) < 3 {
+			skipper.Skipf("This test requires a minimum of 3 worker nodes. However, this environment has %d worker nodes.", len(workerNodesOrdered))
+		}
+	})
+
+	g.AfterEach(func() {
+		g.By("Removing the temp directory")
+		os.RemoveAll(tmpDirEgressIP)
+	})
+
+	g.It("should prevent duplicate MAC responses during EgressIP failover [Serial]", func() {
+		g.By("Checking platform type - this test requires L2 network adjacency")
+		infra, err := oc.AdminConfigClient().ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		if infra.Status.PlatformStatus != nil {
+			platformType := infra.Status.PlatformStatus.Type
+			cloudPlatforms := []configv1.PlatformType{
+				configv1.AWSPlatformType,
+				configv1.GCPPlatformType,
+				configv1.AzurePlatformType,
+				configv1.OpenStackPlatformType,
+			}
+			for _, cp := range cloudPlatforms {
+				if platformType == cp {
+					skipper.Skipf("This test requires L2 network adjacency (baremetal); cloud platform %s is not supported", platformType)
+				}
+			}
+		}
+
+		probeNodeName := workerNodesOrderedNames[0]
+		egressNode1Name := workerNodesOrderedNames[1]
+		egressNode2Name := workerNodesOrderedNames[2]
+		const egressIPObjectName = "egressip-mac-test"
+
+		g.By("Labeling egress nodes as egress-assignable")
+		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode2Name, "k8s.ovn.org/egress-assignable=")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Allocating an EgressIP from egress node 1")
+		nodeEgressIPMap, err := findNodeEgressIPsBaremetal(oc, clientset, []string{egressNode1Name})
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(nodeEgressIPMap).To(o.HaveKey(egressNode1Name))
+		egressIPStr := nodeEgressIPMap[egressNode1Name][0]
+
+		g.By("Creating and applying the EgressIP object")
+		egressIPYamlPath := tmpDirEgressIP + "/" + egressIPYaml
+		egressIPSet := map[string]string{egressIPStr: egressNode1Name}
+		createEgressIPObject(oc, egressIPYamlPath, egressIPObjectName, oc.Namespace(), "", egressIPSet)
+		_, err = runOcWithRetry(oc.AsAdmin(), "create", "-f", egressIPYamlPath)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Verifying EgressIP is assigned to egress node 1")
+		o.Eventually(func() bool {
+			hasIP, assignedNode, err := egressIPStatusHasIP(oc, egressIPObjectName, egressIPStr)
+			return err == nil && hasIP && assignedNode == egressNode1Name
+		}, 60*time.Second, 5*time.Second).Should(o.BeTrue())
+
+		g.By("Getting physical interface names")
+		iface1, err := findBridgePhysicalInterface(oc, egressNode1Name, "br-ex")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		iface2, err := findBridgePhysicalInterface(oc, egressNode2Name, "br-ex")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		probeInterface, err := findBridgePhysicalInterface(oc, probeNodeName, "br-ex")
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Getting MAC addresses of egress nodes")
+		mac1, err := getNodeInterfaceMAC(oc, egressNode1Name, iface1)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		mac2, err := getNodeInterfaceMAC(oc, egressNode2Name, iface2)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Deleting ovnkube-node pod on egress node 1 to trigger EgressIP migration")
+		podInfo, err := ovnkubePod(oc, egressNode1Name)
+		o.Expect(err).NotTo(o.HaveOccurred())
+		err = oc.AsAdmin().KubeClient().CoreV1().Pods("openshift-ovn-kubernetes").Delete(context.Background(), podInfo.podName, metav1.DeleteOptions{})
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Waiting for EgressIP migration to egress node 2")
+		o.Eventually(func() bool {
+			hasIP, assignedNode, err := egressIPStatusHasIP(oc, egressIPObjectName, egressIPStr)
+			return err == nil && hasIP && assignedNode == egressNode2Name
+		}, 120*time.Second, 5*time.Second).Should(o.BeTrue())
+
+		g.By("Checking for duplicate MAC responses")
+		err = checkForDuplicateMACOnNode(oc, probeNodeName, probeInterface, egressIPStr, mac1, mac2, false, 20, 500*time.Millisecond)
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("Cleaning up labels")
+		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode1Name, "k8s.ovn.org/egress-assignable-")
+		o.Expect(err).NotTo(o.HaveOccurred())
+		_, err = runOcWithRetry(oc.AsAdmin(), "label", "node", egressNode2Name, "k8s.ovn.org/egress-assignable-")
+		o.Expect(err).NotTo(o.HaveOccurred())
+	})
+})

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1738,3 +1738,166 @@ func getEgressIP(oc *exutil.CLI, name string) (*EgressIP, error) {
 	}
 	return egressip, nil
 }
+
+func getNodeInterfaceMAC(oc *exutil.CLI, nodeName, interfaceName string) (string, error) {
+	ovnkubePodInfo, err := ovnkubePod(oc, nodeName)
+	if err != nil {
+		return "", fmt.Errorf("failed to find ovnkube-node pod on node %s: %v", nodeName, err)
+	}
+
+	cmd := fmt.Sprintf("ip link show %s", interfaceName)
+	output, err := adminExecInPod(oc, "openshift-ovn-kubernetes", ovnkubePodInfo.podName, ovnkubePodInfo.containerName, cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to get interface %s info on node %s: %v", interfaceName, nodeName, err)
+	}
+
+	macRegex := regexp.MustCompile(`link/ether\s+([0-9a-fA-F:]+)`)
+	matches := macRegex.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("could not parse MAC from ip link show output on node %s: %s", nodeName, output)
+	}
+	return strings.ToLower(strings.TrimSpace(matches[1])), nil
+}
+
+// checkForDuplicateMACOnNode performs arping (IPv4) or ndisc6 (IPv6) checks from a probe node's
+// ovnkube-node pod to detect duplicate MAC address responses after EgressIP migration.
+// Returns error immediately if old node MAC is detected responding.
+
+func checkForDuplicateMACOnNode(oc *exutil.CLI, probeNodeName, interfaceName, egressIP, oldMAC, expectedMAC string, isIPv6 bool, maxChecks int, checkInterval time.Duration) error {
+	macRegexArping := regexp.MustCompile(`\[([0-9a-fA-F:]+)\]`)
+	macRegexNdisc6 := regexp.MustCompile(`Target link-layer address:\s+([0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2}:[0-9a-fA-F]{1,2})`)
+
+	oldMAC = strings.ToLower(oldMAC)
+	expectedMAC = strings.ToLower(expectedMAC)
+
+	probePodInfo, err := ovnkubePod(oc, probeNodeName)
+	if err != nil {
+		return fmt.Errorf("failed to find ovnkube-node pod on probe node %s: %v", probeNodeName, err)
+	}
+
+	var toolName string
+	if isIPv6 {
+		toolName = "ndisc6"
+	} else {
+		toolName = "arping"
+	}
+
+	whichCmd := fmt.Sprintf("which %s 2>&1", toolName)
+	_, whichErr := adminExecInPod(oc, "openshift-ovn-kubernetes", probePodInfo.podName, probePodInfo.containerName, whichCmd)
+	if whichErr != nil {
+		return fmt.Errorf("required binary %s not found in pod %s on node %s", toolName, probePodInfo.podName, probeNodeName)
+	}
+
+	framework.Logf("Checking for duplicate MAC responses using %s from node %s (old MAC: %s, expected MAC: %s)...",
+		toolName, probeNodeName, oldMAC, expectedMAC)
+
+	foundExpected := false
+	for i := 0; i < maxChecks; i++ {
+		var cmd string
+		var macRegex *regexp.Regexp
+
+		if isIPv6 {
+			cmd = fmt.Sprintf("ndisc6 -1 -w 1000 %s %s 2>&1", egressIP, interfaceName)
+			macRegex = macRegexNdisc6
+		} else {
+			cmd = fmt.Sprintf("arping -c 1 -I %s %s 2>&1", interfaceName, egressIP)
+			macRegex = macRegexArping
+		}
+
+		output, execErr := adminExecInPod(oc, "openshift-ovn-kubernetes", probePodInfo.podName, probePodInfo.containerName, cmd)
+		if execErr != nil {
+			framework.Logf("Check %d/%d: %s command returned error: %v; output: %s", i+1, maxChecks, toolName, execErr, output)
+		}
+
+		matches := macRegex.FindStringSubmatch(output)
+		if len(matches) >= 2 {
+			respondingMAC := strings.ToLower(strings.TrimSpace(matches[1]))
+			if respondingMAC == oldMAC {
+				return fmt.Errorf("DUPLICATE MAC DETECTED on check %d: Old node MAC %s responded to %s for egress IP %s after migration. "+
+					"The nftables drop rules should have prevented this response", i+1, oldMAC, toolName, egressIP)
+			} else if respondingMAC == expectedMAC {
+				foundExpected = true
+				framework.Logf("Check %d/%d: New node MAC %s is responding (expected)", i+1, maxChecks, expectedMAC)
+			} else {
+				return fmt.Errorf("unexpected MAC %s (not old %s or expected %s)", respondingMAC, oldMAC, expectedMAC)
+			}
+		}
+
+		if i < maxChecks-1 {
+			time.Sleep(checkInterval)
+		}
+	}
+
+	if !foundExpected {
+		return fmt.Errorf("did not observe expected MAC %s responding to %s for egress IP %s after %d checks",
+			expectedMAC, toolName, egressIP, maxChecks)
+	}
+	framework.Logf("No duplicate MAC detected - nftables rules successfully blocked responses from old node")
+	return nil
+}
+
+// findNodeEgressIPsBaremetal allocates EgressIPs from node egress-ipconfig annotations
+// without requiring the CloudPrivateIPConfig CRD (which only exists on cloud platforms).
+
+func findNodeEgressIPsBaremetal(oc *exutil.CLI, clientset kubernetes.Interface, nodeNames []string) (map[string][]string, error) {
+	var reservedIPs []string
+
+	egressipList, err := listEgressIPs(oc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list EgressIPs: %v", err)
+	}
+	for _, egressip := range egressipList.Items {
+		reservedIPs = append(reservedIPs, egressip.Spec.EgressIPs...)
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for _, node := range nodes.Items {
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				reservedIPs = append(reservedIPs, addr.Address)
+			}
+		}
+	}
+
+	nodeEgressIPs := make(map[string][]string)
+	for _, nodeName := range nodeNames {
+		node, err := clientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		nodeEgressIPConfigs, err := getNodeEgressIPConfiguration(node)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get egress IP configuration for node %s: %v", nodeName, err)
+		}
+		if l := len(nodeEgressIPConfigs); l != 1 {
+			return nil, fmt.Errorf("unexpected length of egress IP configuration for node %s: %d", nodeName, l)
+		}
+		ipnetStr := nodeEgressIPConfigs[0].IFAddr.IPv4
+		if ipnetStr == "" {
+			ipnetStr = nodeEgressIPConfigs[0].IFAddr.IPv6
+			if ipnetStr != "" {
+				_, ipnet, parseErr := net.ParseCIDR(ipnetStr)
+				if parseErr != nil {
+					return nil, fmt.Errorf("failed to parse IPv6 CIDR %s for node %s: %v", ipnetStr, nodeName, parseErr)
+				}
+				ones, _ := ipnet.Mask.Size()
+				if ones < 120 {
+					return nil, fmt.Errorf("IPv6 egress CIDR %s on node %s has prefix /%d which is too large to enumerate; minimum /120 required", ipnetStr, nodeName, ones)
+				}
+			}
+		}
+		freeIPs, err := getFirstFreeIPs(ipnetStr, reservedIPs, configv1.NonePlatformType, 1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to find free EgressIP for node %s: %v", nodeName, err)
+		}
+		nodeEgressIPs[nodeName] = freeIPs
+		for _, freeIP := range freeIPs {
+			reservedIPs = append(reservedIPs, freeIP)
+		}
+	}
+
+	return nodeEgressIPs, nil
+}

--- a/test/extended/networking/egressip_helpers.go
+++ b/test/extended/networking/egressip_helpers.go
@@ -1809,17 +1809,29 @@ func checkForDuplicateMACOnNode(oc *exutil.CLI, probeNodeName, interfaceName, eg
 			framework.Logf("Check %d/%d: %s command returned error: %v; output: %s", i+1, maxChecks, toolName, execErr, output)
 		}
 
-		matches := macRegex.FindStringSubmatch(output)
-		if len(matches) >= 2 {
-			respondingMAC := strings.ToLower(strings.TrimSpace(matches[1]))
-			if respondingMAC == oldMAC {
-				return fmt.Errorf("DUPLICATE MAC DETECTED on check %d: Old node MAC %s responded to %s for egress IP %s after migration. "+
-					"The nftables drop rules should have prevented this response", i+1, oldMAC, toolName, egressIP)
-			} else if respondingMAC == expectedMAC {
+		// Find all MAC matches in the output
+		allMatches := macRegex.FindAllStringSubmatch(output, -1)
+		if len(allMatches) > 0 {
+			var foundExpectedInThisCheck bool
+			for _, match := range allMatches {
+				if len(match) >= 2 {
+					respondingMAC := strings.ToLower(strings.TrimSpace(match[1]))
+					// Reject any match equal to oldMAC (duplicate response)
+					if respondingMAC == oldMAC {
+						return fmt.Errorf("DUPLICATE MAC DETECTED on check %d: Old node MAC %s responded to %s for egress IP %s after migration. "+
+							"The nftables drop rules should have prevented this response", i+1, oldMAC, toolName, egressIP)
+					}
+					if respondingMAC == expectedMAC {
+						foundExpectedInThisCheck = true
+					} else if respondingMAC != oldMAC && respondingMAC != expectedMAC {
+						// Only report unexpected MACs that aren't the old or expected ones
+						return fmt.Errorf("unexpected MAC %s (not old %s or expected %s)", respondingMAC, oldMAC, expectedMAC)
+					}
+				}
+			}
+			if foundExpectedInThisCheck {
 				foundExpected = true
 				framework.Logf("Check %d/%d: New node MAC %s is responding (expected)", i+1, maxChecks, expectedMAC)
-			} else {
-				return fmt.Errorf("unexpected MAC %s (not old %s or expected %s)", respondingMAC, oldMAC, expectedMAC)
 			}
 		}
 
@@ -1887,6 +1899,16 @@ func findNodeEgressIPsBaremetal(oc *exutil.CLI, clientset kubernetes.Interface, 
 				if ones < 120 {
 					return nil, fmt.Errorf("IPv6 egress CIDR %s on node %s has prefix /%d which is too large to enumerate; minimum /120 required", ipnetStr, nodeName, ones)
 				}
+			}
+		} else {
+			// Bound IPv4 CIDR enumeration to prevent exhausting resources with large subnets
+			_, ipnet, parseErr := net.ParseCIDR(ipnetStr)
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse IPv4 CIDR %s for node %s: %v", ipnetStr, nodeName, parseErr)
+			}
+			ones, _ := ipnet.Mask.Size()
+			if ones < 25 {
+				return nil, fmt.Errorf("IPv4 egress CIDR %s on node %s has prefix /%d which is too large to enumerate; maximum /25 supported to prevent resource exhaustion", ipnetStr, nodeName, ones)
 			}
 		}
 		freeIPs, err := getFirstFreeIPs(ipnetStr, reservedIPs, configv1.NonePlatformType, 1)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for EgressIP failover on bare-metal clusters.
  - Verifies that traffic migrates correctly between nodes when the active node becomes unavailable.
  - Confirms that failover does not produce duplicate MAC responses for either IPv4 or IPv6 EgressIPs.
  - Includes validation of EgressIP allocation and assignment during the failover scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->