### PR TITLE
OCPBUGS-115111: Tolerate HyperShift startup pod alerts

### DIFF
--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts.go
@@ -28,13 +28,25 @@ import (
 
 type AllowedAlertsFunc func(featureSet configv1.FeatureSet) (allowedFiringWithBugs, allowedFiring, allowedPendingWithBugs, allowedPending alerts.MetricConditions)
 
+// External-topology guest clusters can transiently report KubePodNotReady while
+// their control-plane operators and platform pods are starting.
+const externalTopologyAlertStartupGracePeriod = 5 * time.Minute
+
+var externalTopologyStartupAlertNamespaces = sets.NewString(
+	"openshift-dns",
+	"openshift-insights",
+	"openshift-ingress-canary",
+)
+
 func testAlerts(events monitorapi.Intervals,
 	allowancesFunc AllowedAlertsFunc,
 	jobType *platformidentification.JobType,
 	clusterStability *monitortestframework.ClusterStabilityDuringTest,
 	restConfig *rest.Config,
 	duration time.Duration,
+	beginning time.Time,
 	recordedResource monitorapi.ResourcesMap) []*junitapi.JUnitTestCase {
+	events = filterExternalTopologyStartupAlertIntervals(events, jobType, beginning)
 
 	// Work with the cluster under test before we run the alert tests. For testing the tests purposes,
 	// please keep any use of the rest.Config isolated to this function and do not have the actual
@@ -74,6 +86,33 @@ func testAlerts(events monitorapi.Intervals,
 
 	ret := RunAlertTests(jobType, clusterStability, allowancesFunc, featureSet, etcdAllowance, events, recordedResource)
 	return ret
+}
+
+func filterExternalTopologyStartupAlertIntervals(events monitorapi.Intervals, jobType *platformidentification.JobType, beginning time.Time) monitorapi.Intervals {
+	if jobType == nil || jobType.Topology != "external" || beginning.IsZero() {
+		return events
+	}
+
+	graceEnd := beginning.Add(externalTopologyAlertStartupGracePeriod)
+	var filtered monitorapi.Intervals
+	for _, event := range events {
+		alertName := event.Locator.Keys[monitorapi.LocatorAlertKey]
+		namespace := monitorapi.NamespaceFromLocator(event.Locator)
+		if alertName != "KubePodNotReady" || !externalTopologyStartupAlertNamespaces.Has(namespace) {
+			filtered = append(filtered, event)
+			continue
+		}
+
+		if !event.To.IsZero() && !event.To.After(graceEnd) {
+			continue
+		}
+		if event.From.Before(graceEnd) {
+			event.From = graceEnd
+		}
+		filtered = append(filtered, event)
+	}
+
+	return filtered
 }
 
 // RunAlertTests is a key entry point for running all per-Alert tests we've defined in all.go AllAlertTests,

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_monitortest.go
@@ -21,6 +21,7 @@ const (
 
 type legacyAlertsMonitorTests struct {
 	adminRESTConfig            *rest.Config
+	beginning                  time.Time
 	duration                   time.Duration
 	recordedResources          monitorapi.ResourcesMap
 	clusterStabilityDuringTest *monitortestframework.ClusterStabilityDuringTest
@@ -44,11 +45,13 @@ func (w *legacyAlertsMonitorTests) StartCollection(ctx context.Context, adminRES
 }
 
 func (w *legacyAlertsMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	w.beginning = beginning
 	w.duration = end.Sub(beginning)
 	return nil, nil, nil
 }
 
 func (w *legacyAlertsMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	w.beginning = beginning
 	w.recordedResources = recordedResources
 	return nil, nil
 }
@@ -65,10 +68,10 @@ func (w *legacyAlertsMonitorTests) EvaluateTestsFromConstructedIntervals(ctx con
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringUpgrade, jobType, w.clusterStabilityDuringTest,
-			w.adminRESTConfig, w.duration, w.recordedResources)...)
+			w.adminRESTConfig, w.duration, w.beginning, w.recordedResources)...)
 	} else {
 		junits = append(junits, testAlerts(finalIntervals, alerts.AllowedAlertsDuringConformance, jobType, w.clusterStabilityDuringTest,
-			w.adminRESTConfig, w.duration, w.recordedResources)...)
+			w.adminRESTConfig, w.duration, w.beginning, w.recordedResources)...)
 	}
 
 	if w.flakeJunits {

--- a/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
+++ b/pkg/monitortests/testframework/legacytestframeworkmonitortests/alerts_test.go
@@ -150,3 +150,90 @@ func TestNoNewAlertsFiringBackstop(t *testing.T) {
 	}
 
 }
+
+func TestFilterExternalTopologyStartupAlertIntervals(t *testing.T) {
+	beginning := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	externalJob := &platformidentification.JobType{Topology: "external"}
+	haJob := &platformidentification.JobType{Topology: "ha"}
+
+	alertInterval := func(alertName, namespace string, from, to time.Duration) monitorapi.Interval {
+		return monitorapi.Interval{
+			Condition: monitorapi.Condition{
+				Locator: monitorapi.Locator{
+					Type: monitorapi.LocatorTypeAlert,
+					Keys: map[monitorapi.LocatorKey]string{
+						monitorapi.LocatorAlertKey:     alertName,
+						monitorapi.LocatorNamespaceKey: namespace,
+					},
+				},
+			},
+			From: beginning.Add(from),
+			To:   beginning.Add(to),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		jobType  *platformidentification.JobType
+		start    time.Time
+		interval monitorapi.Interval
+		expected monitorapi.Intervals
+	}{
+		{
+			name:     "startup interval is ignored for affected namespace",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: nil,
+		},
+		{
+			name:     "interval crossing grace period is clipped",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-insights", time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-insights", 5*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "interval after grace period is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-ingress-canary", 6*time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-ingress-canary", 6*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "unrelated namespace is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-kube-apiserver", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-kube-apiserver", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "unrelated alert is unchanged",
+			jobType:  externalJob,
+			start:    beginning,
+			interval: alertInterval("ClusterOperatorDegraded", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("ClusterOperatorDegraded", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "non-external topology is unchanged",
+			jobType:  haJob,
+			start:    beginning,
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+		{
+			name:     "zero collection start is unchanged",
+			jobType:  externalJob,
+			start:    time.Time{},
+			interval: alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute),
+			expected: monitorapi.Intervals{alertInterval("KubePodNotReady", "openshift-dns", time.Minute, 3*time.Minute)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := filterExternalTopologyStartupAlertIntervals(monitorapi.Intervals{tt.interval}, tt.jobType, tt.start)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Tolerates bounded, expected `KubePodNotReady` alerts during HyperShift guest-cluster startup.

The exception applies only to external control-plane topology and the affected
`openshift-dns`, `openshift-insights`, and `openshift-ingress-canary`
namespaces.

## Why is this change needed?

HyperShift guest clusters can temporarily report these alerts while initial
platform pods converge. The monitor previously evaluated the startup intervals
with normal thresholds, causing false failures.

Intervals that continue beyond the five-minute startup grace period remain
subject to the existing checks.

## How was this tested?

- `go test ./pkg/monitortests/testframework/legacytestframeworkmonitortests`
- `go test ./pkg/monitortests/testframework/... ./pkg/cmd/openshift-tests/dev`
- `go test ./pkg/monitortests/...`

## Jira

https://issues.redhat.com/browse/OCPBUGS-115111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alert evaluation for external-topology environments by ignoring selected startup-related pod readiness alerts during the first five minutes.
  * Correctly trims alerts that overlap the startup grace period while preserving unaffected alerts.
  * Added coverage for startup filtering across supported namespaces, topologies, and collection start times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->