### PR TITLE
NO-JIRA: Add a new test for mass DNS disruption

### DIFF
--- a/pkg/defaultmonitortests/types.go
+++ b/pkg/defaultmonitortests/types.go
@@ -54,6 +54,7 @@ import (
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalgcpcloudservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionexternalservicemonitoring"
 	"github.com/openshift/origin/pkg/monitortests/testframework/disruptionserializer"
+	"github.com/openshift/origin/pkg/monitortests/testframework/dnsdisruptionstats"
 	"github.com/openshift/origin/pkg/monitortests/testframework/e2etestanalyzer"
 	"github.com/openshift/origin/pkg/monitortests/testframework/etcddiskmetricsintervals"
 	"github.com/openshift/origin/pkg/monitortests/testframework/highcputestanalyzer"
@@ -189,6 +190,7 @@ func newDefaultMonitorTests(info monitortestframework.MonitorTestInitializationI
 	monitorTestRegistry.AddMonitorTestOrDie("alert-summary-serializer", "Test Framework", alertanalyzer.NewAlertSummarySerializer())
 	monitorTestRegistry.AddMonitorTestOrDie("metrics-endpoints-down", "Test Framework", metricsendpointdown.NewMetricsEndpointDown())
 	monitorTestRegistry.AddMonitorTestOrDie("interval-duration-sum", "Test Framework", intervaldurationsum.NewIntervalDurationSum())
+	monitorTestRegistry.AddMonitorTestOrDie("dns-disruption-stats", "Test Framework", dnsdisruptionstats.NewDNSDisruptionStats())
 	monitorTestRegistry.AddMonitorTestOrDie("external-service-availability", "Test Framework", disruptionexternalservicemonitoring.NewAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("external-gcp-cloud-service-availability", "Test Framework", disruptionexternalgcpcloudservicemonitoring.NewCloudAvailabilityInvariant())
 	monitorTestRegistry.AddMonitorTestOrDie("external-aws-cloud-service-availability", "Test Framework", disruptionexternalawscloudservicemonitoring.NewCloudAvailabilityInvariant())

--- a/pkg/monitortests/network/legacynetworkmonitortests/disruption_test.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/disruption_test.go
@@ -242,3 +242,63 @@ func Test_dnsOverlapDisruption(t *testing.T) {
 		})
 	}
 }
+
+func Test_noExcessiveDNSDisruption(t *testing.T) {
+	makeDNSEvent := func() monitorapi.Interval {
+		return monitorapi.Interval{
+			Condition: monitorapi.Condition{
+				Locator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeDisruption,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorDisruptionKey: "openshift-api",
+						monitorapi.LocatorConnectionKey: "new",
+					},
+				},
+				Message: monitorapi.Message{
+					Reason:       monitorapi.DisruptionSamplerOutageBeganEventReason,
+					HumanMessage: "DNS lookup timeouts began",
+				},
+			},
+			From: time.Now(),
+			To:   time.Now().Add(1 * time.Second),
+		}
+	}
+
+	testCases := []struct {
+		name       string
+		eventCount int
+		expectFail bool
+	}{
+		{
+			name:       "no DNS events passes",
+			eventCount: 0,
+			expectFail: false,
+		},
+		{
+			name:       "50 DNS events passes",
+			eventCount: 50,
+			expectFail: false,
+		},
+		{
+			name:       "51 DNS events fails",
+			eventCount: 51,
+			expectFail: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			events := monitorapi.Intervals{}
+			for i := 0; i < tc.eventCount; i++ {
+				events = append(events, makeDNSEvent())
+			}
+			results := testNoExcessiveDNSDisruption(events)
+			assert.Equal(t, 1, len(results))
+			if tc.expectFail {
+				assert.NotNil(t, results[0].FailureOutput, "expected failure")
+			} else {
+				assert.Nil(t, results[0].FailureOutput, "expected pass")
+			}
+		})
+	}
+}

--- a/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/monitortest.go
@@ -43,6 +43,7 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	junits = append(junits, testPodSandboxCreation(finalIntervals, w.adminRESTConfig)...)
 	junits = append(junits, testOvnNodeReadinessProbe(finalIntervals, w.adminRESTConfig)...)
 	junits = append(junits, testNoDNSLookupErrorsInDisruptionSamplers(finalIntervals)...)
+	junits = append(junits, testNoExcessiveDNSDisruption(finalIntervals)...)
 	junits = append(junits, testNoOVSVswitchdUnreasonablyLongPollIntervals(finalIntervals)...)
 	junits = append(junits, testPodIPReuse(finalIntervals)...)
 	junits = append(junits, testErrorUpdatingEndpointSlices(finalIntervals)...)

--- a/pkg/monitortests/network/legacynetworkmonitortests/networking.go
+++ b/pkg/monitortests/network/legacynetworkmonitortests/networking.go
@@ -459,6 +459,35 @@ func testNoDNSLookupErrorsInDisruptionSamplers(events monitorapi.Intervals) []*j
 	}
 }
 
+// testNoExcessiveDNSDisruption similar to above test just looks for job runs that were hit really hard, and will fail not flake.
+func testNoExcessiveDNSDisruption(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
+	const testName = "[sig-trt] excessive DNS lookup errors should not be encountered in disruption samples"
+	const threshold = 50
+
+	count := 0
+	for _, event := range events {
+		if event.Message.Reason == monitorapi.DisruptionSamplerOutageBeganEventReason {
+			count++
+		}
+	}
+
+	if count <= threshold {
+		return []*junitapi.JUnitTestCase{
+			{Name: testName},
+		}
+	}
+
+	return []*junitapi.JUnitTestCase{
+		{
+			Name: testName,
+			FailureOutput: &junitapi.FailureOutput{
+				Output: fmt.Sprintf("Found %d DNS lookup timeout disruption events, which exceeds the threshold of %d. "+
+					"This implies persistent DNS issues in the CI cluster running the tests and is often the cause of mass test failures.", count, threshold),
+			},
+		},
+	}
+}
+
 func testNoOVSVswitchdUnreasonablyLongPollIntervals(events monitorapi.Intervals) []*junitapi.JUnitTestCase {
 	const testName = "[sig-network] ovs-vswitchd should not log any unreasonably long poll intervals to system journal"
 	success := &junitapi.JUnitTestCase{Name: testName}

--- a/pkg/monitortests/testframework/dnsdisruptionstats/monitortest.go
+++ b/pkg/monitortests/testframework/dnsdisruptionstats/monitortest.go
@@ -1,0 +1,82 @@
+package dnsdisruptionstats
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/openshift/origin/pkg/dataloader"
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestframework"
+	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+)
+
+type dnsDisruptionStats struct{}
+
+func NewDNSDisruptionStats() monitortestframework.MonitorTest {
+	return &dnsDisruptionStats{}
+}
+
+func (w *dnsDisruptionStats) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (w *dnsDisruptionStats) StartCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	return nil
+}
+
+func (w *dnsDisruptionStats) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	return nil, nil, nil
+}
+
+func (w *dnsDisruptionStats) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	return nil, nil
+}
+
+func (w *dnsDisruptionStats) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
+	return nil, nil
+}
+
+func (w *dnsDisruptionStats) WriteContentToStorage(ctx context.Context, storageDir, timeSuffix string, finalIntervals monitorapi.Intervals, finalResourceState monitorapi.ResourcesMap) error {
+	logger := logrus.WithField("MonitorTest", "DNSDisruptionStats")
+
+	dnsIntervals := finalIntervals.Filter(func(eventInterval monitorapi.Interval) bool {
+		return eventInterval.Message.Reason == monitorapi.DisruptionSamplerOutageBeganEventReason
+	})
+
+	var totalDurationSeconds int
+	for _, interval := range dnsIntervals {
+		totalDurationSeconds += int(interval.To.Sub(interval.From).Seconds())
+	}
+
+	logger.Infof("DNS disruption: %d intervals, %d total seconds", len(dnsIntervals), totalDurationSeconds)
+
+	dataFile := dataloader.DataFile{
+		TableName: "dns_disruption_stats",
+		Schema: map[string]dataloader.DataType{
+			"IntervalCount":        dataloader.DataTypeInteger,
+			"TotalDurationSeconds": dataloader.DataTypeInteger,
+		},
+		Rows: []map[string]string{
+			{
+				"IntervalCount":        fmt.Sprintf("%d", len(dnsIntervals)),
+				"TotalDurationSeconds": fmt.Sprintf("%d", totalDurationSeconds),
+			},
+		},
+	}
+
+	fileName := filepath.Join(storageDir, fmt.Sprintf("dns-disruption-stats%s-%s", timeSuffix, dataloader.AutoDataLoaderSuffix))
+	if err := dataloader.WriteDataFile(fileName, dataFile); err != nil {
+		logger.WithError(err).Warnf("unable to write data file: %s", fileName)
+		return fmt.Errorf("failed to write dns disruption stats: %w", err)
+	}
+
+	return nil
+}
+
+func (w *dnsDisruptionStats) Cleanup(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
We need a more crisp detection mechanism for job runs hitting serious mass disruption. Existing test flakes if we see ANY, that's quite common, but these runs where we have catastrophic outages are difficult to hunt for. This test should make it easy to find job runs across platforms and build clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added DNS disruption statistics monitoring, including outage counts and total disruption duration.
  - Network monitoring now reports when DNS disruption events exceed the permitted threshold of 50 events.
- **Tests**
  - Added coverage for zero disruptions, the 50-event limit, and disruption counts above the limit to verify monitoring results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->