### PR TITLE
OKD-454: Skip OKD job name check for cluster-bot launch jobs

### DIFF
--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -271,7 +271,8 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName, rawJobName string) {
 	// The job RAW name (the one that still has the variant and platform) is used
 	// to perform the OKD check as the stripped version has already lost the variant
 	isOKD := strings.Contains(clusterVersion.Status.Desired.Version, "okd-scos")
-	if isOKD && !strings.Contains(rawJobName, "okd-scos") {
+	isLaunchJob := strings.Contains(rawJobName, "installer-launch")
+	if isOKD && !strings.Contains(rawJobName, "okd-scos") && !isLaunchJob {
 		e2e.Failf("cluster is OKD but job name %q does not contain 'okd-scos'", jobName)
 	}
 	if !isOKD && strings.Contains(rawJobName, "okd-scos") {

--- a/test/extended/ci/job_names.go
+++ b/test/extended/ci/job_names.go
@@ -271,6 +271,7 @@ func validateStandaloneNodeOS(oc *exutil.CLI, jobName, rawJobName string) {
 	// The job RAW name (the one that still has the variant and platform) is used
 	// to perform the OKD check as the stripped version has already lost the variant
 	isOKD := strings.Contains(clusterVersion.Status.Desired.Version, "okd-scos")
+	// Cluster-bot launch jobs are variant-agnostic and don't include okd-scos in their name
 	isLaunchJob := strings.Contains(rawJobName, "installer-launch")
 	if isOKD && !strings.Contains(rawJobName, "okd-scos") && !isLaunchJob {
 		e2e.Failf("cluster is OKD but job name %q does not contain 'okd-scos'", jobName)


### PR DESCRIPTION
## Summary

- Skip the OKD name check in `[sig-ci] [Early] prow job name should match os version` for cluster-bot launch jobs
- Launch jobs use generic names like `release-openshift-origin-installer-launch-aws-modern` that intentionally don't contain variant identifiers like `okd-scos`
- All other OS validation (OS stream, OSImageStream CR, node OS checks) continues to run for launch jobs

## Problem

After promoting `5.0.0-okd-scos.ec.9`, upgrade edge verification via cluster-bot fails with:

> cluster is OKD but job name "release-openshift-origin-installer-launch-aws-modern" does not contain 'okd-scos'

The upgrade itself succeeds — all 56 upgrade tests pass (4.22.0-okd-scos.10 → 5.0.0-okd-scos.ec.9). The failure is purely the job naming convention check.

The nightly's `aws-upgrade-minor` test passes because its job name (`periodic-ci-openshift-release-main-okd-scos-5.0-...`) contains `okd-scos`.

Failing job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/2097729860586704896

Jira: https://issues.redhat.com/browse/OKD-454

## Test plan

- [ ] Verify OKD SCOS clusters launched via cluster-bot no longer fail the job name check
- [ ] Verify OKD SCOS clusters in properly-named jobs (e.g. `okd-scos-*`) still pass the check
- [ ] Verify non-OKD clusters with `okd-scos` in the job name still fail the reverse check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated job-name validation so installer-launch jobs are accepted even when their names do not include the standard OKD-SCOS identifier.
  - Other OKD job names continue to be checked for the required naming convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->