### PR TITLE
Allow openshift/conformance/serial tests 50 min to complete

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -136,7 +136,7 @@ var staticSuites = []ginkgo.TestSuite{
 			// Standard early and late tests are included in the serial suite
 			withExcludedTestsFilter(withStandardEarlyOrLateTests("name.contains('[Suite:openshift/conformance/serial')")),
 		},
-		TestTimeout: 40 * time.Minute,
+		TestTimeout: 50 * time.Minute,
 		Parallelism: 1,
 	},
 	{


### PR DESCRIPTION
The bump from 40 to 50 min is because we have observed significant slowdowns in AWS loadbalancer/healthcheck behavior, causing kube-apiserver to take longer to wait for network loadbalancers to drain so that it can safely shut down. In observation, this means that a KAS rollout now takes ~20 minutes. A test that does a rollout and then reverts its change needs ~40 minutes just for rollouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for the OpenShift conformance test suite from 40 to 50 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->