### PR TITLE
OCPBUGS-115111: Tolerate HyperShift startup pod alerts

### DIFF
--- a/pkg/monitortests/node/watchpods/compute_intervals.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals.go
@@ -47,7 +47,7 @@ func intervalsFromEvents_PodChanges(events monitorapi.Intervals, beginning, end 
 	return intervals
 }
 
-func createPodIntervalsFromInstants(input monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, startTime, endTime time.Time) monitorapi.Intervals {
+func createPodIntervalsFromInstants(input monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, startTime, endTime time.Time, externalTopology bool) monitorapi.Intervals {
 	sort.Stable(ByPodLifecycle(input))
 	// these *static* locators to events. These are NOT the same as the actual event locators because nodes are not consistently assigned.
 	// As such we need to strip out all but the essential locator keys for both pods and containers so we can consistently key them in maps
@@ -123,14 +123,14 @@ func createPodIntervalsFromInstants(input monitorapi.Intervals, recordedResource
 	ret := monitorapi.Intervals{}
 	ret = append(ret,
 		buildTransitionsForCategory(podToStateTransitions, locatorKeyToLocator,
-			monitorapi.PodReasonCreated, monitorapi.PodReasonDeleted, podTimeBounder)...,
+			monitorapi.PodReasonCreated, monitorapi.PodReasonDeleted, podTimeBounder, false)...,
 	)
 	ret = append(ret,
 		buildTransitionsForCategory(containerToLifecycleTransitions, locatorKeyToLocator,
-			monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerExit, containerTimeBounder)...,
+			monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerExit, containerTimeBounder, externalTopology)...,
 	)
 	is := buildTransitionsForCategory(containerToReadinessTransitions, locatorKeyToLocator,
-		monitorapi.ContainerReasonNotReady, "", containerReadinessTimeBounder)
+		monitorapi.ContainerReasonNotReady, "", containerReadinessTimeBounder, false)
 	ret = append(ret,
 		is...,
 	)
@@ -514,7 +514,8 @@ type timeBounder interface {
 func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Interval,
 	locatorKeys map[string]monitorapi.Locator,
 	startReason, endReason monitorapi.IntervalReason,
-	timeBounder timeBounder) monitorapi.Intervals {
+	timeBounder timeBounder,
+	allowMissingInitialWait bool) monitorapi.Intervals {
 
 	ret := monitorapi.Intervals{}
 	// now step through each category and build the to/from interval
@@ -526,6 +527,7 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 		startTime := timeBounder.getStartTime(locator)
 		endTime := timeBounder.getEndTime(locator)
 		prevEvent := emptyEvent(timeBounder.getStartTime(locator))
+		hasObservedEvent := false
 		for i := range instantEvents {
 			hasPrev := len(prevEvent.Message.HumanMessage) > 0 || len(prevEvent.Message.Reason) > 0 || len(prevEvent.Message.Annotations) > 0
 			currEvent := instantEvents[i]
@@ -546,9 +548,19 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 				// but we need the message from the currEvent
 				prevEvent = nextInterval
 				prevEvent.Message = currEvent.Message
+				hasObservedEvent = true
 				continue
 
 			case !hasPrev && currReason != startReason:
+				if allowMissingInitialWait && !hasObservedEvent && currReason == monitorapi.ContainerReasonContainerStart {
+					// External topology can expose a running container before the
+					// initial waiting state is observed. Treat that as the beginning
+					// of the known lifecycle instead of a failed startup.
+					prevEvent = currEvent
+					hasObservedEvent = true
+					continue
+				}
+
 				// we missed the startReason (it probably happened before the watch was established).
 				// adjust the message to indicate that we missed the start event for this locator
 				// TODO: Unfortunate hack required for the nextInterval modification, would like to see a better way here someday
@@ -563,6 +575,7 @@ func buildTransitionsForCategory(locatorToIntervals map[string][]monitorapi.Inte
 			} else {
 				prevEvent = currEvent
 			}
+			hasObservedEvent = true
 			ret = append(ret, nextInterval)
 		}
 		if len(prevEvent.Message.HumanMessage) > 0 || len(prevEvent.Message.Reason) > 0 || len(prevEvent.Message.Annotations) > 0 {

--- a/pkg/monitortests/node/watchpods/compute_intervals_test.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals_test.go
@@ -15,6 +15,106 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestBuildTransitionsForCategory(t *testing.T) {
+	startTime := time.Date(2022, time.March, 7, 18, 41, 46, 0, time.UTC)
+	endTime := startTime.Add(5 * time.Minute)
+	containerLocator := monitorapi.NewLocator().ContainerFromNames("namespace", "pod", "uid", "container")
+	containerKey := containerLocator.OldLocator()
+	locatorKeys := map[string]monitorapi.Locator{containerKey: containerLocator}
+
+	containerStart := monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+		Locator(containerLocator).
+		Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonContainerStart)).
+		Build(startTime.Add(time.Minute), startTime.Add(time.Minute))
+	containerWait := monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+		Locator(containerLocator).
+		Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonContainerWait)).
+		Build(startTime.Add(30*time.Second), startTime.Add(30*time.Second))
+	containerExit := monitorapi.NewInterval(monitorapi.SourcePodMonitor, monitorapi.Info).
+		Locator(containerLocator).
+		Message(monitorapi.NewMessage().Reason(monitorapi.ContainerReasonContainerExit)).
+		Build(startTime.Add(2*time.Minute), startTime.Add(2*time.Minute))
+
+	tests := []struct {
+		name                    string
+		events                  monitorapi.Intervals
+		allowMissingInitialWait bool
+		wantReasons             []monitorapi.IntervalReason
+		wantFirstHumanText      string
+	}{
+		{
+			name:               "standalone topology reports an unobserved initial ContainerWait",
+			events:             monitorapi.Intervals{containerStart},
+			wantReasons:        []monitorapi.IntervalReason{monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerStart},
+			wantFirstHumanText: `missed real "ContainerWait"`,
+		},
+		{
+			name:                    "external topology accepts ContainerStart as the first observed lifecycle state",
+			events:                  monitorapi.Intervals{containerStart},
+			allowMissingInitialWait: true,
+			wantReasons:             []monitorapi.IntervalReason{monitorapi.ContainerReasonContainerStart},
+		},
+		{
+			name:                    "external topology preserves a recorded ContainerWait before ContainerStart",
+			events:                  monitorapi.Intervals{containerWait, containerStart},
+			allowMissingInitialWait: true,
+			wantReasons:             []monitorapi.IntervalReason{monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerStart},
+		},
+		{
+			name:                    "external topology reports an unobserved ContainerWait before ContainerExit",
+			events:                  monitorapi.Intervals{containerExit},
+			allowMissingInitialWait: true,
+			wantReasons:             []monitorapi.IntervalReason{monitorapi.ContainerReasonContainerWait},
+			wantFirstHumanText:      `missed real "ContainerWait"`,
+		},
+		{
+			name:                    "external topology reports an unobserved ContainerWait after a restart",
+			events:                  monitorapi.Intervals{containerWait, containerExit, containerStart},
+			allowMissingInitialWait: true,
+			wantReasons:             []monitorapi.IntervalReason{monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerWait, monitorapi.ContainerReasonContainerStart},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := map[string][]monitorapi.Interval{containerKey: tt.events}
+			got := buildTransitionsForCategory(
+				events,
+				locatorKeys,
+				monitorapi.ContainerReasonContainerWait,
+				monitorapi.ContainerReasonContainerExit,
+				newSimpleTimeBounder(startTime, endTime),
+				tt.allowMissingInitialWait,
+			)
+
+			if assert.Len(t, got, len(tt.wantReasons)) {
+				for i, wantReason := range tt.wantReasons {
+					assert.Equal(t, wantReason, got[i].Message.Reason)
+				}
+			}
+			if tt.wantFirstHumanText != "" && assert.NotEmpty(t, got) {
+				assert.Equal(t, tt.wantFirstHumanText, got[0].Message.HumanMessage)
+			}
+		})
+	}
+
+	t.Run("external topology reports a missing wait after ContainerExit", func(t *testing.T) {
+		events := map[string][]monitorapi.Interval{containerKey: {containerWait, containerExit, containerStart}}
+		got := buildTransitionsForCategory(
+			events,
+			locatorKeys,
+			monitorapi.ContainerReasonContainerWait,
+			monitorapi.ContainerReasonContainerExit,
+			newSimpleTimeBounder(startTime, endTime),
+			true,
+		)
+
+		if assert.Len(t, got, 3) {
+			assert.Equal(t, `missed real "ContainerWait"`, got[1].Message.HumanMessage)
+		}
+	})
+}
+
 func TestPodIntervalCreation(t *testing.T) {
 	files, err := podTests.ReadDir("podTest")
 	if err != nil {
@@ -96,7 +196,7 @@ func (p podIntervalTest) test(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	result := createPodIntervalsFromInstants(inputIntervals, resourceMap, startTime, endTime)
+	result := createPodIntervalsFromInstants(inputIntervals, resourceMap, startTime, endTime, false)
 
 	resultBytes, err := monitorserialization.IntervalsToJSON(result)
 	if err != nil {

--- a/pkg/monitortests/node/watchpods/compute_intervals_test.go
+++ b/pkg/monitortests/node/watchpods/compute_intervals_test.go
@@ -1,6 +1,7 @@
 package watchpods
 
 import (
+	"context"
 	"embed"
 	_ "embed"
 	"encoding/json"
@@ -14,6 +15,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 )
+
+func TestPodWatcherConstructComputedIntervalsRequiresTopology(t *testing.T) {
+	watcher := &podWatcher{}
+
+	_, err := watcher.ConstructComputedIntervals(context.Background(), nil, nil, time.Time{}, time.Time{})
+
+	assert.EqualError(t, err, "cluster infrastructure topology was not initialized")
+}
 
 func TestBuildTransitionsForCategory(t *testing.T) {
 	startTime := time.Date(2022, time.March, 7, 18, 41, 46, 0, time.UTC)

--- a/pkg/monitortests/node/watchpods/monitortest.go
+++ b/pkg/monitortests/node/watchpods/monitortest.go
@@ -2,6 +2,7 @@ package watchpods
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -35,7 +36,7 @@ func (w *podWatcher) PrepareCollection(ctx context.Context, adminRESTConfig *res
 
 	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get cluster infrastructure: %w", err)
+		return errors.New("failed to get cluster infrastructure")
 	}
 	w.externalTopology = infrastructure.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
 

--- a/pkg/monitortests/node/watchpods/monitortest.go
+++ b/pkg/monitortests/node/watchpods/monitortest.go
@@ -19,9 +19,10 @@ import (
 )
 
 type podWatcher struct {
-	kubeClient       kubernetes.Interface
-	podInformer      coreinformers.PodInformer
-	externalTopology bool
+	kubeClient          kubernetes.Interface
+	podInformer         coreinformers.PodInformer
+	externalTopology    bool
+	topologyInitialized bool
 }
 
 func NewPodWatcher() monitortestframework.MonitorTest {
@@ -29,6 +30,9 @@ func NewPodWatcher() monitortestframework.MonitorTest {
 }
 
 func (w *podWatcher) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	w.externalTopology = false
+	w.topologyInitialized = false
+
 	configClient, err := configclient.NewForConfig(adminRESTConfig)
 	if err != nil {
 		return err
@@ -39,6 +43,7 @@ func (w *podWatcher) PrepareCollection(ctx context.Context, adminRESTConfig *res
 		return errors.New("failed to get cluster infrastructure")
 	}
 	w.externalTopology = infrastructure.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
+	w.topologyInitialized = true
 
 	return nil
 }
@@ -61,6 +66,10 @@ func (w *podWatcher) CollectData(ctx context.Context, storageDir string, beginni
 }
 
 func (w *podWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	if !w.topologyInitialized {
+		return nil, errors.New("cluster infrastructure topology was not initialized")
+	}
+
 	constructedIntervals := monitorapi.Intervals{}
 	constructedIntervals = append(constructedIntervals, createPodIntervalsFromInstants(startingIntervals, recordedResources, beginning, end, w.externalTopology)...)
 	constructedIntervals = append(constructedIntervals, intervalsFromEvents_PodChanges(startingIntervals, beginning, end)...)

--- a/pkg/monitortests/node/watchpods/monitortest.go
+++ b/pkg/monitortests/node/watchpods/monitortest.go
@@ -6,17 +6,21 @@ import (
 	"strings"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
+	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/origin/pkg/monitor/monitorapi"
 	"github.com/openshift/origin/pkg/monitortestframework"
 	"github.com/openshift/origin/pkg/test/ginkgo/junitapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
 type podWatcher struct {
-	kubeClient  kubernetes.Interface
-	podInformer coreinformers.PodInformer
+	kubeClient       kubernetes.Interface
+	podInformer      coreinformers.PodInformer
+	externalTopology bool
 }
 
 func NewPodWatcher() monitortestframework.MonitorTest {
@@ -24,6 +28,17 @@ func NewPodWatcher() monitortestframework.MonitorTest {
 }
 
 func (w *podWatcher) PrepareCollection(ctx context.Context, adminRESTConfig *rest.Config, recorder monitorapi.RecorderWriter) error {
+	configClient, err := configclient.NewForConfig(adminRESTConfig)
+	if err != nil {
+		return err
+	}
+
+	infrastructure, err := configClient.ConfigV1().Infrastructures().Get(ctx, "cluster", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get cluster infrastructure: %w", err)
+	}
+	w.externalTopology = infrastructure.Status.ControlPlaneTopology == configv1.ExternalTopologyMode
+
 	return nil
 }
 
@@ -44,9 +59,9 @@ func (w *podWatcher) CollectData(ctx context.Context, storageDir string, beginni
 	return nil, nil, nil
 }
 
-func (*podWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+func (w *podWatcher) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
 	constructedIntervals := monitorapi.Intervals{}
-	constructedIntervals = append(constructedIntervals, createPodIntervalsFromInstants(startingIntervals, recordedResources, beginning, end)...)
+	constructedIntervals = append(constructedIntervals, createPodIntervalsFromInstants(startingIntervals, recordedResources, beginning, end, w.externalTopology)...)
 	constructedIntervals = append(constructedIntervals, intervalsFromEvents_PodChanges(startingIntervals, beginning, end)...)
 
 	return constructedIntervals, nil

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -28,13 +28,25 @@ import (
 
 type AllowedAlertsFunc func(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending alerts.MetricConditions)
 
+// External-topology guest clusters can transiently report KubePodNotReady while
+// their control-plane operators and platform pods are starting.
+const externalTopologyAlertStartupGracePeriod = 5 * time.Minute
+
+var externalTopologyStartupAlertNamespaces = sets.NewString(
+	"openshift-dns",
+	"openshift-insights",
+	"openshift-ingress-canary",
+)
+
 func testAlerts(events monitorapi.Intervals,
 	allowancesFunc AllowedAlertsFunc,
 	jobType *platformidentification.JobType,
 	clusterStability *monitortestframework.ClusterStabilityDuringTest,
 	restConfig *rest.Config,
 	duration time.Duration,
+	beginning time.Time,
 	recordedResource monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
+	events = filterExternalTopologyStartupAlertIntervals(events, jobType, beginning)
 
 	// Work with the cluster under test before we run the alert tests. For testing the tests purposes,
 	// please keep any use of the rest.Config isolated to this function and do not have the actual
@@ -74,6 +86,33 @@ func testAlerts(events monitorapi.Intervals,
 
 	ret := RunAlertTests(jobType, clusterStability, allowancesFunc, featureSet, etcdAllowance, events, recordedResource)
 	return ret
+}
+
+func filterExternalTopologyStartupAlertIntervals(events monitorapi.Intervals, jobType *platformidentification.JobType, beginning time.Time) monitorapi.Intervals {
+	if jobType == nil || jobType.Topology != "external" || beginning.IsZero() {
+		return events
+	}
+
+	graceEnd := beginning.Add(externalTopologyAlertStartupGracePeriod)
+	var filtered monitorapi.Intervals
+	for _, event := range events {
+		alertName := event.Locator.Keys[monitorapi.LocatorAlertKey]
+		namespace := monitorapi.NamespaceFromLocator(event.Locator)
+		if alertName != "KubePodNotReady" || !externalTopologyStartupAlertNamespaces.Has(namespace) {
+			filtered = append(filtered, event)
+			continue
+		}
+
+		if !event.To.IsZero() && !event.To.After(graceEnd) {
+			continue
+		}
+		if event.From.Before(graceEnd) {
+			event.From = graceEnd
+		}
+		filtered = append(filtered, event)
+	}
+
+	return filtered
 }
 
 // RunAlertTests is a key entry point for running all per-Alert tests we've defined in all.go AllAlertTests,

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
@@ -21,6 +21,7 @@ const (
 
 type legacyAlertsMonitorTests struct {
 	adminRESTConfig            *rest.Config
+	beginning                  time.Time
 	duration                   time.Duration
 	recordedResources          monitorapi.ResourcesMap
 	clusterStabilityDuringTest *monitortestframework.ClusterStabilityDuringTest
@@ -44,11 +45,13 @@ func (w *legacyAlertsMonitorTests) StartCollection(ctx context.Context, adminRES
 }
 
 func (w *legacyAlertsMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	w.beginning = beginning
 	w.duration = end.Sub(beginning)
 	return nil, nil, nil
 }
 
 func (w *legacyAlertsMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	w.beginning = beginning
 	w.recordedResources = recordedResources
 	return nil, nil
 }
@@ -65,10 +68,10 @@ func (w *legacyAlertsMonitorTests) EvaluateTestsFromConstructedIntervals(ctx con
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringUpgrade, jobType, w.clusterStabilityDuringTest,
-			w.adminRESTConfig, w.duration, w.recordedResources)...)
+			w.adminRESTConfig, w.duration, w.beginning, w.recordedResources)...)
 	} else {
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringConformance, jobType, w.clusterStabilityDuringTest,
-			w.adminRESTConfig, w.duration, w.recordedResources)...)
+			w.adminRESTConfig, w.duration, w.beginning, w.recordedResources)...)
 	}
 
 	if w.flakeJunits {

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
@@ -150,3 +150,90 @@ func TestNoNewAlertsFiringBackstop(t *testing.T) {
 	}
 
 }
+
+func TestFilterExternalTopologyStartupAlertIntervals(t *testing.T) {
+	beginning := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	externalJob := &platformidentification.JobType{Topology: "external"}
+	haJob := &platformidentification.JobType{Topology: "ha"}
+
+	alertInterval := func(alertName, namespace string, from, to time.Duration) monitorapi.Interval {
+		return monitorapi.Interval{
+			Condition: monitorapi.Condition{
+				Locator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeAlert,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorAlertKey:     alertName,
+						monitorapi.LocatorNamespaceKey: namespace,
+					},
+				},
+			},
+			From: beginning.Add(from),
+			To:   beginning.Add(to),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		jobType  *platformidentification.JobType
+		start    time.Time
+		interval monitorapi.Interval
+		expected monitorapi.Intervals
+	}{
+		{
+			name:     "startup interval is ignored for affected namespace",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: nil,
+		},
+		{
+			name:     "interval crossing grace period is clipped",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-insights", time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-insights", 5*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "interval after grace period is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-ingress-canary", 6*time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-ingress-canary", 6*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "unrelated namespace is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-kube-apiserver", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-kube-apiserver", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "unrelated alert is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("ClusterOperatorDegraded", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("ClusterOperatorDegraded", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "non-external topology is unchanged",
+			jobType:  haJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "zero collection start is unchanged",
+			jobType:  externalJob,
+			start:    time.Time{},
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := filterExternalTopologyStartupAlertIntervals(monitorapi.Intervals{tt.interval}, tt.jobType, tt.start)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Tolerates bounded, expected `KubePodNotReady` alerts during HyperShift guest-cluster startup.

The exception applies only to external control-plane topology and the affected
`openshift-dns`, `openshift-insights`, and `openshift-ingress-canary`
namespaces.

## Why is this change needed?

HyperShift guest clusters can temporarily report these alerts while initial
platform pods converge. The monitor previously evaluated the startup intervals
with normal thresholds, causing false failures.

Intervals that continue beyond the five-minute startup grace period remain
subject to the existing checks.

## How was this tested?

- `go test ./pkg/monitortests/testframework/legacytestframeworkmonitortests`
- `go test ./pkg/monitortests/testframework/... ./pkg/cmd/openshift-tests/dev`
- `go test ./pkg/monitortests/...`

## Jira

https://issues.redhat.com/browse/OCPBUGS-115111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pod lifecycle monitoring for clusters with externally managed control-plane topology.
  - Prevented false “missed start” intervals when initial container startup events are unavailable.
  - Reduced transient startup alerts for selected control-plane components during the first five minutes of monitoring.
  - Startup alerts that continue beyond the grace period are now evaluated from the end of that period.
  - Added validation to ensure cluster topology information is available before computing pod monitoring results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->