### PR TITLE
OCPBUGS-115112: Allow external HyperShift node startup events

### DIFF
--- a/pkg/monitortests/node/legacynodemonitortests/monitortest.go
+++ b/pkg/monitortests/node/legacynodemonitortests/monitortest.go
@@ -2,6 +2,7 @@ package legacynodemonitortests
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/openshift/origin/pkg/monitortestframework"
@@ -15,6 +16,7 @@ import (
 
 type legacyMonitorTests struct {
 	adminRESTConfig *rest.Config
+	beginning       time.Time
 }
 
 func NewLegacyTests() monitortestframework.MonitorTest {
@@ -31,16 +33,22 @@ func (w *legacyMonitorTests) StartCollection(ctx context.Context, adminRESTConfi
 }
 
 func (w *legacyMonitorTests) CollectData(ctx context.Context, storageDir string, beginning, end time.Time) (monitorapi.Intervals, []*junitapi.JUnitTestCase, error) {
+	w.beginning = beginning
 	return nil, nil, nil
 }
 
-func (*legacyMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+func (w *legacyMonitorTests) ConstructComputedIntervals(ctx context.Context, startingIntervals monitorapi.Intervals, recordedResources monitorapi.ResourcesMap, beginning, end time.Time) (monitorapi.Intervals, error) {
+	w.beginning = beginning
 	return nil, nil
 }
 
 func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.Context, finalIntervals monitorapi.Intervals) ([]*junitapi.JUnitTestCase, error) {
 
-	clusterData, _ := platformidentification.BuildClusterData(context.Background(), w.adminRESTConfig)
+	clusterData, clusterDataErrors := platformidentification.BuildClusterData(ctx, w.adminRESTConfig)
+	if clusterData.Topology == "" {
+		return nil, errors.New("unable to determine cluster topology for legacy node monitor evaluation")
+	}
+	finalIntervals = filterExternalTopologyStartupNodeIntervals(finalIntervals, clusterData, w.beginning)
 	var junits []*junitapi.JUnitTestCase
 	junits = append(junits, testDeleteGracePeriodZero(finalIntervals)...)
 	junits = append(junits, testKubeApiserverProcessOverlap(finalIntervals)...)
@@ -77,6 +85,10 @@ func (w *legacyMonitorTests) EvaluateTestsFromConstructedIntervals(ctx context.C
 	isUpgrade := platformidentification.DidUpgradeHappenDuringCollection(finalIntervals, time.Time{}, time.Time{})
 	if isUpgrade {
 		junits = append(junits, testNodeUpgradeTransitions(finalIntervals)...)
+	}
+
+	if clusterDataErrors != nil {
+		return junits, errors.New("unable to collect all cluster metadata for legacy node monitor evaluation")
 	}
 
 	return junits, nil

--- a/pkg/monitortests/node/legacynodemonitortests/startup.go
+++ b/pkg/monitortests/node/legacynodemonitortests/startup.go
@@ -1,0 +1,48 @@
+package legacynodemonitortests
+
+import (
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+)
+
+const externalTopologyNodeStartupGracePeriod = 5 * time.Minute
+
+func filterExternalTopologyStartupNodeIntervals(events monitorapi.Intervals, clusterData platformidentification.ClusterData, beginning time.Time) monitorapi.Intervals {
+	if clusterData.Topology != "external" || beginning.IsZero() {
+		return events
+	}
+
+	graceEnd := beginning.Add(externalTopologyNodeStartupGracePeriod)
+	filtered := make(monitorapi.Intervals, 0, len(events))
+	for _, event := range events {
+		if !isExternalTopologyStartupNodeInterval(event) {
+			filtered = append(filtered, event)
+			continue
+		}
+
+		if !event.To.IsZero() && !event.To.After(graceEnd) {
+			continue
+		}
+		if event.From.Before(graceEnd) {
+			event.From = graceEnd
+		}
+		filtered = append(filtered, event)
+	}
+
+	return filtered
+}
+
+func isExternalTopologyStartupNodeInterval(event monitorapi.Interval) bool {
+	if event.Message.Reason == monitorapi.PodReasonForceDelete &&
+		event.Locator.Keys[monitorapi.LocatorNamespaceKey] == "kube-system" {
+		return true
+	}
+
+	if event.Source == monitorapi.SourceKubeletLog && event.Message.Reason == monitorapi.FailedToAuthenticateWithOpenShiftUser {
+		return true
+	}
+
+	return errImagePullQPSExceededRE.MatchString(event.String())
+}

--- a/pkg/monitortests/node/legacynodemonitortests/startup_test.go
+++ b/pkg/monitortests/node/legacynodemonitortests/startup_test.go
@@ -1,0 +1,108 @@
+package legacynodemonitortests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openshift/origin/pkg/monitor/monitorapi"
+	"github.com/openshift/origin/pkg/monitortestlibrary/platformidentification"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterExternalTopologyStartupNodeIntervals(t *testing.T) {
+	beginning := time.Date(2026, 9, 11, 12, 0, 0, 0, time.UTC)
+	externalCluster := platformidentification.ClusterData{JobType: platformidentification.JobType{Topology: "external"}}
+	standaloneCluster := platformidentification.ClusterData{JobType: platformidentification.JobType{Topology: "ha"}}
+
+	buildInterval := func(source monitorapi.IntervalSource, reason monitorapi.IntervalReason, namespace, humanMessage string, from, to time.Duration) monitorapi.Interval {
+		return monitorapi.NewInterval(source, monitorapi.Info).
+			Locator(monitorapi.Locator{
+				Type: monitorapi.LocatorTypePod,
+				Keys: map[monitorapi.LocatorKey]string{
+					monitorapi.LocatorNamespaceKey: namespace,
+					monitorapi.LocatorNodeKey:      "node-0",
+				},
+			}).
+			Message(monitorapi.NewMessage().Reason(reason).HumanMessage(humanMessage)).
+			Build(beginning.Add(from), beginning.Add(to))
+	}
+
+	tests := []struct {
+		name     string
+		cluster  platformidentification.ClusterData
+		start    time.Time
+		interval monitorapi.Interval
+		expected monitorapi.Intervals
+	}{
+		{
+			name:     "force delete during startup is ignored",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{},
+		},
+		{
+			name:     "anonymous kubelet access during startup is ignored",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourceKubeletLog, monitorapi.FailedToAuthenticateWithOpenShiftUser, "", "system:anonymous cannot get CSINodes", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{},
+		},
+		{
+			name:     "image pull QPS error during startup is ignored",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourceKubeletLog, monitorapi.ContainerErrImagePull, "openshift-dns", "ErrImagePull: pull QPS exceeded", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{},
+		},
+		{
+			name:     "matching interval crossing startup window is clipped",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourceKubeletLog, monitorapi.FailedToAuthenticateWithOpenShiftUser, "", "system:anonymous cannot get CSINodes", time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourceKubeletLog, monitorapi.FailedToAuthenticateWithOpenShiftUser, "", "system:anonymous cannot get CSINodes", 5*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "matching interval after startup window is unchanged",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", 6*time.Minute, 7*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", 6*time.Minute, 7*time.Minute)},
+		},
+		{
+			name:     "force delete in another namespace is unchanged",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "openshift-dns", "", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "openshift-dns", "", time.Minute, 2*time.Minute)},
+		},
+		{
+			name:     "other image pull error is unchanged",
+			cluster:  externalCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourceKubeletLog, monitorapi.ContainerErrImagePull, "openshift-dns", "ErrImagePull: manifest unknown", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourceKubeletLog, monitorapi.ContainerErrImagePull, "openshift-dns", "ErrImagePull: manifest unknown", time.Minute, 2*time.Minute)},
+		},
+		{
+			name:     "non-external topology is unchanged",
+			cluster:  standaloneCluster,
+			start:    beginning,
+			interval: buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", time.Minute, 2*time.Minute)},
+		},
+		{
+			name:     "zero collection start is unchanged",
+			cluster:  externalCluster,
+			start:    time.Time{},
+			interval: buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", time.Minute, 2*time.Minute),
+			expected: monitorapi.Intervals{buildInterval(monitorapi.SourcePodMonitor, monitorapi.PodReasonForceDelete, "kube-system", "", time.Minute, 2*time.Minute)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := filterExternalTopologyStartupNodeIntervals(monitorapi.Intervals{tt.interval}, tt.cluster, tt.start)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Filters expected HyperShift guest-cluster node bootstrap events from
`legacy-node-invariants` during a bounded five-minute startup window:

- Force-deleted pods in `kube-system`
- Kubelet `system:anonymous` authentication failures
- `ErrImagePull` pull-QPS-exceeded errors

The filter applies only to external control-plane topology and preserves intervals that continue beyond the startup window.

## Why is this needed?

These events can occur while HyperShift guest nodes join and images are pulled during initial cluster setup. They currently appear as node-invariant failures. Later events and unrelated topologies remain evaluated.

## Testing

- `go test ./pkg/monitortests/node/legacynodemonitortests`
- `go vet ./...`
- Targeted retries of unrelated connectivity tests
- `git diff --check`

## Jira

OCPBUGS-115112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of expected image-pull failures across additional invalid image formats.
  * Reduced the risk of misclassifying genuine image-pull failures as expected test outcomes.

* **Tests**
  * Added coverage for invalid image references and confirmed that legitimate image-pull failures remain unmatched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->