### PR TITLE
TRT-2830: add REVIEW.md for agentic review responses

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,3 +1,5 @@
+Extra context for agentic review responses, layered on `/openshift-developer:address-review-pr`.
+
 ## Verify and Push
 
 1. Run `make build` and `go vet ./...`.


### PR DESCRIPTION
## Summary
- Replace `.agentic/followup-config.md` with a root `REVIEW.md` so the agentic review-responder can layer origin-specific guidance on `/openshift-developer:address-review-pr`.
- Content is unchanged aside from a one-line header describing that overlay.

Companion PRs:
- sippy: https://github.com/openshift/sippy/pull/4016
- release: https://github.com/openshift/release/pull/85039

https://redhat.atlassian.net/browse/TRT-2830

## Test plan
- [ ] Confirm `REVIEW.md` is at repo root and `.agentic/followup-config.md` is gone
- [ ] Confirm `.agentic/solve-config.md` is unchanged
- [ ] Merge before the release review-responder PR so the new file exists when that step starts looking for it


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for responding to agent-assisted code reviews.
  - Extended the review-response workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->