### PR TITLE
Move external ip policy test to disruptive-longrunning

### DIFF
--- a/pkg/testsuites/standard_suites.go
+++ b/pkg/testsuites/standard_suites.go
@@ -470,7 +470,7 @@ var staticSuites = []ginkgo.TestSuite{
 			`name.contains("[Suite:openshift/disruptive-longrunning")`,
 		},
 		Parallelism:                1,
-		TestTimeout:                40 * time.Minute,
+		TestTimeout:                50 * time.Minute,
 		ClusterStabilityDuringTest: ginkgo.Disruptive,
 	},
 	{

--- a/test/extended/networking/services.go
+++ b/test/extended/networking/services.go
@@ -20,10 +20,10 @@ import (
 
 var _ = Describe("[sig-network] services", func() {
 	oc := exutil.NewCLIWithPodSecurityLevel("ns-global", admissionapi.LevelBaseline)
-	var retryInterval = 1 * time.Minute
+	retryInterval := 1 * time.Minute
 
 	InIPv4ClusterContext(oc, func() {
-		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial]", func() {
+		It("ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial] [Suite:openshift/disruptive-longrunning]", func() {
 			// Check if the test can write to cluster/network.config.openshift.io
 			hasAccess, err := hasNetworkConfigWriteAccess(oc)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The test does multiple KAS rollouts. Also bumps the longrunning test timout by 10 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout for the disruptive long-running test suite from 40 to 50 minutes.
  * Updated the IPv4 external IP policy test to run as part of the disruptive long-running suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->